### PR TITLE
fix(server): close open admin plane on no-auth+public bind — gate admin, keep data up (F4, SPEC-312/313/314)

### DIFF
--- a/packages/server-rust/benches/load_harness/main.rs
+++ b/packages/server-rust/benches/load_harness/main.rs
@@ -244,6 +244,7 @@ async fn main() {
                 lock_registry: None,
                 topic_registry: None,
                 counter_registry: None,
+                admin_enabled: true,
             };
 
             let ws_handler = get(topgun_server::network::handlers::ws_upgrade_handler);

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -367,6 +367,10 @@ async fn main() -> anyhow::Result<()> {
     // the synthesized superuser. The data plane (/health, /ws, /sync, ...) stays live.
     let posture = admin_bind_posture(no_auth, &bind_addr, allow_no_auth_public_bind);
     let mount_admin = posture.mount_admin();
+    // One decision, two enforcement points: the route gate (`mount_admin`) and the
+    // extractor guard (`AppState.admin_enabled`) read the SAME boolean, so they can
+    // never drift. AdminDisabled => both false (admin plane off); otherwise both true.
+    let admin_enabled = mount_admin;
     match posture {
         BindPosture::Allowed => {}
         BindPosture::WarnOverride => {
@@ -830,6 +834,7 @@ async fn main() -> anyhow::Result<()> {
         lock_registry: Some(lock_registry),
         topic_registry: Some(topic_registry),
         counter_registry: Some(counter_registry),
+        admin_enabled,
     };
 
     // Mirror NetworkModule::serve()'s scalar index rebuild for the topgun_server

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -208,6 +208,39 @@ fn is_loopback(addr: &str) -> bool {
     addr == "127.0.0.1" || addr == "::1" || addr.starts_with("localhost")
 }
 
+/// Startup decision for the no-auth + bind-address combination.
+///
+/// With auth disabled, the admin control plane (`/api/admin/*`) synthesizes a
+/// superuser identity, so binding to a non-loopback interface would expose an
+/// unauthenticated control plane to the network. This enum captures whether that
+/// posture is safe, deliberately overridden, or must be refused outright.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BindPosture {
+    /// Safe to proceed: either auth is enforced, or no-auth is loopback-only.
+    Allowed,
+    /// Dangerous posture explicitly opted into by the operator; proceed with a loud warning.
+    WarnOverride,
+    /// Dangerous posture with no opt-out; refuse to start.
+    Refused,
+}
+
+/// Decides startup posture for the no-auth + bind-address combination.
+///
+/// Auth-enforced binds are always allowed (the admin plane is protected by JWT).
+/// No-auth binds are allowed only on loopback, where the control plane is
+/// reachable solely from localhost. A no-auth bind on a non-loopback interface is
+/// refused unless the operator explicitly opts into the exposure.
+fn admin_bind_posture(no_auth: bool, bind_addr: &str, allow_public_override: bool) -> BindPosture {
+    if !no_auth || is_loopback(bind_addr) {
+        return BindPosture::Allowed;
+    }
+    if allow_public_override {
+        BindPosture::WarnOverride
+    } else {
+        BindPosture::Refused
+    }
+}
+
 // ---------------------------------------------------------------------------
 // ClusterStateAdapter — bridges ClusterState to the ClusterService trait
 // ---------------------------------------------------------------------------
@@ -297,6 +330,13 @@ async fn main() -> anyhow::Result<()> {
         .map(|v| matches!(v.to_lowercase().as_str(), "true" | "1"))
         .unwrap_or(false);
 
+    // Deliberate-exposure opt-out: when set to 1 or true, downgrade the
+    // fail-closed refusal of a no-auth + non-loopback bind back to a loud warning
+    // for trusted-network operators who accept the risk.
+    let allow_no_auth_public_bind = std::env::var("TOPGUN_ALLOW_NO_AUTH_PUBLIC_BIND")
+        .map(|v| matches!(v.to_lowercase().as_str(), "true" | "1"))
+        .unwrap_or(false);
+
     // Bind the client WebSocket listener first so we know the actual port.
     // The default interface depends on auth posture: with auth disabled
     // (TOPGUN_NO_AUTH=1) we bind loopback-only so a zero-config local server is
@@ -306,17 +346,29 @@ async fn main() -> anyhow::Result<()> {
     let default_bind = if no_auth { "127.0.0.1" } else { "0.0.0.0" };
     let bind_addr = std::env::var("TOPGUN_BIND_ADDR").unwrap_or_else(|_| default_bind.to_string());
 
-    // When no-auth is active but the operator has overridden the bind address to
-    // a non-loopback interface, the admin control plane (/api/admin/*) becomes
-    // reachable unauthenticated from the network. Warn loudly so the operator
-    // can take corrective action; the bind itself is not altered here.
-    if no_auth && !is_loopback(&bind_addr) {
-        tracing::warn!(
-            bind_addr = %bind_addr,
-            "TOPGUN_NO_AUTH=1 with a non-loopback bind address: /api/admin/* endpoints \
-             are reachable unauthenticated on a network interface. Set TOPGUN_BIND_ADDR=127.0.0.1 \
-             or enable JWT authentication to restrict access."
-        );
+    // When no-auth is active and the bind address is a non-loopback interface, the
+    // admin control plane (/api/admin/*) would be reachable unauthenticated from the
+    // network (no-auth synthesizes a superuser identity). Fail closed by default;
+    // an explicit opt-out downgrades the refusal to a loud warning.
+    match admin_bind_posture(no_auth, &bind_addr, allow_no_auth_public_bind) {
+        BindPosture::Allowed => {}
+        BindPosture::WarnOverride => {
+            tracing::warn!(
+                bind_addr = %bind_addr,
+                "TOPGUN_NO_AUTH=1 with a non-loopback bind address: /api/admin/* endpoints \
+                 are reachable unauthenticated on a network interface. Proceeding because \
+                 TOPGUN_ALLOW_NO_AUTH_PUBLIC_BIND is set — this exposure is deliberate. \
+                 Set TOPGUN_BIND_ADDR=127.0.0.1 or enable JWT authentication to restrict access."
+            );
+        }
+        BindPosture::Refused => {
+            anyhow::bail!(
+                "Refusing to start: TOPGUN_NO_AUTH=1 with a non-loopback bind address ({bind_addr}) \
+                 would expose /api/admin/* unauthenticated on a network interface. Remediate by one of: \
+                 set TOPGUN_BIND_ADDR=127.0.0.1 (loopback-only), enable JWT authentication, or set \
+                 TOPGUN_ALLOW_NO_AUTH_PUBLIC_BIND=1 to deliberately accept this exposure."
+            );
+        }
     }
 
     let listener = TcpListener::bind(format!("{bind_addr}:{}", args.port)).await?;
@@ -1274,5 +1326,72 @@ async fn shutdown_signal() {
     tokio::select! {
         () = ctrl_c => {},
         () = terminate => {},
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{admin_bind_posture, BindPosture};
+
+    #[test]
+    fn auth_enforced_is_always_allowed() {
+        // Auth enforced: the admin plane is JWT-protected regardless of interface.
+        assert_eq!(
+            admin_bind_posture(false, "0.0.0.0", false),
+            BindPosture::Allowed
+        );
+        assert_eq!(
+            admin_bind_posture(false, "127.0.0.1", false),
+            BindPosture::Allowed
+        );
+        // The override flag is irrelevant when auth is enforced.
+        assert_eq!(
+            admin_bind_posture(false, "0.0.0.0", true),
+            BindPosture::Allowed
+        );
+    }
+
+    #[test]
+    fn no_auth_loopback_is_allowed() {
+        // Localhost no-auth dev convenience is preserved across all loopback forms.
+        for addr in ["127.0.0.1", "::1", "localhost", "localhost:8080"] {
+            assert_eq!(
+                admin_bind_posture(true, addr, false),
+                BindPosture::Allowed,
+                "loopback addr {addr} should be Allowed",
+            );
+            // Opt-out is irrelevant on loopback (never a dangerous posture).
+            assert_eq!(
+                admin_bind_posture(true, addr, true),
+                BindPosture::Allowed,
+                "loopback addr {addr} with override should still be Allowed",
+            );
+        }
+    }
+
+    #[test]
+    fn no_auth_public_bind_is_refused() {
+        // Fail closed: no-auth on a non-loopback interface without opt-out aborts.
+        assert_eq!(
+            admin_bind_posture(true, "0.0.0.0", false),
+            BindPosture::Refused
+        );
+        assert_eq!(
+            admin_bind_posture(true, "192.168.1.10", false),
+            BindPosture::Refused
+        );
+    }
+
+    #[test]
+    fn no_auth_public_bind_with_override_warns() {
+        // Documented escape hatch: opt-out downgrades the refusal to a warning.
+        assert_eq!(
+            admin_bind_posture(true, "0.0.0.0", true),
+            BindPosture::WarnOverride
+        );
+        assert_eq!(
+            admin_bind_posture(true, "192.168.1.10", true),
+            BindPosture::WarnOverride
+        );
     }
 }

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -213,23 +213,35 @@ fn is_loopback(addr: &str) -> bool {
 /// With auth disabled, the admin control plane (`/api/admin/*`) synthesizes a
 /// superuser identity, so binding to a non-loopback interface would expose an
 /// unauthenticated control plane to the network. This enum captures whether that
-/// posture is safe, deliberately overridden, or must be refused outright.
+/// posture is safe, deliberately overridden, or has its admin plane disabled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BindPosture {
     /// Safe to proceed: either auth is enforced, or no-auth is loopback-only.
     Allowed,
     /// Dangerous posture explicitly opted into by the operator; proceed with a loud warning.
     WarnOverride,
-    /// Dangerous posture with no opt-out; refuse to start.
-    Refused,
+    /// Dangerous posture with no opt-out; the server starts but the admin control
+    /// plane is not mounted so it cannot be reached unauthenticated from the network.
+    AdminDisabled,
+}
+
+impl BindPosture {
+    /// Whether the admin control plane should be mounted for this posture.
+    ///
+    /// Mounting is suppressed only for [`BindPosture::AdminDisabled`] (no-auth on a
+    /// non-loopback interface with no opt-in), which would otherwise expose the
+    /// synthesized superuser to the network.
+    fn mount_admin(self) -> bool {
+        !matches!(self, BindPosture::AdminDisabled)
+    }
 }
 
 /// Decides startup posture for the no-auth + bind-address combination.
 ///
 /// Auth-enforced binds are always allowed (the admin plane is protected by JWT).
 /// No-auth binds are allowed only on loopback, where the control plane is
-/// reachable solely from localhost. A no-auth bind on a non-loopback interface is
-/// refused unless the operator explicitly opts into the exposure.
+/// reachable solely from localhost. A no-auth bind on a non-loopback interface has
+/// its admin plane disabled unless the operator explicitly opts into the exposure.
 fn admin_bind_posture(no_auth: bool, bind_addr: &str, allow_public_override: bool) -> BindPosture {
     if !no_auth || is_loopback(bind_addr) {
         return BindPosture::Allowed;
@@ -237,7 +249,7 @@ fn admin_bind_posture(no_auth: bool, bind_addr: &str, allow_public_override: boo
     if allow_public_override {
         BindPosture::WarnOverride
     } else {
-        BindPosture::Refused
+        BindPosture::AdminDisabled
     }
 }
 
@@ -348,9 +360,14 @@ async fn main() -> anyhow::Result<()> {
 
     // When no-auth is active and the bind address is a non-loopback interface, the
     // admin control plane (/api/admin/*) would be reachable unauthenticated from the
-    // network (no-auth synthesizes a superuser identity). Fail closed by default;
-    // an explicit opt-out downgrades the refusal to a loud warning.
-    match admin_bind_posture(no_auth, &bind_addr, allow_no_auth_public_bind) {
+    // network (no-auth synthesizes a superuser identity). Rather than refuse to start
+    // (which would kill the legitimate no-auth data-plane demo container), keep the
+    // server up and gate the admin plane: when posture is AdminDisabled the admin
+    // routes are not mounted, so the control plane returns 404 instead of exposing
+    // the synthesized superuser. The data plane (/health, /ws, /sync, ...) stays live.
+    let posture = admin_bind_posture(no_auth, &bind_addr, allow_no_auth_public_bind);
+    let mount_admin = posture.mount_admin();
+    match posture {
         BindPosture::Allowed => {}
         BindPosture::WarnOverride => {
             tracing::warn!(
@@ -361,12 +378,15 @@ async fn main() -> anyhow::Result<()> {
                  Set TOPGUN_BIND_ADDR=127.0.0.1 or enable JWT authentication to restrict access."
             );
         }
-        BindPosture::Refused => {
-            anyhow::bail!(
-                "Refusing to start: TOPGUN_NO_AUTH=1 with a non-loopback bind address ({bind_addr}) \
-                 would expose /api/admin/* unauthenticated on a network interface. Remediate by one of: \
-                 set TOPGUN_BIND_ADDR=127.0.0.1 (loopback-only), enable JWT authentication, or set \
-                 TOPGUN_ALLOW_NO_AUTH_PUBLIC_BIND=1 to deliberately accept this exposure."
+        BindPosture::AdminDisabled => {
+            tracing::warn!(
+                bind_addr = %bind_addr,
+                "TOPGUN_NO_AUTH=1 with a non-loopback bind address: the /api/admin/* control \
+                 plane (and the admin login/SPA) is DISABLED to avoid exposing the unauthenticated \
+                 superuser on a network interface. The data plane (/health, /ws, /sync) stays up. \
+                 To enable the admin plane, set TOPGUN_BIND_ADDR=127.0.0.1 (loopback-only), enable \
+                 JWT authentication, or set TOPGUN_ALLOW_NO_AUTH_PUBLIC_BIND=1 to deliberately \
+                 accept this exposure."
             );
         }
     }
@@ -862,6 +882,7 @@ async fn main() -> anyhow::Result<()> {
     let app = topgun_server::network::module::admin_routes(
         state.config.rate_limit_per_ip,
         state.config.rate_limit_burst,
+        mount_admin,
     )
     // Browser WS dual-mount: /ws is already in admin_routes(); / is the
     // binary-only extra for clients that connect to the root path.
@@ -1370,21 +1391,22 @@ mod tests {
     }
 
     #[test]
-    fn no_auth_public_bind_is_refused() {
-        // Fail closed: no-auth on a non-loopback interface without opt-out aborts.
+    fn no_auth_public_bind_disables_admin() {
+        // Gate, don't refuse: no-auth on a non-loopback interface without opt-out
+        // keeps the server up but disables the admin plane.
         assert_eq!(
             admin_bind_posture(true, "0.0.0.0", false),
-            BindPosture::Refused
+            BindPosture::AdminDisabled
         );
         assert_eq!(
             admin_bind_posture(true, "192.168.1.10", false),
-            BindPosture::Refused
+            BindPosture::AdminDisabled
         );
     }
 
     #[test]
     fn no_auth_public_bind_with_override_warns() {
-        // Documented escape hatch: opt-out downgrades the refusal to a warning.
+        // Documented escape hatch: opt-out keeps the admin plane mounted with a warning.
         assert_eq!(
             admin_bind_posture(true, "0.0.0.0", true),
             BindPosture::WarnOverride
@@ -1393,5 +1415,13 @@ mod tests {
             admin_bind_posture(true, "192.168.1.10", true),
             BindPosture::WarnOverride
         );
+    }
+
+    #[test]
+    fn mount_admin_mapping() {
+        // Only AdminDisabled suppresses mounting; both safe and overridden postures mount.
+        assert!(BindPosture::Allowed.mount_admin());
+        assert!(BindPosture::WarnOverride.mount_admin());
+        assert!(!BindPosture::AdminDisabled.mount_admin());
     }
 }

--- a/packages/server-rust/src/network/handlers/admin_auth.rs
+++ b/packages/server-rust/src/network/handlers/admin_auth.rs
@@ -70,11 +70,21 @@ impl FromRequestParts<AppState> for AdminClaims {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        // When no JWT secret is configured the server runs in no-auth posture
-        // (TOPGUN_NO_AUTH=1). The loopback-only bind means the admin control
-        // plane is reachable only from localhost, so synthesizing a local-admin
-        // identity here is safe and allows the zero-config dashboard panels to
-        // return real data without requiring a token-minting path.
+        // Second enforcement layer for the no-auth admin bypass: even if a route
+        // is mistakenly mounted, refuse to synthesize the superuser when the admin
+        // plane is disabled (no-auth posture on a non-loopback bind). This is
+        // evaluated BEFORE the no-JWT-secret bypass so a disabled plane never falls
+        // through to the synthesized identity.
+        if !state.admin_enabled {
+            return Err(AdminAuthError::NotConfigured);
+        }
+
+        // The synthesized local-admin identity fires ONLY when the admin plane is
+        // enabled (admin_enabled == true) AND no JWT secret is configured
+        // (TOPGUN_NO_AUTH=1). In that posture the bind is loopback-only, so the
+        // admin control plane is reachable only from localhost — synthesizing a
+        // local-admin identity here is safe and lets the zero-config dashboard
+        // panels return real data without requiring a token-minting path.
         let Some(jwt_secret) = state.jwt_secret.as_deref() else {
             return Ok(AdminClaims {
                 user_id: "local-admin".to_string(),
@@ -472,6 +482,30 @@ CQIDAQAB
         assert!(
             claims.roles.contains(&"admin".to_string()),
             "synthesized roles should contain 'admin'"
+        );
+    }
+
+    /// Layer-2 backstop: when the admin plane is disabled (`admin_enabled ==
+    /// false`) the extractor MUST refuse to synthesize the local-admin superuser
+    /// EVEN with no JWT secret configured — so a future route-mounting regression
+    /// cannot re-open the no-auth admin bypass on a non-loopback bind.
+    #[tokio::test]
+    async fn no_auth_disabled_plane_rejected() {
+        let state = AppState {
+            admin_enabled: false,
+            jwt_secret: None,
+            ..AppState::for_test()
+        };
+        // No Authorization header and no JWT secret — without the guard this would
+        // synthesize the superuser; with the guard it must be rejected.
+        let req = axum::http::Request::builder()
+            .body(())
+            .expect("request construction should not fail");
+        let (mut parts, ()) = req.into_parts();
+        let result = AdminClaims::from_request_parts(&mut parts, &state).await;
+        assert!(
+            result.is_err(),
+            "disabled admin plane must reject even with jwt_secret=None, got {result:?}"
         );
     }
 

--- a/packages/server-rust/src/network/handlers/mod.rs
+++ b/packages/server-rust/src/network/handlers/mod.rs
@@ -126,6 +126,12 @@ pub struct AppState {
     /// populated in production wiring so `handle_socket` can release
     /// subscriptions on WebSocket disconnect.
     pub counter_registry: Option<Arc<CounterRegistry>>,
+    /// Second, independent enforcement layer for the no-auth admin bypass.
+    /// When `false`, the `AdminClaims` extractor refuses to synthesize the
+    /// local-admin superuser regardless of how the route was mounted, so a
+    /// future route-mounting regression cannot re-expose the unauthenticated
+    /// admin control plane on a non-loopback bind.
+    pub admin_enabled: bool,
 }
 
 impl AppState {
@@ -173,6 +179,9 @@ impl AppState {
             lock_registry: None,
             topic_registry: None,
             counter_registry: None,
+            // Default-safe: tests exercise the admin plane as enabled unless they
+            // explicitly override this to assert the disabled-plane guard.
+            admin_enabled: true,
         }
     }
 }

--- a/packages/server-rust/src/network/module.rs
+++ b/packages/server-rust/src/network/module.rs
@@ -741,6 +741,9 @@ fn build_app(
         lock_registry,
         topic_registry,
         counter_registry,
+        // This NetworkModule-managed path always mounts the admin plane and
+        // enforces auth, so the extractor guard is enabled to match.
+        admin_enabled: true,
     };
 
     // Delegate all route wiring to admin_routes() — the single source of truth

--- a/packages/server-rust/src/network/module.rs
+++ b/packages/server-rust/src/network/module.rs
@@ -447,107 +447,38 @@ struct AppServices {
 /// - `rate_limit_per_ip`: sustained request rate per IP (requests/second) fed
 ///   to the governor rate limiter on admin and login endpoints.
 /// - `rate_limit_burst`: initial burst capacity for the same governor.
+/// - `mount_admin`: when `false`, the admin control plane is left off the router.
+///   The admin API (`/api/admin/*`), the admin login/token/refresh routes
+///   (`/api/auth/login|token|refresh`), and the `/admin` SPA are NOT mounted, so
+///   they return 404 instead of exposing an unauthenticated superuser on a public
+///   no-auth bind. The data plane (`/health` + probes, `/ws`, `/sync`,
+///   `/metrics`, `/api/status`, `/api/auth/status`, `OpenAPI`) is always mounted.
 ///
-/// Neither parameter has an internal default: callers pass the values they read
-/// from their own `NetworkConfig` so the production rate-limit policy is always
-/// explicit and cannot silently drift.
+/// Neither rate-limit parameter has an internal default: callers pass the values
+/// they read from their own `NetworkConfig` so the production rate-limit policy is
+/// always explicit and cannot silently drift.
 ///
 /// # Panics
 ///
 /// Panics if the governor configuration fails to build (requires non-zero
 /// `rate_limit_burst`; `rate_limit_per_ip` of 0 is clamped to 1 internally).
 /// In practice this cannot happen when values come from a valid `NetworkConfig`.
-pub fn admin_routes(rate_limit_per_ip: u32, rate_limit_burst: u32) -> Router<AppState> {
+pub fn admin_routes(
+    rate_limit_per_ip: u32,
+    rate_limit_burst: u32,
+    mount_admin: bool,
+) -> Router<AppState> {
     // Build a per-IP rate limiter for admin and login endpoints.
     // Replenishment interval derived from rate_limit_per_ip: for 100 req/s the
     // governor refills 1 token every 10 ms. burst_size controls the initial
     // burst window. /ws and /sync are excluded because those have
     // operation-level load shedding instead of HTTP-layer rate limiting.
-    let replenish_interval_ms = (1000 / u64::from(rate_limit_per_ip).max(1)).max(1);
-    let governor_config = GovernorConfigBuilder::default()
-        .key_extractor(PeerIpKeyExtractor)
-        .per_millisecond(replenish_interval_ms)
-        .burst_size(rate_limit_burst)
-        .finish()
-        .expect("GovernorConfig should build with non-zero burst and period");
-
-    let governor_layer = GovernorLayer {
-        config: Arc::new(governor_config),
-    };
-
     // Swagger UI served at /api/docs (only when the `swagger` feature is enabled)
     #[cfg(feature = "swagger")]
     let swagger_ui = utoipa_swagger_ui::SwaggerUi::new("/api/docs")
         .url("/api/openapi.json", AdminApiDoc::openapi());
 
-    // Static SPA serving for admin dashboard.
-    //
-    // The unset default stays the monorepo-relative ./admin-dashboard/dist so
-    // `topgun dev` / `cargo run` from a checkout keeps working. For the prebuilt
-    // npm distribution the SPA lives inside the meta package, whose path the
-    // binary cannot know on its own — so the Node bin shim resolves the bundled
-    // SPA from its own __dirname and injects TOPGUN_ADMIN_DIR before exec'ing
-    // this binary. Layout resolution therefore lives entirely in the shim (one
-    // language, cross-layout-stable); no Rust-side path probing is added.
-    let admin_spa_dir =
-        std::env::var("TOPGUN_ADMIN_DIR").unwrap_or_else(|_| "./admin-dashboard/dist".to_string());
-    let index_html = format!("{admin_spa_dir}/index.html");
-    let serve_dir = ServeDir::new(&admin_spa_dir)
-        .append_index_html_on_directories(true)
-        .fallback(ServeFile::new(index_html));
-
-    // Rate-limited routes: admin API and login are brute-force targets and
-    // get per-IP throttling. All other routes (health, ws, sync, metrics,
-    // docs, status, admin SPA) bypass the governor.
-    let rate_limited_routes = Router::new()
-        .route("/api/auth/login", post(login))
-        .route("/api/auth/token", post(token_exchange_handler))
-        .route("/api/auth/refresh", post(refresh_handler))
-        .route("/api/admin/cluster/status", get(cluster_status))
-        .route("/api/admin/maps", get(list_maps))
-        .route(
-            "/api/admin/settings",
-            get(get_settings).put(update_settings),
-        )
-        .route(
-            "/api/admin/policies",
-            get(list_policies).post(create_policy),
-        )
-        .route("/api/admin/policies/{id}", delete(delete_policy))
-        .route("/api/admin/indexes", get(list_indexes).post(create_index))
-        .route(
-            "/api/admin/indexes/{map}/{attr}",
-            delete(remove_index_handler),
-        )
-        .route(
-            "/api/admin/indexes/{map}/{attr}/status",
-            get(index_backfill_status),
-        )
-        // Vector index admin endpoints — nested under /api/admin/indexes/vector
-        // to avoid collision with the existing /api/admin/indexes/{map}/{attr} routes.
-        .route(
-            "/api/admin/indexes/vector",
-            get(list_vector_indexes).post(create_vector_index),
-        )
-        .route(
-            "/api/admin/indexes/vector/{map}/{name}",
-            delete(remove_vector_index_handler),
-        )
-        .route(
-            "/api/admin/indexes/vector/{map}/{name}/optimize",
-            post(optimize_vector_index_handler),
-        )
-        .route(
-            "/api/admin/indexes/vector/{map}/{name}/optimize/{optimization_id}",
-            delete(cancel_vector_index_optimize_handler),
-        )
-        .route(
-            "/api/admin/indexes/vector/{map}/{name}/status",
-            get(vector_index_status),
-        )
-        .route_layer(governor_layer);
-
-    let router = Router::new()
+    let mut router = Router::new()
         // Health probes -- never rate-limited (Kubernetes liveness/readiness).
         // /healthz is the ops-standard alias for /health/ready: returns 503
         // during startup recovery and 200 once the server is ready. Registered
@@ -565,11 +496,104 @@ pub fn admin_routes(rate_limit_per_ip: u32, rate_limit_burst: u32) -> Router<App
         .route("/api/status", get(server_status))
         // Auth posture probe -- must be on the public router so the admin
         // frontend can call it without a token before deciding to show Login
-        .route("/api/auth/status", get(auth_status))
-        // Rate-limited admin and login routes
-        .merge(rate_limited_routes)
-        // Static SPA for admin dashboard -- served as static files, not rate-limited
-        .nest_service("/admin", serve_dir);
+        .route("/api/auth/status", get(auth_status));
+
+    // The admin control plane is mounted only when `mount_admin` is set. On a
+    // no-auth public bind the binary passes `false` so the unauthenticated
+    // synthesized superuser cannot be reached from the network: the admin API,
+    // the admin login/token/refresh routes, and the /admin SPA are simply absent
+    // (404) rather than guarded by a bypassable auth check.
+    if mount_admin {
+        // Build a per-IP rate limiter for admin and login endpoints.
+        // Replenishment interval derived from rate_limit_per_ip: for 100 req/s the
+        // governor refills 1 token every 10 ms. burst_size controls the initial
+        // burst window. /ws and /sync are excluded because those have
+        // operation-level load shedding instead of HTTP-layer rate limiting.
+        let replenish_interval_ms = (1000 / u64::from(rate_limit_per_ip).max(1)).max(1);
+        let governor_config = GovernorConfigBuilder::default()
+            .key_extractor(PeerIpKeyExtractor)
+            .per_millisecond(replenish_interval_ms)
+            .burst_size(rate_limit_burst)
+            .finish()
+            .expect("GovernorConfig should build with non-zero burst and period");
+
+        let governor_layer = GovernorLayer {
+            config: Arc::new(governor_config),
+        };
+
+        // Static SPA serving for admin dashboard.
+        //
+        // The unset default stays the monorepo-relative ./admin-dashboard/dist so
+        // `topgun dev` / `cargo run` from a checkout keeps working. For the prebuilt
+        // npm distribution the SPA lives inside the meta package, whose path the
+        // binary cannot know on its own — so the Node bin shim resolves the bundled
+        // SPA from its own __dirname and injects TOPGUN_ADMIN_DIR before exec'ing
+        // this binary. Layout resolution therefore lives entirely in the shim (one
+        // language, cross-layout-stable); no Rust-side path probing is added.
+        let admin_spa_dir = std::env::var("TOPGUN_ADMIN_DIR")
+            .unwrap_or_else(|_| "./admin-dashboard/dist".to_string());
+        let index_html = format!("{admin_spa_dir}/index.html");
+        let serve_dir = ServeDir::new(&admin_spa_dir)
+            .append_index_html_on_directories(true)
+            .fallback(ServeFile::new(index_html));
+
+        // Rate-limited routes: admin API and login are brute-force targets and
+        // get per-IP throttling. All other routes (health, ws, sync, metrics,
+        // docs, status, admin SPA) bypass the governor.
+        let rate_limited_routes = Router::new()
+            .route("/api/auth/login", post(login))
+            .route("/api/auth/token", post(token_exchange_handler))
+            .route("/api/auth/refresh", post(refresh_handler))
+            .route("/api/admin/cluster/status", get(cluster_status))
+            .route("/api/admin/maps", get(list_maps))
+            .route(
+                "/api/admin/settings",
+                get(get_settings).put(update_settings),
+            )
+            .route(
+                "/api/admin/policies",
+                get(list_policies).post(create_policy),
+            )
+            .route("/api/admin/policies/{id}", delete(delete_policy))
+            .route("/api/admin/indexes", get(list_indexes).post(create_index))
+            .route(
+                "/api/admin/indexes/{map}/{attr}",
+                delete(remove_index_handler),
+            )
+            .route(
+                "/api/admin/indexes/{map}/{attr}/status",
+                get(index_backfill_status),
+            )
+            // Vector index admin endpoints — nested under /api/admin/indexes/vector
+            // to avoid collision with the existing /api/admin/indexes/{map}/{attr} routes.
+            .route(
+                "/api/admin/indexes/vector",
+                get(list_vector_indexes).post(create_vector_index),
+            )
+            .route(
+                "/api/admin/indexes/vector/{map}/{name}",
+                delete(remove_vector_index_handler),
+            )
+            .route(
+                "/api/admin/indexes/vector/{map}/{name}/optimize",
+                post(optimize_vector_index_handler),
+            )
+            .route(
+                "/api/admin/indexes/vector/{map}/{name}/optimize/{optimization_id}",
+                delete(cancel_vector_index_optimize_handler),
+            )
+            .route(
+                "/api/admin/indexes/vector/{map}/{name}/status",
+                get(vector_index_status),
+            )
+            .route_layer(governor_layer);
+
+        router = router
+            // Rate-limited admin and login routes
+            .merge(rate_limited_routes)
+            // Static SPA for admin dashboard -- served as static files, not rate-limited
+            .nest_service("/admin", serve_dir);
+    }
 
     // Serve the machine-readable OpenAPI JSON spec. In swagger-feature builds the
     // SwaggerUi merge below already registers `/api/openapi.json` (via `.url(...)`),
@@ -722,7 +746,12 @@ fn build_app(
     // Delegate all route wiring to admin_routes() — the single source of truth
     // for the route set both build_app and the binary serve. This ensures the
     // production server and the binary can never drift apart.
-    admin_routes(rate_limit_per_ip, rate_limit_burst)
+    //
+    // This NetworkModule-managed path cannot compute bind posture from a startup
+    // decision (the listener is bound elsewhere), so it always mounts the admin
+    // plane; auth is enforced on this path, so the admin routes are JWT-protected.
+    // The binary serve path computes posture and passes the gated flag itself.
+    admin_routes(rate_limit_per_ip, rate_limit_burst, true)
         .layer(layers)
         .with_state(state)
 }

--- a/packages/server-rust/tests/router_contract.rs
+++ b/packages/server-rust/tests/router_contract.rs
@@ -69,13 +69,14 @@ fn is_allowed_status_login(status: StatusCode) -> bool {
 /// `admin_routes()` + the browser WS dual-mount on `/`.
 /// Using the same construction path ensures the test exercises exactly the
 /// router the binary serves, not a hypothetical variant.
-fn build_binary_router() -> axum::Router {
+fn build_binary_router(mount_admin: bool) -> axum::Router {
     // Use the default rate-limit values from NetworkConfig so the governor is
     // configured exactly as the binary would configure it.
     let default_config = topgun_server::network::config::NetworkConfig::default();
     admin_routes(
         default_config.rate_limit_per_ip,
         default_config.rate_limit_burst,
+        mount_admin,
     )
     // Browser WS dual-mount: the binary's only extra route beyond admin_routes().
     .route(
@@ -90,7 +91,7 @@ async fn binary_router_serves_all_required_routes() {
     // Ensure no JWT_SECRET is set so no-auth endpoints respond normally.
     std::env::remove_var("JWT_SECRET");
 
-    let router = build_binary_router();
+    let router = build_binary_router(true);
 
     // A real loopback address injected as ConnectInfo so the governor's
     // PeerIpKeyExtractor can identify the client IP without a real TCP connection.
@@ -152,7 +153,11 @@ async fn admin_endpoints_bypass_auth_when_no_jwt_secret() {
     // rejecting the request when no JWT secret is configured.
     std::env::remove_var("JWT_SECRET");
 
-    let router = build_binary_router();
+    // mount_admin=true: this test's premise is that the admin plane IS mounted
+    // under for_test() (no-auth) and the AdminClaims extractor synthesizes a
+    // local-admin identity rather than 401ing. The gated-OFF posture is covered
+    // separately by admin_plane_gated_off_returns_404.
+    let router = build_binary_router(true);
 
     // GET endpoints: the store-less for_test() fixture returns 503 (not 401),
     // which proves the auth gate is bypassed.
@@ -210,5 +215,75 @@ async fn admin_endpoints_bypass_auth_when_no_jwt_secret() {
         StatusCode::UNAUTHORIZED,
         "PUT /api/admin/settings returned 401 on no-auth server — \
          AdminClaims extractor should synthesize local-admin for mutating paths too"
+    );
+}
+
+#[tokio::test]
+async fn admin_plane_gated_off_returns_404() {
+    // mount_admin=false is the no-auth public-bind posture: the admin control
+    // plane must be ABSENT (404), not merely auth-guarded. A 404 proves the
+    // synthesized superuser cannot be reached unauthenticated from the network;
+    // a 401 would mean the route is still mounted (a regression). The data plane
+    // (/health) must stay live (200) so the server is still useful.
+    std::env::remove_var("JWT_SECRET");
+
+    let router = build_binary_router(false);
+
+    // ConnectInfo is injected for parity with the other tests even though the
+    // governor layer is absent when the admin plane is gated off.
+    let peer_addr: SocketAddr = "127.0.0.1:12345".parse().expect("valid socket addr");
+
+    // Every gated-off path must return 404 (route absent), NOT 401 (mounted+guarded).
+    let gated_off: &[(Method, &str, Option<&str>)] = &[
+        (Method::GET, "/api/admin/cluster/status", None),
+        (Method::GET, "/api/admin/maps", None),
+        (Method::POST, "/api/auth/login", Some("application/json")),
+    ];
+
+    for (method, path, content_type) in gated_off {
+        let body: axum::body::Body = if *method == Method::POST {
+            axum::body::Body::from(r#"{"username":"admin","password":"test"}"#)
+        } else {
+            axum::body::Body::empty()
+        };
+        let mut builder = Request::builder().method(method.clone()).uri(*path);
+        if let Some(ct) = content_type {
+            builder = builder.header("content-type", *ct);
+        }
+        let mut req = builder.body(body).expect("request should build");
+        req.extensions_mut().insert(ConnectInfo(peer_addr));
+
+        let resp = router
+            .clone()
+            .oneshot(req)
+            .await
+            .expect("router should handle the request");
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "{method} {path} should be 404 when mount_admin=false (admin plane absent), \
+             not {} — a non-404 means the route is still mounted and the gate failed.",
+            resp.status()
+        );
+    }
+
+    // The data plane stays live: /health must return 200 even with admin gated off.
+    let mut req = Request::builder()
+        .method(Method::GET)
+        .uri("/health")
+        .body(axum::body::Body::empty())
+        .expect("request should build");
+    req.extensions_mut().insert(ConnectInfo(peer_addr));
+
+    let resp = router
+        .oneshot(req)
+        .await
+        .expect("router should handle the request");
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "/health should be 200 with admin gated off — the data plane must stay live"
     );
 }


### PR DESCRIPTION
## What

Security audit F4 (DEPTH_SECURITY_AUTHZ.md): `TOPGUN_NO_AUTH=1` + non-loopback bind left `/api/admin/*` reachable unauthenticated with a synthesized superuser.

## Approach (revised — two layers, no refuse-to-start)

First attempt (refuse-to-start) broke the no-auth Docker smoke (containers bind 0.0.0.0). Corrected to **gate the admin plane, keep the data plane up**:
- **SPEC-313 (route gate):** `admin_bind_posture` → `BindPosture::AdminDisabled` on no-auth+non-loopback → `mount_admin()=false`, `/api/admin/*` + admin login/SPA not mounted. Server starts; data plane (/health, /ws, /sync) stays up. Loopback no-auth + auth-enforced still mount admin. `TOPGUN_ALLOW_NO_AUTH_PUBLIC_BIND=1` opts in.
- **SPEC-314 (layer-2 extractor guard):** `AppState.admin_enabled` single source of truth; `AdminClaims` extractor refuses to synthesize the local-admin superuser when `!admin_enabled` — so even if a route is mistakenly mounted (dual-router), the bypass can't re-open.

## Verified locally

- Binary smoke (exact Docker scenario): `TOPGUN_NO_AUTH=1 TOPGUN_BIND_ADDR=0.0.0.0` → /health 200 `{state:ready}`, `GET /api/admin/policies → 404`, warn logged. **Server starts (fixes the PR#58 Docker failure).**
- bin posture tests 5/5; sim-convergence 4/4; clippy -D warnings + fmt clean.

## Merge gate

`gh pr checks` ALL-green incl **build-and-push (Docker)** AND **Simulation Tests**, verified separately.