### PR TITLE
fix(ci): move perf gates + docker multi-arch push off the push-to-main critical path

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,18 +107,18 @@ jobs:
         run: docker rm -f topgun-smoke || true
 
       - name: Build and push multi-arch image
-        # QEMU multi-arch emulation is slow (~45 min) and pushes nothing on a PR
-        # (GHCR login is already PR-skipped above). Skip this step on PRs entirely so
-        # the PR run never times out waiting for a no-op multi-arch build.
-        # On push-to-main this step genuinely runs and pushes linux/amd64+linux/arm64
-        # to GHCR; timeout-minutes raised to 45 to fit within budget.
-        if: github.event_name != 'pull_request'
+        # QEMU emulation of linux/arm64 on an amd64 runner is 5-10x slower than native and
+        # routinely blows past the job timeout on push-to-main (cancelled at 45 min), reddening
+        # the badge while pushing nothing useful for a normal merge. Gate the multi-arch publish
+        # to release tags (v*), where the images are actually consumed. push-to-main and PRs keep
+        # the fast amd64 smoke-test above as the real validation; multi-arch publish runs on tags.
+        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v5
         with:
           context: .
           file: deploy/Dockerfile.server
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,8 @@ on:
   # so PRs never time out waiting for multi-minute harness builds + benchmark scenarios.
   schedule:
     - cron: '0 6 * * *'
+  # Manual trigger for on-demand perf runs (the perf gates gate on schedule || workflow_dispatch).
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -134,7 +136,8 @@ jobs:
     # per-merge perf signal on push-to-main/develop. A regression merged after the 06:00 cron
     # stays invisible until the next nightly tick (~23h). Acceptable for an informational gate,
     # but documented here so the lost push-time signal is explicit, not silent.
-    if: github.event_name == 'schedule'
+    # workflow_dispatch added so an on-demand manual run exercises this gate too.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Informational only — does not block merges while baseline stability is validated
@@ -235,9 +238,12 @@ jobs:
   vector-perf-gate:
     name: Vector Performance Gate
     needs: [check]
-    # Perf gates are informational + slow; run off the PR critical path so timeout-induced
-    # cancellations never redden a PR run. Coverage retained on push-to-main/develop + nightly schedule.
-    if: github.event_name != 'pull_request'
+    # Perf gates are informational + slow + non-deterministic on shared runners (baselines were
+    # measured on M1 Max; Ubuntu runners drift 15-20% run-to-run, so a push-time gate just plays
+    # baseline whack-a-mole and reddens the badge). Run nightly-only (cron schedule) — mirrors
+    # the Performance Gate job. Perf coverage is retained via the nightly schedule + manual
+    # workflow_dispatch, off the push-to-main critical path.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Informational only — baselines measured on M1 Max; Ubuntu runners may differ


### PR DESCRIPTION
## What

Makes the **main CI badge green honestly** by moving non-deterministic / slow informational jobs off the push-to-main path. Closes TODO-437 + TODO-438. **CI-config only — no product code.**

## Root cause (not code regressions)

Two jobs reddened main without indicating any real regression:
- **Vector Performance Gate (failing)**: perf baselines measured on M1 Max; shared Ubuntu runners drift 15-20% run-to-run (query p50 was 1201µs one run, 1408µs the next). SPEC-296 re-tuned the query threshold, but the gate just moved to the hybrid scenario (444µs vs 429µs baseline) — classic baseline whack-a-mole. A perf-regression gate on noisy shared hardware is structurally the wrong place on the push path.
- **Docker multi-arch push (cancelled)**: linux/arm64 via QEMU emulation on an amd64 runner overran even the raised 45-min timeout (cancelled at 45m02s). The amd64 smoke-test (the real validation) passed; only the slow emulated publish timed out.

## Changes

- **rust.yml**: `Vector Performance Gate` now runs on `schedule || workflow_dispatch` only (mirrors `Performance Gate`), off the push path. Added a `workflow_dispatch` trigger and aligned `Performance Gate` to accept it, so on-demand manual perf runs work.
- **docker.yml**: multi-arch `Build and push` gated to release tags (`refs/tags/*`) where the images are consumed. push-to-main + PRs keep the fast amd64 smoke-test as validation.

Perf + multi-arch coverage is **retained** via nightly schedule / manual dispatch / release tags — just not on the push critical path.

## Verification

This PR's own CI is the proof: Rust + Docker + Benchmarks should be **green**, with perf gates **skipped** (not failing/cancelled) and Docker green via smoke-test. All correctness jobs (Check & Lint, Cargo Audit, Cross-Lang, Simulation) unaffected. YAML validated locally. Done via PR-flow (not direct-to-main) per the SPEC-294/295/296 lesson.