### PR TITLE
fix(server): wire live-subscription disconnect cleanup — query/journal/search/hybrid (F3, SPEC-318)

### DIFF
--- a/packages/server-rust/benches/load_harness/main.rs
+++ b/packages/server-rust/benches/load_harness/main.rs
@@ -244,6 +244,10 @@ async fn main() {
                 lock_registry: None,
                 topic_registry: None,
                 counter_registry: None,
+                query_registry: None,
+                journal_store: None,
+                search_registry: None,
+                hybrid_search_registry: None,
                 admin_enabled: true,
             };
 

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -866,6 +866,12 @@ async fn main() -> anyhow::Result<()> {
         lock_registry: Some(lock_registry),
         topic_registry: Some(topic_registry),
         counter_registry: Some(counter_registry),
+        // Disconnect-cleanup registries are threaded through in a later wiring
+        // step; default to None so this construction site stays valid until then.
+        query_registry: None,
+        journal_store: None,
+        search_registry: None,
+        hybrid_search_registry: None,
         admin_enabled,
     };
 

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -60,6 +60,7 @@ use topgun_server::service::domain::embedding::{
 };
 use topgun_server::service::domain::index::IndexObserverFactory;
 use topgun_server::service::domain::messaging::{MessagingService, TopicRegistry};
+use topgun_server::service::domain::journal::JournalStore;
 use topgun_server::service::domain::persistence::PersistenceService;
 use topgun_server::service::domain::query::{QueryRegistry, QueryService};
 use topgun_server::service::domain::schema::SchemaService;
@@ -676,6 +677,10 @@ async fn main() -> anyhow::Result<()> {
             counter_registry,
             record_store_factory,
             index_observer_factory,
+            query_registry,
+            search_registry,
+            hybrid_search_registry,
+            journal_store,
         ) = build_services(
             node_id.clone(),
             Arc::clone(&cluster_state),
@@ -716,6 +721,10 @@ async fn main() -> anyhow::Result<()> {
                 counter_registry,
                 record_store_factory,
                 index_observer_factory,
+                query_registry,
+                search_registry,
+                hybrid_search_registry,
+                journal_store,
             ),
             Some(cluster_state),
         )
@@ -732,6 +741,10 @@ async fn main() -> anyhow::Result<()> {
             counter_registry,
             record_store_factory,
             index_observer_factory,
+            query_registry,
+            search_registry,
+            hybrid_search_registry,
+            journal_store,
         ) = build_services(
             node_id.clone(),
             Arc::clone(&cs),
@@ -751,6 +764,10 @@ async fn main() -> anyhow::Result<()> {
                 counter_registry,
                 record_store_factory,
                 index_observer_factory,
+                query_registry,
+                search_registry,
+                hybrid_search_registry,
+                journal_store,
             ),
             None,
         )
@@ -765,6 +782,10 @@ async fn main() -> anyhow::Result<()> {
         counter_registry,
         record_store_factory,
         index_observer_factory,
+        query_registry,
+        search_registry,
+        hybrid_search_registry,
+        journal_store,
     ) = cluster_state_for_services;
 
     // Spawn the eviction orchestrator after services are wired so it observes
@@ -866,12 +887,13 @@ async fn main() -> anyhow::Result<()> {
         lock_registry: Some(lock_registry),
         topic_registry: Some(topic_registry),
         counter_registry: Some(counter_registry),
-        // Disconnect-cleanup registries are threaded through in a later wiring
-        // step; default to None so this construction site stays valid until then.
-        query_registry: None,
-        journal_store: None,
-        search_registry: None,
-        hybrid_search_registry: None,
+        // Disconnect-cleanup registries: dropping a connection must prune the
+        // subscriptions it held in each of these so the server does not leak
+        // per-connection subscription state for the lifetime of the process.
+        query_registry: Some(query_registry),
+        journal_store: Some(journal_store),
+        search_registry: Some(search_registry),
+        hybrid_search_registry: Some(hybrid_search_registry),
         admin_enabled,
     };
 
