### PR TITLE
fix(query): live top-N windowing — maintain sorted window with ENTER/LEAVE/MOVE (F1, SPEC-317)

### DIFF
--- a/packages/server-rust/src/query/mod.rs
+++ b/packages/server-rust/src/query/mod.rs
@@ -1,3 +1,4 @@
 //! Transport-neutral query utilities shared across HTTP sync and the DAG pipeline.
 
 pub mod cursor;
+pub mod window;

--- a/packages/server-rust/src/query/window.rs
+++ b/packages/server-rust/src/query/window.rs
@@ -1,0 +1,432 @@
+//! Live windowed top-N maintenance for standing query subscriptions.
+//!
+//! A [`LiveWindow`] tracks the in-window membership of one subscription with a `limit`
+//! (sorted top-N). When a mutation arrives it returns the COMPLETE set of
+//! [`WindowDelta`]s the subscriber must receive — including displacement `LEAVE`s (an
+//! `ENTER` pushing the (limit+1)-th row out) and promotion `ENTER`s (a freed slot pulling
+//! a previously-displaced row back in).
+//!
+//! Ordering is delegated to the shared cursor comparator in [`crate::query::cursor`] so
+//! live ordering and keyset-cursor ordering cannot diverge: a row is encoded as a
+//! [`CursorData`] (its sort-field values plus its key as the tie-break) and rows are
+//! compared via [`is_after_cursor`].
+
+use parking_lot::Mutex;
+use topgun_core::messages::base::{ChangeEventType, SortField};
+
+use crate::query::cursor::{is_after_cursor, rmpv_to_json_value, CursorData, SortValue};
+
+// ---------------------------------------------------------------------------
+// WindowDelta
+// ---------------------------------------------------------------------------
+
+/// A single change the subscriber must be told about for one mutation.
+///
+/// Server-internal: it carries the resolved record value and the change classification.
+/// `value` is [`rmpv::Value::Nil`] for a `LEAVE` (the subscriber only needs the key to
+/// drop the row).
+#[derive(Debug, Clone)]
+pub struct WindowDelta {
+    /// Record key the delta applies to.
+    pub key: String,
+    /// Resolved record value (Nil for a `LEAVE`).
+    pub value: rmpv::Value,
+    /// Whether the row entered, updated within, or left the window.
+    pub event: ChangeEventType,
+}
+
+// ---------------------------------------------------------------------------
+// Window row
+// ---------------------------------------------------------------------------
+
+/// A row the window has SEEN (currently in-window or retained-out-of-window).
+///
+/// Retaining out-of-window rows that were once displaced is what lets a freed slot
+/// re-promote the correct previously-displaced row without re-querying the DAG (see the
+/// promotion-data bound on [`LiveWindow::apply_mutation`]).
+#[derive(Debug, Clone)]
+struct WindowRow {
+    key: String,
+    value: rmpv::Value,
+}
+
+// ---------------------------------------------------------------------------
+// LiveWindow
+// ---------------------------------------------------------------------------
+
+/// Interior-mutable sorted top-N window for one subscription.
+///
+/// `QuerySubscription` is `Arc`-stored with no `&mut` path, so all mutable state lives
+/// behind a [`Mutex`] and [`apply_mutation`](Self::apply_mutation) takes `&self`.
+pub struct LiveWindow {
+    /// Sort spec aligned to `Query.sort` (empty = key-only ordering).
+    sort: Vec<SortField>,
+    /// Window size. `None` = unbounded: deltas pass through predicate-only with no
+    /// displacement (behavior unchanged from a pre-windowed subscription).
+    limit: Option<u32>,
+    /// All rows the window has seen and still tracks, ordered by the keyset comparator.
+    ///
+    /// The first `limit` entries (by sort order) are the in-window rows; any trailing
+    /// entries are retained out-of-window candidates available for promotion.
+    state: Mutex<Vec<WindowRow>>,
+}
+
+impl LiveWindow {
+    /// Builds a window from a subscription's sort spec and limit.
+    #[must_use]
+    pub fn new(sort: Vec<SortField>, limit: Option<u32>) -> Self {
+        Self {
+            sort,
+            limit,
+            state: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Encodes a row as a [`CursorData`] so [`is_after_cursor`] can order it against
+    /// other rows using the exact per-field ASC/DESC + `last_key` tie-break semantics the
+    /// keyset cursor uses.
+    fn row_cursor(&self, key: &str, value: &rmpv::Value) -> CursorData {
+        let sort_values: Vec<SortValue> = self
+            .sort
+            .iter()
+            .map(|sf| {
+                let field_val = match value {
+                    rmpv::Value::Map(pairs) => pairs
+                        .iter()
+                        .find(|(k, _)| k.as_str() == Some(sf.field.as_str()))
+                        .map_or(serde_json::Value::Null, |(_, v)| {
+                            rmpv_to_json_value(v).unwrap_or(serde_json::Value::Null)
+                        }),
+                    _ => serde_json::Value::Null,
+                };
+                SortValue {
+                    field: sf.field.clone(),
+                    value: field_val,
+                    direction: sf.direction.clone(),
+                }
+            })
+            .collect();
+
+        CursorData {
+            sort_values,
+            last_key: key.to_string(),
+            predicate_hash: 0,
+            sort_hash: 0,
+            timestamp: 0,
+        }
+    }
+
+    /// Returns `true` when row `a` sorts strictly BEFORE row `b` under the window order.
+    ///
+    /// Implemented as "b comes after a" via the shared cursor comparator so a single
+    /// ordering definition governs both pagination and live windowing.
+    fn row_before(&self, a: &WindowRow, b: &WindowRow) -> bool {
+        let a_cursor = self.row_cursor(&a.key, &a.value);
+        is_after_cursor(&b.key, &b.value, &a_cursor)
+    }
+
+    /// Sorts the tracked rows in place by the keyset comparator (ascending window order).
+    fn sort_state(&self, state: &mut [WindowRow]) {
+        state.sort_by(|a, b| {
+            if self.row_before(a, b) {
+                std::cmp::Ordering::Less
+            } else if self.row_before(b, a) {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        });
+    }
+
+    /// Applies one mutation and returns every delta the subscriber must receive.
+    ///
+    /// `new_value = None` models a delete/tombstone. `matches_predicate` is the caller's
+    /// already-computed predicate result for `new_value` (false for a delete).
+    ///
+    /// Semantics:
+    /// - New matching row sorting inside top-N → `ENTER`; if the window was full, the row
+    ///   now (limit+1)-th leaves via a displacement `LEAVE`.
+    /// - Row leaves (delete / predicate-false / displaced) → `LEAVE`; a freed slot
+    ///   re-promotes the best retained out-of-window row via `ENTER`.
+    /// - Row updated still inside top-N → `UPDATE` (window re-sorted; reorder is conveyed
+    ///   by `UPDATE`, there is no `MOVE` variant). An update that pushes the row out of
+    ///   top-N is a displacement `LEAVE` + promotion `ENTER`.
+    /// - Unbounded (`limit = None`) → predicate-only `ENTER`/`UPDATE`/`LEAVE`, never a
+    ///   displacement.
+    ///
+    /// Promotion-data bound: the window can only re-promote rows it has SEEN enter/leave,
+    /// because the DAG produced only the current page — out-of-window candidates are not
+    /// all resident. When a slot frees and no retained candidate exists, no synthetic
+    /// `ENTER` is emitted (the next matching write fills the slot). This is correct for the
+    /// displacement case this routine targets (a 3rd row pushing a 2nd out, then the 3rd
+    /// leaving re-promoting the 2nd); it is NOT a full re-query-on-delete.
+    pub fn apply_mutation(
+        &self,
+        key: &str,
+        new_value: Option<&rmpv::Value>,
+        matches_predicate: bool,
+    ) -> Vec<WindowDelta> {
+        match self.limit {
+            None => self.apply_unbounded(key, new_value, matches_predicate),
+            Some(limit) => self.apply_bounded(key, new_value, matches_predicate, limit as usize),
+        }
+    }
+
+    /// Unbounded window: predicate-only membership, no displacement and no retention of
+    /// out-of-window rows (there is no "out of window" when the window is unbounded).
+    fn apply_unbounded(
+        &self,
+        key: &str,
+        new_value: Option<&rmpv::Value>,
+        matches_predicate: bool,
+    ) -> Vec<WindowDelta> {
+        let mut state = self.state.lock();
+        let existing = state.iter().position(|r| r.key == key);
+        let stays = matches_predicate && new_value.is_some();
+
+        match (existing, stays) {
+            (None, false) => Vec::new(),
+            (None, true) => {
+                let value = new_value.cloned().unwrap_or(rmpv::Value::Nil);
+                state.push(WindowRow {
+                    key: key.to_string(),
+                    value: value.clone(),
+                });
+                self.sort_state(&mut state);
+                vec![WindowDelta {
+                    key: key.to_string(),
+                    value,
+                    event: ChangeEventType::ENTER,
+                }]
+            }
+            (Some(idx), true) => {
+                let value = new_value.cloned().unwrap_or(rmpv::Value::Nil);
+                state[idx].value = value.clone();
+                self.sort_state(&mut state);
+                vec![WindowDelta {
+                    key: key.to_string(),
+                    value,
+                    event: ChangeEventType::UPDATE,
+                }]
+            }
+            (Some(idx), false) => {
+                state.remove(idx);
+                vec![WindowDelta {
+                    key: key.to_string(),
+                    value: rmpv::Value::Nil,
+                    event: ChangeEventType::LEAVE,
+                }]
+            }
+        }
+    }
+
+    /// Bounded top-N window with displacement and promotion.
+    fn apply_bounded(
+        &self,
+        key: &str,
+        new_value: Option<&rmpv::Value>,
+        matches_predicate: bool,
+        limit: usize,
+    ) -> Vec<WindowDelta> {
+        let mut state = self.state.lock();
+
+        // Snapshot the keys currently in-window (first `limit` by sort order) so we can
+        // diff membership after mutating + re-sorting.
+        let in_window_before: std::collections::HashSet<String> =
+            state.iter().take(limit).map(|r| r.key.clone()).collect();
+
+        let existing = state.iter().position(|r| r.key == key);
+        let stays = matches_predicate && new_value.is_some();
+
+        match (existing, stays) {
+            (None, false) => return Vec::new(),
+            (None, true) => {
+                let value = new_value.cloned().unwrap_or(rmpv::Value::Nil);
+                state.push(WindowRow {
+                    key: key.to_string(),
+                    value,
+                });
+            }
+            (Some(idx), true) => {
+                state[idx].value = new_value.cloned().unwrap_or(rmpv::Value::Nil);
+            }
+            (Some(idx), false) => {
+                // Delete or predicate-false: drop the row entirely (not a retained
+                // candidate — it no longer matches the query).
+                state.remove(idx);
+            }
+        }
+
+        self.sort_state(&mut state);
+
+        // Re-derive in-window membership after the mutation.
+        let in_window_after: std::collections::HashSet<String> =
+            state.iter().take(limit).map(|r| r.key.clone()).collect();
+
+        let mut deltas = Vec::new();
+
+        // Rows that left the top-N (displacement or removal) → LEAVE.
+        for k in &in_window_before {
+            if !in_window_after.contains(k) {
+                deltas.push(WindowDelta {
+                    key: k.clone(),
+                    value: rmpv::Value::Nil,
+                    event: ChangeEventType::LEAVE,
+                });
+            }
+        }
+
+        // Rows that entered the top-N (the new row, or a promoted retained row) → ENTER.
+        for row in state.iter().take(limit) {
+            if !in_window_before.contains(&row.key) {
+                deltas.push(WindowDelta {
+                    key: row.key.clone(),
+                    value: row.value.clone(),
+                    event: ChangeEventType::ENTER,
+                });
+            }
+        }
+
+        // A row that stayed in-window and was the mutated key → UPDATE.
+        if matches_predicate
+            && new_value.is_some()
+            && in_window_before.contains(key)
+            && in_window_after.contains(key)
+        {
+            let value = new_value.cloned().unwrap_or(rmpv::Value::Nil);
+            deltas.push(WindowDelta {
+                key: key.to_string(),
+                value,
+                event: ChangeEventType::UPDATE,
+            });
+        }
+
+        // Trim retained out-of-window candidates: we only need to retain enough to refill
+        // freed slots after later removals. Retaining everything seen would grow unbounded,
+        // so cap retained rows at `limit` beyond the window (a displaced row plus headroom).
+        let retain_cap = limit.saturating_mul(2);
+        if state.len() > retain_cap {
+            state.truncate(retain_cap);
+        }
+
+        deltas
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use topgun_core::messages::base::SortDirection;
+
+    fn sort_asc(field: &str) -> Vec<SortField> {
+        vec![SortField {
+            field: field.to_string(),
+            direction: SortDirection::Asc,
+        }]
+    }
+
+    /// Builds a record `{ field: int_value }`.
+    fn rec(field: &str, v: i64) -> rmpv::Value {
+        rmpv::Value::Map(vec![(
+            rmpv::Value::String(field.into()),
+            rmpv::Value::Integer(v.into()),
+        )])
+    }
+
+    fn events(deltas: &[WindowDelta]) -> Vec<(String, ChangeEventType)> {
+        deltas
+            .iter()
+            .map(|d| (d.key.clone(), d.event.clone()))
+            .collect()
+    }
+
+    fn has(deltas: &[WindowDelta], key: &str, event: &ChangeEventType) -> bool {
+        deltas.iter().any(|d| d.key == key && &d.event == event)
+    }
+
+    #[test]
+    fn displacement_on_third_insert() {
+        // limit=2, sort by score ASC. Insert score 10, 20, then 5.
+        let w = LiveWindow::new(sort_asc("score"), Some(2));
+
+        let d1 = w.apply_mutation("a", Some(&rec("score", 10)), true);
+        assert_eq!(events(&d1), vec![("a".to_string(), ChangeEventType::ENTER)]);
+
+        let d2 = w.apply_mutation("b", Some(&rec("score", 20)), true);
+        assert_eq!(events(&d2), vec![("b".to_string(), ChangeEventType::ENTER)]);
+
+        // "c" at score 5 sorts before both → enters; "b" (score 20) is displaced.
+        let d3 = w.apply_mutation("c", Some(&rec("score", 5)), true);
+        assert!(has(&d3, "c", &ChangeEventType::ENTER));
+        assert!(has(&d3, "b", &ChangeEventType::LEAVE));
+        assert_eq!(d3.len(), 2);
+    }
+
+    #[test]
+    fn promotion_after_in_window_leaves() {
+        // Set up displacement: window holds [c(5), a(10)], b(20) retained out-of-window.
+        let w = LiveWindow::new(sort_asc("score"), Some(2));
+        w.apply_mutation("a", Some(&rec("score", 10)), true);
+        w.apply_mutation("b", Some(&rec("score", 20)), true);
+        w.apply_mutation("c", Some(&rec("score", 5)), true);
+
+        // The in-window "c" leaves (delete). A slot frees → "b" (retained) is promoted.
+        let d = w.apply_mutation("c", None, false);
+        assert!(has(&d, "c", &ChangeEventType::LEAVE));
+        assert!(has(&d, "b", &ChangeEventType::ENTER));
+    }
+
+    #[test]
+    fn update_within_window() {
+        let w = LiveWindow::new(sort_asc("score"), Some(3));
+        w.apply_mutation("a", Some(&rec("score", 10)), true);
+        w.apply_mutation("b", Some(&rec("score", 20)), true);
+
+        // Update "a" to score 15 — still in top-3 → UPDATE only.
+        let d = w.apply_mutation("a", Some(&rec("score", 15)), true);
+        assert_eq!(events(&d), vec![("a".to_string(), ChangeEventType::UPDATE)]);
+    }
+
+    #[test]
+    fn update_out_of_window() {
+        // limit=2, window holds [a(10), b(20)], c(30) retained out-of-window.
+        let w = LiveWindow::new(sort_asc("score"), Some(2));
+        w.apply_mutation("a", Some(&rec("score", 10)), true);
+        w.apply_mutation("b", Some(&rec("score", 20)), true);
+        w.apply_mutation("c", Some(&rec("score", 30)), true); // retained, no in-window change
+
+        // Update "a" to score 100 — pushed out of top-2; "c" (30) promoted in.
+        let d = w.apply_mutation("a", Some(&rec("score", 100)), true);
+        assert!(has(&d, "a", &ChangeEventType::LEAVE));
+        assert!(has(&d, "c", &ChangeEventType::ENTER));
+    }
+
+    #[test]
+    fn unbounded_no_displacement() {
+        // limit=None → predicate-only, no displacement regardless of count.
+        let w = LiveWindow::new(sort_asc("score"), None);
+
+        let d1 = w.apply_mutation("a", Some(&rec("score", 10)), true);
+        assert_eq!(events(&d1), vec![("a".to_string(), ChangeEventType::ENTER)]);
+        let d2 = w.apply_mutation("b", Some(&rec("score", 20)), true);
+        assert_eq!(events(&d2), vec![("b".to_string(), ChangeEventType::ENTER)]);
+        let d3 = w.apply_mutation("c", Some(&rec("score", 5)), true);
+        // Pure ENTER, no LEAVE displacement even though c sorts first.
+        assert_eq!(events(&d3), vec![("c".to_string(), ChangeEventType::ENTER)]);
+
+        // Update within → UPDATE.
+        let d4 = w.apply_mutation("a", Some(&rec("score", 11)), true);
+        assert_eq!(
+            events(&d4),
+            vec![("a".to_string(), ChangeEventType::UPDATE)]
+        );
+
+        // Predicate-false → LEAVE.
+        let d5 = w.apply_mutation("b", Some(&rec("score", 20)), false);
+        assert_eq!(events(&d5), vec![("b".to_string(), ChangeEventType::LEAVE)]);
+    }
+}

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -656,15 +656,20 @@ impl CrdtService {
     /// Broadcasts `QUERY_UPDATE` messages to subscribers of queries targeting the mutated map.
     ///
     /// This method:
-    /// - Evaluates each standing query subscription against the old and new values
-    /// - Determines ENTER/UPDATE/LEAVE change type
+    /// - Routes each standing subscription's mutation through its `LiveWindow`, which is the
+    ///   single authoritative top-N algorithm and returns the complete delta set (ENTER,
+    ///   displacement LEAVE, promotion ENTER, in-window UPDATE, delete LEAVE)
+    /// - Suppresses deltas for rows outside the subscription's active cursor page
     /// - Applies field projection if the subscription has `fields`
     /// - Skips the writing connection (writer exclusion)
-    /// - Updates `previous_result_keys` for accurate future change detection
+    /// - Mirrors window membership into `previous_result_keys` for `on_remove`/`on_clear`/Merkle
+    ///
+    /// The old value is no longer needed for event derivation (the window tracks prior
+    /// membership), so `_old_rmpv_value` is retained only for call-site signature stability.
     fn broadcast_query_updates(
         &self,
         event_payload: &ServerEventPayload,
-        old_rmpv_value: Option<&rmpv::Value>,
+        _old_rmpv_value: Option<&rmpv::Value>,
         exclude_connection_id: Option<ConnectionId>,
     ) {
         let subs = self
@@ -686,49 +691,82 @@ impl CrdtService {
                 }
             }
 
-            // Evaluate old/new against the query predicate.
-            let old_matches =
-                old_rmpv_value.is_some_and(|v| matches_query_predicate(&sub.query, v));
+            // The predicate result the window needs for this mutation. A delete
+            // (`new_rmpv_value == None`) is a non-match, modelled by passing `None` through.
             let new_matches = new_rmpv_value
                 .as_ref()
                 .is_some_and(|v| matches_query_predicate(&sub.query, v));
 
-            let change_type = match (old_matches, new_matches) {
-                (false, true) => {
-                    sub.previous_result_keys.insert(event_payload.key.clone());
-                    topgun_core::messages::base::ChangeEventType::ENTER
+            // Single shared top-N algorithm: the window returns the COMPLETE delta set for
+            // this mutation — the new ENTER, any displacement LEAVE, any promotion ENTER, an
+            // in-window UPDATE, or a LEAVE for deletes/predicate-false rows. An empty result
+            // naturally sends nothing, so no `(false,false)` short-circuit is needed.
+            let deltas = sub.live_window.apply_mutation(
+                &event_payload.key,
+                new_rmpv_value.as_ref(),
+                new_matches,
+            );
+
+            // Decode this subscription's active page bound once (if any) so out-of-page
+            // deltas can be suppressed. `sub.query.cursor` is the only cursor state reachable
+            // from the subscription here; a row strictly before the cursor is on an earlier
+            // page the subscriber is not currently observing.
+            let page_cursor = sub
+                .query
+                .cursor
+                .as_deref()
+                .and_then(crate::query::cursor::decode_cursor);
+
+            for delta in deltas {
+                // Cursor out-of-window filter: drop deltas whose row falls outside this
+                // subscription's active page. LEAVE carries Nil (no row value to test), so it
+                // is always delivered — the subscriber must drop a row it may currently hold.
+                if let Some(ref cursor) = page_cursor {
+                    if !matches!(
+                        delta.event,
+                        topgun_core::messages::base::ChangeEventType::LEAVE
+                    ) && !crate::query::cursor::is_after_cursor(&delta.key, &delta.value, cursor)
+                    {
+                        continue;
+                    }
                 }
-                (true, true) => topgun_core::messages::base::ChangeEventType::UPDATE,
-                (true, false) => {
-                    sub.previous_result_keys.remove(&event_payload.key);
+
+                // Mirror window membership into `previous_result_keys`, which is still the
+                // source of truth for on_remove/on_clear/on_reset and Merkle init.
+                match delta.event {
+                    topgun_core::messages::base::ChangeEventType::ENTER => {
+                        sub.previous_result_keys.insert(delta.key.clone());
+                    }
+                    topgun_core::messages::base::ChangeEventType::LEAVE => {
+                        sub.previous_result_keys.remove(&delta.key);
+                    }
+                    topgun_core::messages::base::ChangeEventType::UPDATE => {}
+                }
+
+                // Apply field projection to ENTER/UPDATE values; LEAVE carries Nil.
+                let value = if matches!(
+                    delta.event,
                     topgun_core::messages::base::ChangeEventType::LEAVE
-                }
-                (false, false) => continue,
-            };
-
-            // Apply field projection if the subscription has fields.
-            let value = if new_matches {
-                let raw = new_rmpv_value.clone().unwrap_or(rmpv::Value::Nil);
-                if let Some(ref fields) = sub.fields {
-                    super::query::project_fields(fields, &raw)
+                ) {
+                    rmpv::Value::Nil
+                } else if let Some(ref fields) = sub.fields {
+                    super::query::project_fields(fields, &delta.value)
                 } else {
-                    raw
-                }
-            } else {
-                rmpv::Value::Nil
-            };
+                    delta.value.clone()
+                };
 
-            let payload = topgun_core::messages::client_events::QueryUpdatePayload {
-                query_id: sub.query_id.clone(),
-                key: event_payload.key.clone(),
-                value,
-                change_type,
-            };
-            let msg = topgun_core::messages::Message::QueryUpdate { payload };
-            if let Ok(bytes) = rmp_serde::to_vec_named(&msg) {
-                use crate::network::connection::OutboundMessage;
-                if let Some(handle) = self.connection_registry.get(sub.connection_id) {
-                    let _ = handle.try_send(OutboundMessage::Binary(bytes));
+                let payload = topgun_core::messages::client_events::QueryUpdatePayload {
+                    query_id: sub.query_id.clone(),
+                    key: delta.key.clone(),
+                    value,
+                    change_type: delta.event,
+                };
+                let msg = topgun_core::messages::Message::QueryUpdate { payload };
+                if let Ok(bytes) = rmp_serde::to_vec_named(&msg) {
+                    use crate::network::connection::OutboundMessage;
+                    if let Some(handle) = self.connection_registry.get(sub.connection_id) {
+                        let _ = handle.try_send(OutboundMessage::Binary(bytes));
+                    }
                 }
             }
         }
@@ -1620,6 +1658,7 @@ mod tests {
                 aggregations: None,
             },
             previous_result_keys: DashSet::new(),
+            live_window: Arc::new(crate::query::window::LiveWindow::new(vec![], None)),
             fields: None,
         });
 
@@ -1690,6 +1729,7 @@ mod tests {
                 aggregations: None,
             },
             previous_result_keys: DashSet::new(),
+            live_window: Arc::new(crate::query::window::LiveWindow::new(vec![], None)),
             fields: None,
         });
 
@@ -2098,6 +2138,7 @@ mod tests {
                 aggregations: None,
             },
             previous_result_keys: DashSet::new(),
+            live_window: Arc::new(crate::query::window::LiveWindow::new(vec![], None)),
             fields: Some(vec!["name".to_string()]),
         });
 
@@ -3025,6 +3066,7 @@ mod tests {
                 aggregations: None,
             },
             previous_result_keys: DashSet::new(),
+            live_window: Arc::new(crate::query::window::LiveWindow::new(vec![], None)),
             fields: None,
         });
         rx

