### PR TITLE
fix(client): resilient reconnect by default (F2: TODO-414 + TODO-429)

### DIFF
--- a/apps/docs-astro/src/content/docs/guides/offline-first.mdx
+++ b/apps/docs-astro/src/content/docs/guides/offline-first.mdx
@@ -86,16 +86,18 @@ function SyncBadge({ mapName, itemKey }: { mapName: string; itemKey: string }) {
 
 ### Global connection state (imperative)
 
-export const connectionEventCode = `// Subscribe to connection state transitions.
-// event.to is a SyncState: CONNECTING | AUTHENTICATING | CONNECTED | OFFLINE | ERROR | DISPOSED
+export const connectionEventCode = `// Subscribe to connection state transitions. event.to is a SyncState:
+// INITIAL | CONNECTING | AUTHENTICATING | SYNCING | CONNECTED | DISCONNECTED | BACKOFF | ERROR
 const unsubscribe = client.onConnectionStateChange((event) => {
-  if (event.to === 'OFFLINE') {
+  if (event.to === 'DISCONNECTED') {
     showToast('You are offline. Changes will sync when you reconnect.');
   }
   if (event.to === 'CONNECTED') {
     hideToast();
   }
-});`;
+});
+// By default the client reconnects indefinitely with capped backoff — a brief
+// server outage recovers on its own. See the Client reference for tuning backoff.`;
 
 <div className="not-prose">
   <CodeBlock title="src/lib/connection.ts" language="typescript" code={connectionEventCode} />

--- a/apps/docs-astro/src/content/docs/reference/client.mdx
+++ b/apps/docs-astro/src/content/docs/reference/client.mdx
@@ -46,7 +46,7 @@ new TopGunClient<TSchema>(config: TopGunClientConfig)
 | `serverUrl` | `string` | Optional. WebSocket URL for single-server mode. Mutually exclusive with `cluster`. |
 | `cluster` | `TopGunClusterConfig` | Optional. Cluster configuration. Mutually exclusive with `serverUrl`. |
 | `nodeId` | `string` | Optional. Auto-generated UUID if omitted. |
-| `backoff` | `Partial<BackoffConfig>` | Optional. Reconnect backoff tuning. |
+| `backoff` | `Partial<BackoffConfig>` | Optional. Reconnect backoff tuning (see [Reconnection & offline recovery](#reconnection--offline-recovery)). |
 | `backpressure` | `Partial<BackpressureConfig>` | Optional. Backpressure thresholds and strategy. |
 | `auth` | `AuthProvider` | Optional. Pluggable auth provider (Clerk, Firebase, BetterAuth, Custom). |
 
@@ -522,7 +522,12 @@ const handle = client.hybridQuery<Article>('articles', {
 public getConnectionState(): SyncState
 ```
 
-Returns the current state from the connection state machine (e.g., `OFFLINE`, `CONNECTING`, `AUTHENTICATING`, `READY`).
+Returns the current state from the connection state machine. `SyncState` is one of
+`INITIAL`, `CONNECTING`, `AUTHENTICATING`, `SYNCING`, `CONNECTED`, `DISCONNECTED`, `BACKOFF`, or
+`ERROR`. During a network outage the client cycles through `DISCONNECTED` (and reconnect backoff),
+returning to `CONNECTED` when the server is reachable again — see
+[Reconnection & offline recovery](#reconnection--offline-recovery). `ERROR` is reached only when a
+caller opted into a finite reconnect budget (`backoff.maxRetries`) and it was exhausted.
 
 ### `onConnectionStateChange(listener)`
 
@@ -553,6 +558,54 @@ public resetConnection(): void
 ```
 
 Reset the connection and state machine. Use after fatal errors to start fresh.
+
+## Reconnection & offline recovery
+
+TopGun is offline-first: a server that is briefly gone — a deploy window, a laptop waking from
+sleep, or even a client that starts *before* the server — is the normal case, not a terminal one.
+
+**By default the client reconnects indefinitely.** When the connection drops (or never came up), the
+client retries with exponential backoff and jitter, capped at a maximum interval, **forever**, until
+the server is reachable again. It never silently gives up. The capped interval bounds the retry rate
+(roughly one attempt per `maxDelayMs`), so unbounded retries do not hammer the server. This holds in
+both the browser and Node/SSR; in the browser a network-return (`online`) event additionally triggers
+an immediate reconnect instead of waiting for the next backoff tick.
+
+Tune it with the `backoff` config:
+
+```typescript
+const client = new TopGunClient({
+  serverUrl: 'ws://localhost:8080',
+  storage: new IDBAdapter(),
+  backoff: {
+    initialDelayMs: 1000, // first retry delay (default 1000)
+    maxDelayMs: 30000,    // backoff cap (default 30000)
+    multiplier: 2,        // exponential factor (default 2)
+    jitter: true,         // randomize delay 0.5x–1.5x (default true)
+    maxRetries: Infinity, // give-up budget (default Infinity = never give up)
+  },
+});
+```
+
+### Bounded retry (opt-in)
+
+Set `backoff.maxRetries` to a finite number if you want the client to stop after a fixed number of
+failed attempts. On exhaustion the client transitions to `SyncState.ERROR` and fires
+`onConnectionStateChange` with that terminal state — an explicit, honest "I have stopped trying"
+signal (never a silent stall). Recover from `ERROR` by calling [`resetConnection()`](#resetconnection),
+which starts a fresh connection with a full retry budget.
+
+```typescript
+client.onConnectionStateChange((event) => {
+  if (event.to === 'ERROR') {
+    // Reconnect budget exhausted — surface to the user and/or retry.
+    client.resetConnection();
+  }
+});
+```
+
+With the default `maxRetries: Infinity`, `SyncState.ERROR` is never reached for transient/network
+failures — the client simply keeps cycling through `DISCONNECTED` and reconnecting.
 
 ## Backpressure
 

--- a/packages/client/src/SyncEngine.ts
+++ b/packages/client/src/SyncEngine.ts
@@ -92,7 +92,14 @@ export interface BackoffConfig {
   multiplier: number;
   /** Whether to add random jitter to delay (default: true) */
   jitter: boolean;
-  /** Maximum number of retry attempts before entering ERROR state (default: 10) */
+  /**
+   * Maximum number of reconnect attempts before giving up (default: Infinity).
+   * With the default, transient/network outages are retried indefinitely at the
+   * capped backoff interval (the offline-first contract). Set a finite number for
+   * a bounded policy: on exhaustion the engine transitions to SyncState.ERROR and
+   * fires onConnectionStateChange with the terminal state — it does NOT retry
+   * forever and does NOT fail silently.
+   */
   maxRetries: number;
 }
 
@@ -128,13 +135,11 @@ export interface SyncEngineConfig {
   onAuthRequired?: (error: AuthRequiredError) => void;
 }
 
-const DEFAULT_BACKOFF_CONFIG: BackoffConfig = {
-  initialDelayMs: 1000,
-  maxDelayMs: 30000,
-  multiplier: 2,
-  jitter: true,
-  maxRetries: 10,
-};
+// NOTE: reconnect/backoff defaults live in ONE place — SingleServerProvider's
+// DEFAULT_CONFIG (the component that actually executes reconnect). SyncEngine no
+// longer keeps a parallel BackoffConfig; `config.backoff` is mapped straight to the
+// connection provider in TopGunClient. This avoids the "two sources of truth, one
+// dead" trap where editing the wrong half changed nothing.
 
 export class SyncEngine {
   private readonly nodeId: string;
@@ -142,7 +147,6 @@ export class SyncEngine {
   private readonly hlc: HLC;
   private readonly stateMachine: SyncStateMachine;
   private readonly heartbeatConfig: HeartbeatConfig;
-  private readonly backoffConfig: BackoffConfig;
 
   // WebSocketManager handles all connection/websocket operations
   private readonly webSocketManager: WebSocketManager;
@@ -232,12 +236,6 @@ export class SyncEngine {
       enabled: config.heartbeat?.enabled ?? true,
     };
 
-    // Merge backoff config with defaults
-    this.backoffConfig = {
-      ...DEFAULT_BACKOFF_CONFIG,
-      ...config.backoff,
-    };
-
     // Merge backpressure config with defaults
     this.backpressureConfig = {
       ...DEFAULT_BACKPRESSURE_CONFIG,
@@ -260,12 +258,13 @@ export class SyncEngine {
     this.webSocketManager = new WebSocketManager({
       connectionProvider: config.connectionProvider,
       stateMachine: this.stateMachine,
-      backoffConfig: this.backoffConfig,
       heartbeatConfig: this.heartbeatConfig,
       onMessage: (msg) => this.handleServerMessage(msg),
       onConnected: () => this.handleConnectionEstablished(),
       onDisconnected: () => this.handleConnectionLost(),
-      onReconnected: () => this.handleReconnection(),
+      // No onReconnected: re-arm + auth for both initial and reconnect is driven
+      // once by handleConnectionEstablished (provider 'connected'), which fires on
+      // every opened socket. A separate reconnect auth path double-sent AUTH (F7).
     });
 
     // Initialize QueryManager with callbacks
@@ -456,27 +455,6 @@ export class SyncEngine {
     }
     // WebSocketManager already stopped heartbeat and transitioned state
     // SyncEngine can do additional cleanup if needed
-  }
-
-  /**
-   * Called when reconnection succeeds.
-   */
-  private handleReconnection(): void {
-    if (this.authToken || this.tokenProvider) {
-      this.stateMachine.transition(SyncState.AUTHENTICATING);
-      this.sendAuth();
-      return;
-    }
-
-    // Auth-optional wait on reconnect: same grace-timeout logic as initial connect.
-    logger.info(
-      { graceMs: this.AUTH_REQUIRED_GRACE_MS },
-      'Reconnected. Waiting briefly for AUTH_REQUIRED...',
-    );
-    this.authRequiredGraceTimer = setTimeout(() => {
-      this.authRequiredGraceTimer = null;
-      this.completeAuthOptionalConnection();
-    }, this.AUTH_REQUIRED_GRACE_MS);
   }
 
   /**

--- a/packages/client/src/SyncState.ts
+++ b/packages/client/src/SyncState.ts
@@ -45,8 +45,21 @@ export const VALID_TRANSITIONS: Record<SyncState, SyncState[]> = {
     SyncState.DISCONNECTED,
   ],
   [SyncState.CONNECTED]: [SyncState.SYNCING, SyncState.DISCONNECTED, SyncState.BACKOFF],
-  [SyncState.DISCONNECTED]: [SyncState.CONNECTING, SyncState.BACKOFF, SyncState.INITIAL],
-  [SyncState.BACKOFF]: [SyncState.CONNECTING, SyncState.DISCONNECTED, SyncState.INITIAL],
+  // DISCONNECTED/BACKOFF → ERROR: the reconnect loop runs while DISCONNECTED, so a
+  // terminal give-up (a finite reconnect cap is exhausted) must be able to surface
+  // ERROR from there. Without this the "gave up" signal would be silently dropped.
+  [SyncState.DISCONNECTED]: [
+    SyncState.CONNECTING,
+    SyncState.BACKOFF,
+    SyncState.INITIAL,
+    SyncState.ERROR,
+  ],
+  [SyncState.BACKOFF]: [
+    SyncState.CONNECTING,
+    SyncState.DISCONNECTED,
+    SyncState.INITIAL,
+    SyncState.ERROR,
+  ],
   [SyncState.ERROR]: [SyncState.INITIAL],
 };
 

--- a/packages/client/src/__tests__/AutoConnectionProvider.test.ts
+++ b/packages/client/src/__tests__/AutoConnectionProvider.test.ts
@@ -7,6 +7,7 @@ jest.mock('../connection/SingleServerProvider', () => {
     SingleServerProvider: jest.fn().mockImplementation(() => ({
       connect: jest.fn().mockRejectedValue(new Error('WebSocket connection failed')),
       forceReconnect: jest.fn(),
+      setMaxReconnectAttempts: jest.fn(),
       close: jest.fn().mockResolvedValue(undefined),
       isConnected: jest.fn().mockReturnValue(false),
       getConnectedNodes: jest.fn().mockReturnValue([]),
@@ -55,6 +56,7 @@ describe('AutoConnectionProvider', () => {
     SingleServerProvider.mockImplementationOnce(() => ({
       connect: jest.fn().mockResolvedValue(undefined),
       forceReconnect: jest.fn(),
+      setMaxReconnectAttempts: jest.fn(),
       close: jest.fn().mockResolvedValue(undefined),
       isConnected: jest.fn().mockReturnValue(true),
       getConnectedNodes: jest.fn().mockReturnValue(['ws-node-1']),
@@ -81,6 +83,83 @@ describe('AutoConnectionProvider', () => {
     expect(provider.getConnectedNodes()).toEqual(['ws-node-1']);
     // fetch should NOT have been called since WS succeeded
     expect(mockFetch).not.toHaveBeenCalled();
+
+    await provider.close();
+  });
+
+  it('probes WS single-shot then promotes the live socket to resilient reconnect', async () => {
+    // require() accesses the Jest-mocked module to inspect constructor args + the promotion call
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SingleServerProvider } = require('../connection/SingleServerProvider');
+
+    const setMaxReconnectAttempts = jest.fn();
+    SingleServerProvider.mockImplementationOnce((cfg: any) => {
+      // Record the config the probe was constructed with for assertions below.
+      (SingleServerProvider as any)._lastCfg = cfg;
+      return {
+        connect: jest.fn().mockResolvedValue(undefined),
+        forceReconnect: jest.fn(),
+        setMaxReconnectAttempts,
+        close: jest.fn().mockResolvedValue(undefined),
+        isConnected: jest.fn().mockReturnValue(true),
+        getConnectedNodes: jest.fn().mockReturnValue(['ws-node-1']),
+        on: jest.fn(),
+        off: jest.fn(),
+        send: jest.fn(),
+        getConnection: jest.fn(),
+        getAnyConnection: jest.fn(),
+      };
+    });
+
+    const provider = new AutoConnectionProvider({
+      url: 'http://localhost:8080',
+      clientId: 'c1',
+      hlc,
+      authToken: 'token',
+      fetchImpl: mockFetch,
+    });
+
+    await provider.connect();
+
+    // Probe is constructed single-shot (no background reconnect loop during negotiation).
+    expect((SingleServerProvider as any)._lastCfg.maxReconnectAttempts).toBe(0);
+    // On success the live socket is promoted to indefinite reconnect (the F2 fix:
+    // the old code left the WS sub-provider at maxReconnectAttempts: 1).
+    expect(setMaxReconnectAttempts).toHaveBeenCalledWith(Infinity);
+    expect(provider.isUsingHttp()).toBe(false);
+
+    await provider.close();
+  });
+
+  it('promotes WS to a caller-configured finite cap when maxReconnectAttempts is set', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SingleServerProvider } = require('../connection/SingleServerProvider');
+    const setMaxReconnectAttempts = jest.fn();
+    SingleServerProvider.mockImplementationOnce(() => ({
+      connect: jest.fn().mockResolvedValue(undefined),
+      forceReconnect: jest.fn(),
+      setMaxReconnectAttempts,
+      close: jest.fn().mockResolvedValue(undefined),
+      isConnected: jest.fn().mockReturnValue(true),
+      getConnectedNodes: jest.fn().mockReturnValue(['ws-node-1']),
+      on: jest.fn(),
+      off: jest.fn(),
+      send: jest.fn(),
+      getConnection: jest.fn(),
+      getAnyConnection: jest.fn(),
+    }));
+
+    const provider = new AutoConnectionProvider({
+      url: 'http://localhost:8080',
+      clientId: 'c1',
+      hlc,
+      authToken: 'token',
+      maxReconnectAttempts: 25,
+      fetchImpl: mockFetch,
+    });
+
+    await provider.connect();
+    expect(setMaxReconnectAttempts).toHaveBeenCalledWith(25);
 
     await provider.close();
   });

--- a/packages/client/src/__tests__/SingleServerProviderReconnect.test.ts
+++ b/packages/client/src/__tests__/SingleServerProviderReconnect.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Reconnect-honesty tests for SingleServerProvider (F2 / TODO-414 + TODO-429).
+ *
+ * Verifies the resilient-by-default reconnect contract:
+ * - Default config retries indefinitely with capped backoff (survives many
+ *   transient drops — the offline-first promise).
+ * - Backoff grows exponentially and is bounded by maxReconnectDelayMs (never
+ *   hammers the server).
+ * - An opt-in finite cap is honoured: on exhaustion the provider stops AND emits
+ *   a typed terminal ReconnectExhaustedError instead of failing silently.
+ */
+
+import { SingleServerProvider, ReconnectExhaustedError } from '../connection/SingleServerProvider';
+
+// --- Controllable mock WebSocket -------------------------------------------
+// mode 'success' → the socket opens shortly after construction.
+// mode 'refuse'  → the socket closes shortly after construction (connection
+//                  refused / server down), driving the provider's reconnect path.
+
+type WsMode = 'success' | 'refuse';
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static mode: WsMode = 'success';
+  static OPEN = 1;
+  static CLOSED = 3;
+  static CONNECTING = 0;
+
+  readyState: number = MockWebSocket.CONNECTING;
+  binaryType = 'blob';
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: ArrayBuffer | string }) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: ((error: unknown) => void) | null = null;
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+    const mode = MockWebSocket.mode;
+    // Resolve open/close asynchronously, mirroring a real socket handshake.
+    setTimeout(() => {
+      if (mode === 'success') {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.();
+      } else {
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.({ code: 1006, reason: 'Connection refused' });
+      }
+    }, 1);
+  }
+
+  send(): void {
+    if (this.readyState !== MockWebSocket.OPEN) throw new Error('WebSocket is not open');
+  }
+
+  close(): void {
+    if (this.readyState === MockWebSocket.CLOSED) return;
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: 1000, reason: 'Normal closure' });
+  }
+
+  /** Simulate a server-initiated drop on an already-open socket. */
+  serverDrop(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: 1006, reason: 'Server dropped' });
+  }
+
+  static reset(): void {
+    MockWebSocket.instances = [];
+    MockWebSocket.mode = 'success';
+  }
+
+  static last(): MockWebSocket {
+    return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  }
+}
+
+(global as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket;
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitUntil(cond: () => boolean, timeoutMs = 4000, interval = 5): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return;
+    await waitMs(interval);
+  }
+  throw new Error('waitUntil timeout');
+}
+
+describe('SingleServerProvider reconnect honesty (F2)', () => {
+  beforeEach(() => {
+    MockWebSocket.reset();
+  });
+
+  afterEach(() => {
+    MockWebSocket.reset();
+  });
+
+  it('defaults to indefinite reconnect — survives far more than the old 10-attempt budget', async () => {
+    MockWebSocket.mode = 'success';
+    const provider = new SingleServerProvider({
+      url: 'ws://localhost:9999',
+      reconnectDelayMs: 2,
+      maxReconnectDelayMs: 8,
+      listenNetworkEvents: false,
+    });
+
+    let reconnects = 0;
+    let terminalError = false;
+    provider.on('reconnected', () => reconnects++);
+    provider.on('error', (err: unknown) => {
+      if (err instanceof ReconnectExhaustedError) terminalError = true;
+    });
+
+    await provider.connect();
+    await waitUntil(() => provider.isConnected());
+
+    // Drop the socket 15 times — well beyond the historical maxReconnectAttempts=10.
+    // A finite-ceiling provider would have emitted a terminal error before here.
+    const DROPS = 15;
+    for (let i = 0; i < DROPS; i++) {
+      MockWebSocket.last().serverDrop();
+      await waitUntil(() => provider.isConnected());
+    }
+
+    expect(reconnects).toBeGreaterThanOrEqual(DROPS);
+    expect(terminalError).toBe(false);
+    expect(provider.isConnected()).toBe(true);
+
+    await provider.close();
+  });
+
+  it('does NOT emit a terminal ReconnectExhaustedError while reconnecting (default) against a down server', async () => {
+    MockWebSocket.mode = 'refuse';
+    const provider = new SingleServerProvider({
+      url: 'ws://localhost:9999',
+      reconnectDelayMs: 2,
+      maxReconnectDelayMs: 8,
+      listenNetworkEvents: false,
+    });
+
+    let terminalError = false;
+    provider.on('error', (err: unknown) => {
+      if (err instanceof ReconnectExhaustedError) terminalError = true;
+    });
+
+    // connect() never resolves against a refusing server; ignore the pending promise.
+    provider.connect().catch(() => {});
+
+    // Let many reconnect cycles churn — default budget is Infinity, so the provider
+    // keeps creating sockets and never gives up.
+    await waitUntil(() => MockWebSocket.instances.length > 12);
+    expect(terminalError).toBe(false);
+
+    await provider.close();
+  });
+
+  it('honours an opt-in finite cap: stops after maxReconnectAttempts and emits a typed terminal error (negative control)', async () => {
+    MockWebSocket.mode = 'refuse';
+    const provider = new SingleServerProvider({
+      url: 'ws://localhost:9999',
+      maxReconnectAttempts: 4,
+      reconnectDelayMs: 2,
+      maxReconnectDelayMs: 8,
+      listenNetworkEvents: false,
+    });
+
+    let terminalError: ReconnectExhaustedError | null = null;
+    provider.on('error', (err: unknown) => {
+      if (err instanceof ReconnectExhaustedError) terminalError = err;
+    });
+
+    provider.connect().catch(() => {});
+
+    await waitUntil(() => terminalError !== null, 4000);
+
+    expect(terminalError).toBeInstanceOf(ReconnectExhaustedError);
+    expect(terminalError!.terminal).toBe(true);
+    expect(terminalError!.attempts).toBe(4);
+    expect(provider.getReconnectAttempts()).toBe(4);
+
+    // After giving up, no further reconnect sockets are created.
+    const countAtGiveUp = MockWebSocket.instances.length;
+    await waitMs(40);
+    expect(MockWebSocket.instances.length).toBe(countAtGiveUp);
+
+    await provider.close();
+  });
+
+  it('backoff grows exponentially and is bounded by maxReconnectDelayMs (no DoS hammering)', () => {
+    const provider = new SingleServerProvider({
+      url: 'ws://localhost:9999',
+      reconnectDelayMs: 1000,
+      backoffMultiplier: 2,
+      maxReconnectDelayMs: 30000,
+      listenNetworkEvents: false,
+    });
+
+    // Pin jitter to 1.0x (random=0.5 → factor 0.5+0.5) for deterministic assertions.
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    try {
+      const delayAt = (attempt: number): number => {
+        (provider as unknown as { reconnectAttempts: number }).reconnectAttempts = attempt;
+        return (provider as unknown as { calculateBackoffDelay(): number }).calculateBackoffDelay();
+      };
+
+      expect(delayAt(0)).toBe(1000);
+      expect(delayAt(1)).toBe(2000);
+      expect(delayAt(2)).toBe(4000);
+      expect(delayAt(3)).toBe(8000);
+
+      // Grows monotonically until the cap, then stays capped — never unbounded.
+      expect(delayAt(10)).toBe(30000);
+      expect(delayAt(100)).toBe(30000);
+      expect(delayAt(1000)).toBe(30000);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it('keeps jittered backoff within [0.5x, 1.5x] of the cap at high attempt counts', () => {
+    const provider = new SingleServerProvider({
+      url: 'ws://localhost:9999',
+      maxReconnectDelayMs: 30000,
+      listenNetworkEvents: false,
+    });
+    (provider as unknown as { reconnectAttempts: number }).reconnectAttempts = 50;
+
+    for (let i = 0; i < 50; i++) {
+      const delay = (
+        provider as unknown as { calculateBackoffDelay(): number }
+      ).calculateBackoffDelay();
+      expect(delay).toBeGreaterThanOrEqual(15000); // 0.5x cap
+      expect(delay).toBeLessThanOrEqual(45000); // 1.5x cap
+    }
+  });
+});

--- a/packages/client/src/connection/AutoConnectionProvider.ts
+++ b/packages/client/src/connection/AutoConnectionProvider.ts
@@ -31,6 +31,21 @@ export interface AutoConnectionProviderConfig {
   syncMaps?: string[];
   /** Custom fetch implementation for HTTP mode */
   fetchImpl?: typeof fetch;
+  /**
+   * Reconnect ceiling for the *persistent* WebSocket connection once WS is the
+   * active transport (default: Infinity — retry indefinitely with capped backoff,
+   * matching SingleServerProvider). This is independent of `maxWsAttempts`, which
+   * only bounds the initial WS-vs-HTTP negotiation probe. Set a finite value for a
+   * bounded policy; on exhaustion the WS sub-provider emits a terminal
+   * ReconnectExhaustedError 'error' event.
+   */
+  maxReconnectAttempts?: number;
+  /** Initial reconnect delay in ms for the persistent WS connection (default: 1000) */
+  reconnectDelayMs?: number;
+  /** Backoff multiplier for the persistent WS connection (default: 2) */
+  backoffMultiplier?: number;
+  /** Maximum reconnect delay in ms for the persistent WS connection (default: 30000) */
+  maxReconnectDelayMs?: number;
 }
 
 /**
@@ -69,24 +84,40 @@ export class AutoConnectionProvider implements IConnectionProvider {
 
     // Try WebSocket first
     const wsUrl = this.toWsUrl(this.config.url);
+    const reconnectDelayMs = this.config.reconnectDelayMs ?? 1000;
 
     for (let attempt = 0; attempt < this.maxWsAttempts; attempt++) {
-      try {
-        const wsProvider = new SingleServerProvider({
-          url: wsUrl,
-          maxReconnectAttempts: 1,
-          reconnectDelayMs: 1000,
-        });
+      // Probe with a single-shot provider: maxReconnectAttempts: 0 so a failed
+      // probe never spins a background reconnect loop while we are still deciding
+      // WS-vs-HTTP. On success we PROMOTE this exact socket to a resilient
+      // persistent connection (no second connect), keeping its browser
+      // online/offline listeners for instant network-return reconnect.
+      const wsProvider = new SingleServerProvider({
+        url: wsUrl,
+        maxReconnectAttempts: 0,
+        reconnectDelayMs,
+        backoffMultiplier: this.config.backoffMultiplier,
+        maxReconnectDelayMs: this.config.maxReconnectDelayMs,
+      });
 
+      try {
         await wsProvider.connect();
 
-        // WebSocket connected successfully
+        // WebSocket connected: promote the probe to a resilient persistent
+        // connection so it survives drops (deploys, sleeps, server bounces)
+        // instead of giving up — the old maxReconnectAttempts: 1 abandoned WS
+        // after a single failed reconnect. Default is Infinity (capped backoff).
+        wsProvider.setMaxReconnectAttempts(this.config.maxReconnectAttempts ?? Infinity);
         this.activeProvider = wsProvider;
         this.proxyEvents(wsProvider);
         logger.info({ url: wsUrl }, 'AutoConnectionProvider: WebSocket connected');
         return;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- caught error is typed as unknown; any is needed to access .message for the debug log during WS retry loop
       } catch (err: any) {
+        // Close the failed probe so it cannot linger (defensive — with
+        // maxReconnectAttempts: 0 there is no background timer, but this also
+        // tears down the socket and any in-flight connect promise).
+        await wsProvider.close().catch(() => {});
         logger.debug(
           { attempt: attempt + 1, maxAttempts: this.maxWsAttempts, err: err.message },
           'AutoConnectionProvider: WebSocket attempt failed',

--- a/packages/client/src/connection/SingleServerProvider.ts
+++ b/packages/client/src/connection/SingleServerProvider.ts
@@ -10,13 +10,47 @@ import { logger } from '../utils/logger';
 
 /**
  * Default configuration values for SingleServerProvider.
+ *
+ * `maxReconnectAttempts` defaults to Infinity: for a real-time + offline product,
+ * a server that is briefly gone (deploy window, laptop sleep, server-started-after-client)
+ * is the NORMAL case, not a terminal one. Giving up after a finite budget silently
+ * stops sync while the app still "works". The retry rate is bounded by the capped
+ * backoff (~1 attempt / maxReconnectDelayMs), so unbounded attempts do not hammer the
+ * server. Callers who genuinely want a bounded policy can set a finite
+ * `maxReconnectAttempts`; exhaustion is then surfaced honestly via a
+ * ReconnectExhaustedError 'error' event (see scheduleReconnect).
  */
 const DEFAULT_CONFIG = {
-  maxReconnectAttempts: 10,
+  maxReconnectAttempts: Infinity,
   reconnectDelayMs: 1000,
   backoffMultiplier: 2,
   maxReconnectDelayMs: 30000,
 };
+
+/**
+ * Emitted via the 'error' connection event when a caller-configured finite
+ * `maxReconnectAttempts` budget is exhausted and the provider stops retrying.
+ * Distinct from transient WebSocket 'error' events (which do NOT stop reconnect):
+ * this is the honest, terminal "giving up" signal. SyncEngine maps it to
+ * SyncState.ERROR so consumers can react instead of silently believing they are
+ * still trying to reconnect. With the default Infinity budget this is never thrown.
+ */
+export class ReconnectExhaustedError extends Error {
+  /** Marks this as the terminal give-up signal (survives cross-realm instanceof gaps). */
+  readonly terminal = true;
+  /** Number of reconnect attempts made before giving up. */
+  readonly attempts: number;
+
+  constructor(attempts: number, url: string) {
+    super(
+      `Reconnect budget exhausted after ${attempts} attempt(s) to ${url}; ` +
+        `giving up (set maxReconnectAttempts: Infinity to retry indefinitely, ` +
+        `or call resetConnection() to start a fresh budget).`,
+    );
+    this.name = 'ReconnectExhaustedError';
+    this.attempts = attempts;
+  }
+}
 
 /**
  * Detach a background timer from the host event loop. A pending reconnect or
@@ -86,70 +120,116 @@ export class SingleServerProvider implements IConnectionProvider {
       // Promise from keeping the Jest event loop alive after test teardown.
       this.pendingConnectReject = reject;
 
-      const clearPending = () => {
-        this.pendingConnectReject = null;
+      // Per-attempt lifecycle flags. `opened` distinguishes a post-establishment
+      // drop (reconnect, don't reject the already-resolved promise) from a failed
+      // connect. `settled` makes succeed()/fail() run exactly once per attempt —
+      // necessary because a single failed connect can surface through onerror AND
+      // onclose AND the timeout, and the undici/WHATWG client does NOT reliably
+      // fire 'close' for a failed connect, so the retry must also be driven from
+      // onerror and the timeout (relying on onclose alone strands the client and
+      // breaks server-after-client recovery — TODO-414).
+      let opened = false;
+      let settled = false;
+
+      const clearConnectionTimeout = () => {
+        if (this.connectionTimeoutId !== null) {
+          clearTimeout(this.connectionTimeoutId);
+          this.connectionTimeoutId = null;
+        }
       };
 
       try {
-        this.ws = new WebSocket(this.url);
-        this.ws.binaryType = 'arraybuffer';
+        const ws = new WebSocket(this.url);
+        this.ws = ws;
+        ws.binaryType = 'arraybuffer';
 
-        this.ws.onopen = () => {
+        const succeed = () => {
+          if (settled) return;
+          settled = true;
+          opened = true;
+          clearConnectionTimeout();
+          this.pendingConnectReject = null;
           this.reconnectAttempts = 0;
           logger.info({ url: this.url }, 'SingleServerProvider connected');
           this.emit('connected', 'default');
-          clearPending();
           resolve();
         };
 
-        this.ws.onerror = (error) => {
-          logger.error({ err: error, url: this.url }, 'SingleServerProvider WebSocket error');
-          this.emit('error', error);
-          // Don't reject here - wait for onclose
-        };
-
-        this.ws.onclose = (event) => {
-          logger.info({ url: this.url, code: event.code }, 'SingleServerProvider disconnected');
+        // An attempt failed to establish (refused / closed-before-open / timed out).
+        // De-duplicated via `settled`; schedules the next retry (the single retry
+        // driver for failed connects).
+        const fail = (reason: string) => {
+          if (settled) return;
+          settled = true;
+          clearConnectionTimeout();
+          this.pendingConnectReject = null;
           this.emit('disconnected', 'default');
-
           if (!this.isClosing) {
             this.scheduleReconnect();
           }
+          reject(new Error(reason));
         };
 
-        this.ws.onmessage = (event) => {
-          this.emit('message', 'default', event.data);
-        };
-
-        // Set up initial connection timeout. Stored as an instance field so
-        // close() can cancel it even if called mid-CONNECTING before onopen fires —
-        // a local variable would be unreachable from close() and keep the Node.js
-        // timer alive past test teardown.
+        // Per-attempt connection timeout, bound to THIS socket (never `this.ws`),
+        // so a timeout from an earlier failed attempt can only ever close its OWN
+        // socket — it can no longer kill a later attempt's in-flight handshake.
         this.connectionTimeoutId = setTimeout(() => {
           this.connectionTimeoutId = null;
-          if (this.ws && this.ws.readyState === WebSocket.CONNECTING) {
-            this.ws.close();
-            clearPending();
-            reject(new Error(`Connection timeout to ${this.url}`));
+          if (ws.readyState !== WebSocket.OPEN) {
+            try {
+              ws.close();
+            } catch {
+              // Closing a still-CONNECTING socket can throw; ignore.
+            }
+            fail(`Connection timeout to ${this.url}`);
           }
         }, this.config.reconnectDelayMs * 5); // 5x initial delay as connection timeout
         unrefTimer(this.connectionTimeoutId);
 
-        // Clear timeout on successful connection
-        const originalOnOpen = this.ws.onopen;
-        const wsRef = this.ws;
-        this.ws.onopen = (ev) => {
-          if (this.connectionTimeoutId !== null) {
-            clearTimeout(this.connectionTimeoutId);
-            this.connectionTimeoutId = null;
-          }
-          if (originalOnOpen) {
-            originalOnOpen.call(wsRef, ev);
+        ws.onopen = () => succeed();
+
+        ws.onerror = (error) => {
+          logger.error({ err: error, url: this.url }, 'SingleServerProvider WebSocket error');
+          this.emit('error', error);
+          // A pre-open error means the connect failed. The client may not fire
+          // 'close', so drive the retry from here. An error on an already-OPEN
+          // socket is left to onclose.
+          if (!opened) {
+            fail('WebSocket connection failed');
           }
         };
+
+        ws.onclose = (event) => {
+          logger.info({ url: this.url, code: event.code }, 'SingleServerProvider disconnected');
+          if (opened) {
+            // Drop AFTER the connection was established: not part of the connect()
+            // promise (already resolved). Emit + reconnect.
+            clearConnectionTimeout();
+            this.emit('disconnected', 'default');
+            if (!this.isClosing) {
+              this.scheduleReconnect();
+            }
+          } else {
+            // Closed before it ever opened — a failed attempt. `settled` makes this
+            // a no-op if onerror/timeout already handled it.
+            fail(`WebSocket closed before open (code ${event.code})`);
+          }
+        };
+
+        ws.onmessage = (event) => {
+          this.emit('message', 'default', event.data);
+        };
       } catch (error) {
-        clearPending();
-        reject(error);
+        // Synchronous construction failure (e.g. invalid URL). Schedule a retry too.
+        clearConnectionTimeout();
+        this.pendingConnectReject = null;
+        if (!settled) {
+          settled = true;
+          if (!this.isClosing) {
+            this.scheduleReconnect();
+          }
+        }
+        reject(error instanceof Error ? error : new Error(String(error)));
       }
     });
   }
@@ -304,9 +384,11 @@ export class SingleServerProvider implements IConnectionProvider {
     if (this.reconnectAttempts >= this.config.maxReconnectAttempts) {
       logger.error(
         { attempts: this.reconnectAttempts, url: this.url },
-        'SingleServerProvider max reconnect attempts reached',
+        'SingleServerProvider max reconnect attempts reached — giving up',
       );
-      this.emit('error', new Error('Max reconnection attempts reached'));
+      // Terminal, typed signal so SyncEngine can transition to SyncState.ERROR
+      // instead of leaving the client silently parked in DISCONNECTED.
+      this.emit('error', new ReconnectExhaustedError(this.reconnectAttempts, this.url));
       return;
     }
 
@@ -411,6 +493,18 @@ export class SingleServerProvider implements IConnectionProvider {
    */
   resetReconnectAttempts(): void {
     this.reconnectAttempts = 0;
+  }
+
+  /**
+   * Update the reconnect ceiling at runtime.
+   *
+   * Used by AutoConnectionProvider to promote a single-shot WebSocket *probe*
+   * (built with maxReconnectAttempts: 0 so it never spins a background loop while
+   * negotiating WS-vs-HTTP) into a *resilient persistent* connection once the
+   * probe succeeds — without opening a second socket.
+   */
+  setMaxReconnectAttempts(maxReconnectAttempts: number): void {
+    this.config.maxReconnectAttempts = maxReconnectAttempts;
   }
 
   /**

--- a/packages/client/src/connection/index.ts
+++ b/packages/client/src/connection/index.ts
@@ -1,4 +1,4 @@
-export { SingleServerProvider } from './SingleServerProvider';
+export { SingleServerProvider, ReconnectExhaustedError } from './SingleServerProvider';
 export type { SingleServerProviderConfig } from '../types';
 export { HttpSyncProvider } from './HttpSyncProvider';
 export type { HttpSyncProviderConfig } from './HttpSyncProvider';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -17,6 +17,7 @@ import { ConnectionPool, PartitionRouter, ClusterClient } from './cluster';
 // Connection provider imports
 import {
   SingleServerProvider,
+  ReconnectExhaustedError,
   HttpSyncProvider,
   AutoConnectionProvider,
   WebSocketConnection,
@@ -127,6 +128,7 @@ export type {
 // Connection provider exports
 export {
   SingleServerProvider,
+  ReconnectExhaustedError,
   HttpSyncProvider,
   AutoConnectionProvider,
   WebSocketConnection,

--- a/packages/client/src/sync/WebSocketManager.ts
+++ b/packages/client/src/sync/WebSocketManager.ts
@@ -20,6 +20,20 @@ import { logger } from '../utils/logger';
 import type { IWebSocketManager, WebSocketManagerConfig } from './types';
 
 /**
+ * Duck-typed check for the terminal reconnect-give-up signal. Matched by the
+ * `terminal === true` flag rather than `instanceof` so it holds across realms
+ * and for any connection provider (single-server, cluster, custom) that adopts
+ * the same convention without importing the connection module here.
+ */
+function isReconnectExhaustedError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { terminal?: unknown }).terminal === true
+  );
+}
+
+/**
  * WebSocketManager implements IWebSocketManager.
  *
  * Manages WebSocket connections via IConnectionProvider.
@@ -61,6 +75,14 @@ export class WebSocketManager implements IWebSocketManager {
     // Set up event handlers
     this.connectionProvider.on('connected', (_nodeId: string) => {
       logger.info('ConnectionProvider connected.');
+      // Re-arm the state machine to CONNECTING on every freshly-opened socket.
+      // On a RECONNECT the machine sits in DISCONNECTED when this fires, so without
+      // this re-arm the following CONNECTING→AUTHENTICATING auth step would instead
+      // be an invalid DISCONNECTED→AUTHENTICATING transition; the AUTH_ACK would then
+      // land in the wrong state and strand the client in CONNECTING (the TODO-414
+      // "connects but never finishes" symptom). No-op on the initial connect, where
+      // WebSocketManager.connect() already transitioned to CONNECTING.
+      this.config.stateMachine.transition(SyncState.CONNECTING);
       this.config.onConnected?.();
     });
 
@@ -73,8 +95,12 @@ export class WebSocketManager implements IWebSocketManager {
     });
 
     this.connectionProvider.on('reconnected', (_nodeId: string) => {
+      // Informational only. Every successful socket open — initial OR reconnect —
+      // drives re-arm + auth exactly once through the 'connected' handler above,
+      // which always fires first. Running auth again here produced a duplicate AUTH
+      // frame and an invalid AUTHENTICATING→CONNECTING transition (the F7 double-auth
+      // bug). Kept purely for provider-level observability.
       logger.info('ConnectionProvider reconnected.');
-      this.config.stateMachine.transition(SyncState.CONNECTING);
       this.config.onReconnected?.();
     });
 
@@ -92,6 +118,16 @@ export class WebSocketManager implements IWebSocketManager {
 
     this.connectionProvider.on('error', (error: Error) => {
       logger.error({ err: error }, 'ConnectionProvider error');
+      // A ReconnectExhaustedError is the terminal "we gave up" signal — only ever
+      // emitted when a caller configured a finite reconnect budget and it ran out.
+      // Surface it honestly as SyncState.ERROR so consumers observing
+      // onConnectionStateChange learn that reconnection has stopped, instead of
+      // believing the client is still silently retrying. Transient WebSocket
+      // 'error' events (which do NOT stop reconnect) carry an ordinary Error and
+      // leave the state machine in DISCONNECTED/backoff.
+      if (isReconnectExhaustedError(error)) {
+        this.config.stateMachine.transition(SyncState.ERROR);
+      }
     });
 
     // Start connection

--- a/packages/client/src/sync/types.ts
+++ b/packages/client/src/sync/types.ts
@@ -11,7 +11,7 @@ import type {
   ConnectionEventHandler,
 } from '../types';
 import type { SyncStateMachine } from '../SyncStateMachine';
-import type { BackoffConfig, HeartbeatConfig, OpLogEntry, TopicQueueConfig } from '../SyncEngine';
+import type { HeartbeatConfig, OpLogEntry, TopicQueueConfig } from '../SyncEngine';
 import type {
   BackpressureConfig,
   BackpressureStatus,
@@ -132,11 +132,6 @@ export interface WebSocketManagerConfig {
    * State machine reference for managing connection states.
    */
   stateMachine: SyncStateMachine;
-
-  /**
-   * Configuration for exponential backoff reconnection.
-   */
-  backoffConfig: BackoffConfig;
 
   /**
    * Configuration for heartbeat mechanism.

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -137,7 +137,12 @@ export interface SingleServerProviderConfig {
   /** WebSocket URL to connect to */
   url: string;
 
-  /** Maximum reconnection attempts (default: 10). Use Infinity for unlimited. */
+  /**
+   * Maximum reconnection attempts before giving up (default: Infinity — retry
+   * indefinitely with capped backoff). Set a finite number for a bounded policy;
+   * on exhaustion the provider emits a terminal ReconnectExhaustedError 'error'
+   * event (SyncEngine maps it to SyncState.ERROR).
+   */
   maxReconnectAttempts?: number;
 
   /** Initial reconnect delay in ms (default: 1000) */

--- a/tests/integration-rust/helpers/index.ts
+++ b/tests/integration-rust/helpers/index.ts
@@ -70,6 +70,13 @@ export async function spawnRustServer(
   options: {
     timeout?: number;
     env?: Record<string, string>;
+    /**
+     * Fixed port to bind. Defaults to 0 (OS-assigned ephemeral port) for parallel
+     * test isolation. Pass a specific port for the server-after-client reconnect
+     * scenario, where the client must be pointed at a known URL BEFORE the server
+     * exists. Either way the harness reads the actually-bound port from stdout.
+     */
+    port?: number;
   } = {},
 ): Promise<SpawnedServer> {
   const timeoutMs =
@@ -81,13 +88,15 @@ export async function spawnRustServer(
   // Allow overriding the binary path in CI for reliable single-process cleanup
   const binaryPath = process.env.RUST_SERVER_BINARY;
 
+  const requestedPort = String(options.port ?? 0);
+
   let proc: child_process.ChildProcess;
 
   if (binaryPath) {
     // Pre-built binary: single process, no cargo wrapper.
-    // Pass --port 0 explicitly to request an OS-assigned ephemeral port,
+    // Pass --port explicitly (default 0 = OS-assigned ephemeral port),
     // since the binary's CLI default is 8080 (matches the documented quick-start).
-    proc = child_process.spawn(binaryPath, ['--port', '0'], {
+    proc = child_process.spawn(binaryPath, ['--port', requestedPort], {
       cwd: REPO_ROOT,
       detached: true,
       stdio: ['ignore', 'pipe', 'inherit'],
@@ -100,11 +109,11 @@ export async function spawnRustServer(
     });
   } else {
     // Development: let cargo build and run the binary.
-    // Pass --port 0 explicitly to request an OS-assigned ephemeral port,
+    // Pass --port explicitly (default 0 = OS-assigned ephemeral port),
     // since the binary's CLI default is 8080 (matches the documented quick-start).
     proc = child_process.spawn(
       'cargo',
-      ['run', '--bin', 'topgun-server', '--release', '--', '--port', '0'],
+      ['run', '--bin', 'topgun-server', '--release', '--', '--port', requestedPort],
       {
         cwd: REPO_ROOT,
         detached: true,

--- a/tests/integration-rust/reconnect.test.ts
+++ b/tests/integration-rust/reconnect.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Live reconnect-honesty tests (F2 / TODO-414 + TODO-429) against the Rust server.
+ *
+ * These exercise the real @topgunbuild/client SDK (TopGunClient → SyncEngine →
+ * SingleServerProvider) over real WebSockets, proving the end-to-end behavior that
+ * the unit tests cannot: recovery against an actual server socket.
+ *
+ *  1. server-after-client: a client constructed while NOTHING is listening keeps
+ *     retrying and connects + syncs once the server comes up later (the exact
+ *     TODO-414 MCP-smoke repro). With the old default (give up after 10 attempts)
+ *     the client would be permanently stuck and this test would time out.
+ *  2. prolonged outage beyond the old 10-attempt budget: the client stays down for
+ *     several seconds of fast retries, far past where a capped-at-10 client would
+ *     have terminally given up, then still recovers when the server appears.
+ *  3. server bounce under a live client: an established client survives the server
+ *     being killed and restarted on the same port (the deploy/crash scenario).
+ */
+
+import * as net from 'net';
+
+import { TopGunClient, SyncState } from '@topgunbuild/client';
+import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
+
+import {
+  spawnRustServer,
+  createRustTestClient,
+  createTestToken,
+  completeMerkleSync,
+  waitUntil,
+  SpawnedServer,
+} from './helpers';
+
+// In-memory storage adapter so the SDK runs headless in Node (no IndexedDB).
+class MemoryStorageAdapter implements IStorageAdapter {
+  private kv = new Map<string, unknown>();
+  private meta = new Map<string, unknown>();
+  private opLog: OpLogEntry[] = [];
+  private pending: OpLogEntry[] = [];
+
+  async initialize(): Promise<void> {}
+  async close(): Promise<void> {}
+  async get(key: string): Promise<any> {
+    return this.kv.get(key);
+  }
+  async put(key: string, value: unknown): Promise<void> {
+    this.kv.set(key, value);
+  }
+  async remove(key: string): Promise<void> {
+    this.kv.delete(key);
+  }
+  async getMeta(key: string): Promise<any> {
+    return this.meta.get(key);
+  }
+  async setMeta(key: string, value: unknown): Promise<void> {
+    this.meta.set(key, value);
+  }
+  async batchPut(entries: Map<string, unknown>): Promise<void> {
+    for (const [k, v] of entries) this.kv.set(k, v);
+  }
+  async appendOpLog(entry: Omit<OpLogEntry, 'id'>): Promise<number> {
+    const id = this.opLog.length + 1;
+    const e = { ...entry, id, synced: 0 } as OpLogEntry;
+    this.opLog.push(e);
+    this.pending.push(e);
+    return id;
+  }
+  async getPendingOps(): Promise<OpLogEntry[]> {
+    return this.pending;
+  }
+  async markOpsSynced(lastId: number): Promise<void> {
+    this.pending = this.pending.filter((op) => (op.id ?? 0) > lastId);
+    this.opLog.forEach((op) => {
+      if ((op.id ?? 0) <= lastId) op.synced = 1;
+    });
+  }
+  async getAllKeys(): Promise<string[]> {
+    return Array.from(this.kv.keys());
+  }
+}
+
+/** Reserve an ephemeral port, then release it so the server can bind it later. */
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (addr && typeof addr === 'object') {
+        const { port } = addr;
+        srv.close(() => resolve(port));
+      } else {
+        srv.close(() => reject(new Error('Could not determine free port')));
+      }
+    });
+  });
+}
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForState(
+  client: TopGunClient,
+  state: SyncState,
+  timeoutMs = 20_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (client.getConnectionState() === state) return;
+    await waitMs(100);
+  }
+  throw new Error(`Timed out waiting for ${state}; last state = ${client.getConnectionState()}`);
+}
+
+function makeClient(port: number): TopGunClient {
+  const token = createTestToken('reconnect-user', ['ADMIN']);
+  return new TopGunClient({
+    serverUrl: `ws://localhost:${port}/ws`,
+    storage: new MemoryStorageAdapter(),
+    auth: { getToken: async () => token },
+    // initialDelayMs also derives the per-attempt connection timeout
+    // (reconnectDelayMs * 5). 200ms → a 1s handshake timeout (ample for a local WS
+    // upgrade) and, since a failed connect only closes via that timeout, a retry
+    // roughly every ~1.2s — brisk enough to exceed 10 attempts within the outage
+    // window without hammering.
+    backoff: { initialDelayMs: 200, maxDelayMs: 400, jitter: true },
+  });
+}
+
+describe('Integration: resilient reconnect (F2 / TODO-414 + TODO-429)', () => {
+  let server: SpawnedServer | null = null;
+  let client: TopGunClient | null = null;
+
+  afterEach(async () => {
+    if (client) {
+      await client.close().catch(() => {});
+      client = null;
+    }
+    if (server) {
+      await server.cleanup().catch(() => {});
+      server = null;
+    }
+  });
+
+  test('client started BEFORE the server connects + syncs once the server comes up', async () => {
+    const port = await findFreePort();
+
+    // Construct the client while nothing is listening — it begins retrying immediately.
+    client = makeClient(port);
+    await client.start();
+
+    // Confirm it is NOT connected yet (server does not exist).
+    await waitMs(500);
+    expect(client.getConnectionState()).not.toBe(SyncState.CONNECTED);
+
+    // Bring the server up on the same port; the client must reconnect on its own.
+    server = await spawnRustServer({ port });
+    await waitForState(client, SyncState.CONNECTED, 20_000);
+    expect(client.getConnectionState()).toBe(SyncState.CONNECTED);
+
+    // And it actually SYNCS: a local write must reach the server. Verify end-to-end
+    // with an independent raw client that Merkle-syncs the map and finds the key.
+    client.getMap<string, { name: string }>('reconnect-map').set('k1', { name: 'after-server' });
+
+    const verifier = await createRustTestClient(server.port, {
+      userId: 'verifier',
+      roles: ['ADMIN'],
+    });
+    await verifier.waitForMessage('AUTH_ACK', 10_000);
+    try {
+      await waitUntil(async () => {
+        const records = await completeMerkleSync(verifier, 'reconnect-map');
+        return records.has('k1');
+      }, 10_000);
+    } finally {
+      verifier.close();
+    }
+  }, 45_000);
+
+  test('survives a prolonged outage well past the old 10-attempt budget, then recovers', async () => {
+    const port = await findFreePort();
+
+    client = makeClient(port);
+    await client.start();
+
+    // Stay down for ~14s of ~0.8s retries — that is well over 10 attempts, far
+    // past where the historical maxReconnectAttempts=10 would have terminally
+    // given up (it would emit ERROR and never recover).
+    await waitMs(14000);
+    expect(client.getConnectionState()).not.toBe(SyncState.CONNECTED);
+    // It must NOT have transitioned to the terminal ERROR state (no silent give-up).
+    expect(client.getConnectionState()).not.toBe(SyncState.ERROR);
+
+    server = await spawnRustServer({ port });
+    await waitForState(client, SyncState.CONNECTED, 20_000);
+    expect(client.getConnectionState()).toBe(SyncState.CONNECTED);
+  }, 60_000);
+
+  test('recovers after the server is bounced under a live client', async () => {
+    const port = await findFreePort();
+
+    // Start server first, connect the client.
+    server = await spawnRustServer({ port });
+    client = makeClient(port);
+    await client.start();
+    await waitForState(client, SyncState.CONNECTED, 20_000);
+
+    // Kill the server (simulating a deploy / crash) and restart it on the same port.
+    await server.cleanup();
+    server = null;
+    await waitForState(client, SyncState.DISCONNECTED, 15_000).catch(() => {
+      // Either DISCONNECTED or a brief CONNECTING churn is acceptable here; the
+      // hard requirement is that it is NOT CONNECTED while the server is down.
+      expect(client!.getConnectionState()).not.toBe(SyncState.CONNECTED);
+    });
+    expect(client.getConnectionState()).not.toBe(SyncState.CONNECTED);
+
+    server = await spawnRustServer({ port });
+    await waitForState(client, SyncState.CONNECTED, 20_000);
+    expect(client.getConnectionState()).toBe(SyncState.CONNECTED);
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

Fixes **F2 (Client SDK audit, HIGH)** — reconnect honesty — bundling **TODO-414** + **TODO-429** in one spec.

Before this change the client gave up reconnecting after `maxReconnectAttempts` (default **10**; the `AutoConnectionProvider` WS sub-provider after **1**) and then silently stopped syncing. For a real-time + offline product this is a silent halt: the app keeps "working" while sync is dead. A server that returns *after* the budget is spent — overnight sleep, redeploy window, **or a client/MCP server that started before the server** (the TODO-414 MCP-smoke repro) — was never rejoined.

## What changed

**Resilient reconnect by default**
- Default reconnect budget is now `Infinity` with capped exponential backoff + jitter (retry rate bounded by `maxDelayMs` — never hammers). Both `SingleServerProvider.DEFAULT_CONFIG` and `BackoffConfig` default to no give-up.
- `AutoConnectionProvider` probes WS single-shot (`maxReconnectAttempts: 0`, no background loop during WS↔HTTP negotiation) and **promotes the live socket to the resilient budget on success** — fixing the sub-provider that abandoned WS after one failed reconnect.

**Honesty**
- Opt-in finite cap still supported: on exhaustion the provider emits a typed terminal `ReconnectExhaustedError`, which the engine maps to `SyncState.ERROR` and surfaces via `onConnectionStateChange` — an explicit "gave up" signal, never a silent stall. `resetConnection()` restarts with a fresh budget. Added `DISCONNECTED/BACKOFF → ERROR` transitions so this can surface.

**Root causes uncovered while making server-after-client recovery actually work**
- `connect()` no longer relies solely on `ws.onclose` to drive retries — the undici/WHATWG client doesn't fire `close` for a failed connect, and a timeout-initiated `close()` of a CONNECTING socket is unreliable too. Retry is now driven from `onerror`/`onclose`/timeout, de-duplicated per attempt. The per-attempt connection timeout is bound to its own socket so a stale timer can't kill a later attempt's in-flight handshake (this was why a server coming up after a burst of failures was never rejoined).
- Consolidated post-connect wiring into the single `connected` handler (re-arm to `CONNECTING` + auth). The old dual `connected`+`reconnected` path double-sent AUTH and did an invalid `DISCONNECTED→AUTHENTICATING` transition, stranding reconnects in `CONNECTING` (F7 symptom).
- Collapsed the two `BackoffConfig` sources of truth to one (the connection provider); removed the dead `SyncEngine`/`WebSocketManager` `backoffConfig`. Fixed the lying `maxRetries` doc.

## Tests

- **jest** (`SingleServerProviderReconnect.test.ts`): indefinite reconnect survives >10 drops; backoff grows + is capped (no DoS); **opt-in cap gives up with a typed terminal error (negative control vs the old 10-attempt behavior)**.
- **integration-rust** (`reconnect.test.ts`, live real SDK → Rust server): client started **before** the server connects + syncs once it comes up (verified end-to-end via an independent Merkle-sync client); survives a prolonged outage well past the old 10-attempt budget; recovers after a server bounce.
- `AutoConnectionProvider.test.ts`: probe-then-promote-to-resilient coverage.

## Docs (TODO-429 requires docs in the same change)
- `apps/docs-astro` client reference: new **Reconnection & offline recovery** section (default Infinity + capped backoff, terminal `ERROR` opt-in, recovery via `resetConnection()`).
- offline-first guide: corrected to real `SyncState` values (`DISCONNECTED`, not the non-existent `OFFLINE`/`DISPOSED`).

## Local gates (all green)
- `pnpm --filter @topgunbuild/client test` — 630 passed
- `pnpm --filter @topgunbuild/client build`, `pnpm -r build`
- `pnpm lint` (0 errors), `pnpm format:check` (clean)
- `pnpm --filter apps-docs-astro build`
- integration-rust `reconnect` (server-after-client / prolonged-outage / bounce) — 3 passed

CI (build-and-push, Simulation, TS Build·Test·Lint, Cross-Language) runs on this PR — **not** merged directly.