### PR TITLE
test(sf-310c): tombstone-aware sim sync + concurrent OR_REMOVE convergence gate (TODO-481)

### DIFF
--- a/packages/server-rust/src/sim/cluster.rs
+++ b/packages/server-rust/src/sim/cluster.rs
@@ -41,7 +41,7 @@ use crate::storage::datastores::NullDataStore;
 use crate::storage::factory::{ObserverFactory, RecordStoreFactory};
 use crate::storage::impls::StorageConfig;
 use crate::storage::merkle_sync::{MerkleObserverFactory, MerkleSyncManager};
-use crate::storage::record::RecordValue;
+use crate::storage::record::{OrMapEntry, RecordValue};
 
 use super::network::{SimNetwork, SimTransport};
 
@@ -365,6 +365,49 @@ fn value_to_rmpv(v: &topgun_core::Value) -> rmpv::Value {
     }
 }
 
+/// Builds an `OR_ADD` `ClientOp` from a stored OR-Map entry.
+///
+/// Carries the entry's value, tag, and timestamp so the destination merges it
+/// via add-wins semantics (`or_record: Some(Some(_))`).
+fn or_add_client_op(map: &str, key: &str, entry: &OrMapEntry) -> ClientOp {
+    ClientOp {
+        id: Some(format!("{map}/{key}/{}", entry.tag)),
+        map_name: map.to_string(),
+        key: key.to_string(),
+        op_type: None,
+        record: None,
+        or_record: Some(Some(ORMapRecord {
+            value: value_to_rmpv(&entry.value),
+            timestamp: entry.timestamp.clone(),
+            tag: entry.tag.clone(),
+            ttl_ms: None,
+        })),
+        or_tag: Some(Some(entry.tag.clone())),
+        write_concern: None,
+        timeout: None,
+    }
+}
+
+/// Builds an `OR_REMOVE` `ClientOp` for a tombstoned tag.
+///
+/// An `OR_REMOVE` carries no value: `or_record: None` + `or_tag: Some(Some(tag))`
+/// is the shape the CRDT merge path classifies as a tag-based removal. Without
+/// this, a removal observed on the source node could never propagate — the
+/// destination would keep resurrecting the removed tag, defeating convergence.
+fn or_remove_client_op(map: &str, key: &str, tag: &str) -> ClientOp {
+    ClientOp {
+        id: Some(format!("{map}/{key}/{tag}#remove")),
+        map_name: map.to_string(),
+        key: key.to_string(),
+        op_type: None,
+        record: None,
+        or_record: None,
+        or_tag: Some(Some(tag.to_string())),
+        write_concern: None,
+        timeout: None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // SimCluster
 // ---------------------------------------------------------------------------
@@ -593,54 +636,55 @@ impl SimCluster {
             let record = store.get(key, false).await?;
 
             if let Some(rec) = record {
-                let client_op = match rec.value {
+                match rec.value {
                     RecordValue::Lww { value, timestamp } => {
                         let lww = LWWRecord {
                             value: Some(value_to_rmpv(&value)),
                             timestamp,
                             ttl_ms: None,
                         };
-                        ClientOp {
-                            id: Some(format!("{map}/{key}")),
-                            map_name: map.to_string(),
-                            key: key.to_string(),
-                            op_type: None,
-                            record: Some(Some(lww)),
-                            or_record: None,
-                            or_tag: None,
-                            write_concern: None,
-                            timeout: None,
+                        entries.push((
+                            node.node_id.clone(),
+                            ClientOp {
+                                id: Some(format!("{map}/{key}")),
+                                map_name: map.to_string(),
+                                key: key.to_string(),
+                                op_type: None,
+                                record: Some(Some(lww)),
+                                or_record: None,
+                                or_tag: None,
+                                write_concern: None,
+                                timeout: None,
+                            },
+                        ));
+                    }
+                    RecordValue::OrMap {
+                        records,
+                        tombstones,
+                    } => {
+                        // Carry the full OR-Map state: every live entry as an
+                        // OR_ADD and every tombstone as an OR_REMOVE. Forwarding
+                        // only `records[0]` (the old behavior) made a two-node
+                        // OR_REMOVE convergence scenario inexpressible — removals
+                        // never crossed the wire, so a removed tag silently
+                        // resurrected on the peer.
+                        for entry in &records {
+                            entries.push((node.node_id.clone(), or_add_client_op(map, key, entry)));
+                        }
+                        for tag in &tombstones {
+                            entries
+                                .push((node.node_id.clone(), or_remove_client_op(map, key, tag)));
                         }
                     }
-                    RecordValue::OrMap { records, .. } => {
-                        // Deliver each OR-Map entry as a separate op.
-                        // Use the first entry's tag as representative for simplicity;
-                        // full OR-Map convergence goes through or_write/merkle_sync_pair.
-                        if records.is_empty() {
-                            continue;
-                        }
-                        let entry = &records[0];
-                        let or_rec = ORMapRecord {
-                            value: value_to_rmpv(&entry.value),
-                            timestamp: entry.timestamp.clone(),
-                            tag: entry.tag.clone(),
-                            ttl_ms: None,
-                        };
-                        ClientOp {
-                            id: Some(format!("{map}/{key}/{}", entry.tag)),
-                            map_name: map.to_string(),
-                            key: key.to_string(),
-                            op_type: None,
-                            record: None,
-                            or_record: Some(Some(or_rec)),
-                            or_tag: Some(Some(entry.tag.clone())),
-                            write_concern: None,
-                            timeout: None,
+                    RecordValue::OrTombstones { tags } => {
+                        // Legacy tombstone-only blob: propagate each removal so a
+                        // peer still holding the tag drops it (remove-wins).
+                        for tag in &tags {
+                            entries
+                                .push((node.node_id.clone(), or_remove_client_op(map, key, tag)));
                         }
                     }
-                    RecordValue::OrTombstones { .. } => continue,
-                };
-                entries.push((node.node_id.clone(), client_op));
+                }
             }
         }
 
@@ -769,30 +813,31 @@ impl SimCluster {
                         timeout: None,
                     }
                 }
-                RecordValue::OrMap { records, .. } => {
-                    // Transfer all OR-Map entries; destination merges via CRDT semantics.
+                RecordValue::OrMap {
+                    records,
+                    tombstones,
+                } => {
+                    // Transfer the full OR-Map state: every live entry as an
+                    // OR_ADD and every tombstone as an OR_REMOVE. The destination
+                    // merges via CRDT semantics (add-wins / remove-wins). Dropping
+                    // tombstones here would let a removed tag resurrect on the
+                    // peer — the exact gap that hid the F1 OR_REMOVE clobber bug.
                     for entry in records {
-                        let op = ClientOp {
-                            id: Some(format!("{map}/{key}/{}", entry.tag)),
-                            map_name: map.to_string(),
-                            key: key.clone(),
-                            op_type: None,
-                            record: None,
-                            or_record: Some(Some(ORMapRecord {
-                                value: value_to_rmpv(&entry.value),
-                                timestamp: entry.timestamp.clone(),
-                                tag: entry.tag.clone(),
-                                ttl_ms: None,
-                            })),
-                            or_tag: Some(Some(entry.tag.clone())),
-                            write_concern: None,
-                            timeout: None,
-                        };
-                        ops.push(op);
+                        ops.push(or_add_client_op(map, &key, entry));
+                    }
+                    for tag in tombstones {
+                        ops.push(or_remove_client_op(map, &key, tag));
                     }
                     continue;
                 }
-                RecordValue::OrTombstones { .. } => continue,
+                RecordValue::OrTombstones { tags } => {
+                    // Legacy tombstone-only blob: propagate each removal so a peer
+                    // still holding the tag drops it (remove-wins).
+                    for tag in tags {
+                        ops.push(or_remove_client_op(map, &key, tag));
+                    }
+                    continue;
+                }
             };
             ops.push(client_op);
         }
@@ -900,6 +945,59 @@ impl SimCluster {
             write_concern: None,
             timeout: None,
         };
+
+        let op = Operation::ClientOp {
+            ctx,
+            payload: ClientOpMessage { payload: client_op },
+        };
+
+        let mut svc = Arc::clone(&node.crdt_service);
+        Service::call(&mut svc, op).await?;
+
+        Ok(())
+    }
+
+    /// Removes an OR-Map entry (by tag) from a specific node.
+    ///
+    /// Mirrors [`or_write`](Self::or_write) but constructs the `OR_REMOVE` shape:
+    /// `or_record: None` + `or_tag: Some(Some(tag))`. The CRDT merge path applies
+    /// this as a tag-based, remove-wins deletion — dropping the matched tag from
+    /// the live entry set and recording it as a tombstone, while preserving every
+    /// concurrent survivor. The removal need not have been observed locally first:
+    /// tombstoning an unseen tag still suppresses a later-arriving add.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the node index is out of range, the node is dead,
+    /// or the CRDT service rejects the operation.
+    pub async fn or_remove(
+        &self,
+        node_idx: usize,
+        map: &str,
+        key: &str,
+        tag: impl Into<String>,
+    ) -> anyhow::Result<()> {
+        let tag = tag.into();
+        let node = self
+            .nodes
+            .get(node_idx)
+            .ok_or_else(|| anyhow::anyhow!("node index {node_idx} out of range"))?;
+
+        if !node.is_alive() {
+            return Err(anyhow::anyhow!("node {node_idx} is dead"));
+        }
+
+        let partition_id = topgun_core::hash_to_partition(key);
+        let ts = Timestamp {
+            millis: 0,
+            counter: 0,
+            node_id: node.node_id.clone(),
+        };
+        let mut ctx = OperationContext::new(0, service_names::CRDT, ts, 5000);
+        ctx.partition_id = Some(partition_id);
+        ctx.caller_origin = CallerOrigin::System;
+
+        let client_op = or_remove_client_op(map, key, &tag);
 
         let op = Operation::ClientOp {
             ctx,

--- a/packages/server-rust/src/sim/cluster.rs
+++ b/packages/server-rust/src/sim/cluster.rs
@@ -821,7 +821,7 @@ impl SimCluster {
                     // OR_ADD and every tombstone as an OR_REMOVE. The destination
                     // merges via CRDT semantics (add-wins / remove-wins). Dropping
                     // tombstones here would let a removed tag resurrect on the
-                    // peer — the exact gap that hid the F1 OR_REMOVE clobber bug.
+                    // peer — the exact gap that hid the OR_REMOVE clobber bug.
                     for entry in records {
                         ops.push(or_add_client_op(map, &key, entry));
                     }

--- a/packages/server-rust/tests/simulation/crdt_convergence.rs
+++ b/packages/server-rust/tests/simulation/crdt_convergence.rs
@@ -107,8 +107,8 @@ async fn concurrent_writes_converge() {
 /// nodes must hold both tags (OR-Map add-wins semantics).
 ///
 /// Uses `sync_all` after the first write to propagate tag-A to node 1, then
-/// `merkle_sync_pair` for full OR-Map convergence because `sync_all` only
-/// forwards the first entry per key.
+/// `merkle_sync_pair` for full OR-Map convergence. Both paths now carry the
+/// complete OR-Map state (every live entry plus every tombstone).
 #[tokio::test]
 async fn ormap_concurrent_add_remove() {
     let mut cluster = SimCluster::new(2, 7);

--- a/packages/server-rust/tests/simulation/proptest_sim.rs
+++ b/packages/server-rust/tests/simulation/proptest_sim.rs
@@ -437,12 +437,12 @@ async fn random_operations_merkle_consistent() {
 }
 
 // ===========================================================================
-// Concurrent OR_REMOVE convergence (blocking gate — closes G4a coverage gap)
+// Concurrent OR_REMOVE convergence (blocking gate — closes the OR-Map coverage gap)
 // ===========================================================================
 //
 // The generic `random_operations_*` properties above only generate LWW writes,
 // so they never exercised the OR-Map merge path. That gap is exactly why the
-// suite missed the F1 OR_REMOVE clobber bug (a blind `OrTombstones` put that
+// suite once missed the OR_REMOVE clobber bug (a blind `OrTombstones` put that
 // destroyed every concurrent OR-Map value for the key). This property drives
 // random interleavings of OR_ADD / OR_REMOVE / one-way sync / partition across
 // a 3-node cluster on overlapping keys and asserts every node converges to the
@@ -653,10 +653,10 @@ async fn assert_or_converged(
 /// Property: concurrent `OR_ADD` / `OR_REMOVE` sequences converge with zero
 /// acknowledged-write loss.
 ///
-/// This is the blocking gate that closes the G4a coverage gap for the F1
-/// `OR_REMOVE` class. The negative control (TODO-481): reverting the F1 fix in
-/// `crdt.rs` to the old blind-clobber `OrTombstones` put MUST make this test
-/// fail — proving the guard actually catches the F1 regression class.
+/// This is the blocking gate that closes the convergence coverage gap for the
+/// `OR_REMOVE` clobber class. Negative control: reverting the server-side
+/// `OR_REMOVE` merge to the old blind-clobber `OrTombstones` put MUST make this
+/// test fail — proving the guard actually catches that regression class.
 #[tokio::test(flavor = "multi_thread")]
 async fn concurrent_or_remove_preserves_convergence() {
     let handle = Handle::current();

--- a/packages/server-rust/tests/simulation/proptest_sim.rs
+++ b/packages/server-rust/tests/simulation/proptest_sim.rs
@@ -18,6 +18,7 @@ use proptest::prelude::*;
 use proptest::test_runner::{Config as PropConfig, TestRunner};
 use tokio::runtime::Handle;
 use topgun_server::sim::cluster::SimCluster;
+use topgun_server::storage::record::RecordValue;
 
 // ---------------------------------------------------------------------------
 // Operation enum
@@ -432,5 +433,254 @@ async fn random_operations_merkle_consistent() {
 
     if let Err(e) = result {
         panic!("random_operations_merkle_consistent failed: {e}");
+    }
+}
+
+// ===========================================================================
+// Concurrent OR_REMOVE convergence (blocking gate — closes G4a coverage gap)
+// ===========================================================================
+//
+// The generic `random_operations_*` properties above only generate LWW writes,
+// so they never exercised the OR-Map merge path. That gap is exactly why the
+// suite missed the F1 OR_REMOVE clobber bug (a blind `OrTombstones` put that
+// destroyed every concurrent OR-Map value for the key). This property drives
+// random interleavings of OR_ADD / OR_REMOVE / one-way sync / partition across
+// a 3-node cluster on overlapping keys and asserts every node converges to the
+// CRDT-correct live set with zero acknowledged-write loss.
+
+/// A single operation in a concurrent OR-Map sequence.
+#[derive(Debug, Clone)]
+enum OrOp {
+    /// `OR_ADD`: node `node_idx % 3` adds a freshly-minted unique tag to `key_idx`.
+    /// A globally-unique tag means each tag maps to exactly one value, so the
+    /// convergent live set is order-independent (no last-writer-wins ambiguity).
+    Add { node_idx: usize, key_idx: usize },
+    /// `OR_REMOVE`: node `node_idx % 3` removes a previously-added `(key, tag)`
+    /// resolved from the add pool by `target % pool.len()`. The removing node is
+    /// frequently NOT the adding node, exercising concurrent cross-node add/remove.
+    Remove { node_idx: usize, target: usize },
+    /// One-way Merkle sync of the OR-Map between two distinct nodes (partition-aware,
+    /// silently dropped across a partitioned link). Creates random partial-delivery
+    /// orders mid-sequence so convergence cannot rely on a tidy delivery schedule.
+    Sync { src_idx: usize, dst_idx: usize },
+    /// Partition the cluster into two non-empty groups.
+    Partition { split: usize },
+    /// Heal all active partitions.
+    Heal,
+}
+
+/// Map name for the OR-Map convergence property (single map keeps the focus on
+/// OR semantics rather than cross-map fan-out).
+const OR_MAP: &str = "orset";
+
+/// Number of distinct keys. A small set forces many adds/removes onto the same
+/// key so concurrent add/remove on intersecting keys is the common case.
+const OR_KEY_COUNT: usize = 3;
+
+/// Strategy for a single OR-Map operation. Adds dominate so the pool fills and
+/// removes have meaningful targets.
+fn arb_or_op() -> impl Strategy<Value = OrOp> {
+    prop_oneof![
+        4 => (any::<usize>(), 0..OR_KEY_COUNT).prop_map(|(node_idx, key_idx)| OrOp::Add {
+            node_idx,
+            key_idx
+        }),
+        3 => (any::<usize>(), any::<usize>())
+            .prop_map(|(node_idx, target)| OrOp::Remove { node_idx, target }),
+        3 => (any::<usize>(), any::<usize>())
+            .prop_map(|(src_idx, dst_idx)| OrOp::Sync { src_idx, dst_idx }),
+        1 => any::<usize>().prop_map(|split| OrOp::Partition { split }),
+        1 => Just(OrOp::Heal),
+    ]
+}
+
+fn arb_or_ops() -> impl Strategy<Value = Vec<OrOp>> {
+    proptest::collection::vec(arb_or_op(), 10..=64)
+}
+
+/// The CRDT-expected outcome for the OR-Map sequence, accumulated during
+/// execution: which tags were acknowledged-added per key, and which were
+/// acknowledged-removed. The convergent live set per key is `added - removed`.
+#[derive(Default)]
+struct OrExpectation {
+    /// key -> set of tags whose `OR_ADD` was acknowledged.
+    added: std::collections::HashMap<String, std::collections::HashSet<String>>,
+    /// key -> set of tags whose `OR_REMOVE` was acknowledged.
+    removed: std::collections::HashMap<String, std::collections::HashSet<String>>,
+}
+
+fn or_key(key_idx: usize) -> String {
+    format!("k{}", key_idx % OR_KEY_COUNT)
+}
+
+/// Executes an OR-Map operation sequence against a fresh fixed-size 3-node
+/// cluster. No nodes are killed or joined, so every acknowledged add must
+/// survive to the convergence check — `0 acked-loss` is directly assertable.
+async fn execute_or_ops(ops: &[OrOp], seed: u64) -> (SimCluster, OrExpectation) {
+    let mut cluster = SimCluster::new(3, seed);
+    cluster.start().expect("cluster should start");
+
+    let mut expect = OrExpectation::default();
+    // Pool of acknowledged (key, tag) adds that removes can target.
+    let mut pool: Vec<(String, String)> = Vec::new();
+    // Globally-monotonic tag sequence guarantees every add gets a unique tag.
+    let mut seq: usize = 0;
+
+    for op in ops {
+        match op {
+            OrOp::Add { node_idx, key_idx } => {
+                let node = node_idx % cluster.nodes.len();
+                let key = or_key(*key_idx);
+                let tag = format!("n{node}-{seq}");
+                seq += 1;
+                // Value is tied 1:1 to the tag so there is never value ambiguity.
+                let value = rmpv::Value::String(tag.as_str().into());
+                if cluster
+                    .or_write(node, OR_MAP, &key, tag.clone(), value)
+                    .await
+                    .is_ok()
+                {
+                    expect
+                        .added
+                        .entry(key.clone())
+                        .or_default()
+                        .insert(tag.clone());
+                    pool.push((key, tag));
+                }
+            }
+            OrOp::Remove { node_idx, target } => {
+                if pool.is_empty() {
+                    continue;
+                }
+                let node = node_idx % cluster.nodes.len();
+                let (key, tag) = pool[target % pool.len()].clone();
+                if cluster
+                    .or_remove(node, OR_MAP, &key, tag.clone())
+                    .await
+                    .is_ok()
+                {
+                    expect.removed.entry(key).or_default().insert(tag);
+                }
+            }
+            OrOp::Sync { src_idx, dst_idx } => {
+                let n = cluster.nodes.len();
+                let src = src_idx % n;
+                // Force a distinct destination.
+                let dst = (dst_idx % n.saturating_sub(1).max(1) + src + 1) % n;
+                if src != dst {
+                    let _ = cluster.merkle_sync_pair(src, dst, OR_MAP).await;
+                }
+            }
+            OrOp::Partition { split } => {
+                let n = cluster.nodes.len();
+                if n < 2 {
+                    continue;
+                }
+                let boundary = (split % (n - 1)) + 1;
+                let all: Vec<usize> = (0..n).collect();
+                cluster.inject_partition(&all[..boundary], &all[boundary..]);
+            }
+            OrOp::Heal => cluster.heal_partition(),
+        }
+    }
+
+    (cluster, expect)
+}
+
+/// Asserts OR-Map convergence: after healing + full Merkle sync, every alive
+/// node holds an identical live tag set per key, equal to `added - removed`.
+///
+/// This single assertion encodes three guarantees:
+/// - **convergence**: all nodes agree on the live set for every key;
+/// - **0 acked-loss**: every acknowledged add that was never removed survives;
+/// - **remove-wins**: every acknowledged remove is absent on every node, with no
+///   resurrection regardless of add/remove/delivery interleaving.
+///
+/// Comparison is on tag *sets*, not serialized bytes: the `records`/`tombstones`
+/// Vec order is an implementation artifact of delivery order, whereas CRDT
+/// convergence is defined on the live-element set.
+async fn assert_or_converged(
+    cluster: &SimCluster,
+    expect: &OrExpectation,
+) -> Result<(), TestCaseError> {
+    let mut keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+    keys.extend(expect.added.keys().cloned());
+    keys.extend(expect.removed.keys().cloned());
+
+    let empty = std::collections::HashSet::new();
+
+    for key in &keys {
+        let added = expect.added.get(key).unwrap_or(&empty);
+        let removed = expect.removed.get(key).unwrap_or(&empty);
+        let expected_live: std::collections::BTreeSet<String> =
+            added.difference(removed).cloned().collect();
+
+        for (idx, node) in cluster.nodes.iter().enumerate() {
+            if !node.is_alive() {
+                continue;
+            }
+            let value = cluster
+                .read(idx, OR_MAP, key)
+                .await
+                .map_err(|e| TestCaseError::fail(format!("read error: {e}")))?;
+
+            // Live tag set as stored on this node (None ⇒ key absent ⇒ empty set).
+            let live: std::collections::BTreeSet<String> = match value {
+                Some(RecordValue::OrMap { records, .. }) => {
+                    records.into_iter().map(|e| e.tag).collect()
+                }
+                Some(RecordValue::OrTombstones { .. }) | None => std::collections::BTreeSet::new(),
+                Some(other) => {
+                    return Err(TestCaseError::fail(format!(
+                        "key {key:?} on node {idx} is non-OR-Map: {other:?}"
+                    )));
+                }
+            };
+
+            if live != expected_live {
+                return Err(TestCaseError::fail(format!(
+                    "OR convergence failure: key={key:?} node={idx}\n  \
+                     expected live tags (added−removed) = {expected_live:?}\n  \
+                     actual live tags                   = {live:?}\n  \
+                     added={added:?} removed={removed:?}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Property: concurrent `OR_ADD` / `OR_REMOVE` sequences converge with zero
+/// acknowledged-write loss.
+///
+/// This is the blocking gate that closes the G4a coverage gap for the F1
+/// `OR_REMOVE` class. The negative control (TODO-481): reverting the F1 fix in
+/// `crdt.rs` to the old blind-clobber `OrTombstones` put MUST make this test
+/// fail — proving the guard actually catches the F1 regression class.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_or_remove_preserves_convergence() {
+    let handle = Handle::current();
+    let mut runner = TestRunner::new(PropConfig {
+        cases: 64,
+        ..PropConfig::default()
+    });
+
+    let result = runner.run(&arb_or_ops(), |ops| {
+        tokio::task::block_in_place(|| {
+            handle.block_on(async {
+                let seed = 1234u64;
+                let (cluster, expect) = execute_or_ops(&ops, seed).await;
+
+                // Heal + full bidirectional Merkle sync, then assert convergence.
+                converge_cluster(&cluster, &[OR_MAP]).await;
+                assert_or_converged(&cluster, &expect).await?;
+
+                Ok(())
+            })
+        })
+    });
+
+    if let Err(e) = result {
+        panic!("concurrent_or_remove_preserves_convergence failed: {e}");
     }
 }


### PR DESCRIPTION
## What & why

Closes the **G4a convergence coverage gap** (TODO-481 / SPEC-310c). The property suite only generated LWW writes, so it never exercised the OR-Map merge path — which is exactly why it missed the **F1 OR_REMOVE clobber** data-loss bug (a blind \`OrTombstones\` put that destroyed every concurrent OR-Map value for a key, fixed in PR #54). This PR makes a two-node concurrent-OR_REMOVE convergence scenario expressible and adds it as a **blocking** proptest gate.

## Changes (test infra only — no production code touched)

- **\`sim/cluster.rs\`**
  - New \`or_remove()\` helper (\`or_record: None\` + \`or_tag: Some(Some(tag))\`), alongside the existing \`or_write\`.
  - Shared \`or_add_client_op\` / \`or_remove_client_op\` op constructors.
  - **\`sync_all\` and \`merkle_sync_pair\` are now tombstone-aware**: both carry the full \`OrMap\` state — every live entry as an OR_ADD **and** every tombstone as an OR_REMOVE — and propagate legacy \`OrTombstones\` blobs. Previously \`sync_all\` forwarded only \`records[0]\` and both paths dropped removals, so a removed tag silently resurrected on the peer.
- **\`tests/simulation/proptest_sim.rs\`**: new property \`concurrent_or_remove_preserves_convergence\` — 3 nodes × random OR_ADD / OR_REMOVE on intersecting keys × random one-way sync / partition → every node converges to \`added − removed\` with **zero acked-loss**. Unique tags (1:1 tag→value) make the convergent live set order-independent; assertion is on tag *sets* (Vec order is a delivery-order artifact).

## Mandatory negative control (per TODO-481)

Temporarily reverted the F1 fix in \`crdt.rs\` to the old blind-clobber (\`OrTombstones { tags: [tag] }\`) and ran the new property — **it failed as required**:

\`\`\`
OR convergence failure: key="k2" node=0
  expected live tags (added−removed) = {"n2-5"}
  actual live tags                   = {}
  added={"n0-1","n2-5"} removed={"n0-1"}
\`\`\`

Removing \`n0-1\` clobbered the concurrent survivor \`n2-5\` → data loss. This proves the guard catches the F1 class. F1 fix then restored; **\`crdt.rs\` is unchanged in this PR**.

## Local verification

- New property: **3× consecutive green** (non-flaky), CI \`-- sim\` filter picks it up (\`proptest_sim::*\`).
- \`cargo test --release -p topgun-server --lib\`: 1350 passed, 0 failed.
- \`cargo clippy --all-targets --all-features -- -D warnings\`: clean.
- \`cargo fmt --check\`: clean. \`cargo build --release\`: clean.

## Notes

- The Simulation Tests job (rust.yml:347) is **blocking** (not continue-on-error) — this gate will gate merges.
- Observation (out of scope, flagged for org-session): the CI \`-- sim\` filter matches \`proptest_sim::*\` by substring but **not** the hand-written \`crdt_convergence::*\` / \`merkle_sync::*\` tests (no "sim" in their path) — those currently don't gate. The new property lives in \`proptest_sim.rs\` precisely so it *is* gated.

Per the stabilization standard: **do not mark G4a green from this PR** — that is the org-session's call after merge + the verified negative control above.