### PR TITLE
fix(merkle): collision-resistant combine across Rust core/server + TS client (SPEC-309a/b/c, F3 high)

### DIFF
--- a/packages/core-rust/src/hash.rs
+++ b/packages/core-rust/src/hash.rs
@@ -278,9 +278,9 @@ mod tests {
         assert_ne!(s1, s2);
     }
 
-    /// Pinned cross-language test vector. SPEC-309c's `hash.test.ts` MUST
-    /// reproduce this exact `u32` output bit-for-bit; it is the anchor that
-    /// proves the Rust and TS `combineHashes` implementations agree.
+    /// Pinned cross-language test vector. The TypeScript `combineHashes` port
+    /// MUST reproduce this exact `u32` output bit-for-bit; it is the anchor that
+    /// proves the Rust and TS implementations agree.
     #[test]
     fn combine_hashes_cross_language_pinned_vector() {
         assert_eq!(combine_hashes(&[0x0000_0064, 0x0000_00c8]), 0xbc1d_ab1c);

--- a/packages/core-rust/src/hash.rs
+++ b/packages/core-rust/src/hash.rs
@@ -40,11 +40,76 @@ pub fn fnv1a_hash(s: &str) -> u32 {
     hash
 }
 
-/// Combines multiple hash values into a single order-independent hash.
+/// Avalanche finalizer constants (`MurmurHash3` `fmix32`).
+const MIX_C1: u32 = 0x85eb_ca6b;
+const MIX_C2: u32 = 0xc2b2_ae35;
+
+/// Avalanche-mixes a single 32-bit hash so that small input differences spread
+/// across all output bits (`MurmurHash3` `fmix32`).
 ///
-/// Uses wrapping addition (`u32::wrapping_add`), which produces the same
-/// result as the TypeScript `(result + h) | 0` followed by `>>> 0` since
-/// overflow behavior is identical modulo 2^32.
+/// This is the non-linear step that defeats compensating-pair collisions: the
+/// combine sums `mix(h)`, not raw `h`, so two entry sets whose raw values happen
+/// to share a sum (e.g. `100 + 200` vs `250 + 50`) no longer share a combined
+/// hash, because `mix` destroys the linear relationship between inputs.
+///
+/// `mix(0) == 0`, which keeps zero an additive identity so the empty-set and
+/// remove-all invariants still resolve to `0`.
+///
+/// # Cross-language note
+///
+/// TypeScript must reproduce this bit-for-bit with `Math.imul` for the multiply
+/// steps and `>>> 0` to stay in unsigned 32-bit space:
+///
+/// ```ts
+/// function mix(h: number): number {
+///   h = (h ^ (h >>> 16)) >>> 0;
+///   h = Math.imul(h, 0x85ebca6b) >>> 0;
+///   h = (h ^ (h >>> 13)) >>> 0;
+///   h = Math.imul(h, 0xc2b2ae35) >>> 0;
+///   h = (h ^ (h >>> 16)) >>> 0;
+///   return h >>> 0;
+/// }
+/// ```
+#[must_use]
+fn mix(mut h: u32) -> u32 {
+    h ^= h >> 16;
+    h = h.wrapping_mul(MIX_C1);
+    h ^= h >> 13;
+    h = h.wrapping_mul(MIX_C2);
+    h ^= h >> 16;
+    h
+}
+
+/// Combines multiple hash values into a single order-independent, collision-
+/// resistant `u32` hash.
+///
+/// # Algorithm
+///
+/// `combine([h0, h1, ...]) = (mix(h0) + mix(h1) + ...) mod 2^32`, where `mix`
+/// is the `MurmurHash3` `fmix32` avalanche finalizer above and `+` is wrapping
+/// 32-bit addition.
+///
+/// Wrapping addition over the abelian group `(Z/2^32, +)` makes the combine:
+/// - **order-independent** — `combine([a, b, c]) == combine([c, a, b])` (trie
+///   buckets and the server's cross-partition fold iterate in non-deterministic
+///   order);
+/// - **associative across calls** — because each leaf value contributes exactly
+///   `mix(h)` to the sum, a plain `wrapping_add` of two `combine` outputs equals
+///   the `combine` of the union of their inputs, so the server (309b) can fold
+///   per-partition roots pairwise.
+///
+/// Summing `mix(h)` rather than raw `h` removes the compensating-pair collision
+/// class: there is no easily-constructible `{a, b} != {a', b'}` with
+/// `combine([a, b]) == combine([a', b'])`.
+///
+/// Empty input combines to `0`; a single input `[h]` combines to the stable
+/// value `mix(h)` (not `h`).
+///
+/// # Cross-language vector (anchor for the TS port)
+///
+/// `combine_hashes(&[0x0000_0064, 0x0000_00c8]) == 0xbc1d_ab1c`
+/// (i.e. inputs `100` and `200`). The TS `combineHashes` MUST reproduce this
+/// exact `u32`; see the pinned-vector test below.
 ///
 /// # Examples
 ///
@@ -60,7 +125,7 @@ pub fn fnv1a_hash(s: &str) -> u32 {
 pub fn combine_hashes(hashes: &[u32]) -> u32 {
     let mut result: u32 = 0;
     for &h in hashes {
-        result = result.wrapping_add(h);
+        result = result.wrapping_add(mix(h));
     }
     result
 }
@@ -163,8 +228,11 @@ mod tests {
 
     #[test]
     fn combine_hashes_single() {
+        // A single input combines to the stable avalanche-mixed value of `h`
+        // (no longer `h` itself), and the result is deterministic.
         let h = fnv1a_hash("single");
-        assert_eq!(combine_hashes(&[h]), h);
+        assert_eq!(combine_hashes(&[h]), mix(h));
+        assert_eq!(combine_hashes(&[h]), combine_hashes(&[h]));
     }
 
     #[test]
@@ -183,16 +251,24 @@ mod tests {
 
     #[test]
     fn combine_hashes_with_zero() {
+        // `mix(0) == 0`, so zero remains an additive identity: appending a
+        // zero-valued entry does not change the combined hash.
         let h = fnv1a_hash("test");
-        assert_eq!(combine_hashes(&[h, 0]), h);
-        assert_eq!(combine_hashes(&[0, h]), h);
+        assert_eq!(combine_hashes(&[h, 0]), combine_hashes(&[h]));
+        assert_eq!(combine_hashes(&[0, h]), combine_hashes(&[h]));
+        assert_eq!(mix(0), 0);
     }
 
     #[test]
     fn combine_hashes_overflow() {
+        // The fold wraps modulo 2^32 over the mixed values.
         let result = combine_hashes(&[0xFFFF_FFFF, 0xFFFF_FFFF, 0xFFFF_FFFF]);
-        // 3 * 0xFFFFFFFF = 0x2FFFFFFFD, mod 2^32 = 0xFFFFFFFD
-        assert_eq!(result, 0xFFFF_FFFD);
+        let expected = mix(0xFFFF_FFFF)
+            .wrapping_mul(3)
+            .wrapping_add(0)
+            .wrapping_add(0);
+        assert_eq!(result, expected);
+        assert_eq!(result, 0x85d4_4dab);
     }
 
     #[test]
@@ -200,5 +276,39 @@ mod tests {
         let s1 = combine_hashes(&[fnv1a_hash("a"), fnv1a_hash("b")]);
         let s2 = combine_hashes(&[fnv1a_hash("c"), fnv1a_hash("d")]);
         assert_ne!(s1, s2);
+    }
+
+    /// Pinned cross-language test vector. SPEC-309c's `hash.test.ts` MUST
+    /// reproduce this exact `u32` output bit-for-bit; it is the anchor that
+    /// proves the Rust and TS `combineHashes` implementations agree.
+    #[test]
+    fn combine_hashes_cross_language_pinned_vector() {
+        assert_eq!(combine_hashes(&[0x0000_0064, 0x0000_00c8]), 0xbc1d_ab1c);
+    }
+
+    #[test]
+    fn combine_hashes_resists_compensating_pairs() {
+        // The two collision vectors from the audit reproduction: under a plain
+        // additive fold `100 + 200 == 250 + 50` and
+        // `0xAAAA0000 + 0x5555 == 0xAAAA5555 + 0`, so divergent sets collided.
+        // The avalanche-mixed combine must keep them distinct.
+        assert_ne!(combine_hashes(&[100, 200]), combine_hashes(&[250, 50]));
+        assert_ne!(
+            combine_hashes(&[0xAAAA_0000, 0x0000_5555]),
+            combine_hashes(&[0xAAAA_5555, 0x0000_0000])
+        );
+    }
+
+    #[test]
+    fn combine_hashes_associative_across_calls() {
+        // Folding two `combine` outputs with `wrapping_add` equals combining the
+        // union — the property the server's cross-partition fold relies on.
+        let a = [fnv1a_hash("a"), fnv1a_hash("b")];
+        let b = [fnv1a_hash("c"), fnv1a_hash("d")];
+        let union: Vec<u32> = a.iter().chain(b.iter()).copied().collect();
+        assert_eq!(
+            combine_hashes(&a).wrapping_add(combine_hashes(&b)),
+            combine_hashes(&union)
+        );
     }
 }

--- a/packages/core-rust/src/hlc.rs
+++ b/packages/core-rust/src/hlc.rs
@@ -332,8 +332,16 @@ impl HLC {
             self.last_millis = system_time;
             self.last_counter = 0;
         } else {
-            // System clock unchanged or behind: increment counter
-            self.last_counter += 1;
+            // System clock unchanged or behind: increment counter.
+            // On u32 counter exhaustion within a single millisecond, roll to the
+            // next millisecond with counter 0 instead of silently wrapping to 0
+            // on the same millisecond, which would break strict monotonicity.
+            if let Some(next) = self.last_counter.checked_add(1) {
+                self.last_counter = next;
+            } else {
+                self.last_millis = self.last_millis.saturating_add(1);
+                self.last_counter = 0;
+            }
         }
 
         Timestamp {
@@ -376,17 +384,35 @@ impl HLC {
             }
         }
 
-        let max_millis = self.last_millis.max(system_time).max(remote.millis);
+        let mut max_millis = self.last_millis.max(system_time).max(remote.millis);
 
+        // Each "+ 1" below can exhaust the u32 counter. On overflow, roll to the
+        // next millisecond with counter 0 instead of silently wrapping on the
+        // same millisecond, which would break strict monotonicity.
         if max_millis == self.last_millis && max_millis == remote.millis {
             // Both clocks on the same millisecond: take max counter + 1
-            self.last_counter = self.last_counter.max(remote.counter) + 1;
+            if let Some(next) = self.last_counter.max(remote.counter).checked_add(1) {
+                self.last_counter = next;
+            } else {
+                max_millis = max_millis.saturating_add(1);
+                self.last_counter = 0;
+            }
         } else if max_millis == self.last_millis {
             // Local logical clock is ahead: just increment
-            self.last_counter += 1;
+            if let Some(next) = self.last_counter.checked_add(1) {
+                self.last_counter = next;
+            } else {
+                max_millis = max_millis.saturating_add(1);
+                self.last_counter = 0;
+            }
         } else if max_millis == remote.millis {
             // Remote clock is ahead: fast-forward
-            self.last_counter = remote.counter + 1;
+            if let Some(next) = remote.counter.checked_add(1) {
+                self.last_counter = next;
+            } else {
+                max_millis = max_millis.saturating_add(1);
+                self.last_counter = 0;
+            }
         } else {
             // System time is ahead of both: reset counter
             self.last_counter = 0;
@@ -613,6 +639,71 @@ mod tests {
         let bytes = rmp_serde::to_vec(&ts).expect("serialize");
         let decoded: Timestamp = rmp_serde::from_slice(&bytes).expect("deserialize");
         assert_eq!(ts, decoded);
+    }
+
+    // ---- HLC counter-overflow rollover tests ----
+
+    #[test]
+    fn now_counter_overflow_rolls_to_next_millisecond() {
+        // System clock stays fixed so now() takes the counter-increment branch.
+        let (clock, _) = FixedClock::new(1_000_000);
+        let mut hlc = HLC::new("test-node".to_string(), Box::new(clock));
+
+        // Drive the logical clock to the brink of u32 counter exhaustion.
+        hlc.last_millis = 1_000_000;
+        hlc.last_counter = u32::MAX;
+
+        let ts = hlc.now();
+
+        assert_eq!(
+            ts.millis, 1_000_001,
+            "counter overflow must roll to the next millisecond"
+        );
+        assert_eq!(
+            ts.counter, 0,
+            "counter must reset to 0 on rollover, not wrap"
+        );
+    }
+
+    #[test]
+    fn update_same_millisecond_counter_overflow_rolls_to_next_millisecond() {
+        // Fix the system clock on the same millisecond as both local and remote
+        // so update() takes the same-millisecond max-counter + 1 branch.
+        let (clock, _) = FixedClock::new(1_000_000);
+        let mut hlc = HLC::new("test-node".to_string(), Box::new(clock));
+
+        hlc.last_millis = 1_000_000;
+        hlc.last_counter = u32::MAX;
+
+        let remote = Timestamp {
+            millis: 1_000_000,
+            counter: u32::MAX,
+            node_id: "remote".to_string(),
+        };
+
+        hlc.update(&remote).expect("update should succeed");
+
+        assert_eq!(
+            hlc.last_millis, 1_000_001,
+            "update counter overflow must roll to the next millisecond"
+        );
+        assert_eq!(
+            hlc.last_counter, 0,
+            "update counter must reset to 0 on rollover, not wrap"
+        );
+
+        // Monotonicity: the next emitted timestamp must exceed the pre-overflow state.
+        let pre_overflow = Timestamp {
+            millis: 1_000_000,
+            counter: u32::MAX,
+            node_id: "test-node".to_string(),
+        };
+        let after = Timestamp {
+            millis: hlc.last_millis,
+            counter: hlc.last_counter,
+            node_id: "test-node".to_string(),
+        };
+        assert!(after > pre_overflow, "rollover must preserve monotonicity");
     }
 
     // ---- HLC::now() monotonicity tests ----

--- a/packages/core-rust/src/merkle.rs
+++ b/packages/core-rust/src/merkle.rs
@@ -7,16 +7,16 @@
 
 use std::collections::HashMap;
 
-use crate::hash::fnv1a_hash;
+use crate::hash::{combine_hashes, fnv1a_hash};
 
 /// A node in the `MerkleTree` prefix trie.
 ///
 /// Internal nodes have `children` (keyed by hex digit). Leaf nodes have `entries`
 /// (keyed by the original string key, mapping to the content hash). The `hash`
-/// field is the wrapping sum of all child/entry hashes.
+/// field is the collision-resistant combine of all child/entry hashes.
 #[derive(Debug, Clone)]
 pub struct MerkleNode {
-    /// Aggregated hash of all descendants (wrapping sum).
+    /// Aggregated hash of all descendants (order-independent collision-resistant combine).
     pub hash: u32,
     /// Child nodes keyed by hex digit (0-9, a-f). Present on internal nodes.
     pub children: HashMap<char, MerkleNode>,
@@ -88,22 +88,18 @@ fn trie_remove_node(node: &mut MerkleNode, key: &str, path: &str, level: usize, 
     node.hash = recalc_internal_hash(&node.children);
 }
 
-/// Recalculates a leaf node's hash from its entries (wrapping sum).
+/// Recalculates a leaf node's hash from its entries using the collision-resistant
+/// order-independent combine.
 fn recalc_leaf_hash(entries: &HashMap<String, u32>) -> u32 {
-    let mut h: u32 = 0;
-    for &val in entries.values() {
-        h = h.wrapping_add(val);
-    }
-    h
+    let values: Vec<u32> = entries.values().copied().collect();
+    combine_hashes(&values)
 }
 
-/// Recalculates an internal node's hash from its children (wrapping sum).
+/// Recalculates an internal node's hash from its children using the collision-resistant
+/// order-independent combine.
 fn recalc_internal_hash(children: &HashMap<char, MerkleNode>) -> u32 {
-    let mut h: u32 = 0;
-    for child in children.values() {
-        h = h.wrapping_add(child.hash);
-    }
-    h
+    let hashes: Vec<u32> = children.values().map(|c| c.hash).collect();
+    combine_hashes(&hashes)
 }
 
 /// A `MerkleTree` for efficient delta synchronization of LWW-Maps.

--- a/packages/core-rust/tests/audit_merkle_repro.rs
+++ b/packages/core-rust/tests/audit_merkle_repro.rs
@@ -1,0 +1,78 @@
+// Permanent regression proof for the Merkle root-hash collision class.
+//
+// Run: SDKROOT=$(xcrun --sdk macosx --show-sdk-path) cargo test -p topgun-core --test audit_merkle_repro -- --nocapture
+//
+// The previous additive (`wrapping_add`) Merkle aggregation let two divergent
+// trees share a root hash via a compensating change across entries, making the
+// root-equality "are we in sync?" signal unsound -> a silent missed diff in
+// delta-sync. The two `assert_ne!` tests below pin that the collision is no
+// longer constructible under the order-independent, collision-resistant combine;
+// the negative control proves the detection is specific to the divergence, not a
+// tree bug.
+
+use topgun_core::merkle::MerkleTree;
+
+#[test]
+fn additive_root_hash_collision_hides_divergence() {
+    let mut a = MerkleTree::default_depth();
+    a.update("a", 100);
+    a.update("b", 200);
+
+    let mut b = MerkleTree::default_depth();
+    b.update("a", 250); // DIFFERENT content
+    b.update("b", 50); // additive scheme would offset so the sum still matched
+
+    // The collision-resistant combine must diverge at the bucket level...
+    assert_ne!(
+        a.get_buckets(""),
+        b.get_buckets(""),
+        "divergent leaves must produce divergent bucket hashes"
+    );
+    // ...and at the root level: two different trees must NOT share a root hash.
+    assert_ne!(
+        a.get_root_hash(),
+        b.get_root_hash(),
+        "two DIFFERENT trees must report DIFFERENT root hashes"
+    );
+}
+
+#[test]
+fn root_equality_used_as_in_sync_signal_is_unsound() {
+    let mut local = MerkleTree::default_depth();
+    local.update("k1", 0xAAAA_0000);
+    local.update("k2", 0x0000_5555);
+
+    let mut remote = MerkleTree::default_depth();
+    remote.update("k1", 0xAAAA_5555); // k1 differs
+    remote.update("k2", 0x0000_0000); // k2 differs; additive sum would have matched
+
+    // Roots differ, so a root-only comparison correctly decides the replicas are
+    // out of sync and drills down -- the divergent keys get reconciled.
+    assert_ne!(
+        local.get_root_hash(),
+        remote.get_root_hash(),
+        "root-only sync must detect that k1 AND k2 both diverge"
+    );
+    let would_sync = local.get_root_hash() != remote.get_root_hash();
+    assert!(
+        would_sync,
+        "root-equality must NOT conclude IN-SYNC when both keys diverge"
+    );
+}
+
+#[test]
+fn negative_control_uncompensated_divergence_is_detected() {
+    let mut a = MerkleTree::default_depth();
+    a.update("a", 100);
+    a.update("b", 200);
+
+    let mut b = MerkleTree::default_depth();
+    b.update("a", 250); // different, NOT compensated
+    b.update("b", 200);
+
+    assert_ne!(
+        a.get_root_hash(),
+        b.get_root_hash(),
+        "uncompensated divergence MUST be detected"
+    );
+}

--- a/packages/core/src/MerkleTree.ts
+++ b/packages/core/src/MerkleTree.ts
@@ -1,5 +1,5 @@
 import { LWWRecord } from './LWWMap';
-import { hashString } from './utils/hash';
+import { combineHashes, hashString } from './utils/hash';
 
 export interface MerkleNode {
   hash: number;
@@ -63,12 +63,8 @@ export class MerkleTree {
       if (node.entries) {
         node.entries.delete(key);
 
-        // Recalculate leaf hash
-        let h = 0;
-        for (const val of node.entries.values()) {
-          h = (h + val) | 0;
-        }
-        node.hash = h >>> 0;
+        // Recalculate leaf hash (collision-resistant combine of item hashes)
+        node.hash = combineHashes([...node.entries.values()]);
       }
       return node.hash;
     }
@@ -85,13 +81,9 @@ export class MerkleTree {
     }
 
     // Recalculate this node's hash from children
-    let h = 0;
-    if (node.children) {
-      for (const child of Object.values(node.children)) {
-        h = (h + child.hash) | 0;
-      }
-    }
-    node.hash = h >>> 0;
+    node.hash = node.children
+      ? combineHashes(Object.values(node.children).map((child) => child.hash))
+      : 0;
     return node.hash;
   }
 
@@ -107,12 +99,8 @@ export class MerkleTree {
       if (!node.entries) node.entries = new Map();
       node.entries.set(key, itemHash);
 
-      // Recalculate leaf hash (Sum of item hashes)
-      let h = 0;
-      for (const val of node.entries.values()) {
-        h = (h + val) | 0;
-      }
-      node.hash = h >>> 0;
+      // Recalculate leaf hash (collision-resistant combine of item hashes)
+      node.hash = combineHashes([...node.entries.values()]);
       return node.hash;
     }
 
@@ -127,11 +115,7 @@ export class MerkleTree {
     this.updateNode(node.children[bucketChar], key, itemHash, pathHash, level + 1);
 
     // Recalculate this node's hash from children
-    let h = 0;
-    for (const child of Object.values(node.children)) {
-      h = (h + child.hash) | 0;
-    }
-    node.hash = h >>> 0;
+    node.hash = combineHashes(Object.values(node.children).map((child) => child.hash));
     return node.hash;
   }
 

--- a/packages/core/src/ORMapMerkleTree.ts
+++ b/packages/core/src/ORMapMerkleTree.ts
@@ -1,5 +1,5 @@
 import { ORMap, ORMapRecord } from './ORMap';
-import { hashString } from './utils/hash';
+import { combineHashes, hashString } from './utils/hash';
 import { hashORMapEntry } from './ORMapMerkle';
 
 /**
@@ -91,12 +91,8 @@ export class ORMapMerkleTree {
       if (!node.entries) node.entries = new Map();
       node.entries.set(key, entryHash);
 
-      // Recalculate leaf hash (Sum of entry hashes)
-      let h = 0;
-      for (const val of node.entries.values()) {
-        h = (h + val) | 0;
-      }
-      node.hash = h >>> 0;
+      // Recalculate leaf hash (collision-resistant combine of entry hashes)
+      node.hash = combineHashes([...node.entries.values()]);
       return node.hash;
     }
 
@@ -111,11 +107,7 @@ export class ORMapMerkleTree {
     this.updateNode(node.children[bucketChar], key, entryHash, pathHash, level + 1);
 
     // Recalculate this node's hash from children
-    let h = 0;
-    for (const child of Object.values(node.children)) {
-      h = (h + child.hash) | 0;
-    }
-    node.hash = h >>> 0;
+    node.hash = combineHashes(Object.values(node.children).map((child) => child.hash));
     return node.hash;
   }
 
@@ -125,12 +117,8 @@ export class ORMapMerkleTree {
       if (node.entries) {
         node.entries.delete(key);
 
-        // Recalculate leaf hash
-        let h = 0;
-        for (const val of node.entries.values()) {
-          h = (h + val) | 0;
-        }
-        node.hash = h >>> 0;
+        // Recalculate leaf hash (collision-resistant combine of entry hashes)
+        node.hash = combineHashes([...node.entries.values()]);
       }
       return node.hash;
     }
@@ -142,13 +130,9 @@ export class ORMapMerkleTree {
     }
 
     // Recalculate this node's hash from children
-    let h = 0;
-    if (node.children) {
-      for (const child of Object.values(node.children)) {
-        h = (h + child.hash) | 0;
-      }
-    }
-    node.hash = h >>> 0;
+    node.hash = node.children
+      ? combineHashes(Object.values(node.children).map((child) => child.hash))
+      : 0;
     return node.hash;
   }
 

--- a/packages/core/src/__tests__/hash.test.ts
+++ b/packages/core/src/__tests__/hash.test.ts
@@ -223,18 +223,25 @@ describe('Hash utilities', () => {
       });
 
       test('should handle single hash', () => {
+        // A single input combines to the stable avalanche-mixed value of `hash`
+        // (no longer `hash` itself), matching the Rust combine_hashes_single test.
         const hash = hashString('single');
         const combined = combineHashes([hash]);
-        expect(combined).toBe(hash >>> 0);
+        expect(combined).toBe(0xf0047af6);
+        expect(combineHashes([hash])).toBe(combined); // deterministic
       });
 
       test('should handle array with zero', () => {
+        // mix(0) === 0, so zero remains an additive identity: appending a
+        // zero-valued entry does not change the combined hash. Matches the Rust
+        // combine_hashes_with_zero test.
         const h1 = hashString('test');
         const combined1 = combineHashes([h1, 0]);
         const combined2 = combineHashes([0, h1]);
 
         expect(combined1).toBe(combined2);
-        expect(combined1).toBe(h1 >>> 0);
+        expect(combined1).toBe(0xd3705a82);
+        expect(combined1).toBe(combineHashes([h1]));
       });
 
       test('should handle large numbers', () => {
@@ -282,6 +289,24 @@ describe('Hash utilities', () => {
         expect(combined1).not.toBe(combined2);
         expect(combined1).not.toBe(combined3);
         expect(combined2).not.toBe(combined3);
+      });
+    });
+
+    describe('Cross-language parity', () => {
+      // Pinned cross-language vector: the Rust combine_hashes(&[0x64, 0xc8]) test
+      // asserts this exact u32. The TS port must reproduce it bit-for-bit so a Rust
+      // replica and a TS replica with identical data agree on Merkle root hashes.
+      test('reproduces the Rust pinned vector for inputs [100, 200]', () => {
+        expect(combineHashes([100, 200])).toBe(0xbc1dab1c >>> 0);
+      });
+
+      // Avalanche mixing must keep compensating pairs distinct: under a plain
+      // additive fold 100 + 200 === 250 + 50, so divergent sets used to collide.
+      test('resists compensating-pair collisions', () => {
+        expect(combineHashes([100, 200])).not.toBe(combineHashes([250, 50]));
+        expect(combineHashes([0xaaaa0000, 0x00005555])).not.toBe(
+          combineHashes([0xaaaa5555, 0x00000000]),
+        );
       });
     });
 

--- a/packages/core/src/utils/hash.ts
+++ b/packages/core/src/utils/hash.ts
@@ -22,11 +22,49 @@ export function hashString(str: string): number {
   return hash >>> 0; // Ensure positive 32-bit integer
 }
 
+// MurmurHash3 fmix32 avalanche finalizer constants.
+const MIX_C1 = 0x85ebca6b;
+const MIX_C2 = 0xc2b2ae35;
+
 /**
- * Combines multiple hash numbers into one order-independent hash.
- * Used for combining bucket hashes in Merkle trees.
+ * Avalanche-mixes a single 32-bit hash so small input differences spread across
+ * all output bits (MurmurHash3 fmix32).
  *
- * Uses simple sum (with overflow handling) for order-independence.
+ * This non-linear step is what defeats compensating-pair collisions: the combine
+ * sums mix(h), not raw h, so two entry sets whose raw values happen to share a
+ * sum (e.g. 100 + 200 vs 250 + 50) no longer share a combined hash.
+ *
+ * mix(0) === 0, which keeps zero an additive identity so the empty-node and
+ * remove-all invariants still resolve to 0.
+ *
+ * Math.imul does the 32-bit multiplies and `>>> 0` stays in unsigned 32-bit
+ * space — this mirrors the Rust mix() bit-for-bit for cross-language parity.
+ */
+function mix(h: number): number {
+  h = (h ^ (h >>> 16)) >>> 0;
+  h = Math.imul(h, MIX_C1) >>> 0;
+  h = (h ^ (h >>> 13)) >>> 0;
+  h = Math.imul(h, MIX_C2) >>> 0;
+  h = (h ^ (h >>> 16)) >>> 0;
+  return h >>> 0;
+}
+
+/**
+ * Combines multiple hash numbers into one order-independent, collision-resistant
+ * 32-bit hash.
+ *
+ * combine([h0, h1, ...]) = (mix(h0) + mix(h1) + ...) mod 2^32, where mix is the
+ * MurmurHash3 fmix32 avalanche above and + is wrapping 32-bit addition.
+ *
+ * Wrapping addition over (Z/2^32, +) makes the combine order-independent (trie
+ * buckets iterate in non-deterministic order) and associative across calls.
+ * Summing mix(h) rather than raw h removes the compensating-pair collision class.
+ *
+ * This must reproduce the Rust combine_hashes bit-for-bit so a Rust replica and a
+ * TS replica holding identical (key, item-hash) sets compute the same Merkle root
+ * hash and sync converges cross-language.
+ *
+ * Empty input combines to 0; a single input [h] combines to mix(h) (not h).
  *
  * @param hashes - Array of hash values to combine
  * @returns Combined hash as 32-bit unsigned integer
@@ -34,7 +72,7 @@ export function hashString(str: string): number {
 export function combineHashes(hashes: number[]): number {
   let result = 0;
   for (const h of hashes) {
-    result = (result + h) | 0; // Simple sum with overflow
+    result = (result + mix(h)) | 0; // Wrapping 32-bit add of avalanche-mixed values
   }
   return result >>> 0;
 }

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -916,7 +916,9 @@ mod tests {
             connection_registry,
         ));
 
-        let expected_root = merkle_manager.with_lww_tree("users", 0, |tree| tree.get_root_hash());
+        // SyncInit returns the cross-partition aggregate, not the raw partition
+        // root, so the expected value is the collision-resistant combine.
+        let expected_root = merkle_manager.aggregate_lww_root_hash("users");
         assert_ne!(
             expected_root, 0,
             "precondition: tree must have non-zero hash"
@@ -1229,7 +1231,9 @@ mod tests {
             Arc::new(ConnectionRegistry::new()),
         ));
 
-        let expected_root = merkle_manager.with_ormap_tree("tags", 0, |tree| tree.get_root_hash());
+        // ORMapSyncInit returns the cross-partition aggregate, not the raw
+        // partition root, so the expected value is the collision-resistant combine.
+        let expected_root = merkle_manager.aggregate_ormap_root_hash("tags");
         assert_ne!(
             expected_root, 0,
             "precondition: OR-Map tree must have non-zero hash"

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -136,9 +136,13 @@ impl SyncService {
     /// `SyncInitMessage` is a FLAT message: `map_name` is directly on the payload struct,
     /// not nested in a `.payload` sub-field (contrast with `MerkleReqBucketMessage`).
     ///
-    /// Returns a scatter-gathered root hash: the `wrapping_add` of all per-partition
-    /// root hashes. This eliminates the Mutex bottleneck on a shared partition 0
-    /// that previously serialized all writes under concurrent load.
+    /// Returns a scatter-gathered root hash: the collision-resistant combine of all
+    /// per-partition root hashes. This eliminates the Mutex bottleneck on a shared
+    /// partition 0 that previously serialized all writes under concurrent load. The
+    /// combine is order-independent (commutative + associative) so `DashMap`'s
+    /// non-deterministic iteration order does not affect the aggregate, yet resists the
+    /// compensating-pair collision that plain additive folding would reintroduce one
+    /// level above the trie.
     #[allow(clippy::unused_async)] // declared async for uniformity with other handlers
     async fn handle_sync_init(
         &self,
@@ -167,7 +171,9 @@ impl SyncService {
     ///
     /// Path encoding operates in two modes:
     /// - **Aggregate mode** (`""` or paths without a 3-digit partition prefix): the server
-    ///   combines results from all partition trees via `wrapping_add` for hashes.
+    ///   combines results from all partition trees via the order-independent,
+    ///   collision-resistant combine for hashes (not plain additive folding, which would
+    ///   reintroduce the compensating-pair collision one level above the trie).
     /// - **Routed mode** (paths beginning with a 3-digit zero-padded partition prefix like
     ///   `"042/abc"`): the server strips the prefix and routes to the specific partition tree.
     #[allow(clippy::too_many_lines)] // two-mode dispatch (routed vs aggregate) with leaf collection is inherently verbose

--- a/packages/server-rust/src/storage/merkle_sync.rs
+++ b/packages/server-rust/src/storage/merkle_sync.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use parking_lot::Mutex;
-use topgun_core::hash::fnv1a_hash;
+use topgun_core::hash::{combine_hashes, fnv1a_hash};
 use topgun_core::merkle::{MerkleTree, ORMapMerkleTree};
 
 use super::factory::ObserverFactory;
@@ -135,19 +135,20 @@ impl MerkleSyncManager {
 
     /// Aggregates LWW root hashes across all partitions for `map_name`.
     ///
-    /// Returns the `wrapping_add` of all per-partition root hashes.
-    /// Returns 0 when no partitions exist for the given map.
-    /// `wrapping_add` is commutative and associative, so the result is
-    /// independent of `DashMap`'s non-deterministic iteration order.
+    /// Combines all per-partition root hashes with the collision-resistant
+    /// `combine_hashes`. Returns 0 when no partitions exist for the given map.
+    /// `combine_hashes` is commutative and associative, so the result is
+    /// independent of `DashMap`'s non-deterministic iteration order, while
+    /// avoiding the compensating-pair collisions a plain additive fold admits.
     #[must_use]
     pub fn aggregate_lww_root_hash(&self, map_name: &str) -> u32 {
-        self.lww_trees
+        let hashes: Vec<u32> = self
+            .lww_trees
             .iter()
             .filter(|entry| entry.key().0 == map_name)
-            .fold(0u32, |acc, entry| {
-                let hash = entry.value().lock().get_root_hash();
-                acc.wrapping_add(hash)
-            })
+            .map(|entry| entry.value().lock().get_root_hash())
+            .collect();
+        combine_hashes(&hashes)
     }
 
     /// Aggregates OR-Map root hashes across all partitions for `map_name`.
@@ -155,36 +156,39 @@ impl MerkleSyncManager {
     /// Same aggregation strategy as `aggregate_lww_root_hash`.
     #[must_use]
     pub fn aggregate_ormap_root_hash(&self, map_name: &str) -> u32 {
-        self.ormap_trees
+        let hashes: Vec<u32> = self
+            .ormap_trees
             .iter()
             .filter(|entry| entry.key().0 == map_name)
-            .fold(0u32, |acc, entry| {
-                let hash = entry.value().lock().get_root_hash();
-                acc.wrapping_add(hash)
-            })
+            .map(|entry| entry.value().lock().get_root_hash())
+            .collect();
+        combine_hashes(&hashes)
     }
 
     /// Aggregates LWW bucket hashes at `path` across all partitions for `map_name`.
     ///
-    /// For each hex bucket character, combines partition values via `wrapping_add`.
-    /// Returns a `HashMap<char, u32>` with the combined hashes, suitable for
-    /// returning as a `SyncRespBuckets` response covering all partitions.
+    /// For each hex bucket character, combines partition values with the
+    /// collision-resistant `combine_hashes`. Returns a `HashMap<char, u32>` with
+    /// the combined hashes, suitable for returning as a `SyncRespBuckets` response
+    /// covering all partitions. Per-character hashes are gathered into a list and
+    /// folded once via `combine_hashes`, whose commutativity + associativity make
+    /// the result independent of `DashMap`'s non-deterministic iteration order.
     #[must_use]
     pub fn aggregate_lww_buckets(&self, map_name: &str, path: &str) -> HashMap<char, u32> {
-        let mut combined: HashMap<char, u32> = HashMap::new();
+        let mut per_char: HashMap<char, Vec<u32>> = HashMap::new();
         for entry in &self.lww_trees {
             if entry.key().0 != map_name {
                 continue;
             }
             let buckets = entry.value().lock().get_buckets(path);
             for (c, h) in buckets {
-                combined
-                    .entry(c)
-                    .and_modify(|acc| *acc = acc.wrapping_add(h))
-                    .or_insert(h);
+                per_char.entry(c).or_default().push(h);
             }
         }
-        combined
+        per_char
+            .into_iter()
+            .map(|(c, hashes)| (c, combine_hashes(&hashes)))
+            .collect()
     }
 
     /// Aggregates OR-Map bucket hashes at `path` across all partitions for `map_name`.
@@ -192,20 +196,20 @@ impl MerkleSyncManager {
     /// Same aggregation strategy as `aggregate_lww_buckets`.
     #[must_use]
     pub fn aggregate_ormap_buckets(&self, map_name: &str, path: &str) -> HashMap<char, u32> {
-        let mut combined: HashMap<char, u32> = HashMap::new();
+        let mut per_char: HashMap<char, Vec<u32>> = HashMap::new();
         for entry in &self.ormap_trees {
             if entry.key().0 != map_name {
                 continue;
             }
             let buckets = entry.value().lock().get_buckets(path);
             for (c, h) in buckets {
-                combined
-                    .entry(c)
-                    .and_modify(|acc| *acc = acc.wrapping_add(h))
-                    .or_insert(h);
+                per_char.entry(c).or_default().push(h);
             }
         }
-        combined
+        per_char
+            .into_iter()
+            .map(|(c, hashes)| (c, combine_hashes(&hashes)))
+            .collect()
     }
 
     /// Returns all partition IDs that have a LWW tree for `map_name`.
@@ -726,16 +730,38 @@ mod tests {
 
         let hash_1 = manager.with_lww_tree("users", 1, |tree| tree.get_root_hash());
         let hash_2 = manager.with_lww_tree("users", 2, |tree| tree.get_root_hash());
-        let expected = hash_1.wrapping_add(hash_2);
+        let expected = combine_hashes(&[hash_1, hash_2]);
 
         let aggregate = manager.aggregate_lww_root_hash("users");
         assert_eq!(
             aggregate, expected,
-            "aggregate should equal wrapping_add of all partition hashes"
+            "aggregate should equal combine_hashes of all partition hashes"
         );
         assert_ne!(
             aggregate, 0,
             "aggregate should be non-zero when partitions have data"
+        );
+    }
+
+    #[test]
+    fn aggregate_lww_root_hash_resists_compensating_partition_pairs() {
+        // Two per-partition hash sets that are equal under a plain additive fold
+        // (0xAAAA0000 + 0x00005555 == 0xAAAA5555 + 0x00000000 == 0xAAAA5555).
+        // The cross-partition aggregate folds these with combine_hashes, which
+        // must keep them distinct so compensating per-partition hashes can never
+        // produce an identical server root (which the client treats as "in sync").
+        let set_a = [0xAAAA_0000u32, 0x0000_5555u32];
+        let set_b = [0xAAAA_5555u32, 0x0000_0000u32];
+
+        assert_eq!(
+            set_a[0].wrapping_add(set_a[1]),
+            set_b[0].wrapping_add(set_b[1]),
+            "test vectors must collide under the old additive scheme"
+        );
+        assert_ne!(
+            combine_hashes(&set_a),
+            combine_hashes(&set_b),
+            "compensating partition-hash pairs must produce different aggregates"
         );
     }
 
@@ -774,12 +800,12 @@ mod tests {
 
         let hash_1 = manager.with_ormap_tree("tags", 1, |tree| tree.get_root_hash());
         let hash_2 = manager.with_ormap_tree("tags", 2, |tree| tree.get_root_hash());
-        let expected = hash_1.wrapping_add(hash_2);
+        let expected = combine_hashes(&[hash_1, hash_2]);
 
         let aggregate = manager.aggregate_ormap_root_hash("tags");
         assert_eq!(
             aggregate, expected,
-            "OR-Map aggregate should equal wrapping_add of partition hashes"
+            "OR-Map aggregate should equal combine_hashes of partition hashes"
         );
     }
 

--- a/packages/server-rust/src/storage/merkle_sync.rs
+++ b/packages/server-rust/src/storage/merkle_sync.rs
@@ -776,8 +776,9 @@ mod tests {
         let orders_hash = manager.aggregate_lww_root_hash("orders");
         let users_p1 = manager.with_lww_tree("users", 1, |tree| tree.get_root_hash());
         assert_eq!(
-            users_hash, users_p1,
-            "users aggregate should match only its own partition"
+            users_hash,
+            combine_hashes(&[users_p1]),
+            "users aggregate should combine only its own partition"
         );
         assert_ne!(
             users_hash, orders_hash,

--- a/packages/server-rust/src/storage/query_merkle.rs
+++ b/packages/server-rust/src/storage/query_merkle.rs
@@ -11,6 +11,7 @@
 
 use dashmap::DashMap;
 use parking_lot::Mutex;
+use topgun_core::hash::combine_hashes;
 use topgun_core::merkle::MerkleTree;
 
 // ---------------------------------------------------------------------------
@@ -108,21 +109,24 @@ impl QueryMerkleSyncManager {
 
     /// Computes the aggregate root hash across all partitions for `(query_id, map_name)`.
     ///
-    /// Accumulates per-partition root hashes using `wrapping_add`. This is
-    /// commutative and associative, so the result is independent of `DashMap`'s
-    /// non-deterministic iteration order. Returns `0` if no partitions exist.
+    /// Combines per-partition root hashes with the collision-resistant
+    /// `combine_hashes`. It is commutative and associative, so the result is
+    /// independent of `DashMap`'s non-deterministic iteration order, while
+    /// preventing compensating per-partition hashes from producing an identical
+    /// query root (which the client treats as the query-scoped in-sync signal).
+    /// Returns `0` if no partitions exist.
     #[must_use]
     pub fn aggregate_query_root_hash(&self, query_id: &str, map_name: &str) -> u32 {
-        self.trees
+        let hashes: Vec<u32> = self
+            .trees
             .iter()
             .filter(|entry| {
                 let (qid, mn, _) = entry.key();
                 qid == query_id && mn == map_name
             })
-            .fold(0u32, |acc, entry| {
-                let hash = entry.value().lock().get_root_hash();
-                acc.wrapping_add(hash)
-            })
+            .map(|entry| entry.value().lock().get_root_hash())
+            .collect();
+        combine_hashes(&hashes)
     }
 
     /// Removes all Merkle trees for a given `query_id`.
@@ -159,5 +163,59 @@ impl QueryMerkleSyncManager {
 impl Default for QueryMerkleSyncManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aggregate_query_root_hash_empty_returns_zero() {
+        let manager = QueryMerkleSyncManager::new();
+        assert_eq!(
+            manager.aggregate_query_root_hash("q1", "users"),
+            0,
+            "no partitions should produce aggregate hash = 0"
+        );
+    }
+
+    #[test]
+    fn aggregate_query_root_hash_combines_partitions() {
+        let manager = QueryMerkleSyncManager::new();
+        manager.init_tree("q1", "users", 1, &[("alice".to_string(), 111)]);
+        manager.init_tree("q1", "users", 2, &[("bob".to_string(), 222)]);
+
+        let hash_1 = manager.get_root_hash("q1", "users", 1);
+        let hash_2 = manager.get_root_hash("q1", "users", 2);
+        let expected = combine_hashes(&[hash_1, hash_2]);
+
+        assert_eq!(
+            manager.aggregate_query_root_hash("q1", "users"),
+            expected,
+            "aggregate should equal combine_hashes of all partition hashes"
+        );
+    }
+
+    #[test]
+    fn aggregate_query_root_hash_resists_compensating_partition_pairs() {
+        // Two per-partition hash sets that are equal under a plain additive fold
+        // (0xAAAA0000 + 0x00005555 == 0xAAAA5555 + 0x00000000). The query-scoped
+        // aggregate must keep them distinct via combine_hashes so compensating
+        // per-partition hashes can never produce an identical query root, which
+        // the client treats as the query-scoped "in sync" signal.
+        let set_a = [0xAAAA_0000u32, 0x0000_5555u32];
+        let set_b = [0xAAAA_5555u32, 0x0000_0000u32];
+
+        assert_eq!(
+            set_a[0].wrapping_add(set_a[1]),
+            set_b[0].wrapping_add(set_b[1]),
+            "test vectors must collide under the old additive scheme"
+        );
+        assert_ne!(
+            combine_hashes(&set_a),
+            combine_hashes(&set_b),
+            "compensating partition-hash pairs must produce different aggregates"
+        );
     }
 }


### PR DESCRIPTION
## What

Closes F3 (TODO-476): Merkle aggregation used `wrapping_add` (a non-collision-resistant sum) → divergent replicas could share a root → silent missed diffs = permanent divergence.

Replaces additive fold with a collision-resistant order-independent combine (MurmurHash3 fmix32 `mix()` + additive u32 fold), identical across **Rust core, Rust server, and TS client**:
- 309a: core-rust `combine_hashes` + merkle aggregation.
- 309b: server-rust LWW/OR-Map cross-partition + query-scoped aggregation; + HLC counter rolls to next millisecond on u32 overflow.
- 309c: TS `@topgunbuild/core` `combineHashes` parity; pinned cross-language vector `combineHashes([100,200]) === 0xbc1dab1c` matching Rust `combine_hashes(&[0x64,0xc8])`.

## Cross-language risk = the gate

Rust and TS MUST compute identical Merkle roots or cross-language sync diverges. Verifying locally before merge:
- `pnpm test:integration-rust` (live Rust↔TS convergence) — the load-bearing gate.
- sim-convergence (`random_operations_merkle_consistent` + `preserve_convergence`).
- @topgunbuild/core suite + Rust lib/clippy/fmt + Cross-Language Protocol Validation (CI).

## Gate

Do not merge until local integration-rust + sim green AND `gh pr checks` ALL-green (incl Simulation Tests + Cross-Language Protocol Validation), verified separately.