### PR TITLE
fix(server): query NULL 3-valued logic + GROUP BY null/empty/missing (TODO-488/489)

### DIFF
--- a/packages/server-rust/src/dag/processors.rs
+++ b/packages/server-rust/src/dag/processors.rs
@@ -99,13 +99,19 @@ impl AggregatorState {
 struct GroupAggregator {
     count: u64,
     fields: HashMap<String, AggregatorState>,
+    /// The first-seen typed value of each GROUP BY field for this bucket, in
+    /// `group_by` order. Retained so `complete()` can emit the original typed
+    /// group value (not the stringified bucket key). A missing field is stored
+    /// as `Nil`, matching the null/missing collapse encoded in the bucket key.
+    group_values: Vec<rmpv::Value>,
 }
 
 impl GroupAggregator {
-    fn new() -> Self {
+    fn new(group_values: Vec<rmpv::Value>) -> Self {
         Self {
             count: 0,
             fields: HashMap::new(),
+            group_values,
         }
     }
 }
@@ -152,6 +158,9 @@ fn rmpv_to_f64(v: &rmpv::Value) -> Option<f64> {
     }
 }
 
+/// Renders a value as a plain string for the `SortProcessor`'s string-fallback
+/// comparison (used only when neither side is numeric). This is a lossy display
+/// form — not a grouping key; GROUP BY uses `tagged_key_part` instead.
 fn rmpv_to_key_part(v: &rmpv::Value) -> String {
     match v {
         rmpv::Value::String(s) => s.as_str().unwrap_or("").to_string(),
@@ -164,15 +173,41 @@ fn rmpv_to_key_part(v: &rmpv::Value) -> String {
     }
 }
 
-fn group_key_string(item: &rmpv::Value, group_by: &[String]) -> String {
-    let mut parts = Vec::with_capacity(group_by.len());
-    for field in group_by {
-        let val = get_field(item, field)
-            .map(rmpv_to_key_part)
-            .unwrap_or_default();
-        parts.push(val);
+/// Encodes one group-by field value into an unambiguous, self-delimiting key part.
+///
+/// Each part carries a one-char type tag so values of different types (and the
+/// empty string vs null) never collide, and string parts are length-prefixed so
+/// composite keys cannot be confused with one another (`["a", "b"]` cannot alias
+/// `["a|b"]`). A present-but-null field maps to the same `N` token as a missing
+/// field (see `group_key_string`), so the two collapse into one "no value" group
+/// — consistent with the predicate engine's NULL handling and `MongoDB` `$group`.
+fn tagged_key_part(v: &rmpv::Value) -> String {
+    match v {
+        rmpv::Value::Nil => "N".to_string(),
+        rmpv::Value::Boolean(b) => format!("B{}", u8::from(*b)),
+        rmpv::Value::Integer(i) => format!("I{i};"),
+        rmpv::Value::F32(f) => format!("F{};", f64::from(*f).to_bits()),
+        rmpv::Value::F64(f) => format!("F{};", f.to_bits()),
+        rmpv::Value::String(s) => {
+            let s = s.as_str().unwrap_or("");
+            format!("S{}:{s}", s.len())
+        }
+        other => format!("O{other:?};"),
     }
-    parts.join("|")
+}
+
+/// Builds the internal GROUP BY bucket key for a row. A missing field and a
+/// present-but-null field both produce the `N` token, so they group together;
+/// the empty string and every typed value remain distinct (see `tagged_key_part`).
+fn group_key_string(item: &rmpv::Value, group_by: &[String]) -> String {
+    let mut key = String::new();
+    for field in group_by {
+        match get_field(item, field) {
+            None => key.push('N'),
+            Some(v) => key.push_str(&tagged_key_part(v)),
+        }
+    }
+    key
 }
 
 // ---------------------------------------------------------------------------
@@ -530,7 +565,16 @@ impl Processor for AggregateProcessor {
         }
         inbox.drain(&mut |item| {
             let key = group_key_string(&item, group_by);
-            let group = self.partial.entry(key).or_insert_with(GroupAggregator::new);
+            let group = self.partial.entry(key).or_insert_with(|| {
+                // Sample the typed group-by values from the first row of the bucket.
+                // A missing field becomes Nil, mirroring the null/missing collapse
+                // in the bucket key, so every row in this bucket shares these values.
+                let group_values = group_by
+                    .iter()
+                    .map(|field| get_field(&item, field).cloned().unwrap_or(rmpv::Value::Nil))
+                    .collect();
+                GroupAggregator::new(group_values)
+            });
             // Every row increments the group cardinality (the unconditional COUNT).
             group.count += 1;
             // Accumulate per-field state only when the row carries a numeric value for that
@@ -598,31 +642,32 @@ impl Processor for AggregateProcessor {
                         ));
                     }
                     AggFunc::Avg => {
-                        let avg = state.map_or(0.0, |s| {
-                            if s.count > 0 {
+                        // AVG over zero numeric observations is undefined; emit Nil
+                        // (the SQL / DataFusion result for AVG of an empty set) rather
+                        // than a misleading 0.0.
+                        let avg = state.and_then(|s| {
+                            (s.count > 0).then(|| {
                                 // Group cardinalities never approach 2^52, so the divisor
                                 // cast is exact in practice.
                                 #[allow(clippy::cast_precision_loss)]
                                 let denom = s.count as f64;
                                 s.sum / denom
-                            } else {
-                                0.0
-                            }
+                            })
                         });
                         pairs.push((
                             rmpv::Value::String(format!("__avg_{field}").into()),
-                            rmpv::Value::F64(avg),
+                            avg.map_or(rmpv::Value::Nil, rmpv::Value::F64),
                         ));
                     }
                 }
             }
 
-            // Also emit the GROUP BY field values for join-back.
-            for field in &self.group_by {
-                pairs.push((
-                    rmpv::Value::String(field.clone().into()),
-                    rmpv::Value::String(key.clone().into()),
-                ));
+            // Also emit the GROUP BY field values for join-back, preserving the
+            // original type. `group_values` is sampled per-field in `group_by`
+            // order during phase 1; a null/missing group field is emitted as Nil.
+            // (`__key` above stays the stringified bucket id used as the entry key.)
+            for (field, value) in self.group_by.iter().zip(&group.group_values) {
+                pairs.push((rmpv::Value::String(field.clone().into()), value.clone()));
             }
             outbox.offer(0, rmpv::Value::Map(pairs));
         }
@@ -1424,9 +1469,9 @@ mod tests {
         let items: Vec<_> = emit_outbox.drain_bucket(0).collect();
         assert_eq!(items.len(), 2, "two distinct groups (A and B)");
 
-        // Find group A
+        // Find group A by its typed group-by column (no longer the encoded __key).
         let group_a = items.iter().find(|item| {
-            get_field(item, "__key")
+            get_field(item, "category")
                 .map(|v| v == &rmpv::Value::String("A".into()))
                 .unwrap_or(false)
         });
@@ -1437,7 +1482,7 @@ mod tests {
         );
 
         let group_b = items.iter().find(|item| {
-            get_field(item, "__key")
+            get_field(item, "category")
                 .map(|v| v == &rmpv::Value::String("B".into()))
                 .unwrap_or(false)
         });
@@ -1512,7 +1557,7 @@ mod tests {
         let group = |k: &str| {
             items
                 .iter()
-                .find(|it| get_field(it, "__key") == Some(&rmpv::Value::String(k.into())))
+                .find(|it| get_field(it, "category") == Some(&rmpv::Value::String(k.into())))
                 .cloned()
                 .unwrap()
         };
@@ -1548,6 +1593,160 @@ mod tests {
             assert!(get_field(it, "__avg_price").is_none(), "AVG not requested");
             assert!(get_field(it, "__sum").is_none(), "no legacy __sum");
         }
+    }
+
+    /// GROUP BY must keep null/missing as one "no value" group, the empty string
+    /// as its own group, and never collapse them together. Pre-fix, all three
+    /// landed in a single `""` bucket (count 4) with a stringified `""` column —
+    /// so the assertions below (a distinct Nil group + a distinct "" group) are a
+    /// negative control on the old behavior.
+    #[test]
+    fn group_by_null_missing_collapse_empty_string_distinct() {
+        let mut proc = AggregateProcessor::new(vec!["cat".to_string()], vec![]);
+        proc.init(&make_context()).unwrap();
+
+        let mut inbox = VecDequeInbox::new(16);
+        // null + missing collapse into one group (2 rows).
+        inbox.push(make_map_item(&[("cat", rmpv::Value::Nil)]));
+        inbox.push(make_map_item(&[("other", rmpv::Value::Integer(1.into()))]));
+        // empty string is a real, distinct value (1 row).
+        inbox.push(make_map_item(&[("cat", rmpv::Value::String("".into()))]));
+        // a normal value (1 row).
+        inbox.push(make_map_item(&[("cat", rmpv::Value::String("x".into()))]));
+
+        proc.process(0, &mut inbox, &mut VecDequeOutbox::new(1, 16))
+            .unwrap();
+        let mut out = VecDequeOutbox::new(1, 16);
+        proc.complete(&mut out).unwrap();
+        let items: Vec<_> = out.drain_bucket(0).collect();
+
+        assert_eq!(
+            items.len(),
+            3,
+            "three groups: {{null,missing}}, {{\"\"}}, {{\"x\"}}"
+        );
+
+        // The Nil group carries null + missing → count 2, emitted column is Nil.
+        let nil_group = items
+            .iter()
+            .find(|it| get_field(it, "cat") == Some(&rmpv::Value::Nil))
+            .expect("a Nil group must exist (null + missing)");
+        assert_eq!(
+            get_f64_field(nil_group, "__count").unwrap() as u64,
+            2,
+            "null and missing collapse into one group of 2"
+        );
+
+        // The empty-string group is distinct from the Nil group.
+        let empty_group = items
+            .iter()
+            .find(|it| get_field(it, "cat") == Some(&rmpv::Value::String("".into())))
+            .expect("empty-string is its own group, distinct from null");
+        assert_eq!(get_f64_field(empty_group, "__count").unwrap() as u64, 1);
+
+        let x_group = items
+            .iter()
+            .find(|it| get_field(it, "cat") == Some(&rmpv::Value::String("x".into())))
+            .expect("the 'x' group must exist");
+        assert_eq!(get_f64_field(x_group, "__count").unwrap() as u64, 1);
+    }
+
+    /// The emitted group-by column preserves the original type (no stringification),
+    /// for both single numeric keys and composite keys. Pre-fix every group column
+    /// was a `String` (the joined bucket key), so an `Integer(30)` assertion fails
+    /// on the old behavior.
+    #[test]
+    fn group_by_preserves_numeric_and_composite_key_types() {
+        // Single numeric key: GROUP BY age.
+        let mut proc = AggregateProcessor::new(vec!["age".to_string()], vec![]);
+        proc.init(&make_context()).unwrap();
+        let mut inbox = VecDequeInbox::new(8);
+        inbox.push(make_map_item(&[("age", rmpv::Value::Integer(30.into()))]));
+        inbox.push(make_map_item(&[("age", rmpv::Value::Integer(30.into()))]));
+        inbox.push(make_map_item(&[("age", rmpv::Value::Integer(40.into()))]));
+        proc.process(0, &mut inbox, &mut VecDequeOutbox::new(1, 8))
+            .unwrap();
+        let mut out = VecDequeOutbox::new(1, 8);
+        proc.complete(&mut out).unwrap();
+        let items: Vec<_> = out.drain_bucket(0).collect();
+        assert_eq!(items.len(), 2, "two numeric groups: 30 and 40");
+        let g30 = items
+            .iter()
+            .find(|it| get_field(it, "age") == Some(&rmpv::Value::Integer(30.into())))
+            .expect("group age=30 must be emitted as a typed Integer, not \"30\"");
+        assert_eq!(get_f64_field(g30, "__count").unwrap() as u64, 2);
+
+        // Composite key: GROUP BY (region, tier) round-trips both columns typed and
+        // does not alias across groups.
+        let mut proc =
+            AggregateProcessor::new(vec!["region".to_string(), "tier".to_string()], vec![]);
+        proc.init(&make_context()).unwrap();
+        let mut inbox = VecDequeInbox::new(8);
+        inbox.push(make_map_item(&[
+            ("region", rmpv::Value::String("eu".into())),
+            ("tier", rmpv::Value::Integer(1.into())),
+        ]));
+        inbox.push(make_map_item(&[
+            ("region", rmpv::Value::String("eu".into())),
+            ("tier", rmpv::Value::Integer(2.into())),
+        ]));
+        proc.process(0, &mut inbox, &mut VecDequeOutbox::new(1, 8))
+            .unwrap();
+        let mut out = VecDequeOutbox::new(1, 8);
+        proc.complete(&mut out).unwrap();
+        let items: Vec<_> = out.drain_bucket(0).collect();
+        assert_eq!(
+            items.len(),
+            2,
+            "composite (eu,1) and (eu,2) are distinct groups"
+        );
+        for it in &items {
+            assert_eq!(
+                get_field(it, "region"),
+                Some(&rmpv::Value::String("eu".into())),
+                "region column is a typed String"
+            );
+            assert!(
+                matches!(get_field(it, "tier"), Some(rmpv::Value::Integer(_))),
+                "tier column preserves its Integer type"
+            );
+        }
+    }
+
+    /// AVG over a group with zero numeric observations emits Nil (the SQL/DataFusion
+    /// result for AVG of an empty set), not 0.0. Pre-fix this returned `F64(0.0)`,
+    /// so the `Nil` assertion is a negative control.
+    #[test]
+    fn avg_over_empty_numeric_group_emits_nil() {
+        let mut proc = AggregateProcessor::new(
+            vec!["cat".to_string()],
+            vec![Aggregation {
+                func: AggFunc::Avg,
+                field: Some("price".to_string()),
+            }],
+        );
+        proc.init(&make_context()).unwrap();
+
+        let mut inbox = VecDequeInbox::new(8);
+        // Two rows in group "x" but `price` is non-numeric → zero numeric observations.
+        inbox.push(make_map_item(&[
+            ("cat", rmpv::Value::String("x".into())),
+            ("price", rmpv::Value::String("n/a".into())),
+        ]));
+        inbox.push(make_map_item(&[("cat", rmpv::Value::String("x".into()))]));
+
+        proc.process(0, &mut inbox, &mut VecDequeOutbox::new(1, 8))
+            .unwrap();
+        let mut out = VecDequeOutbox::new(1, 8);
+        proc.complete(&mut out).unwrap();
+        let items: Vec<_> = out.drain_bucket(0).collect();
+        assert_eq!(items.len(), 1);
+        assert_eq!(get_f64_field(&items[0], "__count").unwrap() as u64, 2);
+        assert_eq!(
+            get_field(&items[0], "__avg_price"),
+            Some(&rmpv::Value::Nil),
+            "AVG of zero numeric observations must be Nil, not 0.0"
+        );
     }
 
     // --- CombineProcessor ---

--- a/packages/server-rust/src/service/domain/predicate.rs
+++ b/packages/server-rust/src/service/domain/predicate.rs
@@ -199,6 +199,17 @@ fn evaluate_leaf(predicate: &PredicateNode, ctx: &EvalContext) -> bool {
         return false;
     };
 
+    // SQL 3-valued logic: a comparison against NULL is UNKNOWN, so the row is
+    // excluded. A present-but-null field is therefore treated identically to an
+    // absent field (which already returned `false` above) — `field = x`,
+    // `field != x`, and every ordered / pattern / membership comparison below
+    // excludes both null and missing rows. `IS NULL` / `IS NOT NULL` are the
+    // only operators that match null/absent fields; they bypass this path via
+    // `evaluate_null_check`.
+    if actual.is_nil() {
+        return false;
+    }
+
     // Resolve comparison value: value_ref takes precedence over value
     let expected = if let Some(ref_str) = &predicate.value_ref {
         let Some(resolved) = resolve_value_ref(ref_str, ctx) else {
@@ -2167,5 +2178,114 @@ mod tests {
         let actual = rmpv::Value::String("user@company.com".into());
         let suffix = rmpv::Value::String("@COMPANY.COM".into());
         assert!(!evaluate_ends_with(&actual, &suffix));
+    }
+
+    // ---- NULL 3-valued logic (SQL semantics) ----
+
+    /// `field != x` must exclude BOTH a present-null field and a missing field,
+    /// while still including real, non-matching values. This is the core F4 fix:
+    /// a comparison against NULL is UNKNOWN, so the row is excluded — and null is
+    /// treated identically to missing. The pre-fix behavior (`null` passing `!= x`)
+    /// would fail the `null` assertion below, making this a negative control.
+    #[test]
+    fn neq_against_null_and_missing_both_excluded() {
+        let pred = leaf(
+            PredicateOp::Neq,
+            "status",
+            rmpv::Value::String("archived".into()),
+        );
+
+        let data_null = make_map(vec![("status", rmpv::Value::Nil)]);
+        let data_missing = make_map(vec![("other", rmpv::Value::Integer(1.into()))]);
+        let data_active = make_map(vec![("status", rmpv::Value::String("active".into()))]);
+        let data_archived = make_map(vec![("status", rmpv::Value::String("archived".into()))]);
+
+        // NEW semantics: null excluded (was the leak), missing excluded (unchanged),
+        // and both behave the same.
+        assert!(
+            !evaluate_predicate(&pred, &EvalContext::data_only(&data_null)),
+            "present-null must be excluded by `!= archived` (3-VL); pre-fix leaked it"
+        );
+        assert!(
+            !evaluate_predicate(&pred, &EvalContext::data_only(&data_missing)),
+            "missing field must be excluded by `!= archived`"
+        );
+        // Negative controls on real values are unchanged.
+        assert!(
+            evaluate_predicate(&pred, &EvalContext::data_only(&data_active)),
+            "control: a real non-matching value still passes `!= archived`"
+        );
+        assert!(
+            !evaluate_predicate(&pred, &EvalContext::data_only(&data_archived)),
+            "control: the matching value is still excluded by `!= archived`"
+        );
+    }
+
+    /// `field = x` against null/missing is UNKNOWN → excluded (was already false
+    /// for both, asserted here to lock the symmetry with Neq).
+    #[test]
+    fn eq_against_null_and_missing_both_excluded() {
+        let pred = leaf(
+            PredicateOp::Eq,
+            "status",
+            rmpv::Value::String("active".into()),
+        );
+        let data_null = make_map(vec![("status", rmpv::Value::Nil)]);
+        let data_missing = make_map(vec![("other", rmpv::Value::Integer(1.into()))]);
+        assert!(!evaluate_predicate(
+            &pred,
+            &EvalContext::data_only(&data_null)
+        ));
+        assert!(!evaluate_predicate(
+            &pred,
+            &EvalContext::data_only(&data_missing)
+        ));
+    }
+
+    /// Ordered comparisons (Gt/Gte/Lt/Lte) against a null field are UNKNOWN →
+    /// excluded, matching SQL 3-VL.
+    #[test]
+    fn ordered_comparisons_against_null_excluded() {
+        let data_null = make_map(vec![("age", rmpv::Value::Nil)]);
+        for op in [
+            PredicateOp::Gt,
+            PredicateOp::Gte,
+            PredicateOp::Lt,
+            PredicateOp::Lte,
+        ] {
+            let label = format!("{op:?}");
+            let pred = leaf(op, "age", rmpv::Value::Integer(18.into()));
+            assert!(
+                !evaluate_predicate(&pred, &EvalContext::data_only(&data_null)),
+                "{label} against a null field must be excluded (3-VL)"
+            );
+        }
+    }
+
+    /// `IS NULL` / `IS NOT NULL` are unaffected by the 3-VL guard: they remain the
+    /// only operators that match null/absent fields.
+    #[test]
+    fn is_null_still_matches_null_and_missing() {
+        let data_null = make_map(vec![("status", rmpv::Value::Nil)]);
+        let data_missing = make_map(vec![("other", rmpv::Value::Integer(1.into()))]);
+        let data_present = make_map(vec![("status", rmpv::Value::String("x".into()))]);
+
+        let is_null = PredicateNode {
+            op: PredicateOp::IsNull,
+            attribute: Some("status".to_string()),
+            ..Default::default()
+        };
+        assert!(evaluate_predicate(
+            &is_null,
+            &EvalContext::data_only(&data_null)
+        ));
+        assert!(evaluate_predicate(
+            &is_null,
+            &EvalContext::data_only(&data_missing)
+        ));
+        assert!(!evaluate_predicate(
+            &is_null,
+            &EvalContext::data_only(&data_present)
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Fixes two single-node query correctness defects from the 2026-06-17 Query/Search depth audit (`DEPTH_QUERY_SEARCH.md`), bundled because they share one semantic decision — how `null`, an absent field, and an empty value are treated. SPEC-319.

### TODO-488 (Query-F4) — `Neq`/comparison vs NULL leaked null rows
`evaluate_leaf` computed `Neq => !values_equal(actual, expected)`, so a present-but-null field passed `field != x` (leaking null rows) while a *missing* field was excluded — inconsistent and wrong vs SQL/DataFusion 3-valued logic.

**Fix:** a resolved `Nil` value is UNKNOWN → the row is excluded for every equality/ordered/pattern/membership comparison, identical to the missing-field case. `IS NULL` / `IS NOT NULL` unaffected.

### TODO-489 (Query-F5/F9) — GROUP BY collapse + stringified key + avg-empty
- null / empty-string / missing all collapsed into one `""` bucket.
- the group-by column was emitted as the **stringified** key (`GROUP BY age` → `"30"`; composite → joined `"a|b"`).
- AVG over zero numeric observations returned `0.0`.

**Fix:**
- Unambiguous type-tagged, length-prefixed group key: **null and missing share one "no value" group** (consistent with the F4 3-VL decision and MongoDB `$group`); **empty-string and every typed value stay distinct**; composite keys cannot alias.
- Retain first-seen **typed** group-by values per bucket and emit them in the group-by column (not the stringified key). `__key` remains the string entry id.
- AVG of an empty numeric group emits `Nil` (SQL/DataFusion).

## Semantics decision (documented, not guessed)
Reference: SQL/DataFusion 3-valued logic + MongoDB `$group` for the document-store "missing field" case.
1. Comparison against NULL is UNKNOWN → row excluded.
2. Present-null ≡ missing (both excluded / one group).
3. Empty-string is a real, distinct value.
4. AVG of empty set → Nil.

> Deviation note: TODO-489's illustrative bullet wrote "{cat:null}/{cat:\"\"}/{} → 3 distinct groups". We deliberately fold **missing into null** (2 groups: Nil + "") to stay consistent with TODO-488 and MongoDB precedent. The correctness win the TODO asks for — null no longer collapses with empty-string, types preserved — is delivered.

## Tests
Behavioral tests + negative controls for both fixes (the negative controls fail on the pre-fix behavior). Existing aggregate tests updated to look up groups by the now-typed group-by column.

## Local gate
- `cargo test --release -p topgun-server --lib` → **1366 passed, 0 failed**
- `cargo clippy --release -p topgun-server --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --check` → clean

## Out of scope (tracked elsewhere)
F7 multi-node combine schema mismatch (cluster G9), F1 live top-N, F2 vector, F3 sub-leaks, F6 dual-engine, F8/F11 cursor edges.