--- a/packages/server-rust/src/service/domain/query.rs
+++ b/packages/server-rust/src/service/domain/query.rs
@@ -28,6 +28,7 @@ use crate::dag::coordinator::{run_dag_local, ClusterQueryCoordinator};
 use crate::query::cursor::{
     build_next_cursor, classify_cursor_status, cursor_query_hashes, decode_cursor, SortValue,
 };
+use crate::query::window::LiveWindow;
 
 use tracing::Instrument;
 
@@ -61,6 +62,17 @@ pub struct QuerySubscription {
     pub query: Query,
     /// Keys that matched on the last evaluation (for ENTER/UPDATE/LEAVE detection).
     pub previous_result_keys: DashSet<String>,
+    /// Sorted top-N window maintaining live membership for this subscription.
+    ///
+    /// Interior-mutable (its state lives behind a `Mutex`), so mutations route through
+    /// `apply_mutation(&self, …)` over the `Arc<QuerySubscription>` with no `&mut` path.
+    /// This is the single authoritative window algorithm — the observer derives every
+    /// ENTER/UPDATE/LEAVE (including top-N displacement and promotion) from it.
+    ///
+    /// Wrapped in `Arc` so the mutation broadcast path can clone the handle cheaply out
+    /// of the `Arc<QuerySubscription>` and call `apply_mutation` without holding the
+    /// subscription borrow.
+    pub live_window: Arc<LiveWindow>,
     /// Optional field projection list. When `Some`, only these fields are
     /// included in `QUERY_RESP` and `QUERY_UPDATE` payloads sent to this subscriber.
     pub fields: Option<Vec<String>>,
@@ -259,26 +271,27 @@ impl QueryMutationObserver {
 
         for sub in &subs {
             let matches_now = Self::matches_query(sub, &rmpv_value);
-            let was_in_previous = sub.previous_result_keys.contains(key);
 
-            match (matches_now, was_in_previous) {
-                (true, false) => {
-                    // ENTER: new match
-                    sub.previous_result_keys.insert(key.to_string());
-                    self.send_update(sub, key, rmpv_value.clone(), ChangeEventType::ENTER);
+            // Route the mutation through the single window algorithm. It returns the
+            // complete delta set the subscriber must receive — predicate ENTER/UPDATE/LEAVE
+            // for unbounded subscriptions, plus top-N displacement LEAVEs and promotion
+            // ENTERs when the query has a limit. There is no second predicate-only path:
+            // membership is owned by the window, and previous_result_keys is kept in sync
+            // with the deltas the window emits.
+            let deltas = sub
+                .live_window
+                .apply_mutation(key, Some(&rmpv_value), matches_now);
+
+            for delta in deltas {
+                match delta.event {
+                    ChangeEventType::ENTER | ChangeEventType::UPDATE => {
+                        sub.previous_result_keys.insert(delta.key.clone());
+                    }
+                    ChangeEventType::LEAVE => {
+                        sub.previous_result_keys.remove(&delta.key);
+                    }
                 }
-                (true, true) => {
-                    // UPDATE: still matches
-                    self.send_update(sub, key, rmpv_value.clone(), ChangeEventType::UPDATE);
-                }
-                (false, true) => {
-                    // LEAVE: no longer matches
-                    sub.previous_result_keys.remove(key);
-                    self.send_update(sub, key, rmpv_value.clone(), ChangeEventType::LEAVE);
-                }
-                (false, false) => {
-                    // No-op
-                }
+                self.send_update(sub, &delta.key, delta.value, delta.event);
             }
         }
     }
@@ -306,17 +319,28 @@ impl MutationObserver for QueryMutationObserver {
         self.evaluate_change(key, record, is_backup);
     }
 
-    fn on_remove(&self, key: &str, record: &Record, is_backup: bool) {
+    fn on_remove(&self, key: &str, _record: &Record, is_backup: bool) {
         if is_backup {
             return;
         }
         let subs = self.registry.get_subscriptions_for_map(&self.map_name);
-        let rmpv_value = extract_rmpv_value(&record.value);
 
         for sub in &subs {
-            if sub.previous_result_keys.contains(key) {
-                sub.previous_result_keys.remove(key);
-                self.send_update(sub, key, rmpv_value.clone(), ChangeEventType::LEAVE);
+            // A delete routes through the same window algorithm as a mutation: removing a
+            // key can both emit a LEAVE for that key and promote a previously-displaced row
+            // into the top-N window (an ENTER). The window owns membership; we mirror its
+            // deltas into previous_result_keys so on_clear/on_reset/Merkle stay correct.
+            let deltas = sub.live_window.apply_mutation(key, None, false);
+            for delta in deltas {
+                match delta.event {
+                    ChangeEventType::ENTER | ChangeEventType::UPDATE => {
+                        sub.previous_result_keys.insert(delta.key.clone());
+                    }
+                    ChangeEventType::LEAVE => {
+                        sub.previous_result_keys.remove(&delta.key);
+                    }
+                }
+                self.send_update(sub, &delta.key, delta.value, delta.event);
             }
         }
     }
@@ -794,6 +818,18 @@ impl QueryService {
             None
         };
 
+        // Seed the live window from THIS initial DAG result page (before field projection,
+        // so sort-field values are still present for ordering). Membership and ordering are
+        // taken from the page the DAG already produced — we do not recompute. Every page row
+        // matched the predicate by construction, so each seeds as an in-window match.
+        let live_window = Arc::new(LiveWindow::new(
+            query.sort.clone().unwrap_or_default(),
+            query.limit,
+        ));
+        for entry in &results {
+            let _ = live_window.apply_mutation(&entry.key, Some(&entry.value), true);
+        }
+
         // Apply field projection if specified
         if let Some(ref proj_fields) = fields {
             for entry in &mut results {
@@ -801,7 +837,9 @@ impl QueryService {
             }
         }
 
-        // Build previous_result_keys from results (after clamping, before Merkle)
+        // Build previous_result_keys from results (after clamping, before Merkle).
+        // The page that seeds previous_result_keys is the same page that seeds the window,
+        // so the two membership views start consistent.
         let previous_keys = DashSet::new();
         for entry in &results {
             previous_keys.insert(entry.key.clone());
@@ -878,6 +916,7 @@ impl QueryService {
             map_name,
             query,
             previous_result_keys: previous_keys,
+            live_window,
             fields,
         };
         self.query_registry.register(subscription);
@@ -1485,6 +1524,23 @@ mod tests {
         ConnectionConfig::default()
     }
 
+    /// Builds a `live_window` for a test subscription whose membership matches the supplied
+    /// pre-existing keys. Tests simulate "this key was already in the result set" by
+    /// pre-populating `previous_result_keys`; the window must start with the same membership
+    /// or the observer (which now derives ENTER/UPDATE/LEAVE from the window) would emit
+    /// ENTER where the test expects UPDATE/LEAVE. Placeholder values are sufficient because
+    /// these tests use unbounded (`limit = None`) queries where membership is presence-only.
+    fn seeded_window(query: &Query, present_keys: &[&str]) -> Arc<LiveWindow> {
+        let window = Arc::new(LiveWindow::new(
+            query.sort.clone().unwrap_or_default(),
+            query.limit,
+        ));
+        for key in present_keys {
+            let _ = window.apply_mutation(key, Some(&rmpv::Value::Nil), true);
+        }
+        window
+    }
+
     // ---- QueryRegistry tests ----
 
     #[test]
@@ -1496,6 +1552,7 @@ mod tests {
             query_id: "q-1".to_string(),
             connection_id: ConnectionId(1),
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: None,
@@ -1511,6 +1568,7 @@ mod tests {
             query_id: "q-1".to_string(),
             connection_id: ConnectionId(1),
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: None,
@@ -1533,6 +1591,7 @@ mod tests {
             query_id: "q-1".to_string(),
             connection_id: ConnectionId(1),
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: None,
@@ -1541,6 +1600,7 @@ mod tests {
             query_id: "q-2".to_string(),
             connection_id: ConnectionId(2),
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: None,
@@ -1549,6 +1609,7 @@ mod tests {
             query_id: "q-3".to_string(),
             connection_id: ConnectionId(1),
             map_name: "orders".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: None,
@@ -1569,6 +1630,7 @@ mod tests {
             query_id: "q-1".to_string(),
             connection_id: ConnectionId(1),
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: None,
@@ -1577,6 +1639,7 @@ mod tests {
             query_id: "q-2".to_string(),
             connection_id: ConnectionId(1),
             map_name: "orders".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: None,
@@ -1605,6 +1668,7 @@ mod tests {
             query_id: "q-1".to_string(),
             connection_id: ConnectionId(1),
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: prev_keys,
             fields: None,
@@ -1639,6 +1703,7 @@ mod tests {
             query_id: "q-1".to_string(),
             connection_id: conn_id,
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: None,
@@ -1686,11 +1751,13 @@ mod tests {
         // Register subscription with key already in previous_result_keys
         let prev_keys = DashSet::new();
         prev_keys.insert("key1".to_string());
+        let query = Query::default(); // match all
         registry.register(QuerySubscription {
             query_id: "q-1".to_string(),
             connection_id: conn_id,
             map_name: "users".to_string(),
-            query: Query::default(), // match all
+            live_window: seeded_window(&query, &["key1"]),
+            query,
             previous_result_keys: prev_keys,
             fields: None,
         });
@@ -1740,19 +1807,21 @@ mod tests {
         // Subscription requires age >= 18
         let prev_keys = DashSet::new();
         prev_keys.insert("key1".to_string());
+        let query = Query {
+            predicate: Some(PredicateNode {
+                op: PredicateOp::Gte,
+                attribute: Some("age".to_string()),
+                value: Some(rmpv::Value::Integer(18.into())),
+                ..Default::default()
+            }),
+            ..Query::default()
+        };
         registry.register(QuerySubscription {
             query_id: "q-1".to_string(),
             connection_id: conn_id,
             map_name: "users".to_string(),
-            query: Query {
-                predicate: Some(PredicateNode {
-                    op: PredicateOp::Gte,
-                    attribute: Some("age".to_string()),
-                    value: Some(rmpv::Value::Integer(18.into())),
-                    ..Default::default()
-                }),
-                ..Query::default()
-            },
+            live_window: seeded_window(&query, &["key1"]),
+            query,
             previous_result_keys: prev_keys,
             fields: None,
         });
@@ -1794,11 +1863,13 @@ mod tests {
 
         let prev_keys = DashSet::new();
         prev_keys.insert("key1".to_string());
+        let query = Query::default();
         registry.register(QuerySubscription {
             query_id: "q-1".to_string(),
             connection_id: conn_id,
             map_name: "users".to_string(),
-            query: Query::default(),
+            live_window: seeded_window(&query, &["key1"]),
+            query,
             previous_result_keys: prev_keys,
             fields: None,
         });
@@ -1838,11 +1909,13 @@ mod tests {
         let prev_keys = DashSet::new();
         prev_keys.insert("k1".to_string());
         prev_keys.insert("k2".to_string());
+        let query = Query::default();
         registry.register(QuerySubscription {
             query_id: "q-1".to_string(),
             connection_id: conn_id,
             map_name: "users".to_string(),
-            query: Query::default(),
+            live_window: seeded_window(&query, &["k1", "k2"]),
+            query,
             previous_result_keys: prev_keys,
             fields: None,
         });
@@ -1890,6 +1963,7 @@ mod tests {
             query_id: "q-1".to_string(),
             connection_id: conn_id,
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query {
                 predicate: Some(PredicateNode {
                     op: PredicateOp::Gte,
@@ -2358,6 +2432,7 @@ mod tests {
             query_id: "q-1".to_string(),
             connection_id: conn1,
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query {
                 predicate: None,
                 r#where: None,
@@ -2375,6 +2450,7 @@ mod tests {
             query_id: "q-2".to_string(),
             connection_id: conn2,
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query {
                 predicate: None,
                 r#where: None,
@@ -2405,6 +2481,7 @@ mod tests {
             query_id: "q-1".to_string(),
             connection_id: conn1,
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query {
                 predicate: None,
                 r#where: None,
@@ -2421,6 +2498,7 @@ mod tests {
             query_id: "q-2".to_string(),
             connection_id: conn1,
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query {
                 predicate: None,
                 r#where: None,
@@ -2572,6 +2650,7 @@ mod tests {
             query_id: "q-sync-1".to_string(),
             connection_id: ConnectionId(1),
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: None,
@@ -2637,6 +2716,7 @@ mod tests {
             query_id: "q-sync-2".to_string(),
             connection_id: ConnectionId(1),
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: None,
@@ -2680,6 +2760,7 @@ mod tests {
             query_id: "q-lookup".to_string(),
             connection_id: ConnectionId(1),
             map_name: "users".to_string(),
+            live_window: seeded_window(&Query::default(), &[]),
             query: Query::default(),
             previous_result_keys: DashSet::new(),
             fields: Some(vec!["name".to_string()]),

--- a/packages/server-rust/src/sim/cluster.rs
+++ b/packages/server-rust/src/sim/cluster.rs
@@ -2582,4 +2582,378 @@ mod tests {
         }
         None
     }
+
+    // -----------------------------------------------------------------------
+    // Live top-N window behavioral tests (subscribe-and-observe).
+    //
+    // These exercise the REAL write-path delta channel: a client connection is
+    // registered on the node, a `QuerySubscribe` op is driven through the
+    // production handler (which seeds the subscription's `LiveWindow` from the
+    // real DAG page), and subsequent `cluster.write()` calls fire
+    // `CrdtService::broadcast_query_updates`, which derives ENTER/UPDATE/LEAVE
+    // via `live_window.apply_mutation` and pushes real `QUERY_UPDATE` frames onto
+    // the connection's outbound channel. The tests decode those frames off the
+    // wire and replay membership — no source inspection.
+    // -----------------------------------------------------------------------
+
+    /// Registers a client connection on `node` and drives a real
+    /// `QuerySubscribe` op through the production handler, seeding the
+    /// subscription's `LiveWindow` from the DAG page. Returns the outbound
+    /// receiver — the SAME channel `broadcast_query_updates` sends
+    /// `QUERY_UPDATE` frames on — so the caller can drain live deltas.
+    async fn subscribe_and_observe(
+        node: &mut SimNode,
+        map_name: &str,
+        query_id: &str,
+        query: Query,
+    ) -> mpsc::Receiver<OutboundMessage> {
+        let config = ConnectionConfig::default();
+        let (handle, rx) = node
+            .connection_registry
+            .register(ConnectionKind::Client, &config);
+
+        let ts = Timestamp {
+            millis: 0,
+            counter: 0,
+            node_id: node.node_id.clone(),
+        };
+        let mut ctx = OperationContext::new(0, service_names::QUERY, ts, 5000);
+        // The handler routes the QUERY_UPDATE stream to whatever connection this
+        // subscription was registered under, so it MUST be the connection whose
+        // receiver we return here.
+        ctx.connection_id = Some(handle.id);
+
+        let payload = topgun_core::messages::QuerySubMessage {
+            payload: topgun_core::messages::query::QuerySubPayload {
+                query_id: query_id.to_string(),
+                map_name: map_name.to_string(),
+                query,
+                fields: None,
+            },
+        };
+        let op = Operation::QuerySubscribe { ctx, payload };
+        Service::call(&mut node.operation_router, op)
+            .await
+            .expect("QuerySubscribe should seed the live window and register the subscription");
+
+        rx
+    }
+
+    /// Drains every currently-ready `QUERY_UPDATE` frame off the outbound
+    /// channel for `query_id`, decoding each from its real MsgPack wire form,
+    /// and returns `(key, change_type)` pairs in arrival order.
+    fn drain_live_updates(
+        rx: &mut mpsc::Receiver<OutboundMessage>,
+        query_id: &str,
+    ) -> Vec<(String, topgun_core::messages::base::ChangeEventType)> {
+        let mut out = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            if let OutboundMessage::Binary(bytes) = msg {
+                if let Ok(topgun_core::messages::Message::QueryUpdate { payload }) =
+                    rmp_serde::from_slice::<topgun_core::messages::Message>(&bytes)
+                {
+                    if payload.query_id == query_id {
+                        out.push((payload.key, payload.change_type));
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Replays an ENTER/LEAVE delta stream into the resulting live membership
+    /// set. UPDATE neither adds nor removes a key. This reconstructs exactly the
+    /// rows a subscriber would currently be holding.
+    fn replay_membership(
+        deltas: &[(String, topgun_core::messages::base::ChangeEventType)],
+    ) -> std::collections::HashSet<String> {
+        use topgun_core::messages::base::ChangeEventType;
+        let mut live = std::collections::HashSet::new();
+        for (key, event) in deltas {
+            match event {
+                ChangeEventType::ENTER => {
+                    live.insert(key.clone());
+                }
+                ChangeEventType::LEAVE => {
+                    live.remove(key);
+                }
+                ChangeEventType::UPDATE => {}
+            }
+        }
+        live
+    }
+
+    fn live_top_n_query() -> Query {
+        use topgun_core::messages::base::{PredicateNode, PredicateOp, SortDirection, SortField};
+        Query {
+            // Predicate every test row satisfies, so membership is governed by
+            // the top-N window, not by predicate filtering.
+            predicate: Some(PredicateNode {
+                op: PredicateOp::Gte,
+                attribute: Some("score".to_string()),
+                value: Some(rmpv::Value::Integer(0i64.into())),
+                children: None,
+                value_ref: None,
+            }),
+            sort: Some(vec![SortField {
+                field: "score".to_string(),
+                direction: SortDirection::Asc,
+            }]),
+            limit: Some(2),
+            ..Default::default()
+        }
+    }
+
+    /// Drives a REMOVE `ClientOp` (`record: Some(None)`) through the node's
+    /// `CrdtService`, mirroring `SimCluster::write` but for a delete. The delete
+    /// reaches `broadcast_query_updates` with `new_rmpv_value == None`, which the
+    /// live window models as a row leaving (freeing a slot for promotion).
+    async fn delete_record(node: &SimNode, map: &str, key: &str) {
+        let partition_id = topgun_core::hash_to_partition(key);
+        let ts = Timestamp {
+            millis: 0,
+            counter: 0,
+            node_id: node.node_id.clone(),
+        };
+        let mut ctx = OperationContext::new(0, service_names::CRDT, ts, 5000);
+        ctx.partition_id = Some(partition_id);
+        ctx.caller_origin = CallerOrigin::System;
+
+        let client_op = ClientOp {
+            id: Some(format!("{map}/{key}/rm")),
+            map_name: map.to_string(),
+            key: key.to_string(),
+            op_type: None,
+            // `Some(None)` is the tombstone form the CRDT service treats as REMOVE.
+            record: Some(None),
+            or_record: None,
+            or_tag: None,
+            write_concern: None,
+            timeout: None,
+        };
+        let op = Operation::ClientOp {
+            ctx,
+            payload: ClientOpMessage { payload: client_op },
+        };
+        let mut svc = Arc::clone(&node.crdt_service);
+        Service::call(&mut svc, op)
+            .await
+            .expect("REMOVE op should succeed");
+    }
+
+    /// NEGATIVE CONTROL: a `limit=2` + sort-ASC live subscription must never let
+    /// the observed live set grow to 3, even though all three writes satisfy the
+    /// predicate. The third (smaller) insert must displace the largest in-window
+    /// row, emitting a compensating LEAVE so membership stays at exactly 2.
+    ///
+    /// VACUITY GUARD: reverting the displacement LEAVE in `query/window.rs`
+    /// (the `in_window_before \ in_window_after` LEAVE loop) makes the third
+    /// insert ENTER with no compensating LEAVE, so the replayed live set drifts
+    /// to 3 and the `== 2` assertion FAILS. The explicit ENTER-for-displacing-row
+    /// and LEAVE-for-displaced-row assertions below stop a trivially-empty frame
+    /// stream from passing the size check vacuously.
+    #[tokio::test]
+    #[cfg(feature = "simulation")]
+    async fn live_top_n_negative_control_membership_stays_two() {
+        use topgun_core::messages::base::ChangeEventType;
+
+        let mut cluster = SimCluster::new(1, 0);
+        cluster.start().expect("cluster start");
+
+        let map_name = "neg_scores";
+        let query_id = "neg-top-n";
+
+        // Single-node DAG bypass so the seed page comes from the real engine.
+        set_membership(&cluster.nodes[0], &["sim-node-0"]);
+        assign_partitions(&cluster.nodes[0], &|_| "sim-node-0".to_string());
+
+        // Subscribe BEFORE any writes: the window seeds empty, then is populated
+        // entirely by the live write-path delta channel.
+        let mut rx = subscribe_and_observe(
+            &mut cluster.nodes[0],
+            map_name,
+            query_id,
+            live_top_n_query(),
+        )
+        .await;
+
+        // Three matching writes: 10, 20, then 5. With limit=2 sort ASC the final
+        // top-2 is {rec-c=5, rec-a=10}; rec-b=20 must be displaced out.
+        cluster
+            .write(0, map_name, "rec-a", score_record(10))
+            .await
+            .expect("write rec-a");
+        cluster
+            .write(0, map_name, "rec-b", score_record(20))
+            .await
+            .expect("write rec-b");
+        cluster
+            .write(0, map_name, "rec-c", score_record(5))
+            .await
+            .expect("write rec-c");
+
+        let deltas = drain_live_updates(&mut rx, query_id);
+
+        // Loud failure if the delta channel produced nothing — a silent empty
+        // stream must not pass the size assertion vacuously.
+        assert!(
+            !deltas.is_empty(),
+            "expected live QUERY_UPDATE frames on the outbound channel, got none"
+        );
+
+        // The displacing row entered and the displaced row left: this is what
+        // keeps the set at 2. Without the displacement LEAVE only the ENTER for
+        // rec-c would arrive.
+        assert!(
+            deltas
+                .iter()
+                .any(|(k, e)| k == "rec-c" && *e == ChangeEventType::ENTER),
+            "rec-c (score 5) must ENTER the top-2 window: {deltas:?}"
+        );
+        assert!(
+            deltas
+                .iter()
+                .any(|(k, e)| k == "rec-b" && *e == ChangeEventType::LEAVE),
+            "rec-b (score 20) must receive a displacement LEAVE: {deltas:?}"
+        );
+
+        let live = replay_membership(&deltas);
+        assert_eq!(
+            live.len(),
+            2,
+            "live set must stay at limit=2, never drift to 3: {live:?} from {deltas:?}"
+        );
+        assert_eq!(
+            live,
+            ["rec-a".to_string(), "rec-c".to_string()]
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>(),
+            "final top-2 must be the two smallest scores (rec-c=5, rec-a=10)"
+        );
+    }
+
+    /// POSITIVE: the live top-N window holds correct membership through
+    /// displacement and promotion while a fault is in effect. A non-queried node
+    /// is partitioned away; the queried node stays alive and its window is
+    /// maintained purely from the local write-path delta channel.
+    ///
+    /// VACUITY GUARD: each membership assertion is driven by the decoded
+    /// QUERY_UPDATE stream, not a test-side recomputation. If the displacement
+    /// LEAVE / promotion ENTER logic in `query/window.rs` were removed, the
+    /// observed live set would carry the wrong rows (drift to 3 on the
+    /// displacement, or fail to re-promote rec-b on the delete) and these
+    /// equality assertions would FAIL.
+    #[tokio::test]
+    #[cfg(feature = "simulation")]
+    async fn live_top_n_window_holds_under_fault() {
+        use topgun_core::messages::base::ChangeEventType;
+
+        let mut cluster = SimCluster::new(2, 7);
+        cluster.start().expect("cluster start");
+
+        let map_name = "fault_top_n";
+        let query_id = "fault-top-n";
+
+        // Each node sees only itself as active so the queried node's single-node
+        // DAG bypass fires for the seed page.
+        set_membership(&cluster.nodes[0], &["sim-node-0"]);
+        set_membership(&cluster.nodes[1], &["sim-node-1"]);
+        assign_partitions(&cluster.nodes[0], &|_| "sim-node-0".to_string());
+        assign_partitions(&cluster.nodes[1], &|_| "sim-node-1".to_string());
+
+        let mut rx = subscribe_and_observe(
+            &mut cluster.nodes[0],
+            map_name,
+            query_id,
+            live_top_n_query(),
+        )
+        .await;
+
+        // Fault: partition the non-queried node-1 away. node-0 (queried) stays
+        // alive and continues to maintain its live window locally.
+        cluster.inject_partition(&[0], &[1]);
+
+        // Fill the window: rec-a=10, rec-b=20 → window {rec-a, rec-b}.
+        cluster
+            .write(0, map_name, "rec-a", score_record(10))
+            .await
+            .expect("write rec-a");
+        cluster
+            .write(0, map_name, "rec-b", score_record(20))
+            .await
+            .expect("write rec-b");
+
+        // Displace: rec-c=5 enters, rec-b=20 is pushed out (window {rec-c, rec-a}).
+        cluster
+            .write(0, map_name, "rec-c", score_record(5))
+            .await
+            .expect("write rec-c");
+
+        // Drain the displacement phase and assert the displacement deltas.
+        let phase1 = drain_live_updates(&mut rx, query_id);
+        assert!(
+            phase1
+                .iter()
+                .any(|(k, e)| k == "rec-c" && *e == ChangeEventType::ENTER),
+            "rec-c must ENTER on displacement: {phase1:?}"
+        );
+        assert!(
+            phase1
+                .iter()
+                .any(|(k, e)| k == "rec-b" && *e == ChangeEventType::LEAVE),
+            "rec-b must receive a displacement LEAVE: {phase1:?}"
+        );
+        let after_displace = replay_membership(&phase1);
+        assert_eq!(
+            after_displace,
+            ["rec-a".to_string(), "rec-c".to_string()]
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>(),
+            "after displacement the window must be the two smallest (rec-c=5, rec-a=10): {phase1:?}"
+        );
+
+        // Promotion: delete the in-window rec-c. A slot frees and the retained
+        // rec-b (20) must be re-promoted into the window (window {rec-a, rec-b}).
+        cluster
+            .write(0, map_name, "rec-c", score_record(5))
+            .await
+            .expect("re-write rec-c before delete");
+        // Drain the redundant UPDATE from the re-write so it does not pollute the
+        // promotion-phase assertions.
+        let _ = drain_live_updates(&mut rx, query_id);
+        delete_record(&cluster.nodes[0], map_name, "rec-c").await;
+
+        let phase2 = drain_live_updates(&mut rx, query_id);
+        assert!(
+            phase2
+                .iter()
+                .any(|(k, e)| k == "rec-c" && *e == ChangeEventType::LEAVE),
+            "deleted rec-c must LEAVE: {phase2:?}"
+        );
+        assert!(
+            phase2
+                .iter()
+                .any(|(k, e)| k == "rec-b" && *e == ChangeEventType::ENTER),
+            "retained rec-b must be re-promoted (ENTER) when rec-c's slot frees: {phase2:?}"
+        );
+
+        // Final membership: replay the FULL stream (displacement + promotion).
+        let mut all = phase1;
+        all.extend(phase2);
+        let final_live = replay_membership(&all);
+        assert_eq!(
+            final_live.len(),
+            2,
+            "window must hold exactly limit=2 rows throughout: {final_live:?}"
+        );
+        assert_eq!(
+            final_live,
+            ["rec-a".to_string(), "rec-b".to_string()]
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>(),
+            "after promotion the top-2 must be rec-a=10, rec-b=20 (rec-c gone): {all:?}"
+        );
+
+        cluster.heal_partition();
+    }
 }


### PR DESCRIPTION
## What

Query/Search audit F1 (DEPTH_QUERY_SEARCH.md / TODO-441, **HIGH**): the flagship live query silently returned wrong results for any `limit`+`sort` subscription. `matches_query` (query.rs:213) evaluated only the predicate, ignoring limit/sort/cursor; the client never clamped. A row entering the filter past the top-N window was pushed as ENTER with no displacement LEAVE → the live result drifted past the limit.

## Fix

New `LiveWindow` (`query/window.rs`): per-subscription sorted top-N window. On each mutation it returns the COMPLETE `WindowDelta` set the subscriber needs — displacement LEAVE (an ENTER pushing the (limit+1)-th row out) and promotion ENTER (a freed slot pulling a previously-displaced row back). Retains once-displaced out-of-window rows so promotion needs no DAG re-query. Live broadcast routed through it (crdt.rs). Phase-2 (Query Consolidation) live windowing.

## Verified locally

- Window units 5/5: `displacement_on_third_insert`, `promotion_after_in_window_leaves`, `update_within_window`, `update_out_of_window`, `unbounded_no_displacement`.
- Sim behavioral: `live_top_n_window_holds_under_fault` + `live_top_n_negative_control_membership_stays_two` (**vacuity guard**: reverting the displacement LEAVE makes the `== 2` assertion FAIL — proves the test catches the drift).
- sim-convergence 4/4 (no regression); clippy -D warnings + fmt clean.

## Merge gate

`gh pr checks` ALL-green incl **build-and-push (Docker)** AND **Simulation Tests** (runs the live top-N sim tests), verified separately.