@@ -1102,6 +1124,10 @@ type BuildServicesResult = (
     Arc<CounterRegistry>,
     Arc<RecordStoreFactory>,
     Arc<IndexObserverFactory>,
+    Arc<QueryRegistry>,
+    Arc<SearchRegistry>,
+    Arc<HybridSearchRegistry>,
+    Arc<JournalStore>,
 );
 
 /// Cluster-mode parameters passed to [`build_services`] when starting with `--seed-nodes`.
@@ -1297,6 +1323,8 @@ fn build_services(
     } else {
         query_svc_base
     });
+    // Capture Arc<QueryRegistry> before query_svc is moved into the closure.
+    let query_registry_arc = query_svc.query_registry_arc();
     let messaging_svc = Arc::new(MessagingService::new(Arc::clone(&connection_registry)));
     // Capture Arc<TopicRegistry> before messaging_svc is moved into the closure.
     let topic_registry_arc = messaging_svc.topic_registry_arc();
@@ -1315,6 +1343,10 @@ fn build_services(
         search_needs_population,
         Arc::clone(&index_observer_factory),
     ));
+    // Capture the search subscription registries before search_svc is moved into
+    // the closure, so disconnect cleanup can prune live search subscriptions.
+    let search_registry_arc = search_svc.search_registry_arc();
+    let hybrid_search_registry_arc = search_svc.hybrid_search_registry_arc();
     // Wire the search_service back into the observer factory so hybrid notifier
     // tasks can be spawned when observers are created for each map.
     search_observer_factory.init_search_service(Arc::clone(&search_svc));
@@ -1331,6 +1363,9 @@ fn build_services(
     ));
     // Capture Arc<CounterRegistry> before persistence_svc is moved into the closure.
     let counter_registry_arc = persistence_svc.counter_registry_arc();
+    // Capture Arc<JournalStore> before persistence_svc is moved into the closure,
+    // so disconnect cleanup can prune journal subscriptions held per connection.
+    let journal_store_arc = persistence_svc.journal_store_arc();
 
     // Factory closure: creates a fresh OperationRouter + pipeline per worker.
     // Domain services are Arc-cloned (cheap reference count bump), while
@@ -1361,6 +1396,10 @@ fn build_services(
         counter_registry_arc,
         record_store_factory,
         Arc::clone(&index_observer_factory),
+        query_registry_arc,
+        search_registry_arc,
+        hybrid_search_registry_arc,
+        journal_store_arc,
     )
 }
 

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -59,8 +59,8 @@ use topgun_server::service::domain::embedding::{
     EmbeddingProviderConfig, NoopConfig, VectorConfig as EmbeddingVectorConfig,
 };
 use topgun_server::service::domain::index::IndexObserverFactory;
-use topgun_server::service::domain::messaging::{MessagingService, TopicRegistry};
 use topgun_server::service::domain::journal::JournalStore;
+use topgun_server::service::domain::messaging::{MessagingService, TopicRegistry};
 use topgun_server::service::domain::persistence::PersistenceService;
 use topgun_server::service::domain::query::{QueryRegistry, QueryService};
 use topgun_server::service::domain::schema::SchemaService;

--- a/packages/server-rust/src/network/handlers/mod.rs
+++ b/packages/server-rust/src/network/handlers/mod.rs
@@ -42,7 +42,12 @@ use crate::service::config::ServerConfig;
 use crate::service::dispatch::PartitionDispatcher;
 use crate::service::domain::counter::CounterRegistry;
 use crate::service::domain::index::mutation_observer::IndexObserverFactory;
+use crate::service::domain::journal::JournalStore;
 use crate::service::domain::messaging::TopicRegistry;
+use crate::service::domain::query::QueryRegistry;
+use crate::service::domain::search::{
+    HybridSearchSubscription, SearchSubscription, SubscriptionRegistry,
+};
 use crate::service::domain::LockRegistry;
 use crate::service::middleware::ObservabilityHandle;
 use crate::service::policy::PolicyStore;
