### PR TITLE
fix(wal): close G3 durability gaps — codec bound (TODO-470), env-race (TODO-468), concurrent crash test

### DIFF
--- a/packages/server-rust/src/storage/crash_safety_proptest.rs
+++ b/packages/server-rust/src/storage/crash_safety_proptest.rs
@@ -782,3 +782,133 @@ async fn max_observed_sequence_reads_watermark_of_compacted_empty_partition() {
          compacted-empty partition, got {max}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Concurrent same-partition durability under crash (F1 / visibility class).
+//
+// The other crash scenarios drive the write path single-threaded-sequentially:
+// every op is appended, then the store is dropped. That schedule can never see
+// the F1 compaction race (compact_log rewriting the active log while an append
+// interleaves) — it slipped past the suite and `kill -9` cannot see it either
+// (the page cache survives a process kill, and steady-state entries usually also
+// reached the inner store before the kill).
+//
+// This test runs append and compaction CONCURRENTLY on ONE partition through the
+// production WriteBehindDataStore write path, then models the crash (drop), and
+// asserts against a FRESH durable inner store recovered from the on-disk WAL —
+// NOT against the OS-cached WAL file. With never-flush config every acked write
+// lives only in the WAL until the crash, so a compaction that drops a
+// concurrently-appended frame is a lost acked write that recovery cannot find.
+//
+// `mark_applied(partition, 0)` is the fault injection: it retains every entry
+// (watermark 0) yet still performs compact_log's read->rewrite->rename on the
+// active file, exactly as the real flush loop's mark_applied does while clients
+// keep writing the same partition. Driving it directly (rather than via the
+// flush loop) is what makes the race deterministic instead of timing-dependent.
+//
+// Negative control: reverting compact_log to acquire the files lock late (the
+// pre-PR#50 shape — read/rewrite/rename without the lock) makes this test drop a
+// large fraction of acked writes and fail.
+// ---------------------------------------------------------------------------
+
+/// Generates `count` distinct keys that all map to `partition` under
+/// `partition_of`, so appends and compaction contend on a single WAL file.
+fn keys_for_partition(map: &str, partition: u32, count: usize) -> Vec<String> {
+    let mut out = Vec::with_capacity(count);
+    let mut i = 0u64;
+    while out.len() < count {
+        let candidate = format!("cp-{i}");
+        if partition_of(map, &candidate) == partition {
+            out.push(candidate);
+        }
+        i += 1;
+    }
+    out
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_compaction_loses_no_acked_write_across_crash() {
+    let dir = tempfile::tempdir().unwrap();
+    let wal_dir = dir.path().to_path_buf();
+
+    // One partition; every key collides onto it so append races compaction on
+    // the same file. 2000 ops reproduces the pre-fix loss reliably (the audit's
+    // repro dropped 1864/2000).
+    let total = 2000usize;
+    let partition = partition_of(TEST_MAP, "anchor");
+    let keys = keys_for_partition(TEST_MAP, partition, total);
+
+    // Production write path; never-flush so acked writes live ONLY in the WAL
+    // until the crash (no leak to the inner store before the drop). None policy
+    // also maximally stresses the append()-flush visibility path (PR #49).
+    let pre_crash_inner: Arc<dyn MapDataStore> = Arc::new(RetainingStore::default());
+    let wal = WalWriter::new(wal_dir.clone(), WalFsyncPolicy::None).expect("WalWriter::new");
+    let store = WriteBehindDataStore::new_with_wal(
+        pre_crash_inner,
+        never_flush_config(),
+        Some(WalBootstrap {
+            wal: Arc::clone(&wal) as Arc<dyn Wal>,
+            sequence_start: 1,
+        }),
+    );
+
+    // Appender: each add returns Ok (an ack) ⇒ its WAL frame is durable per the
+    // append-before-ack contract.
+    let appender = {
+        let store = Arc::clone(&store);
+        let keys = keys.clone();
+        tokio::spawn(async move {
+            for (i, key) in keys.iter().enumerate() {
+                let tag = u64::try_from(i).unwrap() + 1;
+                store
+                    .add(TEST_MAP, key, &lww_value(tag, tag), 0, 1000)
+                    .await
+                    .expect("add must ack");
+            }
+        })
+    };
+
+    // Compactor: hammer mark_applied on the SAME partition, racing the appender's
+    // writes to the active log file.
+    let compactor = {
+        let wal = Arc::clone(&wal);
+        tokio::spawn(async move {
+            for _ in 0..total {
+                wal.mark_applied(partition, 0).await.expect("mark_applied");
+                tokio::task::yield_now().await;
+            }
+        })
+    };
+
+    appender.await.unwrap();
+    compactor.await.unwrap();
+
+    // Crash: the in-memory staging buffer is gone; the on-disk WAL survives.
+    drop(store);
+
+    // Recover into a FRESH durable inner store via the real recovery path and
+    // assert against THAT — not the OS-cached WAL file.
+    let recovered: Arc<RetainingStore> = Arc::new(RetainingStore::default());
+    let recovery = WalRecovery::new(Arc::clone(&wal), Vec::new());
+    recovery
+        .run(Arc::clone(&recovered) as Arc<dyn MapDataStore>)
+        .await
+        .expect("recovery must succeed on an intact WAL");
+    drop(dir);
+
+    // Every acked write must survive. Pre-fix the compaction race silently drops
+    // most concurrently-appended frames and this fails (negative control).
+    let mut missing = Vec::new();
+    for key in &keys {
+        if !recovered.contains(TEST_MAP, key).await {
+            missing.push(key.clone());
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "concurrent compaction lost {} of {total} acked writes across the crash \
+         (first few: {:?})",
+        missing.len(),
+        &missing[..missing.len().min(10)]
+    );
+}

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -94,11 +94,23 @@ impl WriteBehindConfig {
     /// `backoff_base_ms`, `backoff_cap_ms`) retain their [`Self::default`] values.
     #[must_use]
     pub fn from_env() -> Self {
+        Self::from_source(|key| std::env::var(key).ok())
+    }
+
+    /// Construct [`WriteBehindConfig`] from an injected variable source.
+    ///
+    /// `get` maps a variable name to its value (or `None` if unset). This is the
+    /// testable seam behind [`Self::from_env`], which simply passes a closure
+    /// over `std::env::var`. Tests pass a map-backed closure so they exercise the
+    /// full parse logic without mutating process-global environment state —
+    /// eliminating the cross-test env race that made parallel runs flaky.
+    #[must_use]
+    pub fn from_source<F: Fn(&str) -> Option<String>>(get: F) -> Self {
         let defaults = Self::default();
         let mut cfg = defaults.clone();
 
         // Parse TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS → flush_interval_ms (u64)
-        if let Ok(raw) = std::env::var("TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS") {
+        if let Some(raw) = get("TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS") {
             match raw.trim().parse::<u64>() {
                 Ok(ms) => {
                     cfg.flush_interval_ms = ms;
@@ -118,7 +130,7 @@ impl WriteBehindConfig {
         }
 
         // Parse TOPGUN_WRITEBEHIND_BATCH_SIZE → batch_size (u32)
-        if let Ok(raw) = std::env::var("TOPGUN_WRITEBEHIND_BATCH_SIZE") {
+        if let Some(raw) = get("TOPGUN_WRITEBEHIND_BATCH_SIZE") {
             match raw.trim().parse::<u32>() {
                 Ok(size) => {
                     cfg.batch_size = size;
@@ -138,7 +150,7 @@ impl WriteBehindConfig {
         }
 
         // Parse TOPGUN_WRITEBEHIND_CAPACITY → capacity (u64)
-        if let Ok(raw) = std::env::var("TOPGUN_WRITEBEHIND_CAPACITY") {
+        if let Some(raw) = get("TOPGUN_WRITEBEHIND_CAPACITY") {
             match raw.trim().parse::<u64>() {
                 Ok(cap) => {
                     cfg.capacity = cap;
@@ -158,7 +170,7 @@ impl WriteBehindConfig {
         }
 
         // Parse TOPGUN_WRITEBEHIND_SHUTDOWN_TIMEOUT_MS → shutdown_timeout_ms (u64)
-        if let Ok(raw) = std::env::var("TOPGUN_WRITEBEHIND_SHUTDOWN_TIMEOUT_MS") {
+        if let Some(raw) = get("TOPGUN_WRITEBEHIND_SHUTDOWN_TIMEOUT_MS") {
             match raw.trim().parse::<u64>() {
                 Ok(ms) => {
                     cfg.shutdown_timeout_ms = ms;
@@ -178,7 +190,7 @@ impl WriteBehindConfig {
         }
 
         // Parse TOPGUN_WAL_DIR → wal_dir (PathBuf)
-        if let Ok(raw) = std::env::var("TOPGUN_WAL_DIR") {
+        if let Some(raw) = get("TOPGUN_WAL_DIR") {
             let trimmed = raw.trim();
             if !trimmed.is_empty() {
                 cfg.wal_dir = PathBuf::from(trimmed);
@@ -186,7 +198,7 @@ impl WriteBehindConfig {
         }
 
         // Parse TOPGUN_WAL_FSYNC_POLICY → wal_fsync_policy (WalFsyncPolicy)
-        if let Ok(raw) = std::env::var("TOPGUN_WAL_FSYNC_POLICY") {
+        if let Some(raw) = get("TOPGUN_WAL_FSYNC_POLICY") {
             match raw.trim().parse::<WalFsyncPolicy>() {
                 Ok(policy) => {
                     cfg.wal_fsync_policy = policy;
@@ -1966,33 +1978,57 @@ mod tests {
         );
     }
 
-    // AC7: from_env parses TOPGUN_WAL_DIR and TOPGUN_WAL_FSYNC_POLICY
+    /// Build a `from_source` lookup closure from a fixed map of overrides — the
+    /// parallel-safe seam: full parse logic is exercised without touching
+    /// process-global env, so this test cannot race any other test reading the
+    /// same vars (the flake behind G3's withdrawal, TODO-468).
+    fn config_source(vars: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: std::collections::HashMap<String, String> = vars
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |key: &str| map.get(key).cloned()
+    }
+
+    // AC7: from_source parses TOPGUN_WAL_DIR and TOPGUN_WAL_FSYNC_POLICY
     #[test]
-    fn from_env_parses_wal_dir_and_fsync_policy() {
-        // Test TOPGUN_WAL_DIR
-        std::env::set_var("TOPGUN_WAL_DIR", "/tmp/test-wal");
-        let cfg = WriteBehindConfig::from_env();
+    fn from_source_parses_wal_dir_and_fsync_policy() {
+        // TOPGUN_WAL_DIR
+        let cfg =
+            WriteBehindConfig::from_source(config_source(&[("TOPGUN_WAL_DIR", "/tmp/test-wal")]));
         assert_eq!(cfg.wal_dir, std::path::PathBuf::from("/tmp/test-wal"));
-        std::env::remove_var("TOPGUN_WAL_DIR");
 
-        // Test TOPGUN_WAL_FSYNC_POLICY with valid value
-        std::env::set_var("TOPGUN_WAL_FSYNC_POLICY", "per_op");
-        let cfg = WriteBehindConfig::from_env();
+        // TOPGUN_WAL_FSYNC_POLICY with a valid value
+        let cfg =
+            WriteBehindConfig::from_source(config_source(&[("TOPGUN_WAL_FSYNC_POLICY", "per_op")]));
         assert_eq!(cfg.wal_fsync_policy, WalFsyncPolicy::PerOp);
-        std::env::remove_var("TOPGUN_WAL_FSYNC_POLICY");
 
-        // Test TOPGUN_WAL_FSYNC_POLICY with invalid value falls back to Batched
-        std::env::set_var("TOPGUN_WAL_FSYNC_POLICY", "invalid_policy");
-        let cfg = WriteBehindConfig::from_env();
+        // TOPGUN_WAL_FSYNC_POLICY with an invalid value falls back to Batched
+        let cfg = WriteBehindConfig::from_source(config_source(&[(
+            "TOPGUN_WAL_FSYNC_POLICY",
+            "invalid_policy",
+        )]));
         assert_eq!(
             cfg.wal_fsync_policy,
             WalFsyncPolicy::Batched,
             "Invalid policy must fall back to Batched default"
         );
-        std::env::remove_var("TOPGUN_WAL_FSYNC_POLICY");
 
-        // Default is Batched
-        let cfg = WriteBehindConfig::default();
+        // No override → Batched default
+        let cfg = WriteBehindConfig::from_source(config_source(&[]));
         assert_eq!(cfg.wal_fsync_policy, WalFsyncPolicy::Batched);
+    }
+
+    /// Wiring-only smoke test for the real `from_env` → `std::env` seam. The sole
+    /// env-mutating config test, `#[serial]` so it cannot race the env-free tests
+    /// above. Parse logic is covered by `from_source_*`; here we only prove
+    /// `from_env` actually reads the process environment.
+    #[serial_test::serial]
+    #[test]
+    fn from_env_reads_process_environment() {
+        std::env::set_var("TOPGUN_WAL_FSYNC_POLICY", "per_op");
+        let cfg = WriteBehindConfig::from_env();
+        std::env::remove_var("TOPGUN_WAL_FSYNC_POLICY");
+        assert_eq!(cfg.wal_fsync_policy, WalFsyncPolicy::PerOp);
     }
 }

--- a/packages/server-rust/src/storage/eviction_config.rs
+++ b/packages/server-rust/src/storage/eviction_config.rs
@@ -78,11 +78,23 @@ impl EvictionConfig {
     /// other from the default.
     #[must_use]
     pub fn from_env() -> Self {
+        Self::from_source(|key| std::env::var(key).ok())
+    }
+
+    /// Construct [`EvictionConfig`] from an injected variable source.
+    ///
+    /// `get` maps a variable name to its value (or `None` if unset). This is the
+    /// testable seam behind [`Self::from_env`], which simply passes a closure
+    /// over `std::env::var`. Tests pass a map-backed closure so they exercise the
+    /// full parse/validation logic without mutating process-global environment
+    /// state — eliminating the cross-test env race that made parallel runs flaky.
+    #[must_use]
+    pub fn from_source<F: Fn(&str) -> Option<String>>(get: F) -> Self {
         let defaults = Self::default();
         let mut cfg = defaults.clone();
 
         // Parse TOPGUN_MAX_RAM_MB → max_ram_bytes (u64, then multiply by 1 MiB)
-        if let Ok(raw) = std::env::var("TOPGUN_MAX_RAM_MB") {
+        if let Some(raw) = get("TOPGUN_MAX_RAM_MB") {
             match raw.trim().parse::<u64>() {
                 Ok(mb) => {
                     cfg.max_ram_bytes = mb.saturating_mul(1024 * 1024);
@@ -102,7 +114,7 @@ impl EvictionConfig {
         }
 
         // Parse TOPGUN_EVICTION_HIGH_PCT → high_water_pct (u8)
-        if let Ok(raw) = std::env::var("TOPGUN_EVICTION_HIGH_PCT") {
+        if let Some(raw) = get("TOPGUN_EVICTION_HIGH_PCT") {
             match raw.trim().parse::<u8>() {
                 Ok(pct) => {
                     cfg.high_water_pct = pct;
@@ -122,7 +134,7 @@ impl EvictionConfig {
         }
 
         // Parse TOPGUN_EVICTION_LOW_PCT → low_water_pct (u8)
-        if let Ok(raw) = std::env::var("TOPGUN_EVICTION_LOW_PCT") {
+        if let Some(raw) = get("TOPGUN_EVICTION_LOW_PCT") {
             match raw.trim().parse::<u8>() {
                 Ok(pct) => {
                     cfg.low_water_pct = pct;
@@ -142,7 +154,7 @@ impl EvictionConfig {
         }
 
         // Parse TOPGUN_EVICTION_INTERVAL_MS → interval_ms (u64)
-        if let Ok(raw) = std::env::var("TOPGUN_EVICTION_INTERVAL_MS") {
+        if let Some(raw) = get("TOPGUN_EVICTION_INTERVAL_MS") {
             match raw.trim().parse::<u64>() {
                 Ok(ms) => {
                     cfg.interval_ms = ms;
@@ -189,6 +201,20 @@ impl EvictionConfig {
 mod tests {
     use super::*;
     use serial_test::serial;
+    use std::collections::HashMap;
+
+    /// Build a `from_source` lookup closure from a fixed map of overrides.
+    ///
+    /// This is the parallel-safe seam: parsing/validation is exercised in full
+    /// without touching process-global env, so these tests never race each other
+    /// or any other test reading the same vars.
+    fn source(vars: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = vars
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |key: &str| map.get(key).cloned()
+    }
 
     #[test]
     fn default_values_are_sane() {
@@ -202,16 +228,9 @@ mod tests {
         assert!(cfg.high_water_pct <= 100);
     }
 
-    #[serial]
     #[test]
-    fn from_env_without_env_vars_returns_defaults() {
-        // Ensure no TOPGUN_ eviction vars leak from test environment
-        std::env::remove_var("TOPGUN_MAX_RAM_MB");
-        std::env::remove_var("TOPGUN_EVICTION_HIGH_PCT");
-        std::env::remove_var("TOPGUN_EVICTION_LOW_PCT");
-        std::env::remove_var("TOPGUN_EVICTION_INTERVAL_MS");
-
-        let cfg = EvictionConfig::from_env();
+    fn from_source_without_vars_returns_defaults() {
+        let cfg = EvictionConfig::from_source(source(&[]));
         let defaults = EvictionConfig::default();
         assert_eq!(cfg.max_ram_bytes, defaults.max_ram_bytes);
         assert_eq!(cfg.high_water_pct, defaults.high_water_pct);
@@ -219,21 +238,14 @@ mod tests {
         assert_eq!(cfg.interval_ms, defaults.interval_ms);
     }
 
-    #[serial]
     #[test]
-    fn from_env_parses_valid_values() {
-        // Use a serial test to avoid env-var races in parallel test runs
-        std::env::set_var("TOPGUN_MAX_RAM_MB", "2048");
-        std::env::set_var("TOPGUN_EVICTION_HIGH_PCT", "90");
-        std::env::set_var("TOPGUN_EVICTION_LOW_PCT", "60");
-        std::env::set_var("TOPGUN_EVICTION_INTERVAL_MS", "500");
-
-        let cfg = EvictionConfig::from_env();
-
-        std::env::remove_var("TOPGUN_MAX_RAM_MB");
-        std::env::remove_var("TOPGUN_EVICTION_HIGH_PCT");
-        std::env::remove_var("TOPGUN_EVICTION_LOW_PCT");
-        std::env::remove_var("TOPGUN_EVICTION_INTERVAL_MS");
+    fn from_source_parses_valid_values() {
+        let cfg = EvictionConfig::from_source(source(&[
+            ("TOPGUN_MAX_RAM_MB", "2048"),
+            ("TOPGUN_EVICTION_HIGH_PCT", "90"),
+            ("TOPGUN_EVICTION_LOW_PCT", "60"),
+            ("TOPGUN_EVICTION_INTERVAL_MS", "500"),
+        ]));
 
         assert_eq!(cfg.max_ram_bytes, 2048 * 1024 * 1024);
         assert_eq!(cfg.high_water_pct, 90);
@@ -241,17 +253,19 @@ mod tests {
         assert_eq!(cfg.interval_ms, 500);
     }
 
-    #[serial]
+    #[test]
+    fn unparseable_value_falls_back_to_default() {
+        let cfg = EvictionConfig::from_source(source(&[("TOPGUN_MAX_RAM_MB", "not-a-number")]));
+        assert_eq!(cfg.max_ram_bytes, EvictionConfig::default().max_ram_bytes);
+    }
+
     #[test]
     fn watermark_inversion_reverts_both_to_defaults() {
-        // low >= high should trigger atomic revert of BOTH fields
-        std::env::set_var("TOPGUN_EVICTION_HIGH_PCT", "50");
-        std::env::set_var("TOPGUN_EVICTION_LOW_PCT", "75"); // low > high — invalid
-
-        let cfg = EvictionConfig::from_env();
-
-        std::env::remove_var("TOPGUN_EVICTION_HIGH_PCT");
-        std::env::remove_var("TOPGUN_EVICTION_LOW_PCT");
+        // low > high should trigger atomic revert of BOTH fields
+        let cfg = EvictionConfig::from_source(source(&[
+            ("TOPGUN_EVICTION_HIGH_PCT", "50"),
+            ("TOPGUN_EVICTION_LOW_PCT", "75"),
+        ]));
 
         let defaults = EvictionConfig::default();
         assert_eq!(
@@ -264,20 +278,30 @@ mod tests {
         );
     }
 
-    #[serial]
     #[test]
     fn watermark_equal_reverts_both_to_defaults() {
         // low == high is also invalid (requires strict ordering)
-        std::env::set_var("TOPGUN_EVICTION_HIGH_PCT", "70");
-        std::env::set_var("TOPGUN_EVICTION_LOW_PCT", "70");
-
-        let cfg = EvictionConfig::from_env();
-
-        std::env::remove_var("TOPGUN_EVICTION_HIGH_PCT");
-        std::env::remove_var("TOPGUN_EVICTION_LOW_PCT");
+        let cfg = EvictionConfig::from_source(source(&[
+            ("TOPGUN_EVICTION_HIGH_PCT", "70"),
+            ("TOPGUN_EVICTION_LOW_PCT", "70"),
+        ]));
 
         let defaults = EvictionConfig::default();
         assert_eq!(cfg.high_water_pct, defaults.high_water_pct);
         assert_eq!(cfg.low_water_pct, defaults.low_water_pct);
+    }
+
+    /// Wiring-only smoke test for the real `from_env` → `std::env` seam. This is
+    /// the sole env-mutating test and is `#[serial]` so it cannot race the other
+    /// (env-free) config tests. All parse/validation logic is covered above via
+    /// `from_source`; here we only prove `from_env` actually reads the process
+    /// environment.
+    #[serial]
+    #[test]
+    fn from_env_reads_process_environment() {
+        std::env::set_var("TOPGUN_MAX_RAM_MB", "2048");
+        let cfg = EvictionConfig::from_env();
+        std::env::remove_var("TOPGUN_MAX_RAM_MB");
+        assert_eq!(cfg.max_ram_bytes, 2048 * 1024 * 1024);
     }
 }

--- a/packages/server-rust/src/storage/wal/format.rs
+++ b/packages/server-rust/src/storage/wal/format.rs
@@ -47,6 +47,22 @@ pub const FRAME_VERSION: u8 = 1;
 /// Total header bytes: 4 (magic) + 1 (version) + 4 (length) + 4 (crc32c).
 pub const FRAME_HEADER_LEN: usize = 13;
 
+/// Upper bound on a single frame's declared payload length.
+///
+/// The length field is an untrusted on-disk `u32` — a torn write that corrupts
+/// only the length while leaving valid magic+version (a plausible partial-sector
+/// write) could declare up to `u32::MAX` (~4 GiB). `decode_all` would then
+/// `vec![0u8; payload_len]` **before** verifying the CRC, so a single corrupt
+/// length turns recovery into a multi-gigabyte allocation (OOM / crash-loop on
+/// startup). We reject any frame whose declared length exceeds this ceiling
+/// rather than allocate for it.
+///
+/// 64 MiB is far above any legitimate `WalEntry` (one CRDT record: map + key +
+/// value) yet small enough that a rejection allocates nothing. This mirrors the
+/// per-record size caps in Postgres WAL / `RocksDB` log / tikv `raft-engine`,
+/// none of which allocate for an unbounded on-disk length.
+pub const MAX_FRAME_PAYLOAD_LEN: usize = 64 * 1024 * 1024;
+
 // ---------------------------------------------------------------------------
 // FrameDecodeResult
 // ---------------------------------------------------------------------------
@@ -213,6 +229,36 @@ pub fn decode_all(data: &[u8]) -> FrameDecodeResult {
             Err(_) => return FrameDecodeResult::TruncatedTail { complete: entries },
         }
         let stored_crc = u32::from_be_bytes(crc_buf);
+
+        // --- Bound the declared payload length BEFORE allocating ---
+        // The length field is untrusted on-disk data; a corrupt/torn length must
+        // never drive the allocation below. Two distinct rejections, ordered so a
+        // crash-mid-append (the common case) stays recoverable rather than fatal:
+        //
+        // 1. `payload_len > remaining` — the frame extends past the end of the
+        //    data, so it cannot be a complete frame. This is the torn-tail case
+        //    (writer crashed mid-append); replay the intact prefix. This also
+        //    catches the ~4 GiB bloated-length-on-a-small-file DoS, because a huge
+        //    declared length always exceeds the bytes actually present, so we
+        //    return here without allocating `payload_len`.
+        // 2. `payload_len > MAX_FRAME_PAYLOAD_LEN` — enough bytes are present for
+        //    the declared length, but it exceeds any legitimate frame. Refuse
+        //    fatally (Corruption) rather than allocate: with valid frames possibly
+        //    following, a silent truncation could drop acked writes.
+        let remaining =
+            total_len.saturating_sub(usize::try_from(cursor.position()).unwrap_or(usize::MAX));
+        if payload_len > remaining {
+            return FrameDecodeResult::TruncatedTail { complete: entries };
+        }
+        if payload_len > MAX_FRAME_PAYLOAD_LEN {
+            return FrameDecodeResult::Corruption {
+                offset,
+                stored_crc,
+                // The frame is rejected on the length bound before its CRC is
+                // computed; 0 is a sentinel "not computed", stored_crc is real.
+                computed_crc: 0,
+            };
+        }
 
         // --- Read payload ---
         let mut payload = vec![0u8; payload_len];
@@ -464,6 +510,90 @@ mod tests {
     // -----------------------------------------------------------------------
     // AC2: Unknown version — distinct classification
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Bounded payload allocation — a corrupt/bloated length field must never
+    // drive a multi-gigabyte allocation during recovery (DoS / OOM hardening).
+    // -----------------------------------------------------------------------
+
+    /// Build a raw frame header (valid magic + version) with an arbitrary
+    /// declared `length`, followed by `payload` bytes verbatim. The CRC field is
+    /// filled with `0` because these tests exercise the length bound, which is
+    /// checked *before* the CRC is computed.
+    fn raw_frame_with_declared_len(length: u32, payload: &[u8]) -> Vec<u8> {
+        let mut frame = Vec::with_capacity(FRAME_HEADER_LEN + payload.len());
+        frame.extend_from_slice(&FRAME_MAGIC.to_be_bytes());
+        frame.push(FRAME_VERSION);
+        frame.extend_from_slice(&length.to_be_bytes());
+        frame.extend_from_slice(&0u32.to_be_bytes()); // CRC placeholder
+        frame.extend_from_slice(payload);
+        frame
+    }
+
+    #[test]
+    fn bloated_length_is_truncated_tail_without_allocating() {
+        // A frame header claims a ~4 GiB payload but only a handful of bytes
+        // follow. The decoder must NOT allocate `vec![0u8; 4 GiB]`; because the
+        // declared length exceeds the bytes actually present, it is classified as
+        // a truncated tail (crash-mid-append) and the intact prefix is returned.
+        // Pre-fix this test would attempt a ~4 GiB allocation and OOM/abort.
+        let data = raw_frame_with_declared_len(u32::MAX, &[1, 2, 3, 4]);
+
+        match decode_all(&data) {
+            FrameDecodeResult::TruncatedTail { complete } => {
+                assert!(
+                    complete.is_empty(),
+                    "no complete frame precedes the bad one"
+                );
+            }
+            other => panic!("Expected TruncatedTail (no allocation), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bloated_length_after_valid_frame_keeps_prefix() {
+        // A valid frame, then a frame declaring a ~4 GiB payload with no bytes
+        // behind it. The valid prefix must survive; the bloated frame must be
+        // treated as a truncated tail, never allocated.
+        let entry = make_store_entry(1);
+        let mut data = encode(&entry).unwrap();
+        data.extend_from_slice(&raw_frame_with_declared_len(u32::MAX, &[]));
+
+        match decode_all(&data) {
+            FrameDecodeResult::TruncatedTail { complete } => {
+                assert_eq!(complete.len(), 1);
+                assert_eq!(complete[0], entry);
+            }
+            other => panic!("Expected TruncatedTail with intact prefix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oversized_but_present_payload_is_corruption() {
+        // Enough bytes ARE present for the declared length, but it exceeds the
+        // per-frame ceiling. This is genuine corruption (not a torn tail) and
+        // must be refused, not allocated-and-replayed. Built as a single buffer
+        // (header + zero payload in place) to avoid a transient double-copy of
+        // the 64 MiB payload under parallel test memory pressure.
+        let over = MAX_FRAME_PAYLOAD_LEN + 1;
+        let mut data = vec![0u8; FRAME_HEADER_LEN + over];
+        data[0..4].copy_from_slice(&FRAME_MAGIC.to_be_bytes());
+        data[4] = FRAME_VERSION;
+        data[5..9].copy_from_slice(
+            &u32::try_from(over)
+                .expect("over fits in u32 for this test")
+                .to_be_bytes(),
+        );
+        // bytes 9..13 (CRC) and the payload stay zeroed; the length bound is
+        // checked before the CRC, so the CRC value is irrelevant here.
+
+        match decode_all(&data) {
+            FrameDecodeResult::Corruption { offset, .. } => {
+                assert_eq!(offset, 0, "the over-sized frame is the first frame");
+            }
+            other => panic!("Expected Corruption for an over-MAX frame, got {other:?}"),
+        }
+    }
 
     #[test]
     fn unknown_version_is_distinct_from_corruption_and_bad_magic() {


### PR DESCRIPTION
Closes the remaining substance items for G3 durability identified in the storage/WAL depth-audit (DEPTH_STORAGE_WAL.md). Three independent changes, one commit each; no logic bundled with tests.

## 1. TODO-470 — bound WAL frame payload length before allocation (F2, medium)
`format::decode_all` allocated `vec![0u8; payload_len]` from an untrusted on-disk `u32` length field **before** verifying the CRC. A torn write corrupting only the length (valid magic+version) could declare ~4 GiB → multi-gigabyte allocation / OOM / crash-loop on recovery.

Fix — two ordered guards before the allocation:
- `payload_len > remaining bytes` → `TruncatedTail` (torn mid-append tail; replay intact prefix, non-fatal). Also neutralises the bloated-length DoS, since a huge declared length always exceeds the bytes present.
- `payload_len > MAX_FRAME_PAYLOAD_LEN` (64 MiB) → `Corruption` (bytes present but absurd size; refuse rather than risk dropping valid following frames).

Negative controls (debug, parallel): removing the remaining-check makes the bloated-length tests misclassify as Corruption (FAIL); removing both guards makes the oversized-but-present test return TruncatedTail instead of Corruption (FAIL).

## 2. TODO-468 — remove env-race from config tests (the flake behind G3's withdrawal)
`WriteBehindConfig::from_env` / `EvictionConfig::from_env` read process-global `std::env` deep in the parse body; their tests mutated the same vars via `set_var`/`remove_var` without serialization → parallel CI races.

Fix (injection over mutation): extract `from_source(get)` taking a variable-lookup closure; `from_env` is a thin wrapper. Tests pass a map-backed closure — full parse/validation logic, zero process-env mutation, immune to races. One `#[serial]` smoke test per config keeps the real `from_env → std::env` wiring covered.

Negative control: a thread interleaving env mutation with `from_env` reads observed **109611/200000** reads returning another thread's value (~55% under contention). Verification: full lib suite ×3 in parallel green, 1338 passed, non-flaky.

## 3. Rebuild the crash-safety test under concurrent same-partition load (F1/F5)
The existing crash scenarios drive the write path single-threaded-sequentially, so they cannot see the F1 compaction race (and `kill -9` can't either — page cache survives a kill). The new test runs **append and compaction concurrently on one partition** through the production write path, models the crash (drop), recovers into a **fresh durable inner store** via real `WalRecovery`, and asserts against that — not the OS-cached WAL file.

Negative control: reverting `compact_log` to the pre-PR#50 shape (lock released across read→rewrite→rename) makes the test lose **1858/2000** acked writes across the crash (matches the audit's ~1864/2000); with the lock held it loses 0.

## Gate (local, CI mode = debug, parallel)
- `cargo fmt --all --check`: OK
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --lib` ×3: 1338 passed, 0 failed, non-flaky
- `cargo test --all-targets`: all targets green (core 549, server lib 1338, integration incl. cluster_bootstrap + router_contract)
- `cargo build --release -p topgun-server`: clean

## Out of scope (follow-up)
- `admin.rs` `TOPGUN_VECTOR_INDEX_PATH` tests share the same env anti-pattern but are a different component (vector-index handler) — recommend a follow-up TODO.
- F1 segment-rotation (TODO-469 option B / TODO-456), F3 cluster-backup WAL, F4 batched-fsync lock remain tracked separately.

**Do not merge directly** — org-session merges on green CI. G3 stays withdrawn from green until ≥3 green CI runs on main per the stabilization standard.