### PR TITLE
fix(client): live-query/search top-N window clamp (Client-F1, SPEC-320)

### DIFF
--- a/packages/client/src/QueryHandle.ts
+++ b/packages/client/src/QueryHandle.ts
@@ -69,6 +69,12 @@ export class QueryHandle<T> {
   private listeners: Set<SubscribeCallback<T>> = new Set();
   private currentResults: Map<string, T> = new Map();
 
+  // Intent flag distinguishing a live-window handle (render-time top-N clamp
+  // applies) from a page-accumulation handle. Once loadMore() runs, the handle
+  // is permanently in page-accumulation mode and the clamp must NOT apply,
+  // otherwise accumulated pages beyond `limit` would be hidden.
+  private _paginated: boolean = false;
+
   // Change tracking for delta notifications
   private changeTracker = new ChangeTracker<T>();
   private pendingChanges: ChangeEvent<T>[] = [];
@@ -400,6 +406,20 @@ export class QueryHandle<T> {
       });
     }
 
+    // Render-time top-N window clamp. Keeps the HEAD of the sort-ordered array
+    // (the N rows the active comparator ranks first). This is a non-destructive
+    // view slice — currentResults is never mutated — so it composes with the
+    // server's displacement LEAVE retractions without double-dropping rows and
+    // breaking the net-N invariant. Skipped once the handle is paginated, since
+    // loadMore intentionally accumulates rows beyond `limit`.
+    if (
+      !this._paginated &&
+      Number.isInteger(this.filter.limit) &&
+      (this.filter.limit as number) > 0
+    ) {
+      return results.slice(0, this.filter.limit);
+    }
+
     return results;
   }
 
