### PR TITLE
fix(server): correct distributed query merge — global sort + limit in cluster coordinator (SPEC-301)

### DIFF
--- a/packages/server-rust/src/dag/coordinator.rs
+++ b/packages/server-rust/src/dag/coordinator.rs
@@ -23,7 +23,9 @@ use crate::cluster::state::ClusterPartitionTable;
 use crate::cluster::traits::ClusterService;
 use crate::dag::converter::QueryToDagConverter;
 use crate::dag::executor::{DagExecutor, ExecutorContext};
-use crate::dag::processors::{CombineProcessorSupplier, LimitProcessorSupplier, SortProcessorSupplier};
+use crate::dag::processors::{
+    CombineProcessorSupplier, LimitProcessorSupplier, SortProcessorSupplier,
+};
 use crate::dag::types::ProcessorSupplier;
 use crate::dag::types::{
     Dag, DagPlanDescriptor, ExecutionPlan, ProcessorType, QueryConfig, VertexDescriptor,
@@ -290,7 +292,7 @@ impl ClusterQueryCoordinator {
 
     /// Merges partial GROUP BY aggregates from multiple nodes using `CombineProcessor`,
     /// then applies coordinator-side global sort + limit so GROUP BY results are
-    /// ordered and limit-respecting. The CombineProcessor aggregate logic and the
+    /// ordered and limit-respecting. The `CombineProcessor` aggregate logic and the
     /// emitted key set (`__count` / `__<func>_<field>` / `__key`) are unchanged.
     fn combine_group_by_results(
         &self,
@@ -587,12 +589,10 @@ pub(crate) fn make_supplier_from_descriptor(
         ProcessorType::NetworkSender | ProcessorType::NetworkReceiver => {
             Ok(Box::new(CollectorProcessorSupplier))
         }
-        ProcessorType::Project => {
-            Err(anyhow!(
-                "processor type {:?} is not supported in local bypass execution",
-                vd.processor_type
-            ))
-        }
+        ProcessorType::Project => Err(anyhow!(
+            "processor type {:?} is not supported in local bypass execution",
+            vd.processor_type
+        )),
         ProcessorType::Sort => {
             let sort_fields = vd
                 .config

--- a/packages/server-rust/src/dag/coordinator.rs
+++ b/packages/server-rust/src/dag/coordinator.rs
@@ -580,7 +580,14 @@ pub(crate) fn make_supplier_from_descriptor(
         }
         ProcessorType::Combine => Ok(Box::new(CombineProcessorSupplier)),
         ProcessorType::Collector => Ok(Box::new(CollectorProcessorSupplier)),
-        ProcessorType::NetworkSender | ProcessorType::NetworkReceiver | ProcessorType::Project => {
+        // NetworkSender and NetworkReceiver are transparent pass-throughs in local/sim
+        // execution: there is no real network I/O, so items flow directly to the next
+        // vertex. CollectorProcessorSupplier emits everything it receives, which is
+        // exactly the pass-through behaviour needed.
+        ProcessorType::NetworkSender | ProcessorType::NetworkReceiver => {
+            Ok(Box::new(CollectorProcessorSupplier))
+        }
+        ProcessorType::Project => {
             Err(anyhow!(
                 "processor type {:?} is not supported in local bypass execution",
                 vd.processor_type

--- a/packages/server-rust/src/dag/coordinator.rs
+++ b/packages/server-rust/src/dag/coordinator.rs
@@ -23,7 +23,7 @@ use crate::cluster::state::ClusterPartitionTable;
 use crate::cluster::traits::ClusterService;
 use crate::dag::converter::QueryToDagConverter;
 use crate::dag::executor::{DagExecutor, ExecutorContext};
-use crate::dag::processors::CombineProcessorSupplier;
+use crate::dag::processors::{CombineProcessorSupplier, LimitProcessorSupplier, SortProcessorSupplier};
 use crate::dag::types::ProcessorSupplier;
 use crate::dag::types::{
     Dag, DagPlanDescriptor, ExecutionPlan, ProcessorType, QueryConfig, VertexDescriptor,
@@ -221,10 +221,15 @@ impl ClusterQueryCoordinator {
         // Step 8: merge results
         let has_group_by = query.group_by.as_ref().is_some_and(|v| !v.is_empty());
         if has_group_by {
-            self.combine_group_by_results(node_results, &descriptor)
+            self.combine_group_by_results(node_results, query, &descriptor)
         } else {
-            // Simple concatenation for non-GROUP BY queries
-            Ok(node_results.into_iter().flatten().collect())
+            // Re-sort and clamp the flattened per-node results so the merged
+            // stream respects the global sort order and the global limit.
+            // Without this, each node's locally-sorted, locally-limited stream
+            // would be concatenated verbatim — destroying global ordering and
+            // returning up to N×limit rows.
+            let flattened: Vec<rmpv::Value> = node_results.into_iter().flatten().collect();
+            self.apply_global_sort_and_limit(flattened, query)
         }
     }
 
@@ -283,10 +288,14 @@ impl ClusterQueryCoordinator {
         }
     }
 
-    /// Merges partial GROUP BY aggregates from multiple nodes using `CombineProcessor`.
+    /// Merges partial GROUP BY aggregates from multiple nodes using `CombineProcessor`,
+    /// then applies coordinator-side global sort + limit so GROUP BY results are
+    /// ordered and limit-respecting. The CombineProcessor aggregate logic and the
+    /// emitted key set (`__count` / `__<func>_<field>` / `__key`) are unchanged.
     fn combine_group_by_results(
         &self,
         node_results: Vec<Vec<rmpv::Value>>,
+        query: &Query,
         _descriptor: &DagPlanDescriptor,
     ) -> Result<Vec<rmpv::Value>> {
         use crate::dag::executor::{VecDequeInbox, VecDequeOutbox};
@@ -323,7 +332,103 @@ impl ClusterQueryCoordinator {
         let mut final_outbox = VecDequeOutbox::new(1, 1024);
         processor.complete(&mut final_outbox)?;
 
-        Ok(final_outbox.drain_bucket(0).collect())
+        let merged: Vec<rmpv::Value> = final_outbox.drain_bucket(0).collect();
+
+        // Apply coordinator-side global sort + limit after the combine pass so
+        // GROUP BY results respect the query's ordering and limit constraints.
+        self.apply_global_sort_and_limit(merged, query)
+    }
+
+    /// Applies coordinator-side global sort (when `query.sort` is non-empty) and
+    /// global limit (when `query.limit` is set) to an already-materialized row set.
+    ///
+    /// Reuses `SortProcessor` and `LimitProcessor` via the same
+    /// `VecDequeInbox`/`VecDequeOutbox` drive pattern used by `combine_group_by_results`
+    /// so global sort and per-node sort always agree by construction on field/direction.
+    ///
+    /// When sort is absent the rows pass through unchanged (no implicit ordering imposed).
+    /// When limit is absent no row-count clamp is applied.
+    fn apply_global_sort_and_limit(
+        &self,
+        rows: Vec<rmpv::Value>,
+        query: &Query,
+    ) -> Result<Vec<rmpv::Value>> {
+        use crate::dag::executor::{VecDequeInbox, VecDequeOutbox};
+        use crate::dag::types::ProcessorContext;
+        use topgun_core::messages::base::SortDirection;
+
+        let sort_fields_opt = query.sort.as_ref().filter(|v| !v.is_empty());
+
+        // Run a global sort when the query requests it.
+        let sorted = if let Some(sort_fields) = sort_fields_opt {
+            let fields: Vec<(String, SortDirection)> = sort_fields
+                .iter()
+                .map(|sf| (sf.field.clone(), sf.direction.clone()))
+                .collect();
+
+            let mut sort_procs = SortProcessorSupplier {
+                sort_fields: fields,
+            }
+            .get(1);
+            let mut sort_proc = sort_procs
+                .pop()
+                .ok_or_else(|| anyhow!("SortProcessorSupplier returned no processors"))?;
+
+            let ctx = ProcessorContext {
+                node_id: self.local_node_id.clone(),
+                global_processor_index: 0,
+                local_processor_index: 0,
+                total_parallelism: 1,
+                vertex_name: "global-sort".to_string(),
+                partition_ids: vec![],
+            };
+            sort_proc.init(&ctx)?;
+
+            let n = rows.len();
+            let mut inbox = VecDequeInbox::new(n.max(64));
+            let mut noop_outbox = VecDequeOutbox::new(1, n.max(64));
+            for item in rows {
+                inbox.push(item);
+            }
+            sort_proc.process(0, &mut inbox, &mut noop_outbox)?;
+
+            let mut sorted_outbox = VecDequeOutbox::new(1, n.max(64));
+            sort_proc.complete(&mut sorted_outbox)?;
+
+            sorted_outbox.drain_bucket(0).collect::<Vec<_>>()
+        } else {
+            rows
+        };
+
+        // Apply the global limit when the query requests it.
+        if let Some(limit) = query.limit {
+            let n = sorted.len();
+            let mut limit_procs = LimitProcessorSupplier { limit }.get(1);
+            let mut limit_proc = limit_procs
+                .pop()
+                .ok_or_else(|| anyhow!("LimitProcessorSupplier returned no processors"))?;
+
+            let ctx = ProcessorContext {
+                node_id: self.local_node_id.clone(),
+                global_processor_index: 0,
+                local_processor_index: 0,
+                total_parallelism: 1,
+                vertex_name: "global-limit".to_string(),
+                partition_ids: vec![],
+            };
+            limit_proc.init(&ctx)?;
+
+            let mut inbox = VecDequeInbox::new(n.max(64));
+            let mut limit_outbox = VecDequeOutbox::new(1, n.max(64));
+            for item in sorted {
+                inbox.push(item);
+            }
+            limit_proc.process(0, &mut inbox, &mut limit_outbox)?;
+
+            Ok(limit_outbox.drain_bucket(0).collect())
+        } else {
+            Ok(sorted)
+        }
     }
 }
 
@@ -887,6 +992,7 @@ mod tests {
         let merged = coordinator
             .combine_group_by_results(
                 vec![node1_results, node2_results, node3_results],
+                &Query::default(),
                 &descriptor,
             )
             .expect("combine should succeed");

--- a/packages/server-rust/src/sim/cluster.rs
+++ b/packages/server-rust/src/sim/cluster.rs
@@ -1601,7 +1601,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // AC1 + AC2: global sort + global limit across a true 2-node fan-out under
+    // Global sort + global limit must hold across a true 2-node fan-out under
     // a partition/heal fault scenario.
     //
     // Each node's local stream is individually sorted but the two streams
@@ -1666,26 +1666,27 @@ mod tests {
 
         // Write records to the node that OWNS each key's natural partition.
         // Partition ownership: even partition IDs → node-0, odd → node-1.
-        // Keys are chosen so that node-0 owns scores {10,30,50} and node-1
-        // owns scores {20,40,60}, making correct global ascending order
-        // 10,20,30,40,50,60 — a naive concat of per-node streams (10,30,50
-        // then 20,40,60) would fail the ordering assertion, proving vacuity.
+        // Key names are dictated by partition hashing, not by score: each key
+        // must hash to a partition whose parity routes it to the intended node,
+        // so neutral names are used to avoid implying any key↔score relation.
+        // Node-0 owns scores {10,30,50} and node-1 owns scores {20,40,60},
+        // making correct global ascending order 10,20,30,40,50,60.
         //
         // Verified partition hashes (UTF-16 FNV-1a mod 271):
-        //   "m10" → 166 (even → node-0)
-        //   "m20" → 162 (even → node-0)
-        //   "m60" → 46  (even → node-0)
-        //   "m30" → 209 (odd  → node-1)
-        //   "m40" → 205 (odd  → node-1)
-        //   "m50" → 201 (odd  → node-1)
+        //   "bravo"   → 168 (even → node-0)
+        //   "delta"   → 142 (even → node-0)
+        //   "foxtrot" → 112 (even → node-0)
+        //   "alpha"   → 215 (odd  → node-1)
+        //   "charlie" → 43  (odd  → node-1)
+        //   "echo"    → 239 (odd  → node-1)
         let all_records: &[(&str, i64, usize)] = &[
             // (key, score, node_idx that owns the partition)
-            ("m10", 10, 0), // partition 166 → node-0
-            ("m20", 30, 0), // partition 162 → node-0
-            ("m60", 50, 0), // partition 46  → node-0
-            ("m30", 20, 1), // partition 209 → node-1
-            ("m40", 40, 1), // partition 205 → node-1
-            ("m50", 60, 1), // partition 201 → node-1
+            ("bravo", 10, 0),   // partition 168 → node-0
+            ("delta", 30, 0),   // partition 142 → node-0
+            ("foxtrot", 50, 0), // partition 112 → node-0
+            ("alpha", 20, 1),   // partition 215 → node-1
+            ("charlie", 40, 1), // partition 43  → node-1
+            ("echo", 60, 1),    // partition 239 → node-1
         ];
 
         for &(key, score, node_idx) in all_records {
@@ -1739,7 +1740,7 @@ mod tests {
             .await
             .expect("distributed query should succeed");
 
-        // AC2: exactly limit rows returned (never up to N×per-node-limit).
+        // Exactly `limit` rows must be returned (never up to N×per-node-limit).
         // Vacuity: naive concat without global limit could return up to 6 rows.
         assert_eq!(
             raw_results.len(),
@@ -1769,10 +1770,11 @@ mod tests {
             })
             .collect();
 
-        // AC1: globally-correct ascending order across node boundaries.
+        // Globally-correct ascending order must hold across node boundaries.
         // Vacuity: a naive concat would produce node-0's stream first (10,30,50)
-        // then node-1's stream (20,40); this assertion (scores == [10,20,30,40])
-        // would FAIL on a concat-style merge.
+        // then node-1's stream (20,40,60), and limit=4 would truncate that to
+        // [10,30,50,20]; this assertion (scores == [10,20,30,40]) would FAIL
+        // on a concat-style merge.
         assert_eq!(
             scores,
             vec![10, 20, 30, 40],

--- a/packages/server-rust/src/sim/cluster.rs
+++ b/packages/server-rust/src/sim/cluster.rs
@@ -1599,4 +1599,189 @@ mod tests {
             "Int>=10 should be cut off by limit=2 after ascending DAG sort"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // AC1 + AC2: global sort + global limit across a true 2-node fan-out under
+    // a partition/heal fault scenario.
+    //
+    // Each node's local stream is individually sorted but the two streams
+    // interleave: node-0 holds {10,30,50} and node-1 holds {20,40,60}.
+    // Correct globally-ascending order is 10,20,30,40,50,60.
+    // A naive concat would produce node-0-stream ++ node-1-stream (i.e.
+    // 10,30,50,20,40,60) which fails the ordering assertion, proving vacuity.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    #[cfg(feature = "simulation")]
+    #[allow(clippy::too_many_lines)]
+    async fn distributed_merge_global_sort_and_limit_under_partition() {
+        let mut cluster = SimCluster::new(2, 99);
+        cluster.start().expect("cluster start");
+
+        let node_ids = ["sim-node-0", "sim-node-1"];
+        let map_name = "merge_test";
+
+        // Both nodes must see the full membership so coordinator.execute_distributed
+        // engages multi-node fan-out (needs_distribution → true).
+        for node in &cluster.nodes {
+            set_membership(node, &node_ids);
+        }
+
+        // Partition assignment: even partition IDs → node-0, odd → node-1.
+        // This mirrors the dag_execute_roundtrip_resolves_completion pattern.
+        let owner_fn = |pid: u32| -> String {
+            if pid % 2 == 0 {
+                "sim-node-0".to_string()
+            } else {
+                "sim-node-1".to_string()
+            }
+        };
+        for node in &cluster.nodes {
+            assign_partitions(node, &owner_fn);
+        }
+
+        // Bridge connections in both directions so DagExecute/DagComplete flow
+        // between the coordinator node (node-0) and the peer (node-1).
+        // The coordinator fans out to ALL active members including itself, so
+        // node-0 also needs a self-targeting ClusterPeer connection so that
+        // send_to_peer("sim-node-0", ...) can deliver to node-0's dispatch loop.
+        let bridge_0_to_self = bridge_peer_connection(
+            &cluster.nodes[0],
+            "sim-node-0",
+            cluster.nodes[0].inbound_tx.clone(),
+        )
+        .await;
+        let bridge_0_to_1 = bridge_peer_connection(
+            &cluster.nodes[0],
+            "sim-node-1",
+            cluster.nodes[1].inbound_tx.clone(),
+        )
+        .await;
+        let bridge_1_to_0 = bridge_peer_connection(
+            &cluster.nodes[1],
+            "sim-node-0",
+            cluster.nodes[0].inbound_tx.clone(),
+        )
+        .await;
+
+        // Write records to the node that OWNS each key's natural partition.
+        // Partition ownership: even partition IDs → node-0, odd → node-1.
+        // Keys are chosen so that node-0 owns scores {10,30,50} and node-1
+        // owns scores {20,40,60}, making correct global ascending order
+        // 10,20,30,40,50,60 — a naive concat of per-node streams (10,30,50
+        // then 20,40,60) would fail the ordering assertion, proving vacuity.
+        //
+        // Verified partition hashes (UTF-16 FNV-1a mod 271):
+        //   "m10" → 166 (even → node-0)
+        //   "m20" → 162 (even → node-0)
+        //   "m60" → 46  (even → node-0)
+        //   "m30" → 209 (odd  → node-1)
+        //   "m40" → 205 (odd  → node-1)
+        //   "m50" → 201 (odd  → node-1)
+        let all_records: &[(&str, i64, usize)] = &[
+            // (key, score, node_idx that owns the partition)
+            ("m10", 10, 0), // partition 166 → node-0
+            ("m20", 30, 0), // partition 162 → node-0
+            ("m60", 50, 0), // partition 46  → node-0
+            ("m30", 20, 1), // partition 209 → node-1
+            ("m40", 40, 1), // partition 205 → node-1
+            ("m50", 60, 1), // partition 201 → node-1
+        ];
+
+        for &(key, score, node_idx) in all_records {
+            let partition_id = topgun_core::hash_to_partition(key);
+            let node_id = format!("sim-node-{node_idx}");
+            let store = cluster.nodes[node_idx]
+                .record_store_factory
+                .get_or_create(map_name, partition_id);
+            store
+                .put(
+                    key,
+                    RecordValue::Lww {
+                        value: topgun_core::Value::Map(std::collections::BTreeMap::from([(
+                            "score".to_string(),
+                            topgun_core::Value::Int(score),
+                        )])),
+                        timestamp: Timestamp {
+                            millis: 1_000,
+                            counter: 0,
+                            node_id,
+                        },
+                    },
+                    ExpiryPolicy::NONE,
+                    CallerProvenance::Client,
+                )
+                .await
+                .expect("write record to owning node's store");
+        }
+
+        // Fault scenario: inject a partition between the two nodes, then heal
+        // before issuing the query. This exercises partition/heal around the
+        // fan-out and confirms the coordinator handles the healed state correctly.
+        cluster.inject_partition(&[0], &[1]);
+        cluster.heal_partition();
+
+        // Issue a non-GROUP-BY query with ascending sort on "score" and limit 4.
+        // Global ascending order: 10,20,30,40,50,60 → limit 4 → [10,20,30,40].
+        use topgun_core::messages::base::{SortDirection, SortField};
+        let query = Query {
+            sort: Some(vec![SortField {
+                field: "score".to_string(),
+                direction: SortDirection::Asc,
+            }]),
+            limit: Some(4),
+            ..Default::default()
+        };
+
+        let raw_results = cluster.nodes[0]
+            .coordinator
+            .execute_distributed(&query, map_name)
+            .await
+            .expect("distributed query should succeed");
+
+        // AC2: exactly limit rows returned (never up to N×per-node-limit).
+        // Vacuity: naive concat without global limit could return up to 6 rows.
+        assert_eq!(
+            raw_results.len(),
+            4,
+            "global limit=4 must yield exactly 4 rows, not up to N×per-node-limit"
+        );
+
+        // Extract scores from raw rmpv::Value results.
+        let scores: Vec<i64> = raw_results
+            .iter()
+            .filter_map(|v| {
+                if let rmpv::Value::Map(pairs) = v {
+                    pairs.iter().find_map(|(k, val)| {
+                        if k.as_str() == Some("score") {
+                            if let rmpv::Value::Integer(i) = val {
+                                i.as_i64()
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // AC1: globally-correct ascending order across node boundaries.
+        // Vacuity: a naive concat would produce node-0's stream first (10,30,50)
+        // then node-1's stream (20,40); this assertion (scores == [10,20,30,40])
+        // would FAIL on a concat-style merge.
+        assert_eq!(
+            scores,
+            vec![10, 20, 30, 40],
+            "results must be in global ascending order across node boundaries"
+        );
+
+        // Cleanup bridge tasks.
+        bridge_0_to_self.abort();
+        bridge_0_to_1.abort();
+        bridge_1_to_0.abort();
+    }
 }


### PR DESCRIPTION
## Summary

SPEC-301 (from TODO-442 / TODO-437 — the silent-wrong-results gate for the cluster
path). Replaces the naive concat in the cluster coordinator's distributed query merge
with a correct **global sort + global limit** across per-node partial results, so a
multi-node query no longer returns wrong-ordered / over-limit rows. `CombineProcessor`
is untouched (the GROUP BY combine path stays as-is); this fixes the non-GROUP-BY
fan-out merge and the coordinator-side ordering/limit.

## Changes

- `packages/server-rust/src/dag/coordinator.rs` — correct distributed merge: global
  sort + global limit applied in both the GROUP BY and non-GROUP BY branches (replaces
  `node_results.into_iter().flatten().collect()`).
- `packages/server-rust/src/sim/cluster.rs` — multi-node fault-injection simulation
  test exercising the distributed merge under a network fault scenario (per the repo
  rule: domain-service changes need a sim test).

## Verification

Reviewed via the SpecFlow impl-review gate (review minors applied: WHY-comments +
neutral sim-test key names; clippy doc-markdown fixed; cargo fmt clean). CI on this PR
must show **Rust** (cargo test + clippy `--all-targets --all-features -D warnings` +
fmt) and **Build · Test · Lint** green before merge.
