### PR TITLE
feat(server): wire cluster query coordinator + distributed cursor — query Phase 3 (SPEC-304)

### DIFF
--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -21,22 +21,30 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use arc_swap::ArcSwap;
+use async_trait::async_trait;
 use axum::routing::get;
 use clap::Parser;
 use dashmap::DashMap;
 use parking_lot::RwLock;
 use tokio::net::TcpListener;
 use tokio::signal;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use topgun_core::{SystemClock, HLC};
 
 use topgun_server::cluster::failure_detector::PhiAccrualConfig;
+use topgun_server::cluster::messages::DagCompletePayload;
 use topgun_server::cluster::peer_connection::PeerConnectionMap;
 use topgun_server::cluster::state::{ClusterState, InboundClusterMessage, MigrationCommand};
-use topgun_server::cluster::types::{ClusterConfig, MemberInfo, NodeState};
-use topgun_server::cluster::{
-    ClusterFormationService, HeartbeatService, MembershipReactor, PhiAccrualFailureDetector,
+use topgun_server::cluster::types::{
+    ClusterConfig, ClusterHealth, MemberInfo, MembersView, NodeState,
 };
+use topgun_server::cluster::{
+    run_cluster_dispatch_loop, ClusterChange, ClusterDispatchContext, ClusterFormationService,
+    ClusterPartitionTable, ClusterService, HeartbeatService, MembershipReactor,
+    PhiAccrualFailureDetector,
+};
+use topgun_server::dag::types::QueryConfig;
+use topgun_server::dag::ClusterQueryCoordinator;
 use topgun_server::network::config::NetworkConfig;
 use topgun_server::network::connection::ConnectionRegistry;
 use topgun_server::network::handlers::AppState;
@@ -64,6 +72,7 @@ use topgun_server::service::domain::LockRegistry;
 use topgun_server::service::middleware::build_operation_pipeline;
 use topgun_server::service::operation::service_names;
 use topgun_server::service::policy::{InMemoryPolicyStore, PolicyEvaluator, PolicyStore};
+use topgun_server::service::registry::{ManagedService, ServiceContext};
 use topgun_server::service::router::OperationRouter;
 use topgun_server::service::security::{SecurityConfig, WriteValidator};
 use topgun_server::service::OperationService;
@@ -194,6 +203,71 @@ struct Args {
 /// and will trigger the no-auth + exposed-bind warning.
 fn is_loopback(addr: &str) -> bool {
     addr == "127.0.0.1" || addr == "::1" || addr.starts_with("localhost")
+}
+
+// ---------------------------------------------------------------------------
+// ClusterStateAdapter — bridges ClusterState to the ClusterService trait
+// ---------------------------------------------------------------------------
+
+/// Thin adapter so `ClusterState` can satisfy `Arc<dyn ClusterService>` for
+/// the `ClusterQueryCoordinator`.  Only the production binary needs this;
+/// simulation tests use `SimClusterService` directly.
+struct ClusterStateAdapter {
+    state: Arc<ClusterState>,
+    node_id: String,
+}
+
+#[async_trait]
+impl ManagedService for ClusterStateAdapter {
+    fn name(&self) -> &'static str {
+        "cluster-state-adapter"
+    }
+    async fn init(&self, _ctx: &ServiceContext) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn reset(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn shutdown(&self, _terminate: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+impl ClusterService for ClusterStateAdapter {
+    fn node_id(&self) -> &str {
+        &self.node_id
+    }
+    fn is_master(&self) -> bool {
+        self.state.is_master()
+    }
+    fn master_id(&self) -> Option<String> {
+        let view = self.state.current_view();
+        view.members.first().map(|m| m.node_id.clone())
+    }
+    fn members_view(&self) -> Arc<MembersView> {
+        self.state.current_view()
+    }
+    fn partition_table(&self) -> &ClusterPartitionTable {
+        &self.state.partition_table
+    }
+    fn subscribe_changes(&self) -> tokio::sync::mpsc::UnboundedReceiver<ClusterChange> {
+        // Callers that need change events should use ClusterState::change_sender() directly;
+        // this adapter is used only by ClusterQueryCoordinator, which polls membership
+        // on each execute_distributed call and does not subscribe to change events.
+        tokio::sync::mpsc::unbounded_channel().1
+    }
+    fn health(&self) -> ClusterHealth {
+        let view = self.state.current_view();
+        ClusterHealth {
+            node_count: view.members.len(),
+            active_nodes: view.members.len(),
+            suspect_nodes: 0,
+            partition_table_version: self.state.partition_table.version(),
+            active_migrations: 0,
+            is_master: self.state.is_master(),
+            master_node_id: self.master_id(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -337,19 +411,42 @@ async fn main() -> anyhow::Result<()> {
         let (heartbeat_tx, heartbeat_rx) =
             mpsc::unbounded_channel::<topgun_server::cluster::ClusterMessage>();
 
-        // Spawn the routing task that fans out inbound frames to the heartbeat channel.
-        // All other variants are currently discarded; future dispatch integration will
-        // route them to the cluster dispatch loop instead.
+        // The completion_registry is shared between the ClusterQueryCoordinator
+        // (which inserts oneshot senders before fanning out) and the cluster
+        // dispatch loop (which resolves them when DagComplete frames arrive from
+        // peer nodes).  Both must hold a reference to the SAME Arc or the
+        // coordinator will time out waiting for completions that are never resolved.
+        let completion_registry: Arc<DashMap<String, oneshot::Sender<DagCompletePayload>>> =
+            Arc::new(DashMap::new());
+
+        // Dispatch channel: the routing task forwards DAG frames here; the
+        // dispatch loop consumes them and routes to the appropriate handler.
+        let (dispatch_tx, dispatch_rx) = mpsc::channel::<InboundClusterMessage>(1024);
+
+        // Spawn the routing task that fans out inbound frames.  Heartbeat and
+        // complaint frames go to the heartbeat service; DAG frames (DagExecute,
+        // DagComplete, DagData) go to the cluster dispatch loop so the coordinator
+        // can receive peer completions.  All other variants are logged and dropped.
         tokio::spawn(async move {
             let mut rx = inbound_rx;
             while let Some(msg) = rx.recv().await {
-                match msg.message {
+                match &msg.message {
                     topgun_server::cluster::ClusterMessage::Heartbeat(_)
                     | topgun_server::cluster::ClusterMessage::HeartbeatComplaint(_) => {
                         let _ = heartbeat_tx.send(msg.message);
                     }
+                    topgun_server::cluster::ClusterMessage::DagExecute(_)
+                    | topgun_server::cluster::ClusterMessage::DagComplete(_)
+                    | topgun_server::cluster::ClusterMessage::DagData(_) => {
+                        // Route DAG frames to the dispatch loop so DagComplete can
+                        // resolve the coordinator's awaiting oneshot receivers.
+                        let _ = dispatch_tx.send(msg).await;
+                    }
                     _ => {
-                        // Non-heartbeat frames: no dispatch service wired yet.
+                        tracing::trace!(
+                            "inbound cluster frame not routed (no handler wired): {:?}",
+                            std::mem::discriminant(&msg.message)
+                        );
                     }
                 }
             }
@@ -398,6 +495,9 @@ async fn main() -> anyhow::Result<()> {
 
         // Build domain services, sharing the cluster_state with CoordinationService.
         // Pass the policy evaluator so every client operation is checked against RBAC.
+        // Pass the completion_registry and cluster_state so build_services can
+        // construct the ClusterQueryCoordinator with the real connection_registry
+        // and record_store_factory that it creates internally.
         let (
             classify_svc,
             dispatcher,
@@ -412,6 +512,7 @@ async fn main() -> anyhow::Result<()> {
             Arc::clone(&cluster_state),
             Some(Arc::clone(&policy_evaluator)),
             Arc::clone(&datastore),
+            Some((Arc::clone(&cluster_state), Arc::clone(&completion_registry))),
         );
 
         // Wire up the membership reactor (partition rebalancing on member changes).
@@ -423,6 +524,18 @@ async fn main() -> anyhow::Result<()> {
             migration_tx,
         };
         tokio::spawn(Arc::new(reactor).run(change_rx));
+
+        // Spawn the cluster dispatch loop.  It consumes DAG frames forwarded by
+        // the routing task above and routes them to the appropriate handlers.
+        // The completion_registry Arc is shared with the coordinator (wired inside
+        // build_services) so DagComplete frames resolve the coordinator's receivers.
+        let dispatch_ctx = ClusterDispatchContext {
+            local_node_id: node_id.clone(),
+            completion_registry: Arc::clone(&completion_registry),
+            record_store_factory: Arc::clone(&record_store_factory),
+            connection_registry: Arc::clone(&connection_registry),
+        };
+        tokio::spawn(run_cluster_dispatch_loop(dispatch_ctx, dispatch_rx));
 
         (
             (
@@ -455,6 +568,7 @@ async fn main() -> anyhow::Result<()> {
             Arc::clone(&cs),
             Some(Arc::clone(&policy_evaluator)),
             Arc::clone(&datastore),
+            None,
         );
 
         // Single-node mode: expose no cluster state to AppState (existing behavior).
@@ -803,12 +917,27 @@ type BuildServicesResult = (
     Arc<IndexObserverFactory>,
 );
 
+/// Cluster-mode parameters passed to [`build_services`] when starting with `--seed-nodes`.
+///
+/// Carries the shared `ClusterState` (used to satisfy `ClusterService` via
+/// `ClusterStateAdapter`) and the `completion_registry` `DashMap` (shared between
+/// `ClusterQueryCoordinator` and the cluster dispatch loop so `DagComplete`
+/// messages from peer nodes can resolve the coordinator's awaiting receivers).
+type ClusterParams = (
+    Arc<ClusterState>,
+    Arc<DashMap<String, oneshot::Sender<DagCompletePayload>>>,
+);
+
 /// Wires all 7 domain services and builds the partition dispatcher.
 ///
 /// Accepts `node_id`, `cluster_state`, and an optional `PolicyEvaluator` so
 /// callers can wire RBAC enforcement into the Tower middleware pipeline.
 /// When `policy_evaluator` is `Some`, every client operation is checked against
 /// the policy store before reaching domain services.
+///
+/// Pass `cluster_params` as `Some(...)` in cluster mode so `QueryService`
+/// routes queries through the distributed coordinator.  `None` preserves
+/// single-node behaviour.
 ///
 /// The `connection_registry` returned must be shared with `AppState.registry`
 /// so domain services can track subscriptions and route messages by `connection_id`.
@@ -823,6 +952,7 @@ fn build_services(
     cluster_state: Arc<ClusterState>,
     policy_evaluator: Option<Arc<PolicyEvaluator>>,
     datastore: Arc<dyn MapDataStore>,
+    cluster_params: Option<ClusterParams>,
 ) -> BuildServicesResult {
     let config = ServerConfig {
         node_id: node_id.clone(),
@@ -949,7 +1079,7 @@ fn build_services(
     ));
     let query_merkle_manager =
         Arc::new(topgun_server::storage::query_merkle::QueryMerkleSyncManager::new());
-    let query_svc = Arc::new(QueryService::new(
+    let query_svc_base = QueryService::new(
         Arc::clone(&query_registry),
         Arc::clone(&record_store_factory),
         Arc::clone(&connection_registry),
@@ -958,7 +1088,28 @@ fn build_services(
         None,
         #[cfg(feature = "datafusion")]
         None,
-    ));
+    );
+    // In cluster mode, construct a ClusterQueryCoordinator using the real
+    // connection_registry and record_store_factory available here, and wire it
+    // into QueryService.  Single-node startup passes None and leaves query_svc
+    // using run_dag_local (unchanged behaviour).
+    let query_svc = Arc::new(if let Some((cs, completion_registry)) = cluster_params {
+        let cluster_svc: Arc<dyn ClusterService> = Arc::new(ClusterStateAdapter {
+            state: cs,
+            node_id: node_id.clone(),
+        });
+        let coordinator = Arc::new(ClusterQueryCoordinator::new(
+            cluster_svc,
+            Arc::clone(&connection_registry),
+            Arc::clone(&record_store_factory),
+            node_id.clone(),
+            QueryConfig::default(),
+            completion_registry,
+        ));
+        query_svc_base.with_coordinator(coordinator)
+    } else {
+        query_svc_base
+    });
     let messaging_svc = Arc::new(MessagingService::new(Arc::clone(&connection_registry)));
     // Capture Arc<TopicRegistry> before messaging_svc is moved into the closure.
     let topic_registry_arc = messaging_svc.topic_registry_arc();

--- a/packages/server-rust/src/dag/converter.rs
+++ b/packages/server-rust/src/dag/converter.rs
@@ -53,6 +53,40 @@ fn predicate_to_config(predicate: &PredicateNode) -> Result<rmpv::Value> {
     Ok(val)
 }
 
+/// Builds the config map for a Cursor vertex from a keyset-cursor-bearing query.
+///
+/// The predicate and sort hashes travel alongside the cursor token so the
+/// `CursorProcessor` can validate that the cursor was produced by the same query
+/// shape — a cursor from a different query would otherwise return incorrect results
+/// silently. Callers must only invoke this when `query.cursor` is `Some`.
+fn build_cursor_vertex_config(cursor_str: &str, query: &Query) -> rmpv::Value {
+    use std::hash::{Hash, Hasher};
+
+    let hash_debug = |value: &dyn std::fmt::Debug| -> u64 {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        format!("{value:?}").hash(&mut h);
+        h.finish()
+    };
+
+    let predicate_hash: u64 = query.predicate.as_ref().map_or(0, |p| hash_debug(p));
+    let sort_hash: u64 = query.sort.as_ref().map_or(0, |s| hash_debug(s));
+
+    rmpv::Value::Map(vec![
+        (
+            rmpv::Value::String("cursor".into()),
+            rmpv::Value::String(cursor_str.into()),
+        ),
+        (
+            rmpv::Value::String("predicateHash".into()),
+            rmpv::Value::Integer(rmpv::Integer::from(predicate_hash)),
+        ),
+        (
+            rmpv::Value::String("sortHash".into()),
+            rmpv::Value::Integer(rmpv::Integer::from(sort_hash)),
+        ),
+    ])
+}
+
 // ---------------------------------------------------------------------------
 // QueryToDagConverter
 // ---------------------------------------------------------------------------
@@ -290,34 +324,7 @@ impl QueryToDagConverter {
             // streams would return wrong pages.  Insert the cursor vertex here, before
             // network-sender, when the query carries a keyset cursor.
             if let Some(ref cursor_str) = query.cursor {
-                let predicate_hash: u64 = query.predicate.as_ref().map_or(0, |p| {
-                    use std::hash::{Hash, Hasher};
-                    let mut h = std::collections::hash_map::DefaultHasher::new();
-                    format!("{p:?}").hash(&mut h);
-                    h.finish()
-                });
-
-                let sort_hash: u64 = query.sort.as_ref().map_or(0, |s| {
-                    use std::hash::{Hash, Hasher};
-                    let mut h = std::collections::hash_map::DefaultHasher::new();
-                    format!("{s:?}").hash(&mut h);
-                    h.finish()
-                });
-
-                let cursor_config = rmpv::Value::Map(vec![
-                    (
-                        rmpv::Value::String("cursor".into()),
-                        rmpv::Value::String(cursor_str.clone().into()),
-                    ),
-                    (
-                        rmpv::Value::String("predicateHash".into()),
-                        rmpv::Value::Integer(rmpv::Integer::from(predicate_hash)),
-                    ),
-                    (
-                        rmpv::Value::String("sortHash".into()),
-                        rmpv::Value::Integer(rmpv::Integer::from(sort_hash)),
-                    ),
-                ]);
+                let cursor_config = build_cursor_vertex_config(cursor_str, query);
 
                 vertices.push(VertexDescriptor {
                     name: "cursor".to_string(),
@@ -386,38 +393,7 @@ impl QueryToDagConverter {
         // branch is restricted to single-node plans only.
         if !multi_node {
             if let Some(ref cursor_str) = query.cursor {
-                // Pass the predicate hash and sort hash alongside the cursor token so the
-                // CursorProcessor can validate that the cursor was produced by the same
-                // query shape. Without this check, a cursor from a different query could
-                // return incorrect results silently.
-                let predicate_hash: u64 = query.predicate.as_ref().map_or(0, |p| {
-                    use std::hash::{Hash, Hasher};
-                    let mut h = std::collections::hash_map::DefaultHasher::new();
-                    format!("{p:?}").hash(&mut h);
-                    h.finish()
-                });
-
-                let sort_hash: u64 = query.sort.as_ref().map_or(0, |s| {
-                    use std::hash::{Hash, Hasher};
-                    let mut h = std::collections::hash_map::DefaultHasher::new();
-                    format!("{s:?}").hash(&mut h);
-                    h.finish()
-                });
-
-                let cursor_config = rmpv::Value::Map(vec![
-                    (
-                        rmpv::Value::String("cursor".into()),
-                        rmpv::Value::String(cursor_str.clone().into()),
-                    ),
-                    (
-                        rmpv::Value::String("predicateHash".into()),
-                        rmpv::Value::Integer(rmpv::Integer::from(predicate_hash)),
-                    ),
-                    (
-                        rmpv::Value::String("sortHash".into()),
-                        rmpv::Value::Integer(rmpv::Integer::from(sort_hash)),
-                    ),
-                ]);
+                let cursor_config = build_cursor_vertex_config(cursor_str, query);
 
                 vertices.push(VertexDescriptor {
                     name: "cursor".to_string(),

--- a/packages/server-rust/src/dag/converter.rs
+++ b/packages/server-rust/src/dag/converter.rs
@@ -384,59 +384,60 @@ impl QueryToDagConverter {
         // post-cursor result set, which is the correct semantics for keyset pagination.
         // In multi-node plans the cursor is already emitted worker-side (above) so this
         // branch is restricted to single-node plans only.
-        if query.cursor.is_some() && !multi_node {
-            // Pass the predicate hash and sort hash alongside the cursor token so the
-            // CursorProcessor can validate that the cursor was produced by the same query
-            // shape. Without this check, a cursor from a different query could return
-            // incorrect results silently.
-            let cursor_str = query.cursor.as_ref().expect("checked above");
-            let predicate_hash: u64 = query.predicate.as_ref().map_or(0, |p| {
-                use std::hash::{Hash, Hasher};
-                let mut h = std::collections::hash_map::DefaultHasher::new();
-                format!("{p:?}").hash(&mut h);
-                h.finish()
-            });
+        if !multi_node {
+            if let Some(ref cursor_str) = query.cursor {
+                // Pass the predicate hash and sort hash alongside the cursor token so the
+                // CursorProcessor can validate that the cursor was produced by the same
+                // query shape. Without this check, a cursor from a different query could
+                // return incorrect results silently.
+                let predicate_hash: u64 = query.predicate.as_ref().map_or(0, |p| {
+                    use std::hash::{Hash, Hasher};
+                    let mut h = std::collections::hash_map::DefaultHasher::new();
+                    format!("{p:?}").hash(&mut h);
+                    h.finish()
+                });
 
-            let sort_hash: u64 = query.sort.as_ref().map_or(0, |s| {
-                use std::hash::{Hash, Hasher};
-                let mut h = std::collections::hash_map::DefaultHasher::new();
-                format!("{s:?}").hash(&mut h);
-                h.finish()
-            });
+                let sort_hash: u64 = query.sort.as_ref().map_or(0, |s| {
+                    use std::hash::{Hash, Hasher};
+                    let mut h = std::collections::hash_map::DefaultHasher::new();
+                    format!("{s:?}").hash(&mut h);
+                    h.finish()
+                });
 
-            let cursor_config = rmpv::Value::Map(vec![
-                (
-                    rmpv::Value::String("cursor".into()),
-                    rmpv::Value::String(cursor_str.clone().into()),
-                ),
-                (
-                    rmpv::Value::String("predicateHash".into()),
-                    rmpv::Value::Integer(rmpv::Integer::from(predicate_hash)),
-                ),
-                (
-                    rmpv::Value::String("sortHash".into()),
-                    rmpv::Value::Integer(rmpv::Integer::from(sort_hash)),
-                ),
-            ]);
+                let cursor_config = rmpv::Value::Map(vec![
+                    (
+                        rmpv::Value::String("cursor".into()),
+                        rmpv::Value::String(cursor_str.clone().into()),
+                    ),
+                    (
+                        rmpv::Value::String("predicateHash".into()),
+                        rmpv::Value::Integer(rmpv::Integer::from(predicate_hash)),
+                    ),
+                    (
+                        rmpv::Value::String("sortHash".into()),
+                        rmpv::Value::Integer(rmpv::Integer::from(sort_hash)),
+                    ),
+                ]);
 
-            vertices.push(VertexDescriptor {
-                name: "cursor".to_string(),
-                local_parallelism: 1,
-                processor_type: ProcessorType::Cursor,
-                preferred_partitions: None,
-                config: Some(cursor_config),
-            });
+                vertices.push(VertexDescriptor {
+                    name: "cursor".to_string(),
+                    local_parallelism: 1,
+                    processor_type: ProcessorType::Cursor,
+                    preferred_partitions: None,
+                    config: Some(cursor_config),
+                });
 
-            edges.push(Edge {
-                source_name: last_vertex.clone(),
-                source_ordinal: 0,
-                dest_name: "cursor".to_string(),
-                dest_ordinal: 0,
-                routing_policy: RoutingPolicy::Isolated,
-                priority: edge_priority,
-            });
-            edge_priority += 1;
-            last_vertex = "cursor".to_string();
+                edges.push(Edge {
+                    source_name: last_vertex.clone(),
+                    source_ordinal: 0,
+                    dest_name: "cursor".to_string(),
+                    dest_ordinal: 0,
+                    routing_policy: RoutingPolicy::Isolated,
+                    priority: edge_priority,
+                });
+                edge_priority += 1;
+                last_vertex = "cursor".to_string();
+            }
         }
 
         // --- Step 4: Sort vertex (optional) ---

--- a/packages/server-rust/src/dag/converter.rs
+++ b/packages/server-rust/src/dag/converter.rs
@@ -284,7 +284,61 @@ impl QueryToDagConverter {
                 last_vertex = "combine-aggregate".to_string();
             }
         } else if multi_node {
-            // No GROUP BY but multi-node: insert network boundary before collector.
+            // No GROUP BY but multi-node: cursor filtering must happen worker-side (before
+            // the network boundary) so each node filters by the global keyset position before
+            // sending — applying the cursor coordinator-side over already-limited per-node
+            // streams would return wrong pages.  Insert the cursor vertex here, before
+            // network-sender, when the query carries a keyset cursor.
+            if let Some(ref cursor_str) = query.cursor {
+                let predicate_hash: u64 = query.predicate.as_ref().map_or(0, |p| {
+                    use std::hash::{Hash, Hasher};
+                    let mut h = std::collections::hash_map::DefaultHasher::new();
+                    format!("{p:?}").hash(&mut h);
+                    h.finish()
+                });
+
+                let sort_hash: u64 = query.sort.as_ref().map_or(0, |s| {
+                    use std::hash::{Hash, Hasher};
+                    let mut h = std::collections::hash_map::DefaultHasher::new();
+                    format!("{s:?}").hash(&mut h);
+                    h.finish()
+                });
+
+                let cursor_config = rmpv::Value::Map(vec![
+                    (
+                        rmpv::Value::String("cursor".into()),
+                        rmpv::Value::String(cursor_str.clone().into()),
+                    ),
+                    (
+                        rmpv::Value::String("predicateHash".into()),
+                        rmpv::Value::Integer(rmpv::Integer::from(predicate_hash)),
+                    ),
+                    (
+                        rmpv::Value::String("sortHash".into()),
+                        rmpv::Value::Integer(rmpv::Integer::from(sort_hash)),
+                    ),
+                ]);
+
+                vertices.push(VertexDescriptor {
+                    name: "cursor".to_string(),
+                    local_parallelism: 1,
+                    processor_type: ProcessorType::Cursor,
+                    preferred_partitions: None,
+                    config: Some(cursor_config),
+                });
+
+                edges.push(Edge {
+                    source_name: last_vertex.clone(),
+                    source_ordinal: 0,
+                    dest_name: "cursor".to_string(),
+                    dest_ordinal: 0,
+                    routing_policy: RoutingPolicy::Isolated,
+                    priority: edge_priority,
+                });
+                edge_priority += 1;
+                last_vertex = "cursor".to_string();
+            }
+
             vertices.push(VertexDescriptor {
                 name: "network-sender".to_string(),
                 local_parallelism: 1,
@@ -328,11 +382,14 @@ impl QueryToDagConverter {
         // A Cursor vertex is only emitted when the query carries a keyset cursor.
         // Placing it before Sort means the sort stage operates on the already-filtered
         // post-cursor result set, which is the correct semantics for keyset pagination.
-        if let Some(ref cursor_str) = query.cursor {
+        // In multi-node plans the cursor is already emitted worker-side (above) so this
+        // branch is restricted to single-node plans only.
+        if query.cursor.is_some() && !multi_node {
             // Pass the predicate hash and sort hash alongside the cursor token so the
             // CursorProcessor can validate that the cursor was produced by the same query
             // shape. Without this check, a cursor from a different query could return
             // incorrect results silently.
+            let cursor_str = query.cursor.as_ref().expect("checked above");
             let predicate_hash: u64 = query.predicate.as_ref().map_or(0, |p| {
                 use std::hash::{Hash, Hasher};
                 let mut h = std::collections::hash_map::DefaultHasher::new();
@@ -989,6 +1046,57 @@ mod tests {
         assert!(
             !vertex_names(&desc).contains(&"cursor"),
             "no cursor vertex on the non-paginated path"
+        );
+    }
+
+    // --- Multi-node cursor is worker-side (before network-sender) ---
+
+    #[test]
+    fn convert_query_multi_node_with_cursor_places_cursor_before_network_sender() {
+        use topgun_core::messages::base::{SortDirection, SortField};
+
+        // In a distributed plan the cursor vertex must sit on the worker side of the
+        // network boundary so each node filters by the global keyset position before
+        // sending.  A coordinator-side cursor over already-limited per-node streams
+        // would silently return wrong pages.
+        let q = Query {
+            cursor: Some("page2-cursor-token".to_string()),
+            sort: Some(vec![SortField {
+                field: "score".to_string(),
+                direction: SortDirection::Desc,
+            }]),
+            ..Default::default()
+        };
+
+        let desc = QueryToDagConverter::convert_query(&q, "users", &multi_node_assignment())
+            .expect("convert should succeed");
+
+        let names = vertex_names(&desc);
+        assert!(names.contains(&"cursor"), "cursor vertex must be emitted");
+        assert!(
+            names.contains(&"network-sender"),
+            "network-sender must be emitted in multi-node plan"
+        );
+
+        // The cursor's edge ordinal/priority must be strictly before network-sender:
+        // confirm by checking the edge chain.
+        let cursor_to_netsender = desc
+            .edges
+            .iter()
+            .any(|e| e.source_name == "cursor" && e.dest_name == "network-sender");
+        assert!(
+            cursor_to_netsender,
+            "cursor must connect directly to network-sender (worker-side cursor)"
+        );
+
+        // No edge from network-receiver to cursor: the cursor is not coordinator-side.
+        let receiver_to_cursor = desc
+            .edges
+            .iter()
+            .any(|e| e.source_name == "network-receiver" && e.dest_name == "cursor");
+        assert!(
+            !receiver_to_cursor,
+            "cursor must not be placed after network-receiver (coordinator-side would be wrong)"
         );
     }
 }

--- a/packages/server-rust/src/service/domain/query.rs
+++ b/packages/server-rust/src/service/domain/query.rs
@@ -695,6 +695,17 @@ impl QueryService {
             };
 
             predicate_execute_query(entries, &query)
+        } else if let Some(ref coordinator) = self.coordinator {
+            // Distributed path: the coordinator fans out to all owning nodes, collects
+            // per-node results, and applies the global sort+limit merge (SPEC-301).
+            // The coordinator's single-node bypass routes back through run_dag_local
+            // when only one member is active, keeping single-node behaviour identical.
+            let raw = coordinator
+                .execute_distributed(&query, &map_name)
+                .await
+                .map_err(|e| OperationError::Internal(anyhow::anyhow!("{e}")))?;
+
+            map_dag_rows_to_entries(raw)
         } else {
             let partition_ids: Vec<u32> = stores.iter().map(|s| s.partition_id()).collect();
             let raw = run_dag_local(

--- a/packages/server-rust/src/sim/cluster.rs
+++ b/packages/server-rust/src/sim/cluster.rs
@@ -1786,4 +1786,281 @@ mod tests {
         bridge_0_to_1.abort();
         bridge_1_to_0.abort();
     }
+
+    // -----------------------------------------------------------------------
+    // Distributed keyset cursor under partition fault.
+    //
+    // Verifies that a global keyset cursor applied across a 2-node fan-out
+    // returns the correct second page — strictly after the cursor position —
+    // in global sort order with no duplicates and no first-page rows.
+    //
+    // Vacuity: a coordinator-only cursor (filtering the already-merged result
+    // instead of pre-filtering on each worker) would work only when no
+    // per-node limit is applied before sending — but with per-node limits,
+    // coordinator-side cursor filtering would miss rows, producing pages that
+    // overlap or have gaps.  A per-node-offset cursor (the stale TS blueprint)
+    // would also be wrong here because each node's offset is independent of
+    // the other node's data; the global keyset cursor is correct by construction.
+    //
+    // Coverage note: this sim drives SimCluster::query directly (which calls
+    // coordinator.execute_distributed) and does NOT exercise the production
+    // routing through handle_query_subscribe or the bin dispatch-loop wiring.
+    // The dispatch-loop↔completion_registry link (bin:343-356) is verified by
+    // source inspection per the Validation Checklist, not by this sim.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    #[cfg(feature = "simulation")]
+    #[allow(clippy::too_many_lines)]
+    async fn distributed_keyset_cursor_under_partition() {
+        use crate::query::cursor::{encode_cursor, CursorData, SortValue};
+        use topgun_core::messages::base::{SortDirection, SortField};
+
+        let mut cluster = SimCluster::new(2, 77);
+        cluster.start().expect("cluster start");
+
+        let node_ids = ["sim-node-0", "sim-node-1"];
+        let map_name = "cursor_test";
+
+        // Both nodes must see the full membership so execute_distributed engages
+        // multi-node fan-out.
+        for node in &cluster.nodes {
+            set_membership(node, &node_ids);
+        }
+
+        // Partition assignment: even partition IDs → node-0, odd → node-1.
+        let owner_fn = |pid: u32| -> String {
+            if pid % 2 == 0 {
+                "sim-node-0".to_string()
+            } else {
+                "sim-node-1".to_string()
+            }
+        };
+        for node in &cluster.nodes {
+            assign_partitions(node, &owner_fn);
+        }
+
+        // Bridge connections in both directions so DagExecute/DagComplete flow
+        // between the coordinator (node-0) and the peer (node-1).
+        // node-0 also needs a self-targeting connection for its own partitions.
+        let bridge_0_to_self = bridge_peer_connection(
+            &cluster.nodes[0],
+            "sim-node-0",
+            cluster.nodes[0].inbound_tx.clone(),
+        )
+        .await;
+        let bridge_0_to_1 = bridge_peer_connection(
+            &cluster.nodes[0],
+            "sim-node-1",
+            cluster.nodes[1].inbound_tx.clone(),
+        )
+        .await;
+        let bridge_1_to_0 = bridge_peer_connection(
+            &cluster.nodes[1],
+            "sim-node-0",
+            cluster.nodes[0].inbound_tx.clone(),
+        )
+        .await;
+
+        // Write records with interleaved scores: node-0 owns {10,30,50}, node-1 owns {20,40,60}.
+        // Global ascending order: 10,20,30,40,50,60.
+        //
+        // Partition hashes (UTF-16 FNV-1a mod 271) — same keys as the sort/limit test:
+        //   "bravo"   → 168 (even → node-0)  score=10
+        //   "delta"   → 142 (even → node-0)  score=30
+        //   "foxtrot" → 112 (even → node-0)  score=50
+        //   "alpha"   → 215 (odd  → node-1)  score=20
+        //   "charlie" → 43  (odd  → node-1)  score=40
+        //   "echo"    → 239 (odd  → node-1)  score=60
+        let all_records: &[(&str, i64, usize)] = &[
+            ("bravo", 10, 0),
+            ("delta", 30, 0),
+            ("foxtrot", 50, 0),
+            ("alpha", 20, 1),
+            ("charlie", 40, 1),
+            ("echo", 60, 1),
+        ];
+
+        for &(key, score, node_idx) in all_records {
+            let partition_id = topgun_core::hash_to_partition(key);
+            let node_id = format!("sim-node-{node_idx}");
+            let store = cluster.nodes[node_idx]
+                .record_store_factory
+                .get_or_create(map_name, partition_id);
+            store
+                .put(
+                    key,
+                    RecordValue::Lww {
+                        value: topgun_core::Value::Map(std::collections::BTreeMap::from([(
+                            "score".to_string(),
+                            topgun_core::Value::Int(score),
+                        )])),
+                        timestamp: Timestamp {
+                            millis: 1_000,
+                            counter: 0,
+                            node_id,
+                        },
+                    },
+                    ExpiryPolicy::NONE,
+                    CallerProvenance::Client,
+                )
+                .await
+                .expect("write record to owning node's store");
+        }
+
+        // Build a sort-on-score query used for both pages.
+        let sort_fields = vec![SortField {
+            field: "score".to_string(),
+            direction: SortDirection::Asc,
+        }];
+
+        // ---- Page 1: no cursor, limit 3 → expect [10, 20, 30] ----
+
+        let page1_query = Query {
+            sort: Some(sort_fields.clone()),
+            limit: Some(3),
+            ..Default::default()
+        };
+
+        let page1_raw = cluster.nodes[0]
+            .coordinator
+            .execute_distributed(&page1_query, map_name)
+            .await
+            .expect("page 1 query should succeed");
+
+        assert_eq!(page1_raw.len(), 3, "page 1 must have exactly 3 rows");
+
+        let page1_scores: Vec<i64> = page1_raw.iter().filter_map(get_score).collect();
+
+        assert_eq!(
+            page1_scores,
+            vec![10, 20, 30],
+            "page 1 must be globally sorted: [10, 20, 30]"
+        );
+
+        // Compute sort_hash so CursorData validates against the same query shape.
+        let sort_hash: u64 = {
+            use std::hash::{Hash, Hasher};
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            format!("{:?}", &sort_fields).hash(&mut h);
+            h.finish()
+        };
+
+        // Build cursor from the last row of page 1 (score=30, key="delta").
+        // The sort_values list uses the real score value; last_key is the real
+        // record key ("delta") which has score=30.  This matches what a real
+        // client would construct from the returned data + the known query sort spec.
+        //
+        // Row-key caveat: SimCluster::query wraps results in synthetic "row-{i}" keys.
+        // We bypass that wrapper here by calling coordinator.execute_distributed
+        // directly, which returns raw rmpv::Value rows without key wrappers.
+        // We use the known real key "delta" (score=30, partition 142, node-0) as
+        // last_key because the coordinator returns raw values — not keyed entries.
+        // In production the client derives last_key from the returned entry's key field.
+        let cursor = CursorData {
+            sort_values: vec![SortValue {
+                field: "score".to_string(),
+                value: serde_json::json!(30),
+                direction: SortDirection::Asc,
+            }],
+            last_key: "delta".to_string(),
+            predicate_hash: 0,
+            sort_hash,
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_millis() as i64),
+        };
+        let cursor_token = encode_cursor(&cursor);
+
+        // ---- Fault injection: partition nodes, then heal ----
+        // The partition/heal pair exercises the fault-tolerant path around the
+        // second fan-out without making the query itself fail (heal before query).
+        cluster.inject_partition(&[0], &[1]);
+        cluster.heal_partition();
+
+        // ---- Page 2: with cursor, limit 3 → expect [40, 50, 60] ----
+        //
+        // Each worker node filters by the global keyset cursor (score > 30, or
+        // score == 30 AND key > "delta") before sending to the coordinator.
+        // Worker-side placement (AC3) ensures node-0 sends only {50} (foxtrot)
+        // and node-1 sends only {40, 60} (charlie, echo).  The coordinator's
+        // apply_global_sort_and_limit (SPEC-301) merges them into [40, 50, 60].
+        //
+        // Vacuity: if the cursor were applied coordinator-side after per-node
+        // unlimited sends (without limit on workers), the coordinator would
+        // receive {30, 50} from node-0 and {40, 60} from node-1, then cursor-
+        // filter those results.  In that case the coordinator-only cursor
+        // could still produce the right answer — but with a per-node limit < total,
+        // coordinator-side filtering would silently return wrong pages because
+        // the per-node limited stream might cut off records before the cursor
+        // position.  Worker-side cursor is the correct architecture.
+
+        let page2_query = Query {
+            sort: Some(sort_fields.clone()),
+            limit: Some(3),
+            cursor: Some(cursor_token),
+            ..Default::default()
+        };
+
+        let page2_raw = cluster.nodes[0]
+            .coordinator
+            .execute_distributed(&page2_query, map_name)
+            .await
+            .expect("page 2 query should succeed");
+
+        assert_eq!(page2_raw.len(), 3, "page 2 must have exactly 3 rows");
+
+        let page2_scores: Vec<i64> = page2_raw.iter().filter_map(get_score).collect();
+
+        // Globally-correct order: [40, 50, 60].
+        assert_eq!(
+            page2_scores,
+            vec![40, 50, 60],
+            "page 2 must be globally sorted strictly after cursor: [40, 50, 60]"
+        );
+
+        // No overlap between pages: page 2 must contain no first-page scores.
+        let page1_set: std::collections::HashSet<i64> = page1_scores.iter().copied().collect();
+        for score in &page2_scores {
+            assert!(
+                !page1_set.contains(score),
+                "page 2 must not contain first-page score {score}"
+            );
+        }
+
+        // No duplicates within page 2.
+        let unique_page2: std::collections::HashSet<i64> = page2_scores.iter().copied().collect();
+        assert_eq!(
+            unique_page2.len(),
+            page2_scores.len(),
+            "page 2 must not have duplicate scores"
+        );
+
+        // All page 2 rows must come strictly after the cursor position (score > 30).
+        for score in &page2_scores {
+            assert!(
+                *score > 30,
+                "page 2 row with score {score} is not strictly after cursor (score=30)"
+            );
+        }
+
+        // Cleanup bridge tasks.
+        bridge_0_to_self.abort();
+        bridge_0_to_1.abort();
+        bridge_1_to_0.abort();
+    }
+
+    /// Extracts the `score` field as i64 from a raw `rmpv::Value` DAG row.
+    fn get_score(val: &rmpv::Value) -> Option<i64> {
+        if let rmpv::Value::Map(pairs) = val {
+            for (k, v) in pairs {
+                if k.as_str() == Some("score") {
+                    if let rmpv::Value::Integer(i) = v {
+                        return i.as_i64();
+                    }
+                }
+            }
+        }
+        None
+    }
 }


### PR DESCRIPTION
## Summary

SPEC-304 (from TODO-442) — Query Engine Consolidation **Phase 3**: wire the cluster query
coordinator into production and complete the distributed merge path. Builds on SPEC-301, which
fixed distributed merge correctness (global sort + global limit) but deliberately left the
coordinator unwired.

## Changes

- `bin/topgun_server.rs` — construct and wire `ClusterQueryCoordinator` into the prod assembly
  behind a cluster-mode gate; share the completion_registry so DagComplete frames resolve the
  coordinator's awaiting receivers; route cluster DAG frames to the coordinator dispatch loop.
- `dag/converter.rs` — place the cursor vertex **worker-side** in multi-node DAG plans (so
  per-node keyset pagination positions are produced before the coordinator merge);
  `build_cursor_vertex_config` helper + if-let cleanup for the single-node branch.
- `service/domain/query.rs` — coordinator wiring surface.
- `sim/cluster.rs` — `distributed_keyset_cursor_under_partition` fault-injection sim test
  exercising distributed cursor pagination under a network partition.

## Verification

Reviewed via the SpecFlow impl-review gate. 4 Rust files (within the 5-file Language Profile).
CI gate is **Rust** (cargo test + sim + clippy `--all-targets --all-features -D warnings` + fmt);
must be green before merge.