@@ -426,6 +446,9 @@ export class QueryHandle<T> {
    * prune those prior-page rows.
    */
   private mergePageResults(items: { key: string; value: T }[]): void {
+    // Entering page-accumulation mode permanently disables the live-window
+    // top-N clamp so accumulated pages beyond `limit` remain visible.
+    this._paginated = true;
     for (const item of items) {
       this.currentResults.set(item.key, item.value);
     }

--- a/packages/client/src/SearchHandle.ts
+++ b/packages/client/src/SearchHandle.ts
@@ -139,7 +139,19 @@ export class SearchHandle<T = unknown> {
    * @returns Array of search results
    */
   getResults(): SearchResult<T>[] {
-    return Array.from(this.results.values()).sort((a, b) => b.score - a.score);
+    const sorted = Array.from(this.results.values()).sort((a, b) => b.score - a.score);
+
+    // Render-time top-N window clamp read from the current options each call, so
+    // a re-setOptions with a new limit takes effect on the next emission. This is
+    // a non-destructive view slice — this.results is never mutated — so it
+    // composes with the server's displacement LEAVE retractions without
+    // double-dropping rows and breaking the net-N invariant.
+    const limit = this._options?.limit;
+    if (Number.isInteger(limit) && (limit as number) > 0) {
+      return sorted.slice(0, limit);
+    }
+
+    return sorted;
   }
 
   /**

--- a/packages/client/src/__tests__/QueryHandle.limit.test.ts
+++ b/packages/client/src/__tests__/QueryHandle.limit.test.ts
@@ -218,15 +218,17 @@ describe('QueryHandle live-window top-N clamp', () => {
 
     // The temp page-handle that loadMore spins up calls subscribeToQuery and
     // runLocalQuery; we deliver its page-2 rows via the server path and settle it.
-    (engine.subscribeToQuery as jest.Mock).mockImplementation((temp: QueryHandle<{ n: number }>) => {
-      temp.onResult(
-        [
-          { key: 'c', value: { n: 3 } },
-          { key: 'd', value: { n: 4 } },
-        ],
-        'server',
-      );
-    });
+    (engine.subscribeToQuery as jest.Mock).mockImplementation(
+      (temp: QueryHandle<{ n: number }>) => {
+        temp.onResult(
+          [
+            { key: 'c', value: { n: 3 } },
+            { key: 'd', value: { n: 4 } },
+          ],
+          'server',
+        );
+      },
+    );
 
     const handle = new QueryHandle<{ n: number }>(engine, 'm', {
       limit: 2,

--- a/packages/client/src/__tests__/QueryHandle.limit.test.ts
+++ b/packages/client/src/__tests__/QueryHandle.limit.test.ts
@@ -1,0 +1,259 @@
+/**
+ * QueryHandle live-window top-N clamp tests.
+ *
+ * A live `limit:N` subscription must clamp its rendered result set to N rows,
+ * agreeing with the server's authoritative top-N window. The clamp is a
+ * render-time slice of the sorted projection — it must NOT evict rows from the
+ * in-memory `currentResults`, so it composes with the server's displacement
+ * LEAVE retractions without double-dropping to N-1. The clamp is disengaged
+ * once the handle enters page-accumulation mode (loadMore), so intentionally
+ * accumulated multi-page results are never truncated to one page.
+ *
+ * The C-LIVEQ reproduction (client SDK audit negative control) is promoted here
+ * with its assertion inverted: a third matching live ENTER stays clamped at 2,
+ * not 3.
+ */
+
+import { QueryHandle } from '../QueryHandle';
+import { SyncEngine } from '../SyncEngine';
+
+// Mock SyncEngine — the QueryHandle clamp logic is pure and only needs the
+// subscribe/unsubscribe/runLocalQuery surface plus a sync-state tracker stub.
+const makeMockEngine = () =>
+  ({
+    subscribeToQuery: jest.fn(),
+    unsubscribeFromQuery: jest.fn(),
+    runLocalQuery: jest.fn().mockResolvedValue([]),
+    getRecordSyncStateTracker: () => ({
+      onChange: () => () => {},
+      get: () => 'synced',
+    }),
+  }) as unknown as SyncEngine;
+
+describe('QueryHandle live-window top-N clamp', () => {
+  // AC1 — clamp boundary conditions.
+  describe('AC1: getSortedResults clamps to a positive-integer limit only', () => {
+    const seed = (handle: QueryHandle<{ n: number }>): any[] => {
+      let last: any[] = [];
+      handle.subscribe((r) => (last = r));
+      handle.onResult(
+        [
+          { key: 'a', value: { n: 1 } },
+          { key: 'b', value: { n: 2 } },
+          { key: 'c', value: { n: 3 } },
+          { key: 'd', value: { n: 4 } },
+        ],
+        'server',
+      );
+      return last;
+    };
+
+    test('positive-integer limit slices to N (head of sort order)', () => {
+      const handle = new QueryHandle<{ n: number }>(makeMockEngine(), 'm', {
+        limit: 2,
+        sort: { n: 'asc' },
+      });
+      const last = seed(handle);
+      expect(last).toHaveLength(2);
+      expect(last.map((r) => r._key)).toEqual(['a', 'b']);
+    });
+
+    test('unset limit returns the full set', () => {
+      const handle = new QueryHandle<{ n: number }>(makeMockEngine(), 'm', {
+        sort: { n: 'asc' },
+      });
+      expect(seed(handle)).toHaveLength(4);
+    });
+
+    test('limit:0 returns the full set (no clamp)', () => {
+      const handle = new QueryHandle<{ n: number }>(makeMockEngine(), 'm', {
+        limit: 0,
+        sort: { n: 'asc' },
+      });
+      expect(seed(handle)).toHaveLength(4);
+    });
+
+    test('negative limit returns the full set (no clamp)', () => {
+      const handle = new QueryHandle<{ n: number }>(makeMockEngine(), 'm', {
+        limit: -1,
+        sort: { n: 'asc' },
+      });
+      expect(seed(handle)).toHaveLength(4);
+    });
+
+    test('non-finite limit returns the full set (no clamp)', () => {
+      const handle = new QueryHandle<{ n: number }>(makeMockEngine(), 'm', {
+        limit: Number.POSITIVE_INFINITY,
+        sort: { n: 'asc' },
+      });
+      expect(seed(handle)).toHaveLength(4);
+    });
+
+    test('fractional (non-integer) limit returns the full set (no clamp)', () => {
+      const handle = new QueryHandle<{ n: number }>(makeMockEngine(), 'm', {
+        limit: 2.5,
+        sort: { n: 'asc' },
+      });
+      expect(seed(handle)).toHaveLength(4);
+    });
+  });
+
+  // AC2 — inverted C-LIVEQ: a third live ENTER stays clamped at 2.
+  test('AC2: live limit:2 holding a,b stays clamped to [a,b] after onUpdate(c)', () => {
+    const handle = new QueryHandle<{ n: number }>(makeMockEngine(), 'm', {
+      limit: 2,
+      sort: { n: 'asc' },
+    });
+    let last: any[] = [];
+    handle.subscribe((r) => (last = r));
+
+    // Server delivers its authoritative 2-row window.
+    handle.onResult(
+      [
+        { key: 'a', value: { n: 1 } },
+        { key: 'b', value: { n: 2 } },
+      ],
+      'server',
+    );
+    expect(last).toHaveLength(2);
+
+    // A third matching live ENTER arrives. Without the clamp the rendered set
+    // would grow to 3 (the audit's negative control). With the clamp it stays
+    // exactly the two lowest-n rows; c (highest n) is excluded under asc sort.
+    handle.onUpdate('c', { n: 3 });
+    expect(last).toHaveLength(2);
+    expect(last.map((r) => r._key)).toEqual(['a', 'b']);
+    expect(last.map((r) => r._key)).not.toContain('c');
+  });
+
+  // AC3 — an ENTER beyond the window plus a displacement LEAVE nets to N, not N-1.
+  test('AC3: ENTER of a new lowest then displacement LEAVE nets to exactly 2 (no double-drop)', () => {
+    const handle = new QueryHandle<{ n: number }>(makeMockEngine(), 'm', {
+      limit: 2,
+      sort: { n: 'asc' },
+    });
+    let last: any[] = [];
+    handle.subscribe((r) => (last = r));
+
+    handle.onResult(
+      [
+        { key: 'a', value: { n: 1 } },
+        { key: 'b', value: { n: 2 } },
+      ],
+      'server',
+    );
+
+    // New lowest row enters — in-memory set is now {c:0, a:1, b:2}; the rendered
+    // window clamps to [c, a]. b is displaced but still held in currentResults.
+    handle.onUpdate('c', { n: 0 });
+    expect(last.map((r) => r._key)).toEqual(['c', 'a']);
+
+    // Server then sends the displacement LEAVE for the now-out-of-window b.
+    // Because the clamp was a pure slice (not an eviction), this nets to exactly
+    // 2 rows — NOT 1. A destructive clamp would have already dropped b and this
+    // LEAVE would over-prune to a single row.
+    handle.onUpdate('b', null);
+    expect(last).toHaveLength(2);
+    expect(last.map((r) => r._key)).toEqual(['c', 'a']);
+  });
+
+  // AC4 — behavioral proof the clamp does not evict from currentResults: a
+  // later in-window LEAVE promotes the previously-excluded row back into view.
+  test('AC4: excluded row is retained in memory and promoted back after an in-window LEAVE', () => {
+    const handle = new QueryHandle<{ n: number }>(makeMockEngine(), 'm', {
+      limit: 2,
+      sort: { n: 'asc' },
+    });
+    let last: any[] = [];
+    handle.subscribe((r) => (last = r));
+
+    handle.onResult(
+      [
+        { key: 'a', value: { n: 1 } },
+        { key: 'b', value: { n: 2 } },
+      ],
+      'server',
+    );
+
+    // c is excluded by the clamp (highest n) but must remain in currentResults.
+    handle.onUpdate('c', { n: 3 });
+    expect(last.map((r) => r._key)).toEqual(['a', 'b']);
+
+    // A LEAVE of the in-window row a frees a slot. If c had been evicted the
+    // rendered set would now be just [b]; instead c is promoted into the window,
+    // proving the clamp never removed it from currentResults.
+    handle.onUpdate('a', null);
+    expect(last).toHaveLength(2);
+    expect(last.map((r) => r._key)).toEqual(['b', 'c']);
+  });
+
+  // AC6 — no-limit regression: a query without a limit returns all rows.
+  test('AC6: a query with no limit returns all rows (no regression)', () => {
+    const handle = new QueryHandle<{ n: number }>(makeMockEngine(), 'm', {
+      sort: { n: 'asc' },
+    });
+    let last: any[] = [];
+    handle.subscribe((r) => (last = r));
+
+    handle.onResult(
+      [
+        { key: 'a', value: { n: 1 } },
+        { key: 'b', value: { n: 2 } },
+        { key: 'c', value: { n: 3 } },
+      ],
+      'server',
+    );
+    expect(last).toHaveLength(3);
+    expect(last.map((r) => r._key)).toEqual(['a', 'b', 'c']);
+
+    // Live ENTERs keep growing the set — no clamp engages.
+    handle.onUpdate('d', { n: 4 });
+    expect(last).toHaveLength(4);
+  });
+
+  // AC8 — after loadMore accumulates 2 pages of a limit:N live query, all
+  // accumulated rows are returned (> N); the _paginated flag disengages the clamp.
+  test('AC8: loadMore accumulation returns all rows (> limit), not clamped to one page', async () => {
+    const engine = makeMockEngine();
+
+    // The temp page-handle that loadMore spins up calls subscribeToQuery and
+    // runLocalQuery; we deliver its page-2 rows via the server path and settle it.
+    (engine.subscribeToQuery as jest.Mock).mockImplementation((temp: QueryHandle<{ n: number }>) => {
+      temp.onResult(
+        [
+          { key: 'c', value: { n: 3 } },
+          { key: 'd', value: { n: 4 } },
+        ],
+        'server',
+      );
+    });
+
+    const handle = new QueryHandle<{ n: number }>(engine, 'm', {
+      limit: 2,
+      sort: { n: 'asc' },
+    });
+    let last: any[] = [];
+    handle.subscribe((r) => (last = r));
+
+    // Page 1 (the live window) holds 2 rows and is clamped.
+    handle.onResult(
+      [
+        { key: 'a', value: { n: 1 } },
+        { key: 'b', value: { n: 2 } },
+      ],
+      'server',
+    );
+    expect(last).toHaveLength(2);
+
+    // Advance pagination state so loadMore issues a request.
+    handle.updatePaginationInfo({ nextCursor: 'cursor-2', hasMore: true, cursorStatus: 'valid' });
+
+    await handle.loadMore();
+
+    // After accumulating page 2, all 4 rows are visible — the clamp is disengaged
+    // because the handle is now in page-accumulation mode (_paginated === true).
+    expect(last.length).toBeGreaterThan(2);
+    expect(last).toHaveLength(4);
+    expect(last.map((r) => r._key)).toEqual(['a', 'b', 'c', 'd']);
+  });
+});

--- a/packages/client/src/__tests__/Search.test.ts
+++ b/packages/client/src/__tests__/Search.test.ts
@@ -667,6 +667,60 @@ describe('Client Search', () => {
 
       handle.dispose();
     });
+
+    it('clamps getResults() to options.limit, keeping the top-N by score', () => {
+      // require() avoids TypeScript generic constraint mismatch for SearchHandle<T = unknown> in test context
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { SearchHandle } = require('../SearchHandle');
+      const handle = new SearchHandle(syncEngine, 'articles', 'test', { limit: 2 });
+
+      const sentMessage = mockSendMessage.mock.calls[0][0];
+      const subscriptionId = sentMessage.payload.subscriptionId;
+
+      const enter = (key: string, score: number) =>
+        (syncEngine as any).handleServerMessage({
+          type: 'SEARCH_UPDATE',
+          payload: {
+            subscriptionId,
+            key,
+            value: { title: key },
+            score,
+            matchedTerms: ['test'],
+            changeType: 'ENTER',
+          },
+        });
+
+      // Three ENTER deltas arrive; the window must clamp to the top-2 by score.
+      enter('a', 0.9);
+      enter('b', 0.7);
+      enter('c', 0.5);
+
+      const results = handle.getResults();
+      expect(results).toHaveLength(2);
+      expect(results.map((r: any) => r.score)).toEqual([0.9, 0.7]);
+      expect(results.map((r: any) => r.key)).toEqual(['a', 'b']);
+
+      // The excluded row c is retained in this.results, not evicted by the clamp.
+      // Raising its score above an in-window row promotes it back into view —
+      // proving the clamp was a pure render-time slice over the full set.
+      (syncEngine as any).handleServerMessage({
+        type: 'SEARCH_UPDATE',
+        payload: {
+          subscriptionId,
+          key: 'c',
+          value: { title: 'c' },
+          score: 0.95,
+          matchedTerms: ['test'],
+          changeType: 'UPDATE',
+        },
+      });
+
+      const promoted = handle.getResults();
+      expect(promoted).toHaveLength(2);
+      expect(promoted.map((r: any) => r.key)).toEqual(['c', 'a']);
+
+      handle.dispose();
+    });
   });
 
   describe('TopGunClient.searchSubscribe()', () => {

--- a/tests/integration-rust/live-query-limit-clamp.test.ts
+++ b/tests/integration-rust/live-query-limit-clamp.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Cross-boundary live top-N clamp test against the real Rust server.
+ *
+ * Exercises the full @topgunbuild/client SDK (TopGunClient -> SyncEngine ->
+ * QueryHandle) over real WebSockets to a real Rust server, proving the
+ * end-to-end behavior the unit tests cannot: that a live `limit:N` subscription's
+ * EMITTED result set stays clamped to exactly N rows once the server starts
+ * sending top-N displacement deltas for a write that ranks a new row into the
+ * window and pushes an existing row out.
+ *
+ * The Rust server already emits correct displacement (a LEAVE for the displaced
+ * row + an ENTER for the new in-window row). The client's render-time,
+ * non-destructive window slice composes with those deltas so the FINAL rendered
+ * set nets to exactly N in sort order. This mirrors the AC2/AC3 unit scenario at
+ * integration scale: limit:2, sort ascending on a numeric field, seed n=1 and
+ * n=2, then write a new lowest n=0 that displaces n=2 out of the top-2 window.
+ *
+ * Scope note (honesty): against the real server, every observed delta path is
+ * already net-N correct on its own — the initial QUERY_RESP is clamped to N, an
+ * ENTER that ranks outside the window is suppressed entirely, and an in-window
+ * displacement arrives as LEAVE-then-ENTER (never a transient N+1). So this test
+ * proves AC7's literal end-to-end claim (the client's emitted set is exactly N,
+ * correctly ordered, after a server-driven displacement); the client clamp's
+ * extra safety against an unpaired/out-of-order ENTER is exercised by the unit
+ * suite, which can inject that ordering directly. We do NOT assert the clamp is
+ * the load-bearing mechanism here, because the real server never forces it to be.
+ *
+ * Two clients are used deliberately: a separate writer drives the mutation while
+ * the subscriber observes the live query. The server suppresses self-echo of
+ * QUERY_UPDATE deltas back to the originating writer, so a single self-writing
+ * client would never receive the displacement stream this test must verify.
+ */
+
+import { TopGunClient, SyncState } from '@topgunbuild/client';
+import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
+
+import { spawnRustServer, createTestToken, SpawnedServer } from './helpers';
+
+// In-memory storage adapter so the SDK runs headless in Node (no IndexedDB).
+class MemoryStorageAdapter implements IStorageAdapter {
+  private kv = new Map<string, unknown>();
+  private meta = new Map<string, unknown>();
+  private opLog: OpLogEntry[] = [];
+  private pending: OpLogEntry[] = [];
+
+  async initialize(): Promise<void> {}
+  async close(): Promise<void> {}
+  async get(key: string): Promise<any> {
+    return this.kv.get(key);
+  }
+  async put(key: string, value: unknown): Promise<void> {
+    this.kv.set(key, value);
+  }
+  async remove(key: string): Promise<void> {
+    this.kv.delete(key);
+  }
+  async getMeta(key: string): Promise<any> {
+    return this.meta.get(key);
+  }
+  async setMeta(key: string, value: unknown): Promise<void> {
+    this.meta.set(key, value);
+  }
+  async batchPut(entries: Map<string, unknown>): Promise<void> {
+    for (const [k, v] of entries) this.kv.set(k, v);
+  }
+  async appendOpLog(entry: Omit<OpLogEntry, 'id'>): Promise<number> {
+    const id = this.opLog.length + 1;
+    const e = { ...entry, id, synced: 0 } as OpLogEntry;
+    this.opLog.push(e);
+    this.pending.push(e);
+    return id;
+  }
+  async getPendingOps(): Promise<OpLogEntry[]> {
+    return this.pending;
+  }
+  async markOpsSynced(lastId: number): Promise<void> {
+    this.pending = this.pending.filter((op) => (op.id ?? 0) > lastId);
+    this.opLog.forEach((op) => {
+      if ((op.id ?? 0) <= lastId) op.synced = 1;
+    });
+  }
+  async getAllKeys(): Promise<string[]> {
+    return Array.from(this.kv.keys());
+  }
+}
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForState(
+  client: TopGunClient,
+  state: SyncState,
+  timeoutMs = 20_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (client.getConnectionState() === state) return;
+    await waitMs(50);
+  }
+  throw new Error(`Timed out waiting for ${state}; last state = ${client.getConnectionState()}`);
+}
+
+/** Polls a condition rather than sleeping a fixed interval for live emissions. */
+async function waitUntil(
+  predicate: () => boolean,
+  timeoutMs: number,
+  describe: () => string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await waitMs(50);
+  }
+  throw new Error(`Timed out waiting for condition: ${describe()}`);
+}
+
+function makeClient(port: number, userId: string): TopGunClient {
+  const token = createTestToken(userId, ['ADMIN']);
+  return new TopGunClient({
+    serverUrl: `ws://localhost:${port}/ws`,
+    storage: new MemoryStorageAdapter(),
+    auth: { getToken: async () => token },
+    backoff: { initialDelayMs: 200, maxDelayMs: 400, jitter: true },
+  });
+}
+
+describe('Integration: live top-N clamp end-to-end (client <-> Rust server)', () => {
+  let server: SpawnedServer | null = null;
+  let subscriber: TopGunClient | null = null;
+  let writer: TopGunClient | null = null;
+
+  afterEach(async () => {
+    if (subscriber) {
+      await subscriber.close().catch(() => {});
+      subscriber = null;
+    }
+    if (writer) {
+      await writer.close().catch(() => {});
+      writer = null;
+    }
+    if (server) {
+      await server.cleanup().catch(() => {});
+      server = null;
+    }
+  });
+
+  test('limit:2 live query stays clamped to the top-2 by sort order after a displacing write', async () => {
+    server = await spawnRustServer();
+
+    subscriber = makeClient(server.port, 'clamp-subscriber');
+    writer = makeClient(server.port, 'clamp-writer');
+    await subscriber.start();
+    await writer.start();
+    await waitForState(subscriber, SyncState.CONNECTED, 20_000);
+    await waitForState(writer, SyncState.CONNECTED, 20_000);
+
+    // Unique map name so every row in the map matches the (filterless) query and
+    // the displacement is unambiguous — no cross-test pollution under the null
+    // in-memory backend.
+    const mapName = `clamp-map-${Date.now()}`;
+    const writerMap = writer.getMap<string, { n: number }>(mapName);
+
+    // Seed the authoritative top-2 window: ascending sort on `n` ranks a(1), b(2).
+    writerMap.set('a', { n: 1 });
+    writerMap.set('b', { n: 2 });
+
+    // Capture the latest emitted (rendered) result set from the live subscription.
+    let last: Array<{ n: number; _key: string }> = [];
+    const emittedLengths: number[] = [];
+    const handle = subscriber.query<{ n: number }>(mapName, {
+      limit: 2,
+      sort: { n: 'asc' },
+    });
+    const unsubscribe = handle.subscribe((results) => {
+      last = results as Array<{ n: number; _key: string }>;
+      emittedLengths.push(results.length);
+    });
+
+    try {
+      // Wait until the server's authoritative top-2 window has been rendered.
+      await waitUntil(
+        () => last.length === 2 && last[0]?._key === 'a' && last[1]?._key === 'b',
+        20_000,
+        () => `initial top-2 window; got ${JSON.stringify(last.map((r) => r._key))}`,
+      );
+
+      // Write a NEW LOWEST row from the separate writer. The server ranks n=0 ahead
+      // of a(1)/b(2), so the top-2 window becomes [c, a] and b is displaced out.
+      // The server emits the LEAVE(b) + ENTER(c) displacement deltas; the client's
+      // render-time clamp must net these to exactly 2 rendered rows in the end — not
+      // 3 (no clamp) and not a permanent 1 (double-drop of b on top of the clamp).
+      writer.getMap<string, { n: number }>(mapName).set('c', { n: 0 });
+
+      await waitUntil(
+        () => last.length === 2 && last[0]?._key === 'c' && last[1]?._key === 'a',
+        20_000,
+        () => `clamped top-2 after displacement; got ${JSON.stringify(last.map((r) => r._key))}`,
+      );
+
+      // End-to-end assertions: exactly N rows, the correct two by ascending sort.
+      expect(last).toHaveLength(2);
+      expect(last.map((r) => r._key)).toEqual(['c', 'a']);
+      expect(last.map((r) => r.n)).toEqual([0, 1]);
+
+      // The displaced row b is NOT in the rendered window.
+      expect(last.find((r) => r._key === 'b')).toBeUndefined();
+
+      // No emission ever EXCEEDED the limit end-to-end. (On the real server this
+      // holds because deltas are net-N correct per the scope note; the clamp would
+      // additionally guarantee it under an out-of-order ENTER.)
+      expect(Math.max(...emittedLengths)).toBeLessThanOrEqual(2);
+    } finally {
+      unsubscribe();
+    }
+  }, 60_000);
+});

