### PR TITLE
fix(wal): flush tokio file buffer in append() to guarantee read visibility

### DIFF
--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -332,6 +332,17 @@ impl Wal for WalWriter {
             .await
             .map_err(|e| anyhow::anyhow!("WAL write failed for partition {partition}: {e}"))?;
 
+        // Push tokio's internal write buffer out to the OS so a subsequent fresh
+        // read of this partition file (unapplied/recovery/compaction all reopen
+        // the path) observes the entry. This is visibility, not durability:
+        // flush() does not fsync. Durability is governed separately by the policy
+        // match below. Without this, the None policy never leaves tokio's buffer
+        // and a concurrent reader can miss a just-appended entry.
+        pf.file
+            .flush()
+            .await
+            .map_err(|e| anyhow::anyhow!("WAL flush failed for partition {partition}: {e}"))?;
+
         match self.policy {
             WalFsyncPolicy::PerOp => {
                 pf.file.sync_data().await.map_err(|e| {


### PR DESCRIPTION
## Problem

`storage::wal::tests::wal_writer_append_entry_is_readable_before_ack` flaked on main (Rust / Check & Lint, run 27494220282): the full parallel lib suite intermittently saw `unapplied.len() == 0` immediately after `append()` under the `None` fsync policy. Passes in isolation; fails only under CI contention.

## Root cause (real durability/visibility gap, not just a flaky test)

`append()` writes via `tokio::fs::File::write_all`, which buffers in tokio's internal write state. With `WalFsyncPolicy::None` there was no `fsync` **and no `flush`**, so bytes could stay in tokio's buffer. `unapplied()`, recovery, and `compact_log` all reopen the partition path and read with a **fresh** handle (`tokio::fs::read`) — which never observes the still-buffered entry. `PerOp`/`Batched` masked this because `sync_data()` flushes first; `None` never did.

This means `append()` under `None` did not guarantee even **visibility** of a written entry to a subsequent reader — a correctness gap in the WAL layer, surfaced as a flake.

## Fix

`flush()` unconditionally after `write_all` (visibility — cheap, no fsync), keeping `fsync` policy-gated (durability). Separates the two concerns correctly.

## Verification

- topgun-server lib suite: 1330 passed, 0 failed (debug, matches CI)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean

## Caveat

The original flake reproduces only under CI contention; local stress could not reproduce it deterministically. The fix is principled (documented tokio::fs cross-handle visibility requirement) — final confidence comes from CI staying green across runs. Do not squash-merge until CI is green here.

## Follow-up (separate)

Test-isolation: several tests mutate process-global env (`TOPGUN_WAL_FSYNC_POLICY`, `TOPGUN_WAL_DIR`) without serialization (visible as the `invalid_policy` WARN during the failed run) — a distinct latent flake source. Tracked separately.