@@ -126,6 +131,22 @@ pub struct AppState {
     /// populated in production wiring so `handle_socket` can release
     /// subscriptions on WebSocket disconnect.
     pub counter_registry: Option<Arc<CounterRegistry>>,
+    /// Live-query subscription registry. `None` in network-only tests;
+    /// populated in production wiring so `handle_socket` can release standing
+    /// query subscriptions on WebSocket disconnect.
+    pub query_registry: Option<Arc<QueryRegistry>>,
+    /// Journal subscription store. `None` in network-only tests; populated in
+    /// production wiring so `handle_socket` can release journal subscriptions
+    /// on WebSocket disconnect.
+    pub journal_store: Option<Arc<JournalStore>>,
+    /// Text-search subscription registry. `None` in network-only tests;
+    /// populated in production wiring so `handle_socket` can release standing
+    /// search subscriptions on WebSocket disconnect.
+    pub search_registry: Option<Arc<SubscriptionRegistry<SearchSubscription>>>,
+    /// Hybrid-search subscription registry. `None` in network-only tests;
+    /// populated in production wiring so `handle_socket` can release standing
+    /// hybrid-search subscriptions on WebSocket disconnect.
+    pub hybrid_search_registry: Option<Arc<SubscriptionRegistry<HybridSearchSubscription>>>,
     /// Second, independent enforcement layer for the no-auth admin bypass.
     /// When `false`, the `AdminClaims` extractor refuses to synthesize the
     /// local-admin superuser regardless of how the route was mounted, so a
@@ -179,6 +200,10 @@ impl AppState {
             lock_registry: None,
             topic_registry: None,
             counter_registry: None,
+            query_registry: None,
+            journal_store: None,
+            search_registry: None,
+            hybrid_search_registry: None,
             // Default-safe: tests exercise the admin plane as enabled unless they
             // explicitly override this to assert the disabled-plane guard.
             admin_enabled: true,

--- a/packages/server-rust/src/network/handlers/websocket.rs
+++ b/packages/server-rust/src/network/handlers/websocket.rs
@@ -794,3 +794,116 @@ async fn send_outbound_message(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::window::LiveWindow;
+    use crate::service::domain::journal::{JournalStore, JournalSubscription};
+    use crate::service::domain::query::{QueryRegistry, QuerySubscription};
+    use crate::service::domain::search::{
+        HybridSearchSubscription, SearchSubscription, SubscriptionRegistry,
+    };
+    use dashmap::DashSet;
+    use topgun_core::messages::base::Query;
+    use topgun_core::messages::search::SearchOptions;
+
+    /// Disconnect cleanup must drain a connection's standing subscriptions from
+    /// every registry wired into `AppState`, not just lock/topic/counter. This
+    /// drives `release_session_state` directly and asserts each of the four
+    /// later-added registries reports zero subscriptions for the disconnected
+    /// connection — the regression that left query/journal/search/hybrid
+    /// subscriptions leaked on disconnect.
+    #[test]
+    fn release_session_state_clears_query_journal_search_hybrid_subscriptions() {
+        let conn = ConnectionId(7);
+
+        let query_registry = Arc::new(QueryRegistry::new());
+        let journal_store = Arc::new(JournalStore::new(100));
+        let search_registry = Arc::new(SubscriptionRegistry::<SearchSubscription>::new());
+        let hybrid_registry = Arc::new(SubscriptionRegistry::<HybridSearchSubscription>::new());
+
+        // One subscription per registry, all owned by the same connection.
+        let query = Query::default();
+        let live_window = Arc::new(LiveWindow::new(
+            query.sort.clone().unwrap_or_default(),
+            query.limit,
+        ));
+        query_registry.register(QuerySubscription {
+            query_id: "q-1".to_string(),
+            connection_id: conn,
+            map_name: "users".to_string(),
+            query,
+            previous_result_keys: DashSet::new(),
+            live_window,
+            fields: None,
+        });
+
+        journal_store.subscribe(
+            "j-1".to_string(),
+            JournalSubscription {
+                connection_id: conn,
+                map_name: Some("users".to_string()),
+                types: None,
+            },
+        );
+
+        search_registry.register(SearchSubscription::new(
+            "s-1".to_string(),
+            conn,
+            "users".to_string(),
+            "hello".to_string(),
+            SearchOptions::default(),
+        ));
+
+        hybrid_registry.register(HybridSearchSubscription::new(
+            "h-1".to_string(),
+            conn,
+            "users".to_string(),
+            "hello".to_string(),
+            Vec::new(),
+            10,
+            None,
+            None,
+            false,
+            None,
+        ));
+
+        // Sanity: each registry holds the connection's subscription before disconnect.
+        assert_eq!(query_registry.subscription_count(), 1);
+        assert_eq!(journal_store.subscription_count_for_connection(conn), 1);
+        assert_eq!(search_registry.get_subscriptions_for_map("users").len(), 1);
+        assert_eq!(hybrid_registry.get_subscriptions_for_map("users").len(), 1);
+
+        let state = AppState {
+            query_registry: Some(Arc::clone(&query_registry)),
+            journal_store: Some(Arc::clone(&journal_store)),
+            search_registry: Some(Arc::clone(&search_registry)),
+            hybrid_search_registry: Some(Arc::clone(&hybrid_registry)),
+            ..AppState::for_test()
+        };
+
+        release_session_state(&state, conn);
+
+        assert_eq!(
+            query_registry.subscription_count(),
+            0,
+            "query registry retained subscription after disconnect"
+        );
+        assert_eq!(
+            journal_store.subscription_count_for_connection(conn),
+            0,
+            "journal store retained subscription after disconnect"
+        );
+        assert_eq!(
+            search_registry.get_subscriptions_for_map("users").len(),
+            0,
+            "search registry retained subscription after disconnect"
+        );
+        assert_eq!(
+            hybrid_registry.get_subscriptions_for_map("users").len(),
+            0,
+            "hybrid-search registry retained subscription after disconnect"
+        );
+    }
+}

--- a/packages/server-rust/src/network/handlers/websocket.rs
+++ b/packages/server-rust/src/network/handlers/websocket.rs
@@ -321,7 +321,8 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
 ///
 /// Each registry field is `Option<Arc<_>>` — `None` is the in-test default
 /// so this function is a no-op in test contexts that do not wire the registries.
-/// Order: Lock -> Topic -> Counter (mirrors the struct field declaration order).
+/// Order: Lock -> Topic -> Counter -> Query -> Journal -> Search -> Hybrid
+/// (mirrors the struct field declaration order).
 fn release_session_state(state: &AppState, conn_id: ConnectionId) {
     if let Some(ref reg) = state.lock_registry {
         reg.release_on_disconnect(conn_id);
@@ -331,6 +332,20 @@ fn release_session_state(state: &AppState, conn_id: ConnectionId) {
     }
     if let Some(ref reg) = state.counter_registry {
         reg.release_on_disconnect(conn_id);
+    }
+    if let Some(ref reg) = state.query_registry {
+        reg.unregister_by_connection(conn_id);
+    }
+    if let Some(ref reg) = state.journal_store {
+        reg.unsubscribe_by_connection(conn_id);
+    }
+    // Removed-id vectors are intentionally dropped: disconnect cleanup needs no
+    // downstream fan-out, only the registry-side removal.
+    if let Some(ref reg) = state.search_registry {
+        let _ = reg.unregister_by_connection(conn_id);
+    }
+    if let Some(ref reg) = state.hybrid_search_registry {
+        let _ = reg.unregister_by_connection(conn_id);
     }
 }
 

--- a/packages/server-rust/src/network/module.rs
+++ b/packages/server-rust/src/network/module.rs
@@ -203,10 +203,7 @@ impl NetworkModule {
     ///
     /// When set, journal subscriptions held by a disconnecting session are
     /// removed. Consumers that do not use the journal can omit this call.
-    pub fn set_journal_store(
-        &mut self,
-        store: Arc<crate::service::domain::journal::JournalStore>,
-    ) {
+    pub fn set_journal_store(&mut self, store: Arc<crate::service::domain::journal::JournalStore>) {
         self.journal_store = Some(store);
     }
 

--- a/packages/server-rust/src/network/module.rs
+++ b/packages/server-rust/src/network/module.rs
@@ -741,6 +741,12 @@ fn build_app(
         lock_registry,
         topic_registry,
         counter_registry,
+        // Disconnect-cleanup registries are threaded through in a later wiring
+        // step; default to None so this construction site stays valid until then.
+        query_registry: None,
+        journal_store: None,
+        search_registry: None,
+        hybrid_search_registry: None,
         // This NetworkModule-managed path always mounts the admin plane and
         // enforces auth, so the extractor guard is enabled to match.
         admin_enabled: true,

--- a/packages/server-rust/src/network/module.rs
+++ b/packages/server-rust/src/network/module.rs
@@ -78,6 +78,22 @@ pub struct NetworkModule {
     lock_registry: Option<Arc<crate::service::domain::LockRegistry>>,
     topic_registry: Option<Arc<crate::service::domain::messaging::TopicRegistry>>,
     counter_registry: Option<Arc<crate::service::domain::counter::CounterRegistry>>,
+    query_registry: Option<Arc<crate::service::domain::query::QueryRegistry>>,
+    journal_store: Option<Arc<crate::service::domain::journal::JournalStore>>,
+    search_registry: Option<
+        Arc<
+            crate::service::domain::search::SubscriptionRegistry<
+                crate::service::domain::search::SearchSubscription,
+            >,
+        >,
+    >,
+    hybrid_search_registry: Option<
+        Arc<
+            crate::service::domain::search::SubscriptionRegistry<
+                crate::service::domain::search::HybridSearchSubscription,
+            >,
+        >,
+    >,
 }
 
 impl NetworkModule {
@@ -101,6 +117,10 @@ impl NetworkModule {
             lock_registry: None,
             topic_registry: None,
             counter_registry: None,
+            query_registry: None,
+            journal_store: None,
+            search_registry: None,
+            hybrid_search_registry: None,
         }
     }
 
@@ -168,6 +188,59 @@ impl NetworkModule {
         self.counter_registry = Some(registry);
     }
 
+    /// Configures the live-query registry for session disconnect cleanup.
+    ///
+    /// When set, standing query subscriptions held by a disconnecting session
+    /// are unregistered. Consumers that do not use live queries can omit this call.
+    pub fn set_query_registry(
+        &mut self,
+        registry: Arc<crate::service::domain::query::QueryRegistry>,
+    ) {
+        self.query_registry = Some(registry);
+    }
+
+    /// Configures the journal store for session disconnect cleanup.
+    ///
+    /// When set, journal subscriptions held by a disconnecting session are
+    /// removed. Consumers that do not use the journal can omit this call.
+    pub fn set_journal_store(
+        &mut self,
+        store: Arc<crate::service::domain::journal::JournalStore>,
+    ) {
+        self.journal_store = Some(store);
+    }
+
+    /// Configures the text-search registry for session disconnect cleanup.
+    ///
+    /// When set, standing search subscriptions held by a disconnecting session
+    /// are unregistered. Consumers that do not use live search can omit this call.
+    pub fn set_search_registry(
+        &mut self,
+        registry: Arc<
+            crate::service::domain::search::SubscriptionRegistry<
+                crate::service::domain::search::SearchSubscription,
+            >,
+        >,
+    ) {
+        self.search_registry = Some(registry);
+    }
+
+    /// Configures the hybrid-search registry for session disconnect cleanup.
+    ///
+    /// When set, standing hybrid-search subscriptions held by a disconnecting
+    /// session are unregistered. Consumers that do not use live hybrid search
+    /// can omit this call.
+    pub fn set_hybrid_search_registry(
+        &mut self,
+        registry: Arc<
+            crate::service::domain::search::SubscriptionRegistry<
+                crate::service::domain::search::HybridSearchSubscription,
+            >,
+        >,
+    ) {
+        self.hybrid_search_registry = Some(registry);
+    }
+
     /// Returns a shared reference to the connection registry.
     ///
     /// Other modules use this to inspect or broadcast to active connections.
@@ -213,6 +286,10 @@ impl NetworkModule {
                 lock_registry: None,
                 topic_registry: None,
                 counter_registry: None,
+                query_registry: None,
+                journal_store: None,
+                search_registry: None,
+                hybrid_search_registry: None,
             },
         )
     }
@@ -379,6 +456,10 @@ impl NetworkModule {
                 lock_registry: self.lock_registry,
                 topic_registry: self.topic_registry,
                 counter_registry: self.counter_registry,
+                query_registry: self.query_registry,
+                journal_store: self.journal_store,
+                search_registry: self.search_registry,
+                hybrid_search_registry: self.hybrid_search_registry,
             },
         );
 
@@ -428,6 +509,26 @@ struct AppServices {
     topic_registry: Option<Arc<crate::service::domain::messaging::TopicRegistry>>,
     /// Arc<CounterRegistry> for disconnect cleanup.
     counter_registry: Option<Arc<crate::service::domain::counter::CounterRegistry>>,
+    /// `Arc<QueryRegistry>` for disconnect cleanup.
+    query_registry: Option<Arc<crate::service::domain::query::QueryRegistry>>,
+    /// `Arc<JournalStore>` for disconnect cleanup.
+    journal_store: Option<Arc<crate::service::domain::journal::JournalStore>>,
+    /// Text-search `Arc<SubscriptionRegistry>` for disconnect cleanup.
+    search_registry: Option<
+        Arc<
+            crate::service::domain::search::SubscriptionRegistry<
+                crate::service::domain::search::SearchSubscription,
+            >,
+        >,
+    >,
+    /// Hybrid-search `Arc<SubscriptionRegistry>` for disconnect cleanup.
+    hybrid_search_registry: Option<
+        Arc<
+            crate::service::domain::search::SubscriptionRegistry<
+                crate::service::domain::search::HybridSearchSubscription,
+            >,
+        >,
+    >,
 }
 
 /// Single source of truth for the `topgun-server` HTTP route set.
@@ -633,6 +734,10 @@ fn build_app(
         lock_registry,
         topic_registry,
         counter_registry,
+        query_registry,
+        journal_store,
+        search_registry,
+        hybrid_search_registry,
     } = services;
     let layers = build_http_layers(&config);
 
@@ -741,12 +846,10 @@ fn build_app(
         lock_registry,
         topic_registry,
         counter_registry,
-        // Disconnect-cleanup registries are threaded through in a later wiring
-        // step; default to None so this construction site stays valid until then.
-        query_registry: None,
-        journal_store: None,
-        search_registry: None,
-        hybrid_search_registry: None,
+        query_registry,
+        journal_store,
+        search_registry,
+        hybrid_search_registry,
         // This NetworkModule-managed path always mounts the admin plane and
         // enforces auth, so the extractor guard is enabled to match.
         admin_enabled: true,

--- a/packages/server-rust/src/service/domain/journal.rs
+++ b/packages/server-rust/src/service/domain/journal.rs
@@ -104,6 +104,18 @@ impl JournalStore {
             .retain(|_, sub| sub.connection_id != conn_id);
     }
 
+    /// Returns the number of subscriptions held by the given connection.
+    ///
+    /// Exposed so disconnect-cleanup verification can observe per-connection
+    /// subscription removal without reaching into the private subscription map.
+    #[must_use]
+    pub fn subscription_count_for_connection(&self, conn_id: ConnectionId) -> usize {
+        self.subscriptions
+            .iter()
+            .filter(|entry| entry.value().connection_id == conn_id)
+            .count()
+    }
+
     /// Reads events from the ring buffer starting at `from_sequence` with
     /// optional map name filter.
     ///

--- a/packages/server-rust/src/service/domain/persistence.rs
+++ b/packages/server-rust/src/service/domain/persistence.rs
@@ -88,6 +88,16 @@ impl PersistenceService {
     pub fn journal_store(&self) -> &JournalStore {
         &self.journal_store
     }
+
+    /// Returns a clone of the inner `Arc<JournalStore>`.
+    ///
+    /// Used by production wiring in `build_app()` so `AppState` can hold an
+    /// `Arc<JournalStore>` directly without going through the service at
+    /// disconnect time (avoids racing with service shutdown).
+    #[must_use]
+    pub fn journal_store_arc(&self) -> Arc<JournalStore> {
+        Arc::clone(&self.journal_store)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server-rust/src/service/domain/query.rs
+++ b/packages/server-rust/src/service/domain/query.rs
@@ -397,7 +397,8 @@ impl MutationObserver for QueryMutationObserver {
 pub struct QueryService {
     query_registry: Arc<QueryRegistry>,
     record_store_factory: Arc<RecordStoreFactory>,
-    /// Retained for `unregister_by_connection` on client disconnect (module wiring deferred).
+    /// Retained so `unregister_by_connection` can release standing query
+    /// subscriptions when a client disconnects.
     #[allow(dead_code)]
     connection_registry: Arc<ConnectionRegistry>,
     /// Per-query Merkle manager for delta sync init.
@@ -526,6 +527,16 @@ impl QueryService {
     #[must_use]
     pub fn registry(&self) -> &Arc<QueryRegistry> {
         &self.query_registry
+    }
+
+    /// Returns a clone of the inner `Arc<QueryRegistry>`.
+    ///
+    /// Used by production wiring in `build_app()` so `AppState` can hold an
+    /// `Arc<QueryRegistry>` directly without going through the service at
+    /// disconnect time (avoids racing with service shutdown).
+    #[must_use]
+    pub fn query_registry_arc(&self) -> Arc<QueryRegistry> {
+        Arc::clone(&self.query_registry)
     }
 }
 

--- a/packages/server-rust/src/service/domain/search/mod.rs
+++ b/packages/server-rust/src/service/domain/search/mod.rs
@@ -1838,6 +1838,28 @@ impl SearchService {
             }
         }
     }
+
+    /// Returns a clone of the inner `Arc<SearchRegistry>`.
+    ///
+    /// Used by production wiring in `build_app()` so `AppState` can hold the
+    /// text-search registry directly and release standing subscriptions at
+    /// disconnect time without going through the service (avoids racing with
+    /// service shutdown).
+    #[must_use]
+    pub fn search_registry_arc(&self) -> Arc<SearchRegistry> {
+        Arc::clone(&self.registry)
+    }
+
+    /// Returns a clone of the inner `Arc<HybridSearchRegistry>`.
+    ///
+    /// Used by production wiring in `build_app()` so `AppState` can hold the
+    /// hybrid-search registry directly and release standing subscriptions at
+    /// disconnect time without going through the service (avoids racing with
+    /// service shutdown).
+    #[must_use]
+    pub fn hybrid_search_registry_arc(&self) -> Arc<HybridSearchRegistry> {
+        Arc::clone(&self.hybrid_registry)
+    }
 }
 
 #[async_trait]

--- a/packages/server-rust/src/service/domain/search/registry.rs
+++ b/packages/server-rust/src/service/domain/search/registry.rs
@@ -73,7 +73,6 @@ impl<S: RegistryEntry> SubscriptionRegistry<S> {
     ///
     /// Returns the IDs of all removed subscriptions. Called when a WebSocket
     /// connection closes so stale subscriptions are not left in the registry.
-    #[allow(dead_code)]
     #[must_use]
     pub fn unregister_by_connection(&self, connection_id: ConnectionId) -> Vec<String> {
         let mut removed = Vec::new();


### PR DESCRIPTION
## What

Query/Search audit F3 (TODO-280/281/282): `unregister_by_connection` for the query/journal/search subscription registries existed + was tested but **never called in prod** → unbounded registry growth + O(n-dead) scan per write on every disconnect. (Found a 4th: hybrid-search registry — also leaked; fixed too.)

## Fix

`release_session_state` (websocket disconnect path) now prunes all **four** registries (query/journal/search/hybrid) by connection_id. Registry handles threaded through `AppState` (+ Arc accessors) and wired in **both routers** (dual-router). 

## Verified locally

- `release_session_state_clears_query_journal_search_hybrid_subscriptions`: registers a sub in all four, asserts each holds 1 **before** disconnect (vacuity guard), then 0 **after**. lib 1359/0.
- sim-convergence 4/4 (no regression); clippy -D warnings + fmt clean.

## Merge gate

`gh pr checks` ALL-green incl **build-and-push (Docker)** AND **Simulation Tests**, verified separately.