### PR TITLE
fix(sf-294): keep PR CI green — move perf gates + multi-arch push off the PR path

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,6 +107,10 @@ jobs:
         run: docker rm -f topgun-smoke || true
 
       - name: Build and push multi-arch image
+        # QEMU multi-arch emulation is slow (~30 min) and pushes nothing on a PR anyway
+        # (GHCR login is already PR-skipped above). Skip this step on PRs entirely so
+        # the PR run never times out waiting for a no-op multi-arch build.
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,10 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - '.github/workflows/rust.yml'
+  # Perf gates are informational and slow; run them nightly off the PR critical path
+  # so PRs never time out waiting for multi-minute harness builds + benchmark scenarios.
+  schedule:
+    - cron: '0 6 * * *'
 
 env:
   CARGO_TERM_COLOR: always
@@ -122,6 +126,9 @@ jobs:
   perf-gate:
     name: Performance Gate
     needs: [check]
+    # Perf gates are informational + slow; run off the PR critical path so timeout-induced
+    # cancellations never redden a PR run. Coverage retained on push-to-main/develop + nightly schedule.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Informational only — does not block merges while baseline stability is validated
@@ -222,6 +229,9 @@ jobs:
   vector-perf-gate:
     name: Vector Performance Gate
     needs: [check]
+    # Perf gates are informational + slow; run off the PR critical path so timeout-induced
+    # cancellations never redden a PR run. Coverage retained on push-to-main/develop + nightly schedule.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Informational only — baselines measured on M1 Max; Ubuntu runners may differ


### PR DESCRIPTION
## What

Closes TODO-434. The Rust and Docker workflows were going red on every PR purely from **timeout-induced cancellations** of slow, informational jobs — not from real failures. `continue-on-error: true` suppresses a job *failure* but not a *cancellation*, so a timed-out perf/multi-arch job reddened the whole workflow.

## Changes

- **rust.yml**: both `Performance Gate` and `Vector Performance Gate` now run with `if: github.event_name != 'pull_request'` (push-to-main/develop + new nightly `cron: '0 6 * * *'`). Perf coverage retained off the PR critical path.
- **docker.yml**: the multi-arch `Build and push` step is skipped on PRs (`if: github.event_name != 'pull_request'`). GHCR login was already PR-skipped, so this step pushed nothing on a PR anyway — it only burned ~30 min until timeout. The smoke-test build+run (the real PR validation) is unchanged.

## Verification

The fix is workflow-behavioral, so the authoritative proof is this PR's own CI run: the Rust + Docker workflows should now conclude **without any cancelled jobs**, where before they timed out. YAML validated locally (`yaml.safe_load`).