### PR TITLE
refactor(sf-316): remove dead dual-authZ — WriteValidator→WriteAdmission, RBAC sole authorization

### DIFF
--- a/apps/docs-astro/src/content/docs/guides/rbac.mdx
+++ b/apps/docs-astro/src/content/docs/guides/rbac.mdx
@@ -19,6 +19,20 @@ import { AlertBox } from '../../../components/docs/AlertBox';
 
 TopGun enforces **per-collection, per-operation** access control on the server. A Tower middleware layer checks every client read, write, and remove against a policy store before the operation reaches the domain services. This is shipped and active today — you do **not** need to re-implement authorization in your application code. App-layer claim checks are fine as optional defense-in-depth, but server-side enforcement is the authoritative gate.
 
+## Two server-side gates: admission, then authorization
+
+Every client operation passes through two distinct server-side gates, in order. They answer different questions, and only the second one is authorization:
+
+1. **Admission** — a cheap, identity-agnostic integrity and quota gate at the edge. It does not decide *who may touch which collection*; it only rejects malformed or unauthenticated traffic before any policy is consulted. Its responsibilities are: enforce the authentication baseline (`require_auth`), deny anonymous writes, cap payloads at the value-size limit (`max_value_bytes`), sanitize incoming HLC timestamps, and route by trusted origin.
+2. **Authorization** — **RBAC is the sole authorization layer**, and it is the policy engine described in the rest of this page. Once a request clears admission, RBAC is the only thing that decides whether a given principal may `read`, `write`, or `remove` a given collection.
+
+| Gate | Question it answers | Identity-aware? | Mechanism |
+|------|---------------------|-----------------|-----------|
+| Admission | Is this request well-formed, authenticated, and within limits? | No | `require_auth`, deny-anonymous-writes, `max_value_bytes`, HLC sanitization, trusted-origin routing |
+| Authorization | May *this principal* perform *this action* on *this collection*? | Yes | RBAC policies (this page) |
+
+There is exactly one authorization layer — RBAC. Admission is a guard, not a second set of permissions, so there is no per-map ACL or any other authorization mechanism to configure alongside it.
+
 ## How evaluation works
 
 Authorization runs on every client operation (`read`, `write`, `remove`):

--- a/packages/server-rust/benches/load_harness/main.rs
+++ b/packages/server-rust/benches/load_harness/main.rs
@@ -38,7 +38,7 @@ use topgun_server::service::domain::sync::SyncService;
 use topgun_server::service::middleware::build_operation_pipeline;
 use topgun_server::service::operation::service_names;
 use topgun_server::service::router::OperationRouter;
-use topgun_server::service::security::{SecurityConfig, WriteValidator};
+use topgun_server::service::security::{SecurityConfig, WriteAdmission};
 use topgun_server::service::OperationService;
 use topgun_server::storage::datastores::NullDataStore;
 use topgun_server::storage::factory::{ObserverFactory, RecordStoreFactory};
@@ -628,7 +628,7 @@ fn build_services() -> (
             config.node_id.clone(),
             Box::new(SystemClock),
         )));
-        Arc::new(WriteValidator::new(
+        Arc::new(WriteAdmission::new(
             Arc::new(SecurityConfig::default()),
             wv_hlc,
         ))

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -76,7 +76,7 @@ use topgun_server::service::policy::{
 };
 use topgun_server::service::registry::{ManagedService, ServiceContext};
 use topgun_server::service::router::OperationRouter;
-use topgun_server::service::security::{SecurityConfig, WriteValidator};
+use topgun_server::service::security::{SecurityConfig, WriteAdmission};
 use topgun_server::service::OperationService;
 #[cfg(feature = "redb")]
 use topgun_server::storage::datastores::RedbDataStore;
@@ -1239,7 +1239,7 @@ fn build_services(
             config.node_id.clone(),
             Box::new(SystemClock),
         )));
-        Arc::new(WriteValidator::new(
+        Arc::new(WriteAdmission::new(
             Arc::new(SecurityConfig::default()),
             wv_hlc,
         ))

--- a/packages/server-rust/src/lib.rs
+++ b/packages/server-rust/src/lib.rs
@@ -61,18 +61,18 @@ mod integration_tests {
     use crate::service::operation::{service_names, CallerOrigin, OperationResponse};
     use crate::service::registry::{ServiceContext, ServiceRegistry};
     use crate::service::router::OperationRouter;
-    use crate::service::security::{SecurityConfig, WriteValidator};
+    use crate::service::security::{SecurityConfig, WriteAdmission};
     use crate::service::{ClassifyError, OperationService};
     use crate::storage::datastores::NullDataStore;
     use crate::storage::factory::{ObserverFactory, RecordStoreFactory};
     use crate::storage::impls::StorageConfig;
     use crate::storage::merkle_sync::{MerkleObserverFactory, MerkleSyncManager};
-    fn make_write_validator(node_id: &str) -> Arc<WriteValidator> {
+    fn make_write_validator(node_id: &str) -> Arc<WriteAdmission> {
         let hlc = Arc::new(parking_lot::Mutex::new(HLC::new(
             node_id.to_string(),
             Box::new(topgun_core::SystemClock),
         )));
-        Arc::new(WriteValidator::new(
+        Arc::new(WriteAdmission::new(
             Arc::new(SecurityConfig::default()),
             hlc,
         ))

--- a/packages/server-rust/src/network/connection.rs
+++ b/packages/server-rust/src/network/connection.rs
@@ -4,7 +4,7 @@
 //! lock-free concurrent connection tracking via `DashMap`, and
 //! metadata storage for authentication and subscription state.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -14,34 +14,6 @@ use tokio::sync::{mpsc, RwLock};
 use topgun_core::{Principal, Timestamp};
 
 use super::config::ConnectionConfig;
-
-// ---------------------------------------------------------------------------
-// MapPermissions
-// ---------------------------------------------------------------------------
-
-/// Per-map read/write access permissions for a connection.
-///
-/// Defined here (not in `service/security.rs`) to avoid a circular module
-/// dependency: `service` imports from `network`, so placing `MapPermissions`
-/// in `service` would require `network` to import from `service`, creating a cycle.
-/// As a plain data struct with no service logic, it belongs here.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MapPermissions {
-    /// Whether this connection may read from the map.
-    pub read: bool,
-    /// Whether this connection may write to the map.
-    pub write: bool,
-}
-
-impl Default for MapPermissions {
-    fn default() -> Self {
-        Self {
-            read: true,
-            write: true,
-        }
-    }
-}
 
 /// Unique identifier for a connection, assigned by the registry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -156,9 +128,6 @@ pub struct ConnectionMetadata {
     pub last_hlc: Option<Timestamp>,
     /// For cluster peer connections, the remote node's ID.
     pub peer_node_id: Option<String>,
-    /// Per-map access permissions for this connection.
-    /// Maps not present here fall back to `SecurityConfig.default_permissions`.
-    pub map_permissions: HashMap<String, MapPermissions>,
 }
 
 impl Default for ConnectionMetadata {
@@ -171,7 +140,6 @@ impl Default for ConnectionMetadata {
             last_heartbeat: Instant::now(),
             last_hlc: None,
             peer_node_id: None,
-            map_permissions: HashMap::new(),
         }
     }
 }

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -30,7 +30,7 @@ use crate::service::operation::{
     service_names, CallerOrigin, Operation, OperationContext, OperationError, OperationResponse,
 };
 use crate::service::registry::{ManagedService, ServiceContext};
-use crate::service::security::WriteValidator;
+use crate::service::security::WriteAdmission;
 use crate::storage::record::{OrMapEntry, RecordValue};
 use crate::storage::{CallerProvenance, ExpiryPolicy, RecordStoreFactory};
 use crate::traits::SchemaProvider;
@@ -64,11 +64,11 @@ fn matches_query_predicate(query: &topgun_core::messages::base::Query, data: &rm
 /// Merges LWW and OR-Map data into the `RecordStore` and broadcasts
 /// `ServerEvent` messages to connected clients.
 ///
-/// Validation order: auth/ACL/size (`WriteValidator`) → schema (`SchemaProvider`) → CRDT merge.
+/// Validation order: auth/size (`WriteAdmission`) → schema (`SchemaProvider`) → CRDT merge.
 pub struct CrdtService {
     record_store_factory: Arc<RecordStoreFactory>,
     connection_registry: Arc<ConnectionRegistry>,
-    write_validator: Arc<WriteValidator>,
+    write_validator: Arc<WriteAdmission>,
     query_registry: Arc<QueryRegistry>,
     schema_provider: Arc<dyn SchemaProvider>,
 }
@@ -79,7 +79,7 @@ impl CrdtService {
     pub fn new(
         record_store_factory: Arc<RecordStoreFactory>,
         connection_registry: Arc<ConnectionRegistry>,
-        write_validator: Arc<WriteValidator>,
+        write_validator: Arc<WriteAdmission>,
         query_registry: Arc<QueryRegistry>,
         schema_provider: Arc<dyn SchemaProvider>,
     ) -> Self {
@@ -176,22 +176,17 @@ impl CrdtService {
         let sanitized_ts = if let Some(conn_id) = ctx.connection_id {
             let metadata_snapshot = self.snapshot_metadata(conn_id).await?;
             let value_size = estimate_value_size(op);
-            self.write_validator.validate_write(
-                ctx,
-                &metadata_snapshot,
-                &op.map_name,
-                value_size,
-            )?;
-            // Schema validation runs after auth/ACL/size checks.
+            self.write_validator
+                .admit_write(ctx, &metadata_snapshot, &op.map_name, value_size)?;
+            // Schema validation runs after auth/size admission checks.
             self.validate_schema_for_op(op)?;
             Some(self.write_validator.sanitize_hlc())
         } else if ctx.caller_origin == CallerOrigin::HttpClient {
-            // HTTP /sync carries no per-connection ACL handle, but the JWT-validated
+            // HTTP /sync carries no per-connection handle, but the JWT-validated
             // identity is on ctx.principal (set eagerly by the HTTP handler before
-            // dispatch). Derive an honest authenticated flag from it so validate_write's
+            // dispatch). Derive an honest authenticated flag from it so admit_write's
             // auth gate passes for legitimate writes and fail-closes if a principal is
-            // ever absent. Empty map_permissions falls back to default_permissions (HTTP
-            // has no per-connection ACL). Then re-stamp the HLC so a forged client
+            // ever absent. Then re-stamp the HLC so a forged client
             // timestamp cannot win Last-Write-Wins forever.
             let metadata_snapshot = ConnectionMetadata {
                 authenticated: ctx.principal.is_some(),
@@ -199,12 +194,8 @@ impl CrdtService {
                 ..Default::default()
             };
             let value_size = estimate_value_size(op);
-            self.write_validator.validate_write(
-                ctx,
-                &metadata_snapshot,
-                &op.map_name,
-                value_size,
-            )?;
+            self.write_validator
+                .admit_write(ctx, &metadata_snapshot, &op.map_name, value_size)?;
             self.validate_schema_for_op(op)?;
             Some(self.write_validator.sanitize_hlc())
         } else {
@@ -262,7 +253,7 @@ impl CrdtService {
             let metadata_snapshot = self.snapshot_metadata(conn_id).await?;
             for op in ops {
                 let value_size = estimate_value_size(op);
-                self.write_validator.validate_write(
+                self.write_validator.admit_write(
                     ctx,
                     &metadata_snapshot,
                     &op.map_name,
@@ -295,10 +286,10 @@ impl CrdtService {
                 }
             }
         } else if ctx.caller_origin == CallerOrigin::HttpClient {
-            // HTTP /sync batch: no per-connection ACL handle, but the JWT-validated
+            // HTTP /sync batch: no per-connection handle, but the JWT-validated
             // identity is on ctx.principal (set eagerly by the HTTP handler before
             // dispatch). Snapshot an honest authenticated flag from it once at batch
-            // start so validate_write's auth gate passes for legitimate writes and
+            // start so admit_write's auth gate passes for legitimate writes and
             // fail-closes if a principal is ever absent. Then re-stamp every op's HLC so
             // a forged client timestamp cannot win Last-Write-Wins forever.
             let metadata_snapshot = ConnectionMetadata {
@@ -308,7 +299,7 @@ impl CrdtService {
             };
             for op in ops {
                 let value_size = estimate_value_size(op);
-                self.write_validator.validate_write(
+                self.write_validator.admit_write(
                     ctx,
                     &metadata_snapshot,
                     &op.map_name,
@@ -925,7 +916,7 @@ mod tests {
     use crate::service::domain::query::QueryRegistry;
     use crate::service::domain::schema::SchemaService;
     use crate::service::operation::{service_names, OperationContext, OperationResponse};
-    use crate::service::security::{SecurityConfig, WriteValidator};
+    use crate::service::security::{SecurityConfig, WriteAdmission};
     use crate::storage::datastores::NullDataStore;
     use crate::storage::factory::RecordStoreFactory;
     use crate::storage::impls::StorageConfig;
@@ -938,12 +929,12 @@ mod tests {
         ))
     }
 
-    fn make_validator() -> Arc<WriteValidator> {
+    fn make_validator() -> Arc<WriteAdmission> {
         let hlc = Arc::new(Mutex::new(HLC::new(
             "test-node".to_string(),
             Box::new(SystemClock),
         )));
-        Arc::new(WriteValidator::new(
+        Arc::new(WriteAdmission::new(
             Arc::new(SecurityConfig::default()),
             hlc,
         ))
@@ -1254,7 +1245,7 @@ mod tests {
     // Security integration tests (AC1, AC2, AC3, AC8, AC18, AC19, AC20)
     // ---------------------------------------------------------------------------
 
-    fn make_strict_validator() -> Arc<WriteValidator> {
+    fn make_strict_validator() -> Arc<WriteAdmission> {
         let hlc = Arc::new(Mutex::new(HLC::new(
             "server-node".to_string(),
             Box::new(SystemClock),
@@ -1262,9 +1253,8 @@ mod tests {
         let config = SecurityConfig {
             require_auth: true,
             max_value_bytes: 0,
-            ..SecurityConfig::default()
         };
-        Arc::new(WriteValidator::new(Arc::new(config), hlc))
+        Arc::new(WriteAdmission::new(Arc::new(config), hlc))
     }
 
     fn make_strict_service() -> (Arc<CrdtService>, Arc<ConnectionRegistry>) {
@@ -1367,52 +1357,26 @@ mod tests {
         );
     }
 
-    // -- AC2: authenticated + no write perm => Forbidden --
-
-    #[tokio::test]
-    async fn no_write_permission_returns_forbidden() {
-        use crate::network::connection::MapPermissions;
-        let (svc, registry) = make_strict_service();
-        let config = crate::network::config::ConnectionConfig::default();
-        let (handle, _rx) = registry.register(ConnectionKind::Client, &config);
-        {
-            let mut meta = handle.metadata.write().await;
-            meta.authenticated = true;
-            meta.map_permissions.insert(
-                "locked-map".to_string(),
-                MapPermissions {
-                    read: true,
-                    write: false,
-                },
-            );
-        }
-
-        let ctx = make_ctx_with_conn(handle.id);
-        let op = make_lww_put_op(ctx, "locked-map");
-        let result = svc.oneshot(op).await;
-        assert!(
-            matches!(result, Err(OperationError::Forbidden { .. })),
-            "expected Forbidden for no-write-perm connection, got {result:?}"
-        );
-    }
-
     // -- AC8: batch atomic rejection: if 2nd op fails, 1st op's data not written --
     // (Verified via the validate-all-then-apply-all logic in handle_op_batch)
 
     #[tokio::test]
     async fn op_batch_atomic_rejection_when_second_op_fails() {
-        use crate::network::connection::MapPermissions;
-
+        // Atomicity is driven by a surviving admission check (value-size limit):
+        // op-1 is a tombstone REMOVE (size 0, admitted) while op-2 carries an
+        // oversized value that trips `max_value_bytes`. If admission were applied
+        // per-op-then-write instead of validate-all-then-apply-all, op-1's data
+        // would already be persisted when op-2 fails — this test fails the batch
+        // and (below) asserts op-1 left no record behind.
         let hlc = Arc::new(Mutex::new(HLC::new(
             "server-node".to_string(),
             Box::new(SystemClock),
         )));
         let config = SecurityConfig {
-            require_auth: true,
-            max_value_bytes: 0,
-            ..SecurityConfig::default()
+            require_auth: false,
+            max_value_bytes: 8,
         };
-        let validator = Arc::new(WriteValidator::new(Arc::new(config), hlc));
+        let validator = Arc::new(WriteAdmission::new(Arc::new(config), hlc));
         let factory = make_factory();
         let registry = Arc::new(ConnectionRegistry::new());
         let query_registry = Arc::new(QueryRegistry::new());
@@ -1426,18 +1390,6 @@ mod tests {
 
         let conn_config = crate::network::config::ConnectionConfig::default();
         let (handle, _rx) = registry.register(ConnectionKind::Client, &conn_config);
-        {
-            let mut meta = handle.metadata.write().await;
-            meta.authenticated = true;
-            // Grant write to "open-map" but deny write to "locked-map"
-            meta.map_permissions.insert(
-                "locked-map".to_string(),
-                MapPermissions {
-                    read: true,
-                    write: false,
-                },
-            );
-        }
 
         let ctx = {
             let mut ctx = make_ctx();
@@ -1445,26 +1397,35 @@ mod tests {
             ctx
         };
 
+        // op-2 carries a value that serializes well beyond the 8-byte limit.
+        let oversized_record = topgun_core::LWWRecord {
+            value: Some(rmpv::Value::String(
+                "this-value-is-far-larger-than-eight-bytes".into(),
+            )),
+            timestamp: make_timestamp(),
+            ttl_ms: None,
+        };
+
         let ops = vec![
-            // op-1 targets "open-map" — would succeed if applied alone
+            // op-1 is a tombstone REMOVE on "open-map" — size 0, admitted alone.
             topgun_core::messages::base::ClientOp {
                 id: Some("op-1".to_string()),
                 map_name: "open-map".to_string(),
                 key: "key-1".to_string(),
                 op_type: None,
-                record: None,
+                record: Some(None),
                 or_record: None,
                 or_tag: None,
                 write_concern: None,
                 timeout: None,
             },
-            // op-2 targets "locked-map" — will fail validation
+            // op-2 targets "open-map" with an oversized value — fails admission.
             topgun_core::messages::base::ClientOp {
                 id: Some("op-2".to_string()),
-                map_name: "locked-map".to_string(),
+                map_name: "open-map".to_string(),
                 key: "key-2".to_string(),
                 op_type: None,
-                record: None,
+                record: Some(Some(oversized_record)),
                 or_record: None,
                 or_tag: None,
                 write_concern: None,
@@ -1483,12 +1444,22 @@ mod tests {
             },
         };
 
-        // The batch must fail due to op-2
+        // The batch must fail due to op-2's oversized value.
         let result = svc.oneshot(op).await;
         assert!(
-            matches!(result, Err(OperationError::Forbidden { .. })),
-            "expected Forbidden for batch with locked op, got {result:?}"
+            matches!(result, Err(OperationError::ValueTooLarge { .. })),
+            "expected ValueTooLarge for batch with oversized op, got {result:?}"
         );
+
+        // Atomicity: op-1's tombstone must NOT have been applied. Because the batch
+        // is validated-all-then-applied-all, a rejection leaves no store touched for
+        // the target map (no record for key-1 in any partition).
+        for store in factory.get_all_for_map("open-map") {
+            assert!(
+                store.get("key-1", false).await.unwrap().is_none(),
+                "op-1 must not be persisted when the batch is rejected"
+            );
+        }
     }
 
     // -- AC20: REMOVE ops are never rejected due to value size --
@@ -1502,9 +1473,8 @@ mod tests {
         let config = SecurityConfig {
             require_auth: false,
             max_value_bytes: 1, // very small limit
-            ..SecurityConfig::default()
         };
-        let validator = Arc::new(WriteValidator::new(Arc::new(config), hlc));
+        let validator = Arc::new(WriteAdmission::new(Arc::new(config), hlc));
         let factory = make_factory();
         let registry = Arc::new(ConnectionRegistry::new());
         let query_registry = Arc::new(QueryRegistry::new());
@@ -1947,7 +1917,7 @@ mod tests {
             require_auth: false,
             ..SecurityConfig::default()
         };
-        let validator = Arc::new(WriteValidator::new(Arc::new(config), hlc));
+        let validator = Arc::new(WriteAdmission::new(Arc::new(config), hlc));
         let svc = Arc::new(CrdtService::new(
             Arc::clone(&factory),
             Arc::clone(&registry),

--- a/packages/server-rust/src/service/mod.rs
+++ b/packages/server-rust/src/service/mod.rs
@@ -34,5 +34,5 @@ pub use policy::{
 };
 pub use registry::{ManagedService, ServiceContext, ServiceRegistry};
 pub use router::OperationRouter;
-pub use security::{SecurityConfig, WriteValidator};
+pub use security::{SecurityConfig, WriteAdmission};
 pub use worker::{BackgroundRunnable, BackgroundWorker};

--- a/packages/server-rust/src/service/security.rs
+++ b/packages/server-rust/src/service/security.rs
@@ -152,7 +152,6 @@ impl WriteAdmission {
 #[cfg(test)]
 #[allow(clippy::default_trait_access)]
 mod tests {
-    use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -204,7 +203,6 @@ mod tests {
             last_heartbeat: Instant::now(),
             last_hlc: None,
             peer_node_id: None,
-            map_permissions: HashMap::new(),
         }
     }
 

--- a/packages/server-rust/src/service/security.rs
+++ b/packages/server-rust/src/service/security.rs
@@ -1,9 +1,15 @@
-//! Write validation layer: authentication, map-level ACL, value size limits, and HLC sanitization.
+//! Write admission layer: authentication baseline, value size limits, and HLC sanitization.
 //!
-//! The security layer intercepts all client write operations BEFORE they reach CRDT merge:
+//! This is an admission/integrity control at the edge, NOT an authorization layer.
+//! It performs cheap, identity-agnostic gating before client writes reach CRDT merge:
+//! deny anonymous writes, route trusted server-to-server traffic past the gate, enforce
+//! an authentication baseline, bound payload size, and sanitize client-provided HLC
+//! timestamps. Per-resource authorization (who may write which map/record) is owned
+//! exclusively by the RBAC policy engine, which runs separately — admission makes no
+//! identity-aware ACL decision.
 //!
 //! ```text
-//! Client write -> Auth check -> Map ACL check -> Size check -> HLC sanitize -> CRDT merge
+//! Client write -> Auth baseline -> Size check -> HLC sanitize -> CRDT merge
 //! ```
 //!
 //! Operations from trusted origins (`Forwarded`, `Backup`, `Wan`, `System`) bypass all checks.
@@ -13,18 +19,17 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use topgun_core::{Timestamp, HLC};
 
-use crate::network::connection::{ConnectionMetadata, MapPermissions};
+use crate::network::connection::ConnectionMetadata;
 use crate::service::operation::{CallerOrigin, OperationContext, OperationError};
 
 // ---------------------------------------------------------------------------
 // SecurityConfig
 // ---------------------------------------------------------------------------
 
-/// Configuration for the server-side write validation layer.
+/// Configuration for the server-side write admission layer.
 ///
-/// Default is intentionally permissive (`require_auth: false`, unlimited size,
-/// default read+write permissions) to preserve backward compatibility for
-/// deployments without security configuration.
+/// Default is intentionally permissive (`require_auth: false`, unlimited size)
+/// to preserve backward compatibility for deployments without security configuration.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SecurityConfig {
@@ -35,51 +40,53 @@ pub struct SecurityConfig {
     /// 0 means unlimited. Uses `u64` (not `usize`) so this value is stable across
     /// 32-bit and 64-bit platforms and can be safely stored in config files.
     pub max_value_bytes: u64,
-    /// Default permissions for maps not explicitly configured per-connection.
-    pub default_permissions: MapPermissions,
 }
 
 // ---------------------------------------------------------------------------
-// WriteValidator
+// WriteAdmission
 // ---------------------------------------------------------------------------
 
-/// Validates client write operations before they reach CRDT merge.
+/// Admits client write operations before they reach CRDT merge.
+///
+/// This is an identity-agnostic integrity gate, NOT an authorization layer.
+/// Per-resource authorization is owned by the RBAC policy engine elsewhere.
 ///
 /// Checks are applied in order:
-/// 1. Caller origin bypass (trusted server-to-server traffic skips all checks)
-/// 2. Authentication check (if `require_auth` is enabled)
-/// 3. Map-level ACL check (read/write permissions from `ConnectionMetadata`)
+/// 1. Anonymous-write deny (defense-in-depth: writes require an identity)
+/// 2. Caller origin bypass (trusted server-to-server traffic skips all checks)
+/// 3. Authentication baseline (if `require_auth` is enabled)
 /// 4. Value size check (against `max_value_bytes`)
 ///
-/// After validation passes, `sanitize_hlc()` generates a fresh server-side
+/// After admission passes, `sanitize_hlc()` generates a fresh server-side
 /// HLC timestamp that replaces the client-provided timestamp in the stored record.
-pub struct WriteValidator {
+pub struct WriteAdmission {
     config: Arc<SecurityConfig>,
     hlc: Arc<Mutex<HLC>>,
 }
 
-impl WriteValidator {
-    /// Creates a new `WriteValidator` with the given security configuration and server HLC.
+impl WriteAdmission {
+    /// Creates a new `WriteAdmission` with the given security configuration and server HLC.
     #[must_use]
     pub fn new(config: Arc<SecurityConfig>, hlc: Arc<Mutex<HLC>>) -> Self {
         Self { config, hlc }
     }
 
-    /// Validates a write operation against the security policy.
+    /// Admits a write operation against the admission/integrity policy.
     ///
     /// # Arguments
     ///
     /// - `ctx` — operation context, used for caller origin check
-    /// - `metadata` — snapshot of the connection's metadata (auth state, map permissions)
-    /// - `map_name` — target map for the write
+    /// - `metadata` — snapshot of the connection's metadata (auth state)
+    /// - `map_name` — target map for the write; used only for error context
+    ///   (`Forbidden`/`ValueTooLarge`), not for any ACL decision
     /// - `value_size` — serialized byte length of the record payload; pass `0` for `REMOVE`/`OR_REMOVE` ops
     ///
     /// # Errors
     ///
+    /// - `OperationError::Forbidden` — anonymous caller (writes require an identity)
     /// - `OperationError::Unauthorized` — connection is not authenticated when `require_auth` is true
-    /// - `OperationError::Forbidden` — connection lacks write permission for `map_name`
     /// - `OperationError::ValueTooLarge` — record exceeds `max_value_bytes`
-    pub fn validate_write(
+    pub fn admit_write(
         &self,
         ctx: &OperationContext,
         metadata: &ConnectionMetadata,
@@ -96,7 +103,7 @@ impl WriteValidator {
         }
 
         // Trusted server-to-server traffic bypasses all checks. HttpClient
-        // falls through to the same ACL/size checks as Client; its auth
+        // falls through to the same auth/size checks as Client; its auth
         // enforcement is handler-level (HTTP 401 before dispatch) rather
         // than metadata-based.
         if !matches!(
@@ -106,7 +113,7 @@ impl WriteValidator {
             return Ok(());
         }
 
-        // Authentication check via connection metadata. WebSocket/Client writes
+        // Authentication baseline via connection metadata. WebSocket/Client writes
         // pass a snapshot of the live connection metadata; HttpClient writes have
         // no connection_id, so the CRDT service synthesizes a metadata snapshot
         // whose `authenticated` flag is derived from the JWT-validated principal
@@ -115,19 +122,6 @@ impl WriteValidator {
         // fail-closes if a principal is ever absent.
         if self.config.require_auth && !metadata.authenticated {
             return Err(OperationError::Unauthorized);
-        }
-
-        // Map-level ACL check: look up per-connection permissions, fall back to default.
-        let permissions = metadata
-            .map_permissions
-            .get(map_name)
-            .copied()
-            .unwrap_or(self.config.default_permissions);
-
-        if !permissions.write {
-            return Err(OperationError::Forbidden {
-                map_name: map_name.to_string(),
-            });
         }
 
         // Value size check (0 means unlimited).
@@ -166,7 +160,6 @@ mod tests {
     use topgun_core::{SystemClock, HLC};
 
     use super::*;
-    use crate::network::connection::MapPermissions;
     use crate::service::operation::{service_names, CallerOrigin, OperationContext};
 
     fn make_hlc() -> Arc<Mutex<HLC>> {
@@ -215,23 +208,21 @@ mod tests {
         }
     }
 
-    fn make_validator(config: SecurityConfig) -> WriteValidator {
-        WriteValidator::new(Arc::new(config), make_hlc())
+    fn make_admission(config: SecurityConfig) -> WriteAdmission {
+        WriteAdmission::new(Arc::new(config), make_hlc())
     }
 
-    // -- AC11: default config allows unauthenticated writes --
+    // -- Default config admits unauthenticated writes (permissive baseline) --
 
     #[test]
-    fn default_config_allows_unauthenticated_writes() {
-        let validator = make_validator(SecurityConfig::default());
+    fn default_config_admits_unauthenticated_writes() {
+        let admission = make_admission(SecurityConfig::default());
         let ctx = make_ctx_client();
         let metadata = make_metadata(false);
-        assert!(validator
-            .validate_write(&ctx, &metadata, "my-map", 0)
-            .is_ok());
+        assert!(admission.admit_write(&ctx, &metadata, "my-map", 0).is_ok());
     }
 
-    // -- AC1: require_auth + unauthenticated => Unauthorized --
+    // -- R8(a): require_auth + unauthenticated => Unauthorized --
 
     #[test]
     fn require_auth_rejects_unauthenticated() {
@@ -239,54 +230,46 @@ mod tests {
             require_auth: true,
             ..SecurityConfig::default()
         };
-        let validator = make_validator(config);
+        let admission = make_admission(config);
         let ctx = make_ctx_client();
         let metadata = make_metadata(false);
-        let result = validator.validate_write(&ctx, &metadata, "my-map", 0);
+        let result = admission.admit_write(&ctx, &metadata, "my-map", 0);
         assert!(matches!(result, Err(OperationError::Unauthorized)));
     }
 
-    // -- AC3: require_auth + authenticated + write perm => Ok --
+    // -- R8(b): require_auth + authenticated => Ok --
 
     #[test]
-    fn require_auth_allows_authenticated_with_write_perm() {
+    fn require_auth_admits_authenticated() {
         let config = SecurityConfig {
             require_auth: true,
             ..SecurityConfig::default()
         };
-        let validator = make_validator(config);
+        let admission = make_admission(config);
         let ctx = make_ctx_client();
         let metadata = make_metadata(true);
-        assert!(validator
-            .validate_write(&ctx, &metadata, "my-map", 0)
-            .is_ok());
+        assert!(admission.admit_write(&ctx, &metadata, "my-map", 0).is_ok());
     }
 
-    // -- AC2: authenticated + no write perm => Forbidden --
+    // -- R8(c) + negative control: anonymous origin => Forbidden --
 
     #[test]
-    fn no_write_permission_returns_forbidden() {
-        let config = SecurityConfig {
-            require_auth: true,
-            ..SecurityConfig::default()
-        };
-        let validator = make_validator(config);
-        let ctx = make_ctx_client();
-        let mut metadata = make_metadata(true);
-        metadata.map_permissions.insert(
-            "locked-map".to_string(),
-            MapPermissions {
-                read: true,
-                write: false,
-            },
-        );
-        let result = validator.validate_write(&ctx, &metadata, "locked-map", 0);
+    fn anonymous_origin_is_rejected_with_forbidden() {
+        // NEGATIVE CONTROL: removing the deny-anonymous guard in `admit_write`
+        // makes this assertion fail (an anonymous write would be admitted Ok).
+        // That green->red flip is the entire point of this test — it proves the
+        // guard is load-bearing, not dead code.
+        let admission = make_admission(SecurityConfig::default());
+        let mut ctx = OperationContext::new(1, service_names::CRDT, make_timestamp(), 5000);
+        ctx.caller_origin = CallerOrigin::Anonymous;
+        let metadata = make_metadata(false);
+        let result = admission.admit_write(&ctx, &metadata, "my-map", 0);
         assert!(
-            matches!(result, Err(OperationError::Forbidden { map_name }) if map_name == "locked-map")
+            matches!(result, Err(OperationError::Forbidden { map_name }) if map_name == "my-map")
         );
     }
 
-    // -- AC6: value exceeds max_value_bytes => ValueTooLarge --
+    // -- R8(d): value exceeds max_value_bytes => ValueTooLarge --
 
     #[test]
     fn oversized_value_returns_value_too_large() {
@@ -294,10 +277,10 @@ mod tests {
             max_value_bytes: 100,
             ..SecurityConfig::default()
         };
-        let validator = make_validator(config);
+        let admission = make_admission(config);
         let ctx = make_ctx_client();
         let metadata = make_metadata(false);
-        let result = validator.validate_write(&ctx, &metadata, "my-map", 101);
+        let result = admission.admit_write(&ctx, &metadata, "my-map", 101);
         assert!(matches!(
             result,
             Err(OperationError::ValueTooLarge {
@@ -307,7 +290,7 @@ mod tests {
         ));
     }
 
-    // -- AC7: value exactly at max_value_bytes => Ok --
+    // -- R8(e): value exactly at max_value_bytes => Ok --
 
     #[test]
     fn exactly_max_value_bytes_succeeds() {
@@ -315,15 +298,15 @@ mod tests {
             max_value_bytes: 100,
             ..SecurityConfig::default()
         };
-        let validator = make_validator(config);
+        let admission = make_admission(config);
         let ctx = make_ctx_client();
         let metadata = make_metadata(false);
-        assert!(validator
-            .validate_write(&ctx, &metadata, "my-map", 100)
+        assert!(admission
+            .admit_write(&ctx, &metadata, "my-map", 100)
             .is_ok());
     }
 
-    // -- AC12: max_value_bytes=0 means unlimited --
+    // -- R8(f): max_value_bytes=0 means unlimited --
 
     #[test]
     fn zero_max_value_bytes_means_unlimited() {
@@ -331,73 +314,48 @@ mod tests {
             max_value_bytes: 0,
             ..SecurityConfig::default()
         };
-        let validator = make_validator(config);
+        let admission = make_admission(config);
         let ctx = make_ctx_client();
         let metadata = make_metadata(false);
-        assert!(validator
-            .validate_write(&ctx, &metadata, "my-map", u64::MAX)
+        assert!(admission
+            .admit_write(&ctx, &metadata, "my-map", u64::MAX)
             .is_ok());
     }
 
-    // -- AC9: Forwarded origin bypasses all checks --
+    // -- R8(g): Forwarded (trusted) origin bypasses all checks --
 
     #[test]
     fn forwarded_origin_bypasses_all_checks() {
         let config = SecurityConfig {
             require_auth: true,
             max_value_bytes: 1,
-            default_permissions: MapPermissions {
-                read: false,
-                write: false,
-            },
         };
-        let validator = make_validator(config);
+        let admission = make_admission(config);
         let ctx = make_ctx_forwarded();
         let metadata = make_metadata(false); // not authenticated
                                              // value_size=1000 > max_value_bytes=1, but bypass skips it
-        assert!(validator
-            .validate_write(&ctx, &metadata, "my-map", 1000)
+        assert!(admission
+            .admit_write(&ctx, &metadata, "my-map", 1000)
             .is_ok());
     }
 
-    // -- AC10: System origin bypasses all checks --
+    // -- R8(g): System (trusted) origin bypasses all checks --
 
     #[test]
     fn system_origin_bypasses_all_checks() {
         let config = SecurityConfig {
             require_auth: true,
             max_value_bytes: 1,
-            default_permissions: MapPermissions {
-                read: false,
-                write: false,
-            },
         };
-        let validator = make_validator(config);
+        let admission = make_admission(config);
         let ctx = make_ctx_system();
         let metadata = make_metadata(false);
-        assert!(validator
-            .validate_write(&ctx, &metadata, "my-map", 1000)
+        assert!(admission
+            .admit_write(&ctx, &metadata, "my-map", 1000)
             .is_ok());
     }
 
-    // -- AC13: MapPermissions defaults to read=true, write=true --
-
-    #[test]
-    fn map_permissions_default_is_read_write() {
-        let perms = MapPermissions::default();
-        assert!(perms.read);
-        assert!(perms.write);
-    }
-
-    // -- AC14: map_permissions defaults to empty HashMap --
-
-    #[test]
-    fn connection_metadata_map_permissions_defaults_to_empty() {
-        let meta = ConnectionMetadata::default();
-        assert!(meta.map_permissions.is_empty());
-    }
-
-    // -- AC15: sanitize_hlc returns timestamp with server's node_id --
+    // -- R8(h): sanitize_hlc returns timestamp with server's node_id --
 
     #[test]
     fn sanitize_hlc_returns_server_node_id() {
@@ -405,18 +363,18 @@ mod tests {
             "server-node".to_string(),
             Box::new(SystemClock),
         )));
-        let validator = WriteValidator::new(Arc::new(SecurityConfig::default()), hlc);
-        let ts = validator.sanitize_hlc();
+        let admission = WriteAdmission::new(Arc::new(SecurityConfig::default()), hlc);
+        let ts = admission.sanitize_hlc();
         assert_eq!(ts.node_id, "server-node");
     }
 
-    // -- AC16: successive sanitize_hlc calls produce monotonically increasing timestamps --
+    // -- R8(h): successive sanitize_hlc calls produce monotonically increasing timestamps --
 
     #[test]
     fn successive_sanitize_hlc_calls_are_monotonic() {
-        let validator = WriteValidator::new(Arc::new(SecurityConfig::default()), make_hlc());
-        let ts1 = validator.sanitize_hlc();
-        let ts2 = validator.sanitize_hlc();
+        let admission = WriteAdmission::new(Arc::new(SecurityConfig::default()), make_hlc());
+        let ts1 = admission.sanitize_hlc();
+        let ts2 = admission.sanitize_hlc();
         // Counter or millis must advance
         let t1 = (ts1.millis, ts1.counter);
         let t2 = (ts2.millis, ts2.counter);
@@ -426,68 +384,5 @@ mod tests {
             t2 > t1 || ts2.counter > ts1.counter,
             "HLC must strictly advance"
         );
-    }
-
-    // -- Default permissions fallback --
-
-    #[test]
-    fn falls_back_to_default_permissions_when_map_not_in_per_connection_map() {
-        let config = SecurityConfig {
-            default_permissions: MapPermissions {
-                read: true,
-                write: false,
-            },
-            ..SecurityConfig::default()
-        };
-        let validator = make_validator(config);
-        let ctx = make_ctx_client();
-        let metadata = make_metadata(true); // no per-map permissions set
-        let result = validator.validate_write(&ctx, &metadata, "any-map", 0);
-        assert!(matches!(result, Err(OperationError::Forbidden { .. })));
-    }
-
-    // -- Anonymous origin is always rejected --
-
-    #[test]
-    fn anonymous_origin_is_rejected_with_forbidden() {
-        let validator = make_validator(SecurityConfig::default());
-        let mut ctx = OperationContext::new(1, service_names::CRDT, make_timestamp(), 5000);
-        ctx.caller_origin = CallerOrigin::Anonymous;
-        let metadata = make_metadata(false);
-        let result = validator.validate_write(&ctx, &metadata, "my-map", 0);
-        assert!(
-            matches!(result, Err(OperationError::Forbidden { map_name }) if map_name == "my-map")
-        );
-    }
-
-    // -- Per-connection map permissions override default --
-
-    #[test]
-    fn per_connection_permissions_override_default() {
-        let config = SecurityConfig {
-            default_permissions: MapPermissions {
-                read: true,
-                write: false,
-            }, // default: no write
-            ..SecurityConfig::default()
-        };
-        let validator = make_validator(config);
-        let ctx = make_ctx_client();
-        let mut metadata = make_metadata(true);
-        // Explicitly grant write for "allowed-map"
-        metadata.map_permissions.insert(
-            "allowed-map".to_string(),
-            MapPermissions {
-                read: true,
-                write: true,
-            },
-        );
-        // "allowed-map" should succeed despite default denying writes
-        assert!(validator
-            .validate_write(&ctx, &metadata, "allowed-map", 0)
-            .is_ok());
-        // "other-map" falls back to default (no write)
-        let result = validator.validate_write(&ctx, &metadata, "other-map", 0);
-        assert!(matches!(result, Err(OperationError::Forbidden { .. })));
     }
 }

--- a/packages/server-rust/src/sim/cluster.rs
+++ b/packages/server-rust/src/sim/cluster.rs
@@ -36,7 +36,7 @@ use crate::service::domain::{
 use crate::service::operation::{service_names, CallerOrigin, Operation, OperationContext};
 use crate::service::registry::{ManagedService, ServiceContext};
 use crate::service::router::OperationRouter;
-use crate::service::security::{SecurityConfig, WriteValidator};
+use crate::service::security::{SecurityConfig, WriteAdmission};
 use crate::storage::datastores::NullDataStore;
 use crate::storage::factory::{ObserverFactory, RecordStoreFactory};
 use crate::storage::impls::StorageConfig;
@@ -169,7 +169,7 @@ impl SimNode {
         let node_id = node_id.into();
 
         let hlc = Arc::new(Mutex::new(HLC::new(node_id.clone(), Box::new(SystemClock))));
-        let write_validator = Arc::new(WriteValidator::new(
+        let write_validator = Arc::new(WriteAdmission::new(
             Arc::new(SecurityConfig::default()),
             hlc,
         ));


### PR DESCRIPTION
## Summary

Subtraction + rename. This PR removes a dead second authorization mechanism and renames the edge gate to reflect what it actually is:

- Renamed `WriteValidator` → `WriteAdmission` — the cheap, identity-agnostic integrity/quota gate (deny-anonymous, trusted-origin routing, auth baseline, value-size limit, HLC sanitization).
- Deleted the dead per-map ACL surface: `MapPermissions`, `map_permissions`, `default_permissions`. These were never wired into an authorization decision.
- **RBAC is now the sole authorization layer.** There is exactly one identity-aware policy engine; admission is a guard, not a second set of permissions.

## Verification

- Zero dead-identifier grep: `grep -rn 'MapPermissions\|map_permissions\|default_permissions\|WriteValidator' packages/server-rust/src` → **0**.
- Lib suite: **1353 passed / 0 failed**.
- Clippy: `cargo clippy --all-targets --all-features -p topgun-server -- -D warnings` → **clean**.
- Fmt: `cargo fmt --check` → **clean**.
- AC10: `git diff main..HEAD -- service/policy/ middleware/authorization.rs` → **EMPTY** (RBAC code untouched).
- Negative-control red-proof executed: removing the deny-anonymous guard flips `anonymous_origin_is_rejected_with_forbidden` **RED**; restored byte-identical → **GREEN**.
- Docs build: `pnpm --filter apps-docs-astro build` → **succeeds**.

## Reference validation (R6)

Reference validation confirms the admission-controller ⊥ policy-engine split. omnigraph cleanly separates auth.rs (identity-agnostic bearer-token ingest/integrity at the edge) from a dedicated Cedar policy.rs that is identity-aware and per-resource (explicit PolicyAction::Read/Change/Admin authorization decisions). arroyo's edge gate is validate_query — a structural/integrity admission check distinct from any identity-aware authorization. Neither reference folds per-resource ACL into the edge integrity gate. This matches the rename: WriteAdmission is the cheap, identity-agnostic integrity/quota gate (deny-anonymous, trusted-origin routing, auth baseline, size limit, HLC sanitize) while RBAC remains the sole identity-aware policy engine. No divergence found; the rename and ACL deletion are industry-aligned.

## Notes

AC12 pre-merge gate (`gh pr checks` ALL-green incl. build-and-push + Simulation; no merge to main) is owned by /sf:review + the merge flow.