--- a/tests/integration-rust/live-query-limit-clamp.test.ts
+++ b/tests/integration-rust/live-query-limit-clamp.test.ts
@@ -4,26 +4,38 @@
  * Exercises the full @topgunbuild/client SDK (TopGunClient -> SyncEngine ->
  * QueryHandle) over real WebSockets to a real Rust server, proving the
  * end-to-end behavior the unit tests cannot: that a live `limit:N` subscription's
- * EMITTED result set stays clamped to exactly N rows once the server starts
- * sending top-N displacement deltas for a write that ranks a new row into the
- * window and pushes an existing row out.
+ * EMITTED result set stays clamped to exactly N rows BOTH on the initial snapshot
+ * of pre-seeded data AND after the server starts sending top-N displacement deltas
+ * for a write that ranks a new row into the window and pushes an existing row out.
  *
- * The Rust server already emits correct displacement (a LEAVE for the displaced
- * row + an ENTER for the new in-window row). The client's render-time,
- * non-destructive window slice composes with those deltas so the FINAL rendered
- * set nets to exactly N in sort order. This mirrors the AC2/AC3 unit scenario at
- * integration scale: limit:2, sort ascending on a numeric field, seed n=1 and
- * n=2, then write a new lowest n=0 that displaces n=2 out of the top-2 window.
+ * The flow: seed THREE rows (one more than the limit) and wait for them to be
+ * APPLIED server-side, then subscribe with limit:2 ascending. The initial rendered
+ * window is the top-2 [a, b] — the third seed row d(3) is below the window. Then a
+ * separate writer adds a new lowest n=0 that displaces b out, so the window nets to
+ * [c, a]. The Rust server emits correct displacement (a LEAVE for the displaced row
+ * + an ENTER for the new in-window row); the client's render-time, non-destructive
+ * window slice composes with those deltas so the FINAL rendered set nets to exactly
+ * N in sort order. This mirrors the AC1/AC2/AC3 unit scenarios at integration scale.
  *
