### PR TITLE
fix(crdt): OR-Map server merge — RMW OR_ADD/OR_REMOVE, stop concurrent-value loss (SPEC-310a+b, F1 critical)

### DIFF
--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -2204,4 +2204,638 @@ mod tests {
             other => panic!("expected Message, got {other:?}"),
         }
     }
+
+    // -----------------------------------------------------------------------
+    // OR-Map data-loss regression (add-wins / remove-wins / convergence).
+    //
+    // These assert the FIXED behaviour at the SERVER boundary: ops flow through
+    // CrdtService::apply_single_op (via oneshot) and the inbound
+    // SyncService::handle_ormap_push_diff ingest path, and the stored
+    // RecordValue::OrMap { records, tombstones } is read back and compared.
+    // The earlier audit repro demonstrated OR_REMOVE of one tag destroying every
+    // concurrent value under the key; the inverted forms below lock in survival.
+    // -----------------------------------------------------------------------
+
+    use topgun_core::hash_to_partition;
+
+    /// Builds a CRDT op context routed to the key's hash partition so the single
+    /// ClientOp path (which honours `ctx.partition_id`) and the SyncService
+    /// push-diff path (which uses `hash_to_partition(key)`) land on the same store.
+    fn make_ctx_for_key(key: &str) -> OperationContext {
+        let mut ctx = make_ctx();
+        ctx.partition_id = Some(hash_to_partition(key));
+        ctx
+    }
+
+    fn or_add_op(map: &str, key: &str, value: &str, tag: &str) -> Operation {
+        let or_rec = topgun_core::ORMapRecord {
+            value: rmpv::Value::String(value.into()),
+            timestamp: make_timestamp(),
+            tag: tag.to_string(),
+            ttl_ms: None,
+        };
+        Operation::ClientOp {
+            // connection_id = None -> tags used as-is, no sanitize/regeneration.
+            ctx: make_ctx_for_key(key),
+            payload: topgun_core::messages::ClientOpMessage {
+                payload: topgun_core::messages::base::ClientOp {
+                    id: Some(format!("add-{tag}")),
+                    map_name: map.to_string(),
+                    key: key.to_string(),
+                    op_type: None,
+                    record: None,
+                    or_record: Some(Some(or_rec)),
+                    or_tag: None,
+                    write_concern: None,
+                    timeout: None,
+                },
+            },
+        }
+    }
+
+    fn or_remove_op(map: &str, key: &str, tag: &str) -> Operation {
+        Operation::ClientOp {
+            ctx: make_ctx_for_key(key),
+            payload: topgun_core::messages::ClientOpMessage {
+                payload: topgun_core::messages::base::ClientOp {
+                    id: Some(format!("rm-{tag}")),
+                    map_name: map.to_string(),
+                    key: key.to_string(),
+                    op_type: None,
+                    record: None,
+                    or_record: None,
+                    or_tag: Some(Some(tag.to_string())),
+                    write_concern: None,
+                    timeout: None,
+                },
+            },
+        }
+    }
+
+    fn make_service_with_factory() -> (Arc<CrdtService>, Arc<RecordStoreFactory>) {
+        let factory = make_factory();
+        let registry = Arc::new(ConnectionRegistry::new());
+        let query_registry = Arc::new(QueryRegistry::new());
+        let svc = Arc::new(CrdtService::new(
+            Arc::clone(&factory),
+            registry,
+            make_validator(),
+            query_registry,
+            Arc::new(SchemaService::new()),
+        ));
+        (svc, factory)
+    }
+
+    /// Reads back the stored OR-Map for a key at its hash partition.
+    async fn read_or_map(
+        factory: &Arc<RecordStoreFactory>,
+        map: &str,
+        key: &str,
+    ) -> (Vec<String>, Vec<String>) {
+        let store = factory.get_or_create(map, hash_to_partition(key));
+        let value = store.get(key, false).await.unwrap().map(|r| r.value);
+        match value {
+            Some(RecordValue::OrMap {
+                records,
+                tombstones,
+            }) => {
+                let mut tags: Vec<String> = records.into_iter().map(|e| e.tag).collect();
+                tags.sort();
+                let mut tombs = tombstones;
+                tombs.sort();
+                (tags, tombs)
+            }
+            Some(RecordValue::OrTombstones { tags }) => {
+                let mut tombs = tags;
+                tombs.sort();
+                (Vec::new(), tombs)
+            }
+            Some(RecordValue::Lww { .. }) | None => (Vec::new(), Vec::new()),
+        }
+    }
+
+    /// Returns the survivor values (not tags) for a key, for human-readable
+    /// assertions like "play survives".
+    async fn read_or_map_values(
+        factory: &Arc<RecordStoreFactory>,
+        map: &str,
+        key: &str,
+    ) -> Vec<String> {
+        let store = factory.get_or_create(map, hash_to_partition(key));
+        match store.get(key, false).await.unwrap().map(|r| r.value) {
+            Some(RecordValue::OrMap { records, .. }) => records
+                .into_iter()
+                .map(|e| format!("{:?}", e.value))
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    // AC1: add-wins — OR_REMOVE of one tag preserves concurrent survivors.
+    #[tokio::test]
+    async fn or_remove_preserves_concurrent_value_add_wins() {
+        let (svc, factory) = make_service_with_factory();
+
+        svc.clone()
+            .oneshot(or_add_op("tags", "item-1", "work", "t1"))
+            .await
+            .unwrap();
+        svc.clone()
+            .oneshot(or_add_op("tags", "item-1", "play", "t2"))
+            .await
+            .unwrap();
+
+        let (tags_before, _) = read_or_map(&factory, "tags", "item-1").await;
+        assert_eq!(
+            tags_before,
+            vec!["t1", "t2"],
+            "both adds present before remove"
+        );
+
+        svc.clone()
+            .oneshot(or_remove_op("tags", "item-1", "t1"))
+            .await
+            .unwrap();
+
+        let (records, tombstones) = read_or_map(&factory, "tags", "item-1").await;
+        assert_eq!(
+            records,
+            vec!["t2"],
+            "removing t1 must NOT destroy t2 (add-wins); stored records={records:?}"
+        );
+        assert_eq!(tombstones, vec!["t1"], "t1 must be tombstoned");
+
+        let survivors = read_or_map_values(&factory, "tags", "item-1").await;
+        assert!(
+            survivors.iter().any(|v| v.contains("play")),
+            "\"play\" (t2) must survive the remove of t1; survivors={survivors:?}"
+        );
+    }
+
+    // AC2: remove-wins — a tombstoned tag is never resurrected by a later OR_ADD.
+    #[tokio::test]
+    async fn or_add_after_remove_does_not_resurrect_remove_wins() {
+        let (svc, factory) = make_service_with_factory();
+
+        svc.clone()
+            .oneshot(or_add_op("tags", "item-2", "hello", "tag-x"))
+            .await
+            .unwrap();
+        svc.clone()
+            .oneshot(or_remove_op("tags", "item-2", "tag-x"))
+            .await
+            .unwrap();
+        // Re-add the SAME tag after it was removed — observed-remove forbids resurrection.
+        svc.clone()
+            .oneshot(or_add_op("tags", "item-2", "hello", "tag-x"))
+            .await
+            .unwrap();
+
+        let (records, tombstones) = read_or_map(&factory, "tags", "item-2").await;
+        assert!(
+            !records.contains(&"tag-x".to_string()),
+            "tag-x must NOT reappear in visible records after remove (remove-wins); records={records:?}"
+        );
+        assert_eq!(
+            tombstones,
+            vec!["tag-x"],
+            "tag-x must remain tombstoned; tombstones={tombstones:?}"
+        );
+    }
+
+    // AC3 (i): apply_single_op convergence — same op set delivered in DIFFERENT
+    // orders to two independent stores yields byte-identical OrMap state.
+    #[tokio::test]
+    async fn convergence_apply_single_op_order_independent() {
+        let (svc_a, factory_a) = make_service_with_factory();
+        let (svc_b, factory_b) = make_service_with_factory();
+
+        // An interleaved op set with duplicate tags and an add-after-remove.
+        let key = "conv-1";
+        let ops_order_a: Vec<Operation> = vec![
+            or_add_op("tags", key, "a", "ta"),
+            or_add_op("tags", key, "b", "tb"),
+            or_remove_op("tags", key, "ta"),
+            or_add_op("tags", key, "a-dup", "ta"), // resurrection attempt
+            or_add_op("tags", key, "c", "tc"),
+            or_remove_op("tags", key, "tc"),
+        ];
+        // Different delivery order to store B (removes before some adds, dup tags).
+        let ops_order_b: Vec<Operation> = vec![
+            or_add_op("tags", key, "c", "tc"),
+            or_add_op("tags", key, "b", "tb"),
+            or_remove_op("tags", key, "tc"),
+            or_add_op("tags", key, "a", "ta"),
+            or_remove_op("tags", key, "ta"),
+            or_add_op("tags", key, "a-dup", "ta"),
+        ];
+
+        for op in ops_order_a {
+            svc_a.clone().oneshot(op).await.unwrap();
+        }
+        for op in ops_order_b {
+            svc_b.clone().oneshot(op).await.unwrap();
+        }
+
+        let state_a = read_or_map(&factory_a, "tags", key).await;
+        let state_b = read_or_map(&factory_b, "tags", key).await;
+        assert_eq!(
+            state_a, state_b,
+            "apply_single_op convergence: stores must agree on (records, tombstones)"
+        );
+
+        // Byte-identical after canonical (sorted) ordering: serialize the sorted
+        // unified OrMap and compare bytes, not merely the visible state.
+        let canonical = |s: &(Vec<String>, Vec<String>)| rmp_serde::to_vec_named(s).unwrap();
+        assert_eq!(
+            canonical(&state_a),
+            canonical(&state_b),
+            "serialized OrMap bytes must be identical after canonical ordering"
+        );
+        // Sanity: the convergent state is ta-removed, tc-removed, tb survives.
+        assert_eq!(state_a.0, vec!["tb"], "only tb survives");
+        assert_eq!(state_a.1, vec!["ta", "tc"], "ta and tc tombstoned");
+    }
+
+    // AC3 (ii) + AC4: inbound handle_ormap_push_diff convergence — one store emits
+    // an ORMapEntry diff, the other ingests it (and vice-versa); both converge to
+    // byte-identical state, tombstones are not discarded, concurrent records are
+    // not clobbered.
+    #[tokio::test]
+    async fn convergence_handle_ormap_push_diff_both_directions() {
+        use crate::service::domain::sync::SyncService;
+        use crate::storage::merkle_sync::MerkleSyncManager;
+        use topgun_core::messages::{ORMapEntry, ORMapPushDiff, ORMapPushDiffPayload};
+
+        let (svc_a, factory_a) = make_service_with_factory();
+        let (svc_b, factory_b) = make_service_with_factory();
+
+        let sync_a = Arc::new(SyncService::new(
+            Arc::new(MerkleSyncManager::default()),
+            Arc::clone(&factory_a),
+            Arc::new(ConnectionRegistry::new()),
+        ));
+        let sync_b = Arc::new(SyncService::new(
+            Arc::new(MerkleSyncManager::default()),
+            Arc::clone(&factory_b),
+            Arc::new(ConnectionRegistry::new()),
+        ));
+
+        let key = "conv-diff";
+        // Store A: add t1, add t2, remove t1  -> records {t2}, tombstones {t1}
+        svc_a
+            .clone()
+            .oneshot(or_add_op("tags", key, "work", "t1"))
+            .await
+            .unwrap();
+        svc_a
+            .clone()
+            .oneshot(or_add_op("tags", key, "play", "t2"))
+            .await
+            .unwrap();
+        svc_a
+            .clone()
+            .oneshot(or_remove_op("tags", key, "t1"))
+            .await
+            .unwrap();
+
+        // Store B: concurrent add t3 (a survivor that must NOT be clobbered on ingest).
+        svc_b
+            .clone()
+            .oneshot(or_add_op("tags", key, "concurrent", "t3"))
+            .await
+            .unwrap();
+
+        // Build A's diff entry from its stored OR-Map.
+        let store_a = factory_a.get_or_create("tags", hash_to_partition(key));
+        let (a_records, a_tombs) = match store_a.get(key, false).await.unwrap().unwrap().value {
+            RecordValue::OrMap {
+                records,
+                tombstones,
+            } => (records, tombstones),
+            other => panic!("expected OrMap, got {other:?}"),
+        };
+        let a_entry = ORMapEntry {
+            key: key.to_string(),
+            records: a_records
+                .iter()
+                .map(|e| topgun_core::ORMapRecord {
+                    value: value_to_rmpv(&e.value),
+                    timestamp: e.timestamp.clone(),
+                    tag: e.tag.clone(),
+                    ttl_ms: None,
+                })
+                .collect(),
+            tombstones: a_tombs.clone(),
+        };
+        // AC4: the emitted entry carries BOTH surviving records AND tombstones.
+        assert!(
+            !a_entry.records.is_empty(),
+            "emitted ORMapEntry must carry surviving records (t2)"
+        );
+        assert_eq!(
+            a_entry.tombstones,
+            vec!["t1".to_string()],
+            "emitted ORMapEntry must carry the tombstone set (t1)"
+        );
+
+        // Ingest A's diff into B via handle_ormap_push_diff (the inbound path).
+        sync_b
+            .clone()
+            .oneshot(Operation::ORMapPushDiff {
+                ctx: make_ctx_sync(),
+                payload: ORMapPushDiff {
+                    payload: ORMapPushDiffPayload {
+                        map_name: "tags".to_string(),
+                        entries: vec![a_entry],
+                    },
+                },
+            })
+            .await
+            .unwrap();
+
+        // Build B's diff (now t2 + t3 survive, t1 tombstoned) and ingest into A.
+        let store_b = factory_b.get_or_create("tags", hash_to_partition(key));
+        let (b_records, b_tombs) = match store_b.get(key, false).await.unwrap().unwrap().value {
+            RecordValue::OrMap {
+                records,
+                tombstones,
+            } => (records, tombstones),
+            other => panic!("expected OrMap, got {other:?}"),
+        };
+        // AC4: a client joining after the remove does NOT see t1 and DOES see survivors.
+        let b_tags: Vec<&str> = b_records.iter().map(|e| e.tag.as_str()).collect();
+        assert!(
+            !b_tags.contains(&"t1"),
+            "ingest must NOT resurrect removed t1; tags={b_tags:?}"
+        );
+        assert!(
+            b_tags.contains(&"t2") && b_tags.contains(&"t3"),
+            "ingest must preserve survivor t2 AND concurrent local t3; tags={b_tags:?}"
+        );
+        assert!(b_tombs.contains(&"t1".to_string()), "t1 tombstone retained");
+
+        let b_entry = ORMapEntry {
+            key: key.to_string(),
+            records: b_records
+                .iter()
+                .map(|e| topgun_core::ORMapRecord {
+                    value: value_to_rmpv(&e.value),
+                    timestamp: e.timestamp.clone(),
+                    tag: e.tag.clone(),
+                    ttl_ms: None,
+                })
+                .collect(),
+            tombstones: b_tombs.clone(),
+        };
+        sync_a
+            .clone()
+            .oneshot(Operation::ORMapPushDiff {
+                ctx: make_ctx_sync(),
+                payload: ORMapPushDiff {
+                    payload: ORMapPushDiffPayload {
+                        map_name: "tags".to_string(),
+                        entries: vec![b_entry],
+                    },
+                },
+            })
+            .await
+            .unwrap();
+
+        // Both stores must now be byte-identical: records {t2,t3}, tombstones {t1}.
+        let state_a = read_or_map(&factory_a, "tags", key).await;
+        let state_b = read_or_map(&factory_b, "tags", key).await;
+        assert_eq!(
+            state_a, state_b,
+            "handle_ormap_push_diff convergence: stores must agree after bidirectional ingest"
+        );
+        assert_eq!(
+            rmp_serde::to_vec_named(&state_a).unwrap(),
+            rmp_serde::to_vec_named(&state_b).unwrap(),
+            "serialized OrMap bytes must be identical after bidirectional diff ingest"
+        );
+        assert_eq!(state_a.0, vec!["t2", "t3"], "t2 and t3 survive");
+        assert_eq!(state_a.1, vec!["t1"], "t1 tombstoned");
+    }
+
+    // AC6: tombstoning a tag CHANGES the OR-Map merkle hash, and a key reduced to
+    // tombstones-only is NOT dropped from peer-visible suppression state.
+    #[tokio::test]
+    async fn merkle_hash_changes_on_tombstone_and_retains_tombstone_only_key() {
+        use crate::storage::merkle_sync::{MerkleMutationObserver, MerkleSyncManager};
+
+        let key = "merkle-1";
+        let partition = hash_to_partition(key);
+        let merkle = Arc::new(MerkleSyncManager::default());
+        let observer = Arc::new(MerkleMutationObserver::new(
+            Arc::clone(&merkle),
+            "tags".to_string(),
+            partition,
+        ));
+        let factory = Arc::new(RecordStoreFactory::new(
+            StorageConfig::default(),
+            Arc::new(NullDataStore),
+            vec![observer as Arc<dyn crate::storage::mutation_observer::MutationObserver>],
+        ));
+        let registry = Arc::new(ConnectionRegistry::new());
+        let svc = Arc::new(CrdtService::new(
+            Arc::clone(&factory),
+            registry,
+            make_validator(),
+            Arc::new(QueryRegistry::new()),
+            Arc::new(SchemaService::new()),
+        ));
+
+        svc.clone()
+            .oneshot(or_add_op("tags", key, "v", "m1"))
+            .await
+            .unwrap();
+        let hash_after_add = merkle.with_ormap_tree("tags", partition, |t| t.get_root_hash());
+        assert_ne!(hash_after_add, 0, "add must produce a non-zero merkle hash");
+
+        svc.clone()
+            .oneshot(or_remove_op("tags", key, "m1"))
+            .await
+            .unwrap();
+        let hash_after_remove = merkle.with_ormap_tree("tags", partition, |t| t.get_root_hash());
+
+        assert_ne!(
+            hash_after_remove, hash_after_add,
+            "tombstoning a tag must CHANGE the OR-Map merkle hash"
+        );
+        // Key reduced to tombstones-only must still be peer-visible (non-zero hash),
+        // not silently dropped — otherwise remove-wins suppression cannot replicate.
+        assert_ne!(
+            hash_after_remove, 0,
+            "tombstone-only key must NOT be dropped from suppression state"
+        );
+
+        // Confirm the stored value really is tombstones-only.
+        let (records, tombstones) = read_or_map(&factory, "tags", key).await;
+        assert!(records.is_empty(), "no active records after remove");
+        assert_eq!(tombstones, vec!["m1"], "m1 tombstoned");
+    }
+
+    fn make_ctx_sync() -> OperationContext {
+        OperationContext::new(1, service_names::SYNC, make_timestamp(), 5000)
+    }
+
+    // AC9: concurrent-OR_REMOVE convergence proptest.
+    //
+    // The SimCluster harness only expresses LWW writes (no OR_ADD/OR_REMOVE) and
+    // adding an or_remove helper to it is out of scope, so the F1 scenario cannot
+    // be reached through the sim proptests. Instead this proptest mirrors the AC3
+    // two-store oracle: it generates random interleaved OR_ADD/OR_REMOVE sequences
+    // with a small reused tag pool (so concurrent adds, removes, and resurrection
+    // attempts collide), delivers the SAME multiset of ops in two DIFFERENT orders
+    // to two independent CrdtService/RecordStore pairs, and asserts the stored
+    // OrMap (records + tombstones) converges byte-identically AND that the OR-Map
+    // merkle hash agrees. This is the proptest that would have caught F1.
+    use crate::storage::merkle_sync::{MerkleMutationObserver, MerkleSyncManager};
+    use proptest::prelude::*;
+
+    #[derive(Debug, Clone)]
+    enum OrAction {
+        Add { tag: u8, value: u8 },
+        Remove { tag: u8 },
+    }
+
+    fn arb_or_action() -> impl Strategy<Value = OrAction> {
+        // Tag pool deliberately tiny (0..4) so adds/removes of the SAME tag
+        // interleave, exercising add-wins, remove-wins, and resurrection paths.
+        prop_oneof![
+            (0u8..4, 0u8..16).prop_map(|(tag, value)| OrAction::Add { tag, value }),
+            (0u8..4).prop_map(|tag| OrAction::Remove { tag }),
+        ]
+    }
+
+    fn action_to_op(action: &OrAction, map: &str, key: &str) -> Operation {
+        match action {
+            OrAction::Add { tag, value } => {
+                or_add_op(map, key, &format!("v{value}"), &format!("tag-{tag}"))
+            }
+            OrAction::Remove { tag } => or_remove_op(map, key, &format!("tag-{tag}")),
+        }
+    }
+
+    /// Builds a CrdtService whose RecordStore feeds a MerkleSyncManager, so the
+    /// OR-Map merkle hash can be read back for the key's partition.
+    fn make_service_with_merkle(
+        map: &str,
+        partition: u32,
+    ) -> (
+        Arc<CrdtService>,
+        Arc<RecordStoreFactory>,
+        Arc<MerkleSyncManager>,
+    ) {
+        let merkle = Arc::new(MerkleSyncManager::default());
+        let observer = Arc::new(MerkleMutationObserver::new(
+            Arc::clone(&merkle),
+            map.to_string(),
+            partition,
+        ));
+        let factory = Arc::new(RecordStoreFactory::new(
+            StorageConfig::default(),
+            Arc::new(NullDataStore),
+            vec![observer as Arc<dyn crate::storage::mutation_observer::MutationObserver>],
+        ));
+        let svc = Arc::new(CrdtService::new(
+            Arc::clone(&factory),
+            Arc::new(ConnectionRegistry::new()),
+            make_validator(),
+            Arc::new(QueryRegistry::new()),
+            Arc::new(SchemaService::new()),
+        ));
+        (svc, factory, merkle)
+    }
+
+    #[test]
+    fn proptest_concurrent_or_remove_convergence() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+
+        let mut runner = proptest::test_runner::TestRunner::new(proptest::test_runner::Config {
+            cases: 64,
+            ..proptest::test_runner::Config::default()
+        });
+
+        let map = "tags";
+        let key = "conv-prop";
+        let partition = hash_to_partition(key);
+
+        runner
+            .run(
+                &(
+                    proptest::collection::vec(arb_or_action(), 1..24),
+                    any::<u64>(),
+                ),
+                |(actions, shuffle_seed)| {
+                    runtime.block_on(async {
+                        let (svc_a, factory_a, merkle_a) = make_service_with_merkle(map, partition);
+                        let (svc_b, factory_b, merkle_b) = make_service_with_merkle(map, partition);
+
+                        // Deliver to A in generated order.
+                        for action in &actions {
+                            svc_a
+                                .clone()
+                                .oneshot(action_to_op(action, map, key))
+                                .await
+                                .unwrap();
+                        }
+
+                        // Deliver the SAME multiset to B in a different order: a
+                        // deterministic rotation derived from the case seed.
+                        let mut reordered = actions.clone();
+                        if !reordered.is_empty() {
+                            let rot = (shuffle_seed as usize) % reordered.len();
+                            reordered.rotate_left(rot);
+                        }
+                        for action in &reordered {
+                            svc_b
+                                .clone()
+                                .oneshot(action_to_op(action, map, key))
+                                .await
+                                .unwrap();
+                        }
+
+                        let state_a = read_or_map(&factory_a, map, key).await;
+                        let state_b = read_or_map(&factory_b, map, key).await;
+
+                        prop_assert_eq!(
+                            &state_a,
+                            &state_b,
+                            "OrMap (records, tombstones) must converge across orders"
+                        );
+                        prop_assert_eq!(
+                            rmp_serde::to_vec_named(&state_a).unwrap(),
+                            rmp_serde::to_vec_named(&state_b).unwrap(),
+                            "serialized OrMap bytes must be identical after convergence"
+                        );
+
+                        // Merkle consistency: convergent stores must hash identically.
+                        let hash_a =
+                            merkle_a.with_ormap_tree(map, partition, |t| t.get_root_hash());
+                        let hash_b =
+                            merkle_b.with_ormap_tree(map, partition, |t| t.get_root_hash());
+                        prop_assert_eq!(
+                            hash_a,
+                            hash_b,
+                            "OR-Map merkle hashes must agree after convergence"
+                        );
+
+                        // Remove-wins invariant: no surviving record may be tombstoned.
+                        for tag in &state_a.0 {
+                            prop_assert!(
+                                !state_a.1.contains(tag),
+                                "a tombstoned tag must never appear in the visible record set"
+                            );
+                        }
+
+                        Ok(())
+                    })
+                },
+            )
+            .unwrap();
+    }
 }

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -392,23 +392,35 @@ impl CrdtService {
                 (entry, or_rec.clone())
             };
 
-            // Read existing OR-Map entries so the new entry is merged in rather than replacing.
-            // OR-Map add-wins semantics require all concurrent additions to be preserved.
+            // Read existing OR-Map state so the new entry is merged in rather than replacing.
+            // OR-Map add-wins semantics require all concurrent additions to be preserved,
+            // while observed-remove semantics require an already-tombstoned tag to stay
+            // suppressed (remove-wins: no resurrection). Inlined here rather than wiring
+            // core-rust ORMap because that primitive owns its own HLC + Merkle and is keyed
+            // map-wide; constructing one to mutate a single per-key storage slot would cost
+            // more than the set algebra it replaces. The algebra below matches core-rust
+            // ORMap (retain survivors, skip tombstoned re-adds) exactly.
             let record_value = {
                 let existing = store
                     .get(&op.key, false)
                     .await
                     .map_err(OperationError::Internal)?;
-                let mut records: Vec<OrMapEntry> = match existing.map(|r| r.value) {
-                    Some(RecordValue::OrMap { records, .. }) => records,
-                    _ => Vec::new(),
-                };
-                // Remove any existing entry with the same tag (idempotent re-add).
-                records.retain(|e| e.tag != new_entry.tag);
-                records.push(new_entry);
-                RecordValue::OrMap {
-                    records,
-                    tombstones: vec![],
+                let (mut records, tombstones) = read_or_map_state(existing.map(|r| r.value));
+
+                // Remove-wins: a tag already observed-removed is never resurrected.
+                if tombstones.contains(&new_entry.tag) {
+                    RecordValue::OrMap {
+                        records,
+                        tombstones,
+                    }
+                } else {
+                    // Remove any existing entry with the same tag (idempotent re-add).
+                    records.retain(|e| e.tag != new_entry.tag);
+                    records.push(new_entry);
+                    RecordValue::OrMap {
+                        records,
+                        tombstones,
+                    }
                 }
             };
 
@@ -438,9 +450,27 @@ impl CrdtService {
                 .and_then(|o| o.as_ref())
                 .expect("or_tag is Some(Some(_))");
 
-            // OR_REMOVE is tag-based; no timestamp sanitization needed
-            let record_value = RecordValue::OrTombstones {
-                tags: vec![tag.clone()],
+            // OR_REMOVE is tag-based; no timestamp sanitization needed.
+            // Read-modify-write over the unified OrMap shape: drop only the matched tag
+            // from records (preserving every concurrent survivor) and append the removed
+            // tag to the tombstone set. Writing the legacy destructive OrTombstones blob
+            // here would clobber all concurrent records, which is the data-loss bug.
+            let record_value = {
+                let existing = store
+                    .get(&op.key, false)
+                    .await
+                    .map_err(OperationError::Internal)?;
+                let (mut records, mut tombstones) = read_or_map_state(existing.map(|r| r.value));
+
+                records.retain(|e| e.tag != *tag);
+                // Dedup: a re-issued remove must not duplicate the tombstone.
+                if !tombstones.contains(tag) {
+                    tombstones.push(tag.clone());
+                }
+                RecordValue::OrMap {
+                    records,
+                    tombstones,
+                }
             };
             store
                 .put(
@@ -784,6 +814,24 @@ fn lww_record_to_record_value(record: &LWWRecord<rmpv::Value>) -> RecordValue {
     RecordValue::Lww {
         value,
         timestamp: record.timestamp.clone(),
+    }
+}
+
+/// Reads the current OR-Map state (active records + observed-remove tombstones)
+/// from a stored value, normalizing every prior storage shape into the unified pair.
+///
+/// Folds the retained read-only `OrTombstones` legacy blob into the tombstone set on
+/// read so legacy records participate in remove-wins on first touch (a subsequent
+/// add then correctly sees the tombstones and does not resurrect a removed tag).
+/// An absent or non-OR value yields empty state.
+fn read_or_map_state(value: Option<RecordValue>) -> (Vec<OrMapEntry>, Vec<String>) {
+    match value {
+        Some(RecordValue::OrMap {
+            records,
+            tombstones,
+        }) => (records, tombstones),
+        Some(RecordValue::OrTombstones { tags }) => (Vec::new(), tags),
+        _ => (Vec::new(), Vec::new()),
     }
 }
 

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -400,13 +400,16 @@ impl CrdtService {
                     .await
                     .map_err(OperationError::Internal)?;
                 let mut records: Vec<OrMapEntry> = match existing.map(|r| r.value) {
-                    Some(RecordValue::OrMap { records }) => records,
+                    Some(RecordValue::OrMap { records, .. }) => records,
                     _ => Vec::new(),
                 };
                 // Remove any existing entry with the same tag (idempotent re-add).
                 records.retain(|e| e.tag != new_entry.tag);
                 records.push(new_entry);
-                RecordValue::OrMap { records }
+                RecordValue::OrMap {
+                    records,
+                    tombstones: vec![],
+                }
             };
 
             store

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -2314,6 +2314,40 @@ mod tests {
         }
     }
 
+    /// Like `read_or_map` but pairs each surviving tag with its record value
+    /// (debug-formatted), so convergence assertions catch value divergence and
+    /// not merely tag/tombstone-set divergence. The reused-tag proptest pool makes
+    /// this matter: two stores could agree on the surviving tag set yet disagree on
+    /// which value won for a given tag.
+    async fn read_or_map_full(
+        factory: &Arc<RecordStoreFactory>,
+        map: &str,
+        key: &str,
+    ) -> (Vec<(String, String)>, Vec<String>) {
+        let store = factory.get_or_create(map, hash_to_partition(key));
+        match store.get(key, false).await.unwrap().map(|r| r.value) {
+            Some(RecordValue::OrMap {
+                records,
+                tombstones,
+            }) => {
+                let mut pairs: Vec<(String, String)> = records
+                    .into_iter()
+                    .map(|e| (e.tag, format!("{:?}", e.value)))
+                    .collect();
+                pairs.sort();
+                let mut tombs = tombstones;
+                tombs.sort();
+                (pairs, tombs)
+            }
+            Some(RecordValue::OrTombstones { tags }) => {
+                let mut tombs = tags;
+                tombs.sort();
+                (Vec::new(), tombs)
+            }
+            Some(RecordValue::Lww { .. }) | None => (Vec::new(), Vec::new()),
+        }
+    }
+
     /// Returns the survivor values (not tags) for a key, for human-readable
     /// assertions like "play survives".
     async fn read_or_map_values(
@@ -2455,6 +2489,15 @@ mod tests {
         // Sanity: the convergent state is ta-removed, tc-removed, tb survives.
         assert_eq!(state_a.0, vec!["tb"], "only tb survives");
         assert_eq!(state_a.1, vec!["ta", "tc"], "ta and tc tombstoned");
+
+        // Values (not just tags) must converge too: a tag winning with a different
+        // value on each store would pass the tag-set check but is still divergence.
+        let full_a = read_or_map_full(&factory_a, "tags", key).await;
+        let full_b = read_or_map_full(&factory_b, "tags", key).await;
+        assert_eq!(
+            full_a, full_b,
+            "apply_single_op convergence: records (tag→value) AND tombstones must agree"
+        );
     }
 
     // AC3 (ii) + AC4: inbound handle_ormap_push_diff convergence — one store emits
@@ -2617,6 +2660,14 @@ mod tests {
         );
         assert_eq!(state_a.0, vec!["t2", "t3"], "t2 and t3 survive");
         assert_eq!(state_a.1, vec!["t1"], "t1 tombstoned");
+
+        // Values (not just tags) must converge after bidirectional ingest.
+        let full_a = read_or_map_full(&factory_a, "tags", key).await;
+        let full_b = read_or_map_full(&factory_b, "tags", key).await;
+        assert_eq!(
+            full_a, full_b,
+            "handle_ormap_push_diff convergence: records (tag→value) AND tombstones must agree"
+        );
     }
 
     // AC6: tombstoning a tag CHANGES the OR-Map merkle hash, and a key reduced to
@@ -2818,6 +2869,16 @@ mod tests {
                             rmp_serde::to_vec_named(&state_b).unwrap(),
                             "serialized OrMap bytes must be identical after convergence"
                         );
+
+                        // Convergence here is asserted on the (tag, tombstone) sets,
+                        // NOT on per-tag values. The pool deliberately re-adds the
+                        // SAME tag with DIFFERENT values, and OR_ADD has no value
+                        // tiebreak (first-arrival wins), so a reused tag's value is
+                        // order-dependent across the two delivery orders. This is not
+                        // a production concern: real OR_ADD tags are globally unique
+                        // (HLC-based), so a tag never carries two values. Per-tag
+                        // value convergence IS asserted in the deterministic
+                        // convergence_* tests above, which use unique tags.
 
                         // Merkle consistency: convergent stores must hash identically.
                         let hash_a =

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -2462,6 +2462,7 @@ mod tests {
     // byte-identical state, tombstones are not discarded, concurrent records are
     // not clobbered.
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn convergence_handle_ormap_push_diff_both_directions() {
         use crate::service::domain::sync::SyncService;
         use crate::storage::merkle_sync::MerkleSyncManager;
@@ -2788,7 +2789,11 @@ mod tests {
                         // deterministic rotation derived from the case seed.
                         let mut reordered = actions.clone();
                         if !reordered.is_empty() {
-                            let rot = (shuffle_seed as usize) % reordered.len();
+                            // Modulo by the (usize) length bounds the result below
+                            // reordered.len(), so the narrowing back to usize cannot
+                            // truncate.
+                            let rot = usize::try_from(shuffle_seed).unwrap_or(usize::MAX)
+                                % reordered.len();
                             reordered.rotate_left(rot);
                         }
                         for action in &reordered {

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -2684,14 +2684,15 @@ mod tests {
     // AC9: concurrent-OR_REMOVE convergence proptest.
     //
     // The SimCluster harness only expresses LWW writes (no OR_ADD/OR_REMOVE) and
-    // adding an or_remove helper to it is out of scope, so the F1 scenario cannot
-    // be reached through the sim proptests. Instead this proptest mirrors the AC3
-    // two-store oracle: it generates random interleaved OR_ADD/OR_REMOVE sequences
-    // with a small reused tag pool (so concurrent adds, removes, and resurrection
-    // attempts collide), delivers the SAME multiset of ops in two DIFFERENT orders
-    // to two independent CrdtService/RecordStore pairs, and asserts the stored
-    // OrMap (records + tombstones) converges byte-identically AND that the OR-Map
-    // merkle hash agrees. This is the proptest that would have caught F1.
+    // adding an or_remove helper to it is out of scope, so the concurrent-OR_REMOVE
+    // scenario cannot be reached through the sim proptests. Instead this proptest
+    // mirrors the two-store convergence oracle: it generates random interleaved
+    // OR_ADD/OR_REMOVE sequences with a small reused tag pool (so concurrent adds,
+    // removes, and resurrection attempts collide), delivers the SAME multiset of ops
+    // in two DIFFERENT orders to two independent CrdtService/RecordStore pairs, and
+    // asserts the stored OrMap (records + tombstones) converges byte-identically AND
+    // that the OR-Map merkle hash agrees. This is the proptest that would have caught
+    // the concurrent-OR_REMOVE add-wins/remove-wins data-loss regression.
     use crate::storage::merkle_sync::{MerkleMutationObserver, MerkleSyncManager};
     use proptest::prelude::*;
 

--- a/packages/server-rust/src/service/domain/index/mutation_observer.rs
+++ b/packages/server-rust/src/service/domain/index/mutation_observer.rs
@@ -275,7 +275,10 @@ mod tests {
 
     fn make_ormap_record() -> Record {
         Record {
-            value: RecordValue::OrMap { records: vec![] },
+            value: RecordValue::OrMap {
+                records: vec![],
+                tombstones: vec![],
+            },
             metadata: RecordMetadata::new(1_000_000, 64),
         }
     }

--- a/packages/server-rust/src/service/domain/search/mod.rs
+++ b/packages/server-rust/src/service/domain/search/mod.rs
@@ -815,7 +815,7 @@ impl MutationObserver for SearchMutationObserver {
 fn record_to_rmpv(record_value: &RecordValue) -> rmpv::Value {
     match record_value {
         RecordValue::Lww { value, .. } => value_to_rmpv(value),
-        RecordValue::OrMap { records } => {
+        RecordValue::OrMap { records, .. } => {
             // OR-Map entries carry individual Values indexed by tag.
             // Wrap as an array of values for text extraction.
             let items: Vec<rmpv::Value> = records.iter().map(|e| value_to_rmpv(&e.value)).collect();

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -417,7 +417,10 @@ impl SyncService {
                             .get_or_create(&map_name, key_partition);
                         if let Ok(Some(record)) = store.get(&key, false).await {
                             match record.value {
-                                RecordValue::OrMap { records, .. } => {
+                                RecordValue::OrMap {
+                                    records,
+                                    tombstones,
+                                } => {
                                     let wire_records: Vec<ORMapRecord<rmpv::Value>> = records
                                         .into_iter()
                                         .map(|r| ORMapRecord {
@@ -427,10 +430,12 @@ impl SyncService {
                                             ttl_ms: None,
                                         })
                                         .collect();
+                                    // Carry tombstones so remove-wins suppression and
+                                    // add-wins survival both replicate to the peer.
                                     entries.push(ORMapEntry {
                                         key,
                                         records: wire_records,
-                                        tombstones: Vec::new(),
+                                        tombstones,
                                     });
                                 }
                                 RecordValue::OrTombstones { tags } => {
@@ -507,7 +512,10 @@ impl SyncService {
                     .get_or_create(&map_name, key_partition);
                 if let Ok(Some(record)) = store.get(&key, false).await {
                     match record.value {
-                        RecordValue::OrMap { records, .. } => {
+                        RecordValue::OrMap {
+                            records,
+                            tombstones,
+                        } => {
                             let wire_records: Vec<ORMapRecord<rmpv::Value>> = records
                                 .into_iter()
                                 .map(|r| ORMapRecord {
@@ -517,10 +525,12 @@ impl SyncService {
                                     ttl_ms: None,
                                 })
                                 .collect();
+                            // Carry tombstones so remove-wins suppression and
+                            // add-wins survival both replicate to the peer.
                             entries.push(ORMapEntry {
                                 key,
                                 records: wire_records,
-                                tombstones: Vec::new(),
+                                tombstones,
                             });
                         }
                         RecordValue::OrTombstones { tags } => {
@@ -582,7 +592,10 @@ impl SyncService {
                 .get_or_create(&map_name, key_partition);
             match store.get(&key, false).await {
                 Ok(Some(record)) => match record.value {
-                    RecordValue::OrMap { records, .. } => {
+                    RecordValue::OrMap {
+                        records,
+                        tombstones,
+                    } => {
                         let wire_records: Vec<ORMapRecord<rmpv::Value>> = records
                             .into_iter()
                             .map(|r| ORMapRecord {
@@ -592,10 +605,12 @@ impl SyncService {
                                 ttl_ms: None,
                             })
                             .collect();
+                        // Carry tombstones so remove-wins suppression and
+                        // add-wins survival both replicate to the peer.
                         entries.push(ORMapEntry {
                             key,
                             records: wire_records,
-                            tombstones: Vec::new(),
+                            tombstones,
                         });
                     }
                     RecordValue::OrTombstones { tags } => {
@@ -660,23 +675,57 @@ impl SyncService {
             let store = self
                 .record_store_factory
                 .get_or_create(&map_name, key_partition);
-            // Convert wire-format ORMapRecords to storage OrMapEntries.
-            let storage_records: Vec<crate::storage::record::OrMapEntry> = entry
-                .records
-                .iter()
-                .map(|r| crate::storage::record::OrMapEntry {
+            // Read-modify-write: fold inbound records + tombstones into the
+            // locally-stored OR-Map rather than blind-clobbering it. Discarding
+            // either side would resurrect removed entries (remove-wins broken) or
+            // drop concurrent additions (add-wins broken).
+            use std::collections::BTreeSet;
+
+            let (mut merged_records, mut tombstones): (
+                Vec<crate::storage::record::OrMapEntry>,
+                BTreeSet<String>,
+            ) = match store.get(&entry.key, false).await {
+                Ok(Some(local)) => match local.value {
+                    RecordValue::OrMap {
+                        records,
+                        tombstones,
+                    } => (records, tombstones.into_iter().collect()),
+                    // Legacy persisted blob: fold its tags into the unified view.
+                    RecordValue::OrTombstones { tags } => (Vec::new(), tags.into_iter().collect()),
+                    RecordValue::Lww { .. } => (Vec::new(), BTreeSet::new()),
+                },
+                _ => (Vec::new(), BTreeSet::new()),
+            };
+
+            // Union inbound tombstones (remove-wins) before applying records, so a
+            // tag tombstoned anywhere suppresses its record everywhere.
+            tombstones.extend(entry.tombstones.iter().cloned());
+
+            // Drop any locally-stored record whose tag is now tombstoned.
+            merged_records.retain(|r| !tombstones.contains(&r.tag));
+
+            // Apply inbound records (add-wins): keep a record unless its tag is
+            // tombstoned. De-duplicate by tag so repeated pushes are idempotent.
+            for r in &entry.records {
+                if tombstones.contains(&r.tag) {
+                    continue;
+                }
+                if merged_records.iter().any(|existing| existing.tag == r.tag) {
+                    continue;
+                }
+                merged_records.push(crate::storage::record::OrMapEntry {
                     value: crate::service::domain::crdt::rmpv_to_value(&r.value),
                     tag: r.tag.clone(),
                     timestamp: r.timestamp.clone(),
-                })
-                .collect();
+                });
+            }
 
             store
                 .put(
                     &entry.key,
                     RecordValue::OrMap {
-                        records: storage_records,
-                        tombstones: vec![],
+                        records: merged_records,
+                        tombstones: tombstones.into_iter().collect(),
                     },
                     ExpiryPolicy::NONE,
                     CallerProvenance::CrdtMerge,

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -664,6 +664,7 @@ impl SyncService {
         ctx: &crate::service::operation::OperationContext,
         payload: messages::ORMapPushDiff,
     ) -> Result<OperationResponse, OperationError> {
+        use std::collections::BTreeSet;
         use topgun_core::messages::{ServerEventPayload, ServerEventType};
 
         let map_name = payload.payload.map_name;
@@ -679,8 +680,6 @@ impl SyncService {
             // locally-stored OR-Map rather than blind-clobbering it. Discarding
             // either side would resurrect removed entries (remove-wins broken) or
             // drop concurrent additions (add-wins broken).
-            use std::collections::BTreeSet;
-
             let (mut merged_records, mut tombstones): (
                 Vec<crate::storage::record::OrMapEntry>,
                 BTreeSet<String>,

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -417,7 +417,7 @@ impl SyncService {
                             .get_or_create(&map_name, key_partition);
                         if let Ok(Some(record)) = store.get(&key, false).await {
                             match record.value {
-                                RecordValue::OrMap { records } => {
+                                RecordValue::OrMap { records, .. } => {
                                     let wire_records: Vec<ORMapRecord<rmpv::Value>> = records
                                         .into_iter()
                                         .map(|r| ORMapRecord {
@@ -507,7 +507,7 @@ impl SyncService {
                     .get_or_create(&map_name, key_partition);
                 if let Ok(Some(record)) = store.get(&key, false).await {
                     match record.value {
-                        RecordValue::OrMap { records } => {
+                        RecordValue::OrMap { records, .. } => {
                             let wire_records: Vec<ORMapRecord<rmpv::Value>> = records
                                 .into_iter()
                                 .map(|r| ORMapRecord {
@@ -582,7 +582,7 @@ impl SyncService {
                 .get_or_create(&map_name, key_partition);
             match store.get(&key, false).await {
                 Ok(Some(record)) => match record.value {
-                    RecordValue::OrMap { records } => {
+                    RecordValue::OrMap { records, .. } => {
                         let wire_records: Vec<ORMapRecord<rmpv::Value>> = records
                             .into_iter()
                             .map(|r| ORMapRecord {
@@ -676,6 +676,7 @@ impl SyncService {
                     &entry.key,
                     RecordValue::OrMap {
                         records: storage_records,
+                        tombstones: vec![],
                     },
                     ExpiryPolicy::NONE,
                     CallerProvenance::CrdtMerge,

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -724,7 +724,7 @@ impl SyncService {
                     &entry.key,
                     RecordValue::OrMap {
                         records: merged_records,
-                        tombstones: tombstones.into_iter().collect(),
+                        tombstones: tombstones.iter().cloned().collect(),
                     },
                     ExpiryPolicy::NONE,
                     CallerProvenance::CrdtMerge,
@@ -732,8 +732,14 @@ impl SyncService {
                 .await
                 .map_err(|e| OperationError::Internal(anyhow::anyhow!("{e}")))?;
 
-            // Broadcast OR_ADD event for each entry.
+            // Broadcast OR_ADD only for inbound records that actually survived the
+            // merge. A record whose tag is tombstoned (remove-wins) was suppressed
+            // from stored state, so emitting an OR_ADD for it would tell subscribers
+            // to resurrect a removed entry.
             for record in &entry.records {
+                if tombstones.contains(&record.tag) {
+                    continue;
+                }
                 let event_payload = ServerEventPayload {
                     map_name: map_name.clone(),
                     key: entry.key.clone(),

--- a/packages/server-rust/src/sim/cluster.rs
+++ b/packages/server-rust/src/sim/cluster.rs
@@ -612,7 +612,7 @@ impl SimCluster {
                             timeout: None,
                         }
                     }
-                    RecordValue::OrMap { records } => {
+                    RecordValue::OrMap { records, .. } => {
                         // Deliver each OR-Map entry as a separate op.
                         // Use the first entry's tag as representative for simplicity;
                         // full OR-Map convergence goes through or_write/merkle_sync_pair.
@@ -769,7 +769,7 @@ impl SimCluster {
                         timeout: None,
                     }
                 }
-                RecordValue::OrMap { records } => {
+                RecordValue::OrMap { records, .. } => {
                     // Transfer all OR-Map entries; destination merges via CRDT semantics.
                     for entry in records {
                         let op = ClientOp {

--- a/packages/server-rust/src/storage/datastores/postgres.rs
+++ b/packages/server-rust/src/storage/datastores/postgres.rs
@@ -636,13 +636,14 @@ mod tests {
                     node_id: "node-2".to_string(),
                 },
             }],
+            tombstones: vec![],
         };
 
         let bytes = rmp_serde::to_vec_named(&value).expect("serialize");
         let restored: RecordValue = rmp_serde::from_slice(&bytes).expect("deserialize");
 
         match restored {
-            RecordValue::OrMap { records } => {
+            RecordValue::OrMap { records, .. } => {
                 assert_eq!(records.len(), 1);
                 assert_eq!(records[0].tag, "tag-1");
                 assert!(matches!(records[0].value, Value::Int(42)));

--- a/packages/server-rust/src/storage/merkle_sync.rs
+++ b/packages/server-rust/src/storage/merkle_sync.rs
@@ -285,12 +285,22 @@ fn compute_lww_hash(key: &str, millis: u64, counter: u32, node_id: &str) -> u32 
 
 /// Computes the entry hash for an OR-Map record.
 ///
-/// Sorts tags for determinism, then hashes `"key:tag1|tag2|..."`.
-fn compute_ormap_hash(key: &str, records: &[super::record::OrMapEntry]) -> u32 {
+/// Sorts active tags and tombstone tags independently for determinism, then
+/// hashes `"key:tag1|tag2|...#tomb1|tomb2|..."`. Tombstones are folded in so the
+/// hash changes when a tag is removed — otherwise peers cannot observe a
+/// tombstone-only delta and remove-wins suppression would not replicate.
+fn compute_ormap_hash(
+    key: &str,
+    records: &[super::record::OrMapEntry],
+    tombstones: &[String],
+) -> u32 {
     let mut tags: Vec<&str> = records.iter().map(|r| r.tag.as_str()).collect();
     tags.sort_unstable();
     let joined = tags.join("|");
-    fnv1a_hash(&format!("key:{key}|{joined}"))
+    let mut tomb_tags: Vec<&str> = tombstones.iter().map(String::as_str).collect();
+    tomb_tags.sort_unstable();
+    let joined_tombs = tomb_tags.join("|");
+    fnv1a_hash(&format!("key:{key}|{joined}#{joined_tombs}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -334,8 +344,11 @@ impl MerkleMutationObserver {
                 self.manager
                     .update_lww(&self.map_name, self.partition_id, key, hash);
             }
-            RecordValue::OrMap { records, .. } => {
-                let hash = compute_ormap_hash(key, records);
+            RecordValue::OrMap {
+                records,
+                tombstones,
+            } => {
+                let hash = compute_ormap_hash(key, records, tombstones);
                 self.manager
                     .update_ormap(&self.map_name, self.partition_id, key, hash);
             }

--- a/packages/server-rust/src/storage/merkle_sync.rs
+++ b/packages/server-rust/src/storage/merkle_sync.rs
@@ -334,7 +334,7 @@ impl MerkleMutationObserver {
                 self.manager
                     .update_lww(&self.map_name, self.partition_id, key, hash);
             }
-            RecordValue::OrMap { records } => {
+            RecordValue::OrMap { records, .. } => {
                 let hash = compute_ormap_hash(key, records);
                 self.manager
                     .update_ormap(&self.map_name, self.partition_id, key, hash);
@@ -472,6 +472,7 @@ mod tests {
                         node_id: "node-1".to_string(),
                     },
                 }],
+                tombstones: vec![],
             },
             #[allow(clippy::cast_possible_wrap)]
             metadata: RecordMetadata::new(millis as i64, 64),

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -114,7 +114,12 @@ pub enum RecordValue {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         tombstones: Vec<String>,
     },
-    /// Tombstone markers for OR-Map deletions.
+    /// Legacy tombstone-only markers for OR-Map deletions.
+    ///
+    /// Retained read-only: new code NEVER writes this variant — removals now live
+    /// in `OrMap.tombstones` alongside active records. Kept decodable so blobs
+    /// persisted by older servers still deserialize on restart, and folded into
+    /// the unified `OrMap.tombstones` view when read by the merge path.
     OrTombstones {
         /// Tags of removed OR-Map entries.
         tags: Vec<String>,
@@ -145,4 +150,83 @@ pub struct Record {
     pub value: RecordValue,
     /// Server-internal metadata (NOT sent over the wire).
     pub metadata: RecordMetadata,
+}
+
+#[cfg(test)]
+mod or_map_tombstone_tests {
+    use super::*;
+
+    fn ts(millis: u64, counter: u32) -> Timestamp {
+        Timestamp {
+            millis,
+            counter,
+            node_id: "node-a".to_string(),
+        }
+    }
+
+    /// Active records and tombstones must coexist in the same serialized blob:
+    /// the unified `OrMap` shape carries live additions and observed-remove
+    /// tombstones together, so neither half may be dropped on round-trip.
+    #[test]
+    fn or_map_records_and_tombstones_coexist_round_trip() {
+        let original = RecordValue::OrMap {
+            records: vec![
+                OrMapEntry {
+                    value: Value::String("alice".to_string()),
+                    tag: "tag-1".to_string(),
+                    timestamp: ts(100, 0),
+                },
+                OrMapEntry {
+                    value: Value::Int(42),
+                    tag: "tag-2".to_string(),
+                    timestamp: ts(101, 0),
+                },
+            ],
+            tombstones: vec!["tag-removed-1".to_string(), "tag-removed-2".to_string()],
+        };
+
+        let bytes = rmp_serde::to_vec_named(&original).expect("serialize OrMap");
+        let decoded: RecordValue = rmp_serde::from_slice(&bytes).expect("deserialize OrMap");
+
+        match decoded {
+            RecordValue::OrMap {
+                records,
+                tombstones,
+            } => {
+                assert_eq!(records.len(), 2, "both active records must survive");
+                assert_eq!(records[0].tag, "tag-1");
+                assert_eq!(records[1].tag, "tag-2");
+                assert_eq!(
+                    tombstones,
+                    vec!["tag-removed-1".to_string(), "tag-removed-2".to_string()],
+                    "tombstones must survive alongside records"
+                );
+            }
+            other => panic!("expected OrMap, got {other:?}"),
+        }
+    }
+
+    /// Legacy tombstone-only blobs persisted by older servers must still decode
+    /// on restart — no migration, no un-decodable key (durability guarantee).
+    #[test]
+    fn legacy_or_tombstones_blob_round_trips() {
+        let legacy = RecordValue::OrTombstones {
+            tags: vec!["legacy-tag-1".to_string(), "legacy-tag-2".to_string()],
+        };
+
+        let bytes = rmp_serde::to_vec_named(&legacy).expect("serialize legacy OrTombstones");
+        let decoded: RecordValue =
+            rmp_serde::from_slice(&bytes).expect("legacy blob must still decode");
+
+        match decoded {
+            RecordValue::OrTombstones { tags } => {
+                assert_eq!(
+                    tags,
+                    vec!["legacy-tag-1".to_string(), "legacy-tag-2".to_string()],
+                    "legacy tombstone tags must round-trip intact"
+                );
+            }
+            other => panic!("expected OrTombstones, got {other:?}"),
+        }
+    }
 }

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -106,6 +106,13 @@ pub enum RecordValue {
     OrMap {
         /// All currently active entries in the OR-Map.
         records: Vec<OrMapEntry>,
+        /// Tags of entries that have been removed but not yet garbage-collected.
+        ///
+        /// Coexists with `records` so both live additions and observed-remove
+        /// tombstones are carried in the same storage slot. Empty on all paths
+        /// today; the read-modify-write `OR_REMOVE` fix populates this field.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        tombstones: Vec<String>,
     },
     /// Tombstone markers for OR-Map deletions.
     OrTombstones {

--- a/packages/server-rust/tests/simulation/crdt_convergence.rs
+++ b/packages/server-rust/tests/simulation/crdt_convergence.rs
@@ -9,7 +9,7 @@ use topgun_server::storage::record::{OrMapEntry, RecordValue};
 /// are present in its entry set. Panics with a descriptive message otherwise.
 fn assert_or_tags(value: &RecordValue, expected_tags: &[&str]) {
     match value {
-        RecordValue::OrMap { records } => {
+        RecordValue::OrMap { records, .. } => {
             let present: Vec<&str> = records
                 .iter()
                 .map(|e: &OrMapEntry| e.tag.as_str())


### PR DESCRIPTION
## What

Closes the **F1 critical data-loss bug** (TODO-474): server OR_REMOVE wrote a tombstones-only `RecordValue` via blind `put`, wholesale replacing the key's `OrMap{records}` and destroying all concurrent OR-Map values (durable loss + permanent divergence for clients joining after a remove).

SPEC-310a (enum-shape) + SPEC-310b (RMW logic + convergence tests), 9 commits.

- **310a:** `RecordValue::OrMap` gains a `tombstones` field + mechanical compile-sweep of explicit-field sites (no behavior change).
- **310b:** OR_ADD/OR_REMOVE do read-modify-write preserving `records` + `tombstones` (add-wins/remove-wins); `OrTombstones` demoted to read-only (legacy-blob decode, never written); merkle folds tombstones into the OR-Map hash; sync emits unified `ORMapEntry`; OR_ADD broadcast skipped for tombstone-suppressed push-diff records.

## Process note

These 9 commits were authored directly on local main; moved to this branch and local main reset to origin/main, per the branch→PR→gate→merge standard. AC9 (merge-flow gate) is owned here, not by /sf:done.

## Gate (verified locally — incl. the blocking sim-convergence gate F2 broke)

- `cargo test --profile ci-sim --features simulation -p topgun-server -- sim` → **all green**; `random_operations_preserve_convergence` + `random_operations_merkle_consistent` PASS (this is the gate the F2 regression tripped; F1 fix keeps it green).
- `cargo test --release -p topgun-server --lib` → 1346 passed / 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean.

## Follow-up (carved out)

- TODO-481 / SPEC-310c: sim/cluster two-node OR_REMOVE harness + blocking sim fuzz gate (extends convergence coverage to the concurrent-OR_REMOVE scenario end-to-end).
- TODO-479/480: tombstone GC/pruning + eventual removal of the read-only OrTombstones variant.

## Merge gate

Do not merge until `gh pr checks` is ALL-green (incl. Simulation Tests), verified as a separate step.