- * Scope note (honesty): against the real server, every observed delta path is
- * already net-N correct on its own — the initial QUERY_RESP is clamped to N, an
- * ENTER that ranks outside the window is suppressed entirely, and an in-window
+ * Determinism: the writer's `set()` calls are optimistic and batched, so the seed
+ * is gated behind waitForSynced(writer) — the QUERY_SUB is sent only once all seed
+ * writes have drained and been APPLIED on the server. Without this gate the
+ * subscriber's QUERY_SUB can race ahead of the seed reaching the server, and on a
+ * cold first spawn a seed write can land in the gap between the server taking the
+ * snapshot and activating the live subscription — surfacing in neither the snapshot
+ * nor a delta. That race (not a client replay gap — the server replays pre-seeded
+ * data on subscribe, verified independently) was the intermittent PR #65 red.
+ *
+ * Scope note (honesty): against the real server, every observed path is already
+ * net-N correct on its own — the initial QUERY_RESP is itself limit-clamped to N,
+ * an ENTER that ranks outside the window is suppressed entirely, and an in-window
  * displacement arrives as LEAVE-then-ENTER (never a transient N+1). So this test
- * proves AC7's literal end-to-end claim (the client's emitted set is exactly N,
- * correctly ordered, after a server-driven displacement); the client clamp's
- * extra safety against an unpaired/out-of-order ENTER is exercised by the unit
- * suite, which can inject that ordering directly. We do NOT assert the clamp is
- * the load-bearing mechanism here, because the real server never forces it to be.
+ * proves the literal end-to-end claim (the client's emitted set is exactly N,
+ * correctly ordered, on both the initial snapshot and after a server-driven
+ * displacement); the client clamp's extra safety against an unpaired/out-of-order
+ * ENTER and against an over-full snapshot is exercised load-bearingly by the unit
+ * suite, which can inject those directly. We do NOT assert the client clamp is the
+ * load-bearing mechanism here, because the real server never forces it to be.
  *
  * Two clients are used deliberately: a separate writer drives the mutation while
  * the subscriber observes the live query. The server suppresses self-echo of
@@ -115,6 +127,28 @@ async function waitUntil(
   throw new Error(`Timed out waiting for condition: ${describe()}`);
 }
 
+/**
+ * Resolves once the client has no unacknowledged pending operations — i.e. every
+ * optimistic local write has round-tripped to the server and been APPLIED. The
+ * writer's `set()` calls are optimistic and batched, so without this wait the
+ * subscriber's QUERY_SUB can race AHEAD of the seed writes reaching the server;
+ * the server then either snapshots an empty map OR (on a cold first spawn) lands
+ * a write in the gap between taking the snapshot and activating the live
+ * subscription, so the seed surfaces in neither the snapshot nor a delta. Gating
+ * the subscribe on a fully-drained writer makes the seed deterministically
+ * present in the initial QUERY_RESP snapshot.
+ */
+async function waitForSynced(client: TopGunClient, timeoutMs = 20_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (client.getPendingOpsCount() === 0) return;
+    await waitMs(25);
+  }
+  throw new Error(
+    `Timed out waiting for writer to drain; pending = ${client.getPendingOpsCount()}`,
+  );
+}
+
 function makeClient(port: number, userId: string): TopGunClient {
   const token = createTestToken(userId, ['ADMIN']);
   return new TopGunClient({
@@ -161,9 +195,21 @@ describe('Integration: live top-N clamp end-to-end (client <-> Rust server)', ()
     const mapName = `clamp-map-${Date.now()}`;
     const writerMap = writer.getMap<string, { n: number }>(mapName);
 
-    // Seed the authoritative top-2 window: ascending sort on `n` ranks a(1), b(2).
+    // Seed THREE rows — one MORE than the limit — so the initial window is
+    // genuinely over-full and the rendered initial snapshot must be clamped down
+    // to exactly `limit`. Ascending sort on `n` ranks a(1), b(2), then d(3); with
+    // limit:2 the authoritative top-2 window is [a, b] and d(3) is below the
+    // window. (Seeding only `limit` rows — as the original test did — never
+    // exercises an initial-snapshot clamp, since `limit` rows trivially fit.)
     writerMap.set('a', { n: 1 });
     writerMap.set('b', { n: 2 });
+    writerMap.set('d', { n: 3 });
+
+    // Gate the subscribe on the writer fully draining its pending ops, so all
+    // three seed rows are APPLIED server-side BEFORE the QUERY_SUB. This removes
+    // the snapshot-vs-write race that otherwise lets the subscriber observe an
+    // empty initial window on a cold spawn (the original flake on PR #65).
+    await waitForSynced(writer);
 
     // Capture the latest emitted (rendered) result set from the live subscription.
     let last: Array<{ n: number; _key: string }> = [];
@@ -178,15 +224,21 @@ describe('Integration: live top-N clamp end-to-end (client <-> Rust server)', ()
     });
 
     try {
-      // Wait until the server's authoritative top-2 window has been rendered.
+      // The initial rendered window is exactly the top-2 [a, b] — d(3) is clamped
+      // out of the window end-to-end. (Against the real server the QUERY_RESP
+      // snapshot is itself limit-clamped to 2 rows; the client's render-time slice
+      // is the defense-in-depth half, exercised load-bearingly by the unit suite.)
       await waitUntil(
         () => last.length === 2 && last[0]?._key === 'a' && last[1]?._key === 'b',
         20_000,
-        () => `initial top-2 window; got ${JSON.stringify(last.map((r) => r._key))}`,
+        () => `initial clamped top-2 window; got ${JSON.stringify(last.map((r) => r._key))}`,
       );
 
+      // The below-window seed row d(3) is never in the rendered window.
+      expect(last.find((r) => r._key === 'd')).toBeUndefined();
+
       // Write a NEW LOWEST row from the separate writer. The server ranks n=0 ahead
-      // of a(1)/b(2), so the top-2 window becomes [c, a] and b is displaced out.
+      // of a(1)/b(2)/d(3), so the top-2 window becomes [c, a] and b is displaced out.
       // The server emits the LEAVE(b) + ENTER(c) displacement deltas; the client's
       // render-time clamp must net these to exactly 2 rendered rows in the end — not
       // 3 (no clamp) and not a permanent 1 (double-drop of b on top of the clamp).
@@ -203,8 +255,10 @@ describe('Integration: live top-N clamp end-to-end (client <-> Rust server)', ()
       expect(last.map((r) => r._key)).toEqual(['c', 'a']);
       expect(last.map((r) => r.n)).toEqual([0, 1]);
 
-      // The displaced row b is NOT in the rendered window.
+      // Neither the displaced row b nor the always-below-window row d is in the
+      // rendered window.
       expect(last.find((r) => r._key === 'b')).toBeUndefined();
+      expect(last.find((r) => r._key === 'd')).toBeUndefined();
 
       // No emission ever EXCEEDED the limit end-to-end. (On the real server this
       // holds because deltas are net-N correct per the scope note; the clamp would


### PR DESCRIPTION
## What

Client SDK audit F1 (TODO-495, HIGH): the client-side live query/search never clamped the result set to `limit` — `getSortedResults` sorted but didn't slice → the live set grew past `limit` (limit:2 → 3 rows). The **client half** of the live top-N gap; the server half (SPEC-317) is already merged.

## Fix (non-destructive render-time clamp)

- Render-time top-N clamp: `results.slice(0, limit)` on the sort-ordered **view**; `currentResults` is never mutated → composes with the server's displacement-LEAVE retractions **without double-dropping**.
- `_paginated` intent flag: `loadMore` accumulates pages beyond `limit` deliberately → clamp must NOT apply in pagination mode.

## sf-320 re-address (was red on PR #65)

The integration test `live-query-limit-clamp.test.ts` was failing intermittently on its **first** `waitUntil` — the subscriber observed an empty initial window.

**Root cause established (not a client gap):**
- The Rust server **does** replay pre-seeded data on subscribe — a filterless live query's initial `QUERY_RESP` carries the current snapshot, and that snapshot is itself limit-clamped server-side (verified directly with raw-protocol probes; `queries.test.ts` covers the same path green).
- The client `QueryHandle` surfaces and clamps both the initial snapshot (`onResult`) and live deltas (`onUpdate`) — covered load-bearingly by `QueryHandle.limit.test.ts` AC1.
- The flake was **test-design**: the test seeded from a *separate* writer using optimistic/batched writes, then subscribed *immediately*. That created a concurrent snapshot-vs-write window; on a cold first spawn a seed write could land in the gap between the server taking the snapshot and activating the live subscription → surfacing in neither the snapshot nor a delta → `[]` forever (reproduced 1/16, cold-start).

**Test fix (deterministic + stronger coverage):**
- Gate the subscribe on `waitForSynced(writer)` (`getPendingOpsCount() === 0`) so all seed rows are APPLIED server-side before `QUERY_SUB` — mirrors `queries.test.ts`'s OP_ACK wait. Eliminates the race (10/10 cold spawns green).
- Seed **3 rows (one beyond `limit`)** so the initial rendered window must clamp to exactly N end-to-end — the original 2-row seed never exercised an initial-snapshot clamp.
- Merged `origin/main` to pick up the now-blocking `integration-rust` CI gate (PR #66) + the group-by fix.

## Verified

- jest client unit: `QueryHandle.limit` (11) + `Search` clamp — green.
- integration-rust **blocking** suite (11 suites / 76 tests, incl. `live-query-limit-clamp`) — green locally and in CI.
- `gh pr checks` ALL-green incl. **Integration tests (blocking)**.