### PR TITLE
fix(client): offline-durability bundle — ORMap server-persist, oplog compaction, atomic commit, durable drop-oldest (SPEC-321)

### DIFF
--- a/examples/sync-lab/src/lib/memory-storage.ts
+++ b/examples/sync-lab/src/lib/memory-storage.ts
@@ -1,4 +1,4 @@
-import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
+import type { IStorageAdapter, OpLogEntry, StorageMutation } from '@topgunbuild/client';
 
 /**
  * In-memory storage adapter for the Sync Lab demo.
@@ -56,9 +56,21 @@ export class MemoryStorageAdapter implements IStorageAdapter {
   }
 
   async markOpsSynced(lastId: number): Promise<void> {
-    this.opLog.forEach(e => {
-      if (e.id <= lastId) e.synced = 1;
-    });
+    // Delete acked ops — the durable record is the source of truth (matches IDBAdapter).
+    this.opLog = this.opLog.filter(e => e.id > lastId);
+  }
+
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter(e => e.id !== id);
+  }
+
+  async commitWrite(mutations: StorageMutation[], op: Omit<OpLogEntry, 'id'>): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.data;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value);
+    }
+    return this.appendOpLog(op);
   }
 
   async getAllKeys(): Promise<string[]> {

--- a/packages/adapter-better-auth/src/__tests__/TopGunAdapter.integration.test.ts
+++ b/packages/adapter-better-auth/src/__tests__/TopGunAdapter.integration.test.ts
@@ -86,6 +86,22 @@ class MemoryStorageAdapter implements IStorageAdapter {
     });
   }
 
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: any }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.data;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value as never);
+    }
+    return this.appendOpLog(op);
+  }
+
   async getAllKeys(): Promise<string[]> {
     return Array.from(this.data.keys());
   }

--- a/packages/adapter-better-auth/src/__tests__/TopGunAdapter.test.ts
+++ b/packages/adapter-better-auth/src/__tests__/TopGunAdapter.test.ts
@@ -76,6 +76,22 @@ class MemoryStorageAdapter implements IStorageAdapter {
     });
   }
 
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: any }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.data;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value as never);
+    }
+    return this.appendOpLog(op);
+  }
+
   async getAllKeys(): Promise<string[]> {
     return Array.from(this.data.keys());
   }

--- a/packages/adapters/src/IDBAdapter.ts
+++ b/packages/adapters/src/IDBAdapter.ts
@@ -1,5 +1,5 @@
 import type { LWWRecord, ORMapRecord } from '@topgunbuild/core';
-import { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
+import { IStorageAdapter, OpLogEntry, StorageMutation } from '@topgunbuild/client';
 import { openDB } from 'idb';
 import type { IDBPDatabase } from 'idb';
 
@@ -7,7 +7,15 @@ import type { IDBPDatabase } from 'idb';
  * Represents an operation queued before IndexedDB is ready.
  */
 interface QueuedOperation {
-  type: 'put' | 'remove' | 'setMeta' | 'appendOpLog' | 'markOpsSynced' | 'batchPut';
+  type:
+    | 'put'
+    | 'remove'
+    | 'setMeta'
+    | 'appendOpLog'
+    | 'markOpsSynced'
+    | 'batchPut'
+    | 'commitWrite'
+    | 'deleteOp';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- queued operation args are heterogeneous across operation types; a discriminated union would require one args type per op type
   args: any[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- resolve/reject carry the result of the eventual async operation whose type varies by op type
@@ -111,6 +119,12 @@ export class IDBAdapter implements IStorageAdapter {
             break;
           case 'batchPut':
             result = await this.batchPutInternal(op.args[0]);
+            break;
+          case 'commitWrite':
+            result = await this.commitWriteInternal(op.args[0], op.args[1]);
+            break;
+          case 'deleteOp':
+            result = await this.deleteOpInternal(op.args[0]);
             break;
         }
         op.resolve(result);
@@ -238,18 +252,55 @@ export class IDBAdapter implements IStorageAdapter {
     return this.queueOrExecute('markOpsSynced', [lastId], () => this.markOpsSyncedInternal(lastId));
   }
 
+  // Compaction: DELETE acked ops (id <= lastId) rather than flagging them. A synced op has
+  // no further use — the durable kv_store/meta_store record committed alongside it is the
+  // source of truth — and retaining flagged rows grew op_log unboundedly across all sessions.
   private async markOpsSyncedInternal(lastId: number): Promise<void> {
     const tx = this.db?.transaction('op_log', 'readwrite');
     if (!tx) return;
-
-    let cursor = await tx.store.openCursor();
-    while (cursor) {
-      if (cursor.value.id <= lastId) {
-        const update = { ...cursor.value, synced: 1 };
-        await cursor.update(update);
-      }
-      cursor = await cursor.continue();
-    }
+    await tx.store.delete(IDBKeyRange.upperBound(lastId));
     await tx.done;
+  }
+
+  async deleteOp(id: number): Promise<void> {
+    return this.queueOrExecute('deleteOp', [id], () => this.deleteOpInternal(id));
+  }
+
+  private async deleteOpInternal(id: number): Promise<void> {
+    await this.db?.delete('op_log', id);
+  }
+
+  async commitWrite(mutations: StorageMutation[], op: Omit<OpLogEntry, 'id'>): Promise<number> {
+    return this.queueOrExecute('commitWrite', [mutations, op], () =>
+      this.commitWriteInternal(mutations, op),
+    );
+  }
+
+  // Crash-consistent local write: apply every KV/meta mutation AND append the op log entry
+  // in ONE readwrite transaction spanning all affected stores, so a record and its pending
+  // op are never observable independently (no record-without-op, no op-without-record).
+  private async commitWriteInternal(
+    mutations: StorageMutation[],
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    if (!this.db) {
+      throw new Error('IDBAdapter.commitWrite called before database is ready');
+    }
+    const storeNames = new Set<'kv_store' | 'meta_store'>(['kv_store']);
+    for (const m of mutations) {
+      storeNames.add(m.store === 'meta' ? 'meta_store' : 'kv_store');
+    }
+    const tx = this.db.transaction([...storeNames, 'op_log'], 'readwrite');
+    for (const m of mutations) {
+      const store = tx.objectStore(m.store === 'meta' ? 'meta_store' : 'kv_store');
+      if (m.type === 'remove') {
+        await store.delete(m.key);
+      } else {
+        await store.put({ key: m.key, value: m.value });
+      }
+    }
+    const id = (await tx.objectStore('op_log').add({ ...op, synced: 0 })) as number;
+    await tx.done;
+    return id;
   }
 }

--- a/packages/adapters/src/__tests__/IDBAdapter.test.ts
+++ b/packages/adapters/src/__tests__/IDBAdapter.test.ts
@@ -365,6 +365,119 @@ describe('IDBAdapter', () => {
     });
   });
 
+  // SPEC-321 — offline-durability bundle (F4/F5/F6) at the IndexedDB layer.
+  describe('atomic commit, compaction-on-sync, single-op delete (SPEC-321)', () => {
+    // Count ALL op_log rows (including any that an old flag-only markOpsSynced would retain).
+    const countOpRows = async (a: IDBAdapter): Promise<number> => {
+      await a.waitForReady();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- reach into the raw idb handle to count rows the public API filters out
+      return (a as any).db.count('op_log');
+    };
+
+    it('commitWrite persists the KV record, meta, AND the op in one go', async () => {
+      await adapter.initialize(getUniqueDbName());
+      await adapter.waitForReady();
+
+      const id = await adapter.commitWrite(
+        [
+          { store: 'kv', type: 'put', key: 'tags:list1', value: [{ value: 'work', tag: 't1' }] },
+          { store: 'meta', type: 'put', key: '__sys__:tags:tombstones', value: ['t0'] },
+        ],
+        { key: 'list1', op: 'OR_ADD', synced: 0, mapName: 'tags' },
+      );
+
+      expect(typeof id).toBe('number');
+      expect(await adapter.get('tags:list1')).toEqual([{ value: 'work', tag: 't1' }]);
+      expect(await adapter.getMeta('__sys__:tags:tombstones')).toEqual(['t0']);
+      const pending = await adapter.getPendingOps();
+      expect(pending.length).toBe(1);
+      expect(pending[0].key).toBe('list1');
+    });
+
+    it('commitWrite is atomic: a failed mutation leaves NEITHER the record nor the op', async () => {
+      await adapter.initialize(getUniqueDbName());
+      await adapter.waitForReady();
+
+      // A function value is not structured-cloneable → the put rejects and aborts the whole
+      // transaction before the op_log.add runs (models a mid-commit IndexedDB failure).
+      await expect(
+        adapter.commitWrite(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentionally non-cloneable value to force a DataCloneError / txn abort
+          [{ store: 'kv', type: 'put', key: 'm:k1', value: (() => {}) as any }],
+          { key: 'k1', op: 'PUT', synced: 0, mapName: 'm' },
+        ),
+      ).rejects.toBeDefined();
+
+      expect(await adapter.get('m:k1')).toBeUndefined();
+      expect(await adapter.getPendingOps()).toHaveLength(0);
+      expect(await countOpRows(adapter)).toBe(0);
+    });
+
+    it('markOpsSynced DELETES acked rows (does not just flag them)', async () => {
+      await adapter.initialize(getUniqueDbName());
+      await adapter.waitForReady();
+
+      await adapter.appendOpLog({ key: 'k1', op: 'PUT', value: 'v1', synced: 0, mapName: 'm' });
+      const id2 = await adapter.appendOpLog({
+        key: 'k2',
+        op: 'PUT',
+        value: 'v2',
+        synced: 0,
+        mapName: 'm',
+      });
+      await adapter.appendOpLog({ key: 'k3', op: 'PUT', value: 'v3', synced: 0, mapName: 'm' });
+
+      await adapter.markOpsSynced(id2);
+
+      // Total ROW count drops to 1 — the acked rows are gone, not flagged-and-retained.
+      expect(await countOpRows(adapter)).toBe(1);
+      const pending = await adapter.getPendingOps();
+      expect(pending.map((p) => p.key)).toEqual(['k3']);
+    });
+
+    it('deleteOp removes a single op by id', async () => {
+      await adapter.initialize(getUniqueDbName());
+      await adapter.waitForReady();
+
+      const id1 = await adapter.appendOpLog({ key: 'k1', op: 'PUT', synced: 0, mapName: 'm' });
+      await adapter.appendOpLog({ key: 'k2', op: 'PUT', synced: 0, mapName: 'm' });
+
+      await adapter.deleteOp(id1);
+
+      expect(await countOpRows(adapter)).toBe(1);
+      const pending = await adapter.getPendingOps();
+      expect(pending.map((p) => p.key)).toEqual(['k2']);
+    });
+
+    it('a committed (record, op) pair survives a reload (new adapter, same db)', async () => {
+      const dbName = getUniqueDbName();
+      await adapter.initialize(dbName);
+      await adapter.waitForReady();
+      await adapter.commitWrite(
+        [{ store: 'kv', type: 'put', key: 'm:k1', value: { value: 'hi' } }],
+        {
+          key: 'k1',
+          op: 'PUT',
+          synced: 0,
+          mapName: 'm',
+        },
+      );
+      await adapter.close();
+
+      // Reload: a fresh adapter over the SAME database.
+      const reloaded = new IDBAdapter();
+      await reloaded.initialize(dbName);
+      await reloaded.waitForReady();
+      try {
+        expect(await reloaded.get('m:k1')).toEqual({ value: 'hi' });
+        const pending = await reloaded.getPendingOps();
+        expect(pending.map((p) => p.key)).toEqual(['k1']);
+      } finally {
+        await reloaded.close();
+      }
+    });
+  });
+
   describe('persistence across operations', () => {
     it('should persist data between get/put cycles', async () => {
       const dbName = getUniqueDbName();

--- a/packages/client/src/IStorageAdapter.ts
+++ b/packages/client/src/IStorageAdapter.ts
@@ -18,6 +18,20 @@ export interface OpLogEntry {
   mapName: string; // Added mapName for filtering
 }
 
+/**
+ * A single store-level mutation that participates in an atomic {@link IStorageAdapter.commitWrite}.
+ * `put` writes `value` under `key`; `remove` deletes `key`. `store` selects the durable
+ * namespace: `'kv'` for record/value entries, `'meta'` for ORMap tombstone lists and
+ * sync watermarks.
+ */
+export interface StorageMutation {
+  store: 'kv' | 'meta';
+  type: 'put' | 'remove';
+  key: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mutation values are storage-schema agnostic (LWWRecord, ORMapRecord[], tombstone arrays); stored opaquely
+  value?: any;
+}
+
 export interface IStorageAdapter {
   initialize(dbName: string): Promise<void>;
   close(): Promise<void>;
@@ -48,7 +62,33 @@ export interface IStorageAdapter {
   // OpLog
   appendOpLog(entry: Omit<OpLogEntry, 'id'>): Promise<number>;
   getPendingOps(): Promise<OpLogEntry[]>;
+  /**
+   * Compacts the op log by **deleting** every op with `id <= lastId`. A synced op has no
+   * further use — the durable KV/meta record written alongside it (see {@link commitWrite})
+   * is the source of truth — so retaining acked ops only bloats the store unboundedly.
+   * (Previously this flipped a `synced` flag and never deleted.)
+   */
   markOpsSynced(lastId: number): Promise<void>;
+
+  /**
+   * Deletes a single op by its numeric auto-increment id. Used by the `drop-oldest`
+   * backpressure strategy to keep memory and disk in agreement (otherwise a dropped op
+   * resurrects on the next reload). Callers holding a stringified id must coerce to a
+   * number at the boundary.
+   */
+  deleteOp(id: number): Promise<void>;
+
+  /**
+   * Atomically commits a set of KV/meta mutations together with the op-log entry that
+   * records the mutation, in a **single** durable transaction, returning the appended op's
+   * auto-increment id. This is the crash-consistent local-write primitive: a record and its
+   * pending op are never observable independently (no record-without-op, no op-without-record).
+   *
+   * Adapters that cannot span stores in one transaction MUST still implement the method as
+   * an awaited sequential best-effort commit (op appended last so a partial failure leaves a
+   * record without an op rather than the reverse).
+   */
+  commitWrite(mutations: StorageMutation[], op: Omit<OpLogEntry, 'id'>): Promise<number>;
 
   // Iteration
   getAllKeys(): Promise<string[]>;

--- a/packages/client/src/SyncEngine.ts
+++ b/packages/client/src/SyncEngine.ts
@@ -13,7 +13,7 @@ import type {
   GcPruneMessage,
   BatchMessage,
 } from '@topgunbuild/core';
-import type { IStorageAdapter } from './IStorageAdapter';
+import type { IStorageAdapter, StorageMutation } from './IStorageAdapter';
 import { QueryHandle } from './QueryHandle';
 import type { QueryFilter } from './QueryHandle';
 import type { HybridQueryHandle, HybridQueryFilter } from './HybridQueryHandle';
@@ -246,6 +246,17 @@ export class SyncEngine {
     this.backpressureController = new BackpressureController({
       config: this.backpressureConfig,
       opLog: this.opLog, // Pass reference, not copy
+      // Durable drop: when drop-oldest evicts an unsynced op from the in-memory opLog, also
+      // delete it from storage so it cannot resurrect on the next reload (memory/disk agree).
+      // op.id is a stringified integer; coerce to the numeric storage id at this boundary.
+      onOpDropped: (opId: string) => {
+        const numericId = parseInt(opId, 10);
+        if (!isNaN(numericId)) {
+          this.storageAdapter
+            .deleteOp(numericId)
+            .catch((err) => logger.error({ err, opId }, 'Failed to delete dropped op from storage'));
+        }
+      },
     });
 
     // Merge topic queue config with defaults to ensure consistent backpressure behavior
@@ -354,6 +365,10 @@ export class SyncEngine {
         this.lastSyncTimestamp = ts.millis;
         await this.saveOpLog();
       },
+      // Persist server-origin ORMap merges (merkle leaf + diff) so they survive offline
+      // reload — same canonical helpers as the local-write + applyServerEvent paths.
+      persistKey: (name, key) => this.persistORMapKey(name, key),
+      persistTombstones: (name) => this.persistORMapTombstones(name),
     });
 
     // Initialize Conflict Resolver client
@@ -648,6 +663,12 @@ export class SyncEngine {
       orTag?: string;
       timestamp: Timestamp;
     },
+    /**
+     * KV/meta mutations that must commit atomically with this op (the record/records-array
+     * put + ORMap tombstone meta). When provided, the op + mutations land in ONE durable
+     * transaction (crash-consistent); otherwise the op is appended alone.
+     */
+    mutations?: StorageMutation[],
   ): Promise<string> {
     // Check backpressure before adding new operation (delegates to BackpressureController)
     await this.backpressureController.checkBackpressure();
@@ -663,8 +684,17 @@ export class SyncEngine {
       synced: false,
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- IStorageAdapter.appendOpLog accepts any; the op log entry is typed internally but the adapter interface is backend-agnostic
-    const id = await this.storageAdapter.appendOpLog(opLogEntry as any);
+    // Commit-first ordering: persist durably BEFORE touching the in-memory opLog. If the
+    // commit rejects, no op is pushed — the in-memory opLog and the durable op_log stay
+    // consistent (no op-without-record in either layer) — and we rethrow so the caller's
+    // .catch surfaces the durability failure. The atomic commitWrite keeps the (record, op)
+    // pair crash-consistent on disk; the bare appendOpLog path is for ops with no KV write.
+    const id =
+      mutations && mutations.length > 0
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any -- adapter OpLogEntry (numeric id/synced) differs from the engine's; the adapter stores it opaquely
+          await this.storageAdapter.commitWrite(mutations, opLogEntry as any)
+        : // eslint-disable-next-line @typescript-eslint/no-explicit-any -- IStorageAdapter.appendOpLog accepts any; the op log entry is typed internally but the adapter interface is backend-agnostic
+          await this.storageAdapter.appendOpLog(opLogEntry as any);
     opLogEntry.id = String(id);
 
     this.opLog.push(opLogEntry as OpLogEntry);
@@ -1020,6 +1050,19 @@ export class SyncEngine {
         .markOpsSynced(maxSyncedId)
         .catch((err) => logger.error({ err }, 'Failed to mark ops synced'));
     }
+
+    // Compaction (in-memory): splice acked ops out of opLog so it holds only pending ops.
+    // Without this the array grows for the whole session and getPendingOpsCount() scans O(n)
+    // on every write. The tracker was already notified above; the durable KV record is the
+    // source of truth, so a synced op has no further in-memory use.
+    if (ackedCount > 0 || maxSyncedId !== -1) {
+      for (let i = this.opLog.length - 1; i >= 0; i--) {
+        if (this.opLog[i].synced) {
+          this.opLog.splice(i, 1);
+        }
+      }
+    }
+
     // Check low water mark after ACKs reduce pending count (delegates to BackpressureController)
     if (ackedCount > 0) {
       this.backpressureController.checkLowWaterMark();
@@ -1114,13 +1157,41 @@ export class SyncEngine {
       } else if (localMap instanceof ORMap) {
         if (eventType === 'OR_ADD' && orRecord) {
           localMap.apply(key, orRecord);
-          // We need to store ORMap records differently in storageAdapter or use a convention
-          // For now, skipping persistent storage update for ORMap in this example
+          // Persist server-origin ORMap state so it survives an offline reload — symmetric
+          // with the LWW path above. Uses the same storage convention as local ORMap writes.
+          await this.persistORMapKey(mapName, key);
         } else if (eventType === 'OR_REMOVE' && orTag) {
           localMap.applyTombstone(orTag);
+          // The removed key's record list changed and the tombstone set grew — persist both.
+          await this.persistORMapKey(mapName, key);
+          await this.persistORMapTombstones(mapName);
         }
       }
     }
+  }
+
+  /**
+   * Canonical ORMap key persistence. Writes the full record list for `key` under the
+   * `mapName:key` convention (or removes the entry when empty). Single source of truth for
+   * both local-write (TopGunClient) and server-origin (applyServerEvent / ORMapSyncHandler)
+   * ORMap persistence so the two paths cannot diverge.
+   */
+  public async persistORMapKey(mapName: string, key: string): Promise<void> {
+    const map = this.maps.get(mapName);
+    if (!(map instanceof ORMap)) return;
+    const records = map.getRecords(key);
+    if (records.length > 0) {
+      await this.storageAdapter.put(`${mapName}:${key}`, records);
+    } else {
+      await this.storageAdapter.remove(`${mapName}:${key}`);
+    }
+  }
+
+  /** Canonical ORMap tombstone persistence (the `__sys__:mapName:tombstones` meta key). */
+  public async persistORMapTombstones(mapName: string): Promise<void> {
+    const map = this.maps.get(mapName);
+    if (!(map instanceof ORMap)) return;
+    await this.storageAdapter.setMeta(`__sys__:${mapName}:tombstones`, map.getTombstones());
   }
 
   /**

--- a/packages/client/src/SyncEngine.ts
+++ b/packages/client/src/SyncEngine.ts
@@ -254,7 +254,9 @@ export class SyncEngine {
         if (!isNaN(numericId)) {
           this.storageAdapter
             .deleteOp(numericId)
-            .catch((err) => logger.error({ err, opId }, 'Failed to delete dropped op from storage'));
+            .catch((err) =>
+              logger.error({ err, opId }, 'Failed to delete dropped op from storage'),
+            );
         }
       },
     });

--- a/packages/client/src/TopGunClient.ts
+++ b/packages/client/src/TopGunClient.ts
@@ -6,7 +6,7 @@ import type {
   EntryProcessorResult,
   SearchOptions,
 } from '@topgunbuild/core';
-import type { IStorageAdapter } from './IStorageAdapter';
+import type { IStorageAdapter, StorageMutation } from './IStorageAdapter';
 import { SyncEngine } from './SyncEngine';
 import type { BackoffConfig, SqlQueryResult } from './SyncEngine';
 import type {
@@ -647,12 +647,15 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- key and value types are erased at the wrapper level; actual types flow from the caller's overload
     lwwMap.set = (key: any, value: any, ttlMs?: number) => {
       const record = originalSet(key, value, ttlMs);
-      this.storageAdapter
-        .put(`${name}:${key}`, record)
-        .catch((err) => logger.error({ err }, 'Failed to put record to storage'));
+      // Atomic durable write: the KV record + its op-log entry commit in ONE transaction
+      // (crash-consistent — no record-without-op / op-without-record). The optimistic
+      // in-memory mutation above is unaffected; on commit failure the op is not queued.
+      const mutations: StorageMutation[] = [
+        { store: 'kv', type: 'put', key: `${name}:${key}`, value: record },
+      ];
       this.syncEngine
-        .recordOperation(name, 'PUT', String(key), { record, timestamp: record.timestamp })
-        .catch((err) => logger.error({ err }, 'Failed to record PUT op'));
+        .recordOperation(name, 'PUT', String(key), { record, timestamp: record.timestamp }, mutations)
+        .catch((err) => logger.error({ err }, 'Failed to commit PUT op'));
       return record;
     };
 
@@ -660,15 +663,18 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- key type is erased at the wrapper level; actual type flows from the caller's overload
     lwwMap.remove = (key: any) => {
       const tombstone = originalRemove(key);
-      this.storageAdapter
-        .put(`${name}:${key}`, tombstone)
-        .catch((err) => logger.error({ err }, 'Failed to put tombstone to storage'));
+      const mutations: StorageMutation[] = [
+        { store: 'kv', type: 'put', key: `${name}:${key}`, value: tombstone },
+      ];
       this.syncEngine
-        .recordOperation(name, 'REMOVE', String(key), {
-          record: tombstone,
-          timestamp: tombstone.timestamp,
-        })
-        .catch((err) => logger.error({ err }, 'Failed to record REMOVE op'));
+        .recordOperation(
+          name,
+          'REMOVE',
+          String(key),
+          { record: tombstone, timestamp: tombstone.timestamp },
+          mutations,
+        )
+        .catch((err) => logger.error({ err }, 'Failed to commit REMOVE op'));
       return tombstone;
     };
 
@@ -712,15 +718,19 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
     orMap.add = (key: any, value: any, ttlMs?: number) => {
       const record = originalAdd(key, value, ttlMs);
 
-      // Persist records
-      this.persistORMapKey(name, orMap, key);
-
+      // Atomic durable write: the records-array KV put + its op-log entry in ONE transaction.
+      const mutations: StorageMutation[] = [
+        { store: 'kv', type: 'put', key: `${name}:${key}`, value: orMap.getRecords(key) },
+      ];
       this.syncEngine
-        .recordOperation(name, 'OR_ADD', String(key), {
-          orRecord: record,
-          timestamp: record.timestamp,
-        })
-        .catch((err) => logger.error({ err }, 'Failed to record OR_ADD op'));
+        .recordOperation(
+          name,
+          'OR_ADD',
+          String(key),
+          { orRecord: record, timestamp: record.timestamp },
+          mutations,
+        )
+        .catch((err) => logger.error({ err }, 'Failed to commit OR_ADD op'));
       return record;
     };
 
@@ -730,15 +740,33 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
       const tombstones = originalRemove(key, value);
       const timestamp = this.syncEngine.getHLC().now();
 
-      // Update storage for the key (items removed)
-      this.persistORMapKey(name, orMap, key);
-      // Update storage for tombstones
-      this.persistORMapTombstones(name, orMap);
+      // The removed key's record list shrank and the tombstone set grew — commit both the KV
+      // records-array (or delete when empty) and the tombstone meta atomically with the FIRST
+      // OR_REMOVE op. Subsequent tombstone tags for this remove are op-only appends; the
+      // durable KV/meta state is already captured by the first commit.
+      const records = orMap.getRecords(key);
+      const mutations: StorageMutation[] = [
+        {
+          store: 'kv',
+          type: records.length > 0 ? 'put' : 'remove',
+          key: `${name}:${key}`,
+          value: records,
+        },
+        { store: 'meta', type: 'put', key: `__sys__:${name}:tombstones`, value: orMap.getTombstones() },
+      ];
 
+      let first = true;
       for (const tag of tombstones) {
         this.syncEngine
-          .recordOperation(name, 'OR_REMOVE', String(key), { orTag: tag, timestamp })
-          .catch((err) => logger.error({ err }, 'Failed to record OR_REMOVE op'));
+          .recordOperation(
+            name,
+            'OR_REMOVE',
+            String(key),
+            { orTag: tag, timestamp },
+            first ? mutations : undefined,
+          )
+          .catch((err) => logger.error({ err }, 'Failed to commit OR_REMOVE op'));
+        first = false;
       }
       return tombstones;
     };
@@ -779,21 +807,6 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
     } catch (e) {
       logger.error({ mapName: name, err: e }, 'Failed to restore ORMap');
     }
-  }
-
-  private async persistORMapKey<K, V>(mapName: string, orMap: ORMap<K, V>, key: K) {
-    const records = orMap.getRecords(key);
-    if (records.length > 0) {
-      await this.storageAdapter.put(`${mapName}:${key}`, records);
-    } else {
-      await this.storageAdapter.remove(`${mapName}:${key}`);
-    }
-  }
-
-  private async persistORMapTombstones<K, V>(mapName: string, orMap: ORMap<K, V>) {
-    const tombstoneKey = `__sys__:${mapName}:tombstones`;
-    const tombstones = orMap.getTombstones();
-    await this.storageAdapter.setMeta(tombstoneKey, tombstones);
   }
 
   /**

--- a/packages/client/src/TopGunClient.ts
+++ b/packages/client/src/TopGunClient.ts
@@ -654,7 +654,13 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
         { store: 'kv', type: 'put', key: `${name}:${key}`, value: record },
       ];
       this.syncEngine
-        .recordOperation(name, 'PUT', String(key), { record, timestamp: record.timestamp }, mutations)
+        .recordOperation(
+          name,
+          'PUT',
+          String(key),
+          { record, timestamp: record.timestamp },
+          mutations,
+        )
         .catch((err) => logger.error({ err }, 'Failed to commit PUT op'));
       return record;
     };
@@ -752,7 +758,12 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
           key: `${name}:${key}`,
           value: records,
         },
-        { store: 'meta', type: 'put', key: `__sys__:${name}:tombstones`, value: orMap.getTombstones() },
+        {
+          store: 'meta',
+          type: 'put',
+          key: `__sys__:${name}:tombstones`,
+          value: orMap.getTombstones(),
+        },
       ];
 
       let first = true;

--- a/packages/client/src/__tests__/EncryptedStorageAdapter.test.ts
+++ b/packages/client/src/__tests__/EncryptedStorageAdapter.test.ts
@@ -44,9 +44,23 @@ class MockStorageAdapter implements IStorageAdapter {
     return this.opLog.filter((o) => o.synced === 0);
   }
   async markOpsSynced(lastId: number): Promise<void> {
-    this.opLog.forEach((o) => {
-      if (o.id && o.id <= lastId) o.synced = 1;
-    });
+    this.opLog = this.opLog.filter((o) => !o.id || o.id > lastId);
+  }
+
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((o) => o.id !== id);
+  }
+
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: any }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.store;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value);
+    }
+    return this.appendOpLog(op);
   }
 
   async getAllKeys(): Promise<string[]> {

--- a/packages/client/src/__tests__/ORMapPersistence.test.ts
+++ b/packages/client/src/__tests__/ORMapPersistence.test.ts
@@ -52,9 +52,24 @@ class MemoryStorageAdapter implements IStorageAdapter {
 
   async markOpsSynced(lastId: number): Promise<void> {
     this._pendingOps = this._pendingOps.filter((op) => op.id! > lastId);
-    this.opLog.forEach((op) => {
-      if (op.id! <= lastId) op.synced = 1;
-    });
+    this.opLog = this.opLog.filter((op) => op.id! > lastId);
+  }
+
+  async deleteOp(id: number): Promise<void> {
+    this._pendingOps = this._pendingOps.filter((op) => op.id !== id);
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: any }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.metaStore : this.kvStore;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value);
+    }
+    return this.appendOpLog(op);
   }
 
   async getAllKeys(): Promise<string[]> {

--- a/packages/client/src/__tests__/QueryManager.test.ts
+++ b/packages/client/src/__tests__/QueryManager.test.ts
@@ -29,6 +29,8 @@ function createMockStorageAdapter(): jest.Mocked<IStorageAdapter> {
     appendOpLog: jest.fn().mockResolvedValue(1),
     getPendingOps: jest.fn().mockResolvedValue([]),
     markOpsSynced: jest.fn().mockResolvedValue(undefined),
+    deleteOp: jest.fn().mockResolvedValue(undefined),
+    commitWrite: jest.fn().mockResolvedValue(1),
     getAllKeys: jest.fn().mockResolvedValue([]),
   };
 }

--- a/packages/client/src/__tests__/QueryOnce.test.ts
+++ b/packages/client/src/__tests__/QueryOnce.test.ts
@@ -53,6 +53,22 @@ class MemoryStorageAdapter implements IStorageAdapter {
   }
   async markOpsSynced(lastId: number): Promise<void> {
     this.pending = this.pending.filter((op) => (op.id ?? 0) > lastId);
+    this.opLog = this.opLog.filter((op) => (op.id ?? 0) > lastId);
+  }
+  async deleteOp(id: number): Promise<void> {
+    this.pending = this.pending.filter((op) => op.id !== id);
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: unknown }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.kv;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value);
+    }
+    return this.appendOpLog(op);
   }
   async getAllKeys(): Promise<string[]> {
     return Array.from(this.kv.keys());

--- a/packages/client/src/__tests__/QueryOnce.test.ts
+++ b/packages/client/src/__tests__/QueryOnce.test.ts
@@ -60,7 +60,12 @@ class MemoryStorageAdapter implements IStorageAdapter {
     this.opLog = this.opLog.filter((op) => op.id !== id);
   }
   async commitWrite(
-    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: unknown }>,
+    mutations: Array<{
+      store: 'kv' | 'meta';
+      type: 'put' | 'remove';
+      key: string;
+      value?: unknown;
+    }>,
     op: Omit<OpLogEntry, 'id'>,
   ): Promise<number> {
     for (const m of mutations) {

--- a/packages/client/src/__tests__/SyncEngine.test.ts
+++ b/packages/client/src/__tests__/SyncEngine.test.ts
@@ -84,6 +84,8 @@ function createMockStorageAdapter(): jest.Mocked<IStorageAdapter> {
     appendOpLog: jest.fn().mockResolvedValue(1),
     getPendingOps: jest.fn().mockResolvedValue([]),
     markOpsSynced: jest.fn().mockResolvedValue(undefined),
+    deleteOp: jest.fn().mockResolvedValue(undefined),
+    commitWrite: jest.fn().mockResolvedValue(1),
     getAllKeys: jest.fn().mockResolvedValue([]),
   };
 }

--- a/packages/client/src/__tests__/SyncEngineAuthOptional.test.ts
+++ b/packages/client/src/__tests__/SyncEngineAuthOptional.test.ts
@@ -88,6 +88,8 @@ function createMockStorageAdapter(): jest.Mocked<IStorageAdapter> {
     appendOpLog: jest.fn().mockResolvedValue(1),
     getPendingOps: jest.fn().mockResolvedValue([]),
     markOpsSynced: jest.fn().mockResolvedValue(undefined),
+    deleteOp: jest.fn().mockResolvedValue(undefined),
+    commitWrite: jest.fn().mockResolvedValue(1),
     getAllKeys: jest.fn().mockResolvedValue([]),
   };
 }

--- a/packages/client/src/__tests__/TopGunClient.test.ts
+++ b/packages/client/src/__tests__/TopGunClient.test.ts
@@ -100,6 +100,22 @@ class MemoryStorageAdapter implements IStorageAdapter {
     });
   }
 
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: any }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.metaStore : this.kvStore;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value as never);
+    }
+    return this.appendOpLog(op);
+  }
+
   async getAllKeys(): Promise<string[]> {
     return Array.from(this.kvStore.keys());
   }

--- a/packages/client/src/__tests__/backpressure.test.ts
+++ b/packages/client/src/__tests__/backpressure.test.ts
@@ -58,6 +58,11 @@ function createMockStorage(): IStorageAdapter {
     }),
     getPendingOps: jest.fn().mockResolvedValue([]),
     markOpsSynced: jest.fn().mockResolvedValue(undefined),
+    deleteOp: jest.fn().mockResolvedValue(undefined),
+    commitWrite: jest.fn().mockImplementation(() => {
+      opId++;
+      return Promise.resolve(opId);
+    }),
     close: jest.fn().mockResolvedValue(undefined),
     batchPut: jest.fn().mockResolvedValue(undefined),
   };

--- a/packages/client/src/__tests__/heartbeat.test.ts
+++ b/packages/client/src/__tests__/heartbeat.test.ts
@@ -77,6 +77,8 @@ function createMockStorageAdapter(): jest.Mocked<IStorageAdapter> {
     appendOpLog: jest.fn().mockResolvedValue(1),
     getPendingOps: jest.fn().mockResolvedValue([]),
     markOpsSynced: jest.fn().mockResolvedValue(undefined),
+    deleteOp: jest.fn().mockResolvedValue(undefined),
+    commitWrite: jest.fn().mockResolvedValue(1),
     getAllKeys: jest.fn().mockResolvedValue([]),
   };
 }

--- a/packages/client/src/__tests__/offline-durability.test.ts
+++ b/packages/client/src/__tests__/offline-durability.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Offline-durability regression suite (SPEC-321 — Client SDK depth-audit F3/F4/F5/F6).
+ *
+ * These are the permanent, INVERTED counterparts of the audit reproduction harness
+ * (`client_sdk_repro.test.ts.txt`): each test asserts the FIXED behavior, and carries a
+ * negative control proving the fix is load-bearing (the value really persists / the op is
+ * really deleted / on commit failure neither layer is written).
+ *
+ * Findings keyed to DEPTH_CLIENT_SDK.md:
+ *   F3 (TODO-496) — server-origin ORMap state is persisted (survives offline reload).
+ *   F4 (TODO-499) — drop-oldest deletes the op from storage too (no resurrection).
+ *   F5 (TODO-497) — oplog compacts on ack in BOTH memory and storage.
+ *   F6 (TODO-498) — local write is atomic (commit-first ordering; no op-without-record).
+ */
+import { SyncEngine, SyncEngineConfig, OpLogEntry } from '../SyncEngine';
+import { IStorageAdapter, StorageMutation } from '../IStorageAdapter';
+import { BackpressureController } from '../sync/BackpressureController';
+import { ORMapSyncHandler } from '../sync/ORMapSyncHandler';
+import { DEFAULT_BACKPRESSURE_CONFIG } from '../BackpressureConfig';
+import { ORMap, LWWMap, HLC, serialize, deserialize } from '@topgunbuild/core';
+import type {
+  IConnectionProvider,
+  IConnection,
+  ConnectionProviderEvent,
+  ConnectionEventHandler,
+} from '../types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test shims a minimal global crypto for nodeId/uuid generation in jsdom-less node
+(global as any).crypto = (global as any).crypto ?? { randomUUID: () => 'uuid-' + Math.random() };
+
+// A fully controllable provider: we drive connected/message by hand.
+class MockProvider implements IConnectionProvider {
+  listeners = new Map<ConnectionProviderEvent, Set<ConnectionEventHandler>>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- captured outbound frames are decoded msgpack of arbitrary message shape
+  sent: any[] = [];
+  connectedFlag = false;
+  async connect(): Promise<void> {
+    this.connectedFlag = true;
+  }
+  getConnection(): IConnection {
+    return { send: () => {}, close: () => {}, readyState: 1 } as IConnection;
+  }
+  getAnyConnection(): IConnection {
+    return this.getConnection();
+  }
+  isConnected(): boolean {
+    return this.connectedFlag;
+  }
+  getConnectedNodes(): string[] {
+    return this.connectedFlag ? ['default'] : [];
+  }
+  on(e: ConnectionProviderEvent, h: ConnectionEventHandler): void {
+    if (!this.listeners.has(e)) this.listeners.set(e, new Set());
+    this.listeners.get(e)!.add(h);
+  }
+  off(e: ConnectionProviderEvent, h: ConnectionEventHandler): void {
+    this.listeners.get(e)?.delete(h);
+  }
+  send(data: ArrayBuffer | Uint8Array): void {
+    this.sent.push(deserialize(data instanceof Uint8Array ? data : new Uint8Array(data)));
+  }
+  forceReconnect(): void {}
+  async close(): Promise<void> {
+    this.connectedFlag = false;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- event args are heterogeneous per event type
+  emit(e: ConnectionProviderEvent, ...args: any[]): void {
+    this.listeners.get(e)?.forEach((h) => h(...args));
+  }
+}
+
+/**
+ * In-memory storage adapter with full commitWrite/deleteOp support, inspectable backing
+ * maps, and a `failCommit` toggle that models an IndexedDB transaction abort (throws BEFORE
+ * mutating any store, so neither the KV record nor the op is written — the atomicity contract).
+ */
+interface MemStore extends IStorageAdapter {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  __kv: Map<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  __meta: Map<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  __ops: any[];
+  failCommit: boolean;
+}
+function memStorage(): MemStore {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const kv = new Map<string, any>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const meta = new Map<string, any>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ops: any[] = [];
+  let counter = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const self: any = {
+    failCommit: false,
+    initialize: async () => {},
+    close: async () => {},
+    get: async (k: string) => kv.get(k),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    put: async (k: string, v: any) => void kv.set(k, v),
+    remove: async (k: string) => void kv.delete(k),
+    getMeta: async (k: string) => meta.get(k),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setMeta: async (k: string, v: any) => void meta.set(k, v),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    batchPut: async (e: Map<string, any>) => e.forEach((v, k) => kv.set(k, v)),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    appendOpLog: async (e: any) => {
+      const id = ++counter;
+      ops.push({ ...e, id, synced: 0 });
+      return id;
+    },
+    getPendingOps: async () => ops.filter((o) => o.synced === 0),
+    // Delete-on-sync (matches IDBAdapter): remove acked rows, do not flag them.
+    markOpsSynced: async (lastId: number) => {
+      for (let i = ops.length - 1; i >= 0; i--) if (ops[i].id <= lastId) ops.splice(i, 1);
+    },
+    deleteOp: async (id: number) => {
+      const i = ops.findIndex((o) => o.id === id);
+      if (i >= 0) ops.splice(i, 1);
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    commitWrite: async (mutations: StorageMutation[], op: any) => {
+      if (self.failCommit) throw new Error('injected commit failure');
+      for (const m of mutations) {
+        const target = m.store === 'meta' ? meta : kv;
+        if (m.type === 'remove') target.delete(m.key);
+        else target.set(m.key, m.value);
+      }
+      const id = ++counter;
+      ops.push({ ...op, id, synced: 0 });
+      return id;
+    },
+    getAllKeys: async () => Array.from(kv.keys()),
+    __kv: kv,
+    __meta: meta,
+    __ops: ops,
+  };
+  return self as MemStore;
+}
+
+function makeEngine(storage: IStorageAdapter): { engine: SyncEngine; provider: MockProvider } {
+  const provider = new MockProvider();
+  const engine = new SyncEngine({
+    nodeId: 'n1',
+    connectionProvider: provider,
+    storageAdapter: storage,
+    heartbeat: { enabled: false },
+  } as SyncEngineConfig);
+  return { engine, provider };
+}
+
+describe('Offline durability (SPEC-321 — F3/F4/F5/F6)', () => {
+  // ============================================================
+  // F3 — server-origin ORMap state IS persisted (survives reload)
+  // ============================================================
+  describe('F3: server-origin ORMap persistence', () => {
+    test('server OR_ADD persists the records array (symmetric with LWW PUT)', async () => {
+      const storage = memStorage();
+      const { engine, provider } = makeEngine(storage);
+
+      const orMap = new ORMap<string, string>(engine.getHLC());
+      engine.registerMap('tags', orMap);
+      const lww = new LWWMap<string, string>(engine.getHLC());
+      engine.registerMap('docs', lww);
+
+      provider.emit(
+        'message',
+        'default',
+        serialize({
+          type: 'SERVER_EVENT',
+          payload: {
+            mapName: 'tags',
+            eventType: 'OR_ADD',
+            key: 'list1',
+            orRecord: { value: 'work', tag: 't1', timestamp: engine.getHLC().now() },
+          },
+        }),
+      );
+      provider.emit(
+        'message',
+        'default',
+        serialize({
+          type: 'SERVER_EVENT',
+          payload: {
+            mapName: 'docs',
+            eventType: 'PUT',
+            key: 'd1',
+            record: { value: 'hello', timestamp: engine.getHLC().now() },
+          },
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 10));
+
+      const kv = storage.__kv;
+      // CONTROL: LWW server event persisted (unchanged).
+      expect(kv.has('docs:d1')).toBe(true);
+      // FIX (audit asserted false): ORMap server event IS persisted now.
+      expect(kv.has('tags:list1')).toBe(true);
+      // Negative control: the persisted value is the real records array, not a stub —
+      // i.e. a reload would restore the tag.
+      const stored = kv.get('tags:list1');
+      expect(Array.isArray(stored)).toBe(true);
+      expect(stored.some((r: { value: string }) => r.value === 'work')).toBe(true);
+      // And memory still has it (the gap was durability-only).
+      expect(orMap.get('list1')).toContain('work');
+      engine.close();
+    });
+
+    test('server OR_REMOVE persists the tombstone set', async () => {
+      const storage = memStorage();
+      const { engine, provider } = makeEngine(storage);
+      const orMap = new ORMap<string, string>(engine.getHLC());
+      engine.registerMap('tags', orMap);
+
+      provider.emit(
+        'message',
+        'default',
+        serialize({
+          type: 'SERVER_EVENT',
+          payload: {
+            mapName: 'tags',
+            eventType: 'OR_ADD',
+            key: 'list1',
+            orRecord: { value: 'work', tag: 't1', timestamp: engine.getHLC().now() },
+          },
+        }),
+      );
+      provider.emit(
+        'message',
+        'default',
+        serialize({
+          type: 'SERVER_EVENT',
+          payload: { mapName: 'tags', eventType: 'OR_REMOVE', key: 'list1', orTag: 't1' },
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Tombstone meta persisted under the canonical key.
+      const tombstones = storage.__meta.get('__sys__:tags:tombstones');
+      expect(Array.isArray(tombstones)).toBe(true);
+      expect(tombstones).toContain('t1');
+      engine.close();
+    });
+
+    test('ORMapSyncHandler diff merge persists each merged key + tombstones', async () => {
+      const persistKey = jest.fn().mockResolvedValue(undefined);
+      const persistTombstones = jest.fn().mockResolvedValue(undefined);
+      const map = new ORMap<string, string>(new HLC('n1'));
+      const handler = new ORMapSyncHandler({
+        getMap: () => map,
+        sendMessage: () => true,
+        hlc: new HLC('n1'),
+        onTimestampUpdate: async () => {},
+        persistKey,
+        persistTombstones,
+      });
+
+      await handler.handleORMapDiffResponse({
+        mapName: 'tags',
+        entries: [
+          {
+            key: 'list1',
+            records: [{ value: 'work', tag: 't9', timestamp: new HLC('n1').now() }],
+            tombstones: [],
+          },
+        ],
+      });
+
+      // FIX: the server-origin merge is persisted (audit: never persisted).
+      expect(persistKey).toHaveBeenCalledWith('tags', 'list1');
+      expect(persistTombstones).toHaveBeenCalledWith('tags');
+      expect(map.get('list1')).toContain('work');
+    });
+  });
+
+  // ============================================================
+  // F5 — oplog compacts on ack (memory AND storage)
+  // ============================================================
+  describe('F5: oplog compaction on ack', () => {
+    test('acked ops are spliced from memory and deleted from storage', async () => {
+      const storage = memStorage();
+      const { engine } = makeEngine(storage);
+      const lww = new LWWMap<string, string>(engine.getHLC());
+      engine.registerMap('m', lww);
+
+      // Three durable local writes.
+      for (let i = 0; i < 3; i++) {
+        const rec = { value: `v${i}`, timestamp: engine.getHLC().now() };
+        await engine.recordOperation(
+          'm',
+          'PUT',
+          `k${i}`,
+          { record: rec, timestamp: rec.timestamp },
+          [{ store: 'kv', type: 'put', key: `m:k${i}`, value: rec }],
+        );
+      }
+
+      // Negative control: BEFORE ack, all three ops are pending in both layers.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((engine as any).opLog.length).toBe(3);
+      expect(storage.__ops.length).toBe(3);
+
+      // Server acks all ops up to the last id.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (engine as any).handleOpAck({ payload: { lastId: '3', achievedLevel: 1, results: [] } });
+      await new Promise((r) => setTimeout(r, 5));
+
+      // FIX: in-memory oplog spliced AND storage rows deleted (audit: neither compacts).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((engine as any).opLog.length).toBe(0);
+      expect(storage.__ops.length).toBe(0);
+      // The durable KV records remain — they are the source of truth.
+      expect(storage.__kv.has('m:k0')).toBe(true);
+      expect(storage.__kv.has('m:k2')).toBe(true);
+      engine.close();
+    });
+  });
+
+  // ============================================================
+  // F6 — atomic local write (commit-first ordering)
+  // ============================================================
+  describe('F6: atomic local write', () => {
+    test('successful write persists BOTH the record and its op', async () => {
+      const storage = memStorage();
+      const { engine } = makeEngine(storage);
+      const rec = { value: 'hi', timestamp: engine.getHLC().now() };
+      await engine.recordOperation('m', 'PUT', 'k1', { record: rec, timestamp: rec.timestamp }, [
+        { store: 'kv', type: 'put', key: 'm:k1', value: rec },
+      ]);
+
+      expect(storage.__kv.has('m:k1')).toBe(true);
+      expect(storage.__ops.length).toBe(1);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((engine as any).opLog.length).toBe(1);
+      engine.close();
+    });
+
+    test('mid-commit failure leaves NEITHER the record nor the op (no op-without-record)', async () => {
+      const storage = memStorage();
+      const { engine } = makeEngine(storage);
+      storage.failCommit = true;
+
+      const rec = { value: 'hi', timestamp: engine.getHLC().now() };
+      await expect(
+        engine.recordOperation('m', 'PUT', 'k1', { record: rec, timestamp: rec.timestamp }, [
+          { store: 'kv', type: 'put', key: 'm:k1', value: rec },
+        ]),
+      ).rejects.toThrow('injected commit failure');
+
+      // FIX: atomic commit → neither store written.
+      expect(storage.__kv.has('m:k1')).toBe(false);
+      expect(storage.__ops.length).toBe(0);
+      // Commit-first ordering: the in-memory oplog was NOT pushed on failure (no op-without-record).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((engine as any).opLog.length).toBe(0);
+      engine.close();
+    });
+  });
+
+  // ============================================================
+  // F4 — durable drop-oldest (memory + storage agree)
+  // ============================================================
+  describe('F4: durable drop-oldest', () => {
+    test('controller deletes the dropped op via onOpDropped (memory + storage)', async () => {
+      const storage = memStorage();
+      // Seed storage with two ops mirroring the in-memory opLog (IStorageAdapter op shape).
+      await storage.appendOpLog({ mapName: 'm', op: 'PUT', key: '1', synced: 0 });
+      await storage.appendOpLog({ mapName: 'm', op: 'PUT', key: '2', synced: 0 });
+
+      const opLog: OpLogEntry[] = [];
+      const dropped: string[] = [];
+      const ctrl = new BackpressureController({
+        config: { ...DEFAULT_BACKPRESSURE_CONFIG, strategy: 'drop-oldest', maxPendingOps: 2 },
+        opLog,
+        onOpDropped: (opId: string) => {
+          dropped.push(opId);
+          const n = parseInt(opId, 10);
+          if (!isNaN(n)) void storage.deleteOp(n);
+        },
+      });
+      const mk = (id: string): OpLogEntry => ({
+        id,
+        mapName: 'm',
+        opType: 'PUT',
+        key: id,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        timestamp: { millis: 1, counter: 0, nodeId: 'n' } as any,
+        synced: false,
+      });
+      opLog.push(mk('1'), mk('2'));
+
+      await ctrl.checkBackpressure(); // at capacity → drop oldest ('1')
+
+      // Memory: op '1' gone.
+      expect(opLog.map((o) => o.id)).toEqual(['2']);
+      // FIX: onOpDropped fired and storage op 1 deleted (audit: controller had no storage path).
+      expect(dropped).toEqual(['1']);
+      await new Promise((r) => setTimeout(r, 5));
+      expect(storage.__ops.map((o) => o.id)).toEqual([2]);
+    });
+  });
+});

--- a/packages/client/src/adapters/EncryptedStorageAdapter.ts
+++ b/packages/client/src/adapters/EncryptedStorageAdapter.ts
@@ -1,4 +1,4 @@
-import { IStorageAdapter, OpLogEntry } from '../IStorageAdapter';
+import { IStorageAdapter, OpLogEntry, StorageMutation } from '../IStorageAdapter';
 import { EncryptionManager } from '../crypto/EncryptionManager';
 
 /**
@@ -104,7 +104,14 @@ export class EncryptedStorageAdapter implements IStorageAdapter {
   // --- OpLog ---
 
   async appendOpLog(entry: Omit<OpLogEntry, 'id'>): Promise<number> {
-    // Encrypt sensitive fields: value, record, orRecord
+    return this.wrapped.appendOpLog(await this.encryptOpEntry(entry));
+  }
+
+  /**
+   * Encrypts the sensitive op-log fields (value, record, orRecord). 'key', 'op', 'mapName',
+   * 'orTag', 'hlc', 'synced' remain plaintext for indexing. Shared by appendOpLog + commitWrite.
+   */
+  private async encryptOpEntry(entry: Omit<OpLogEntry, 'id'>): Promise<Omit<OpLogEntry, 'id'>> {
     const encryptedEntry = { ...entry };
 
     if (entry.value !== undefined) {
@@ -124,9 +131,26 @@ export class EncryptedStorageAdapter implements IStorageAdapter {
       encryptedEntry.orRecord = { iv: enc.iv, data: enc.data } as any;
     }
 
-    // Note: 'key', 'op', 'mapName', 'orTag', 'hlc', 'synced' remain plaintext for indexing
+    return encryptedEntry;
+  }
 
-    return this.wrapped.appendOpLog(encryptedEntry);
+  async commitWrite(mutations: StorageMutation[], op: Omit<OpLogEntry, 'id'>): Promise<number> {
+    // Encrypt each put mutation's value (removes carry no value); the wrapped adapter
+    // provides the atomic single-transaction guarantee over the encrypted blobs.
+    const encryptedMutations: StorageMutation[] = await Promise.all(
+      mutations.map(async (m) => {
+        if (m.type === 'put' && m.value !== undefined) {
+          const enc = await EncryptionManager.encrypt(this.key, m.value);
+          return { ...m, value: { iv: enc.iv, data: enc.data } };
+        }
+        return m;
+      }),
+    );
+    return this.wrapped.commitWrite(encryptedMutations, await this.encryptOpEntry(op));
+  }
+
+  async deleteOp(id: number): Promise<void> {
+    return this.wrapped.deleteOp(id);
   }
 
   async getPendingOps(): Promise<OpLogEntry[]> {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -25,7 +25,7 @@ import {
 } from './connection';
 
 // Type imports
-import type { IStorageAdapter, OpLogEntry } from './IStorageAdapter';
+import type { IStorageAdapter, OpLogEntry, StorageMutation } from './IStorageAdapter';
 import type { LWWRecord, PredicateNode } from '@topgunbuild/core';
 import type {
   QueryFilter,
@@ -168,6 +168,7 @@ export type { AuthProvider, AuthEvent, AuthEventType, TokenExchangeConfig } from
 export type {
   IStorageAdapter,
   OpLogEntry,
+  StorageMutation,
   LWWRecord,
   PredicateNode,
   QueryFilter,

--- a/packages/client/src/sync/BackpressureController.ts
+++ b/packages/client/src/sync/BackpressureController.ts
@@ -29,6 +29,7 @@ import { logger } from '../utils/logger';
 export class BackpressureController implements IBackpressureController {
   private readonly config: BackpressureConfig;
   private readonly opLog: OpLogEntry[];
+  private readonly onOpDropped?: (opId: string) => void;
 
   // Internal state
   private backpressurePaused: boolean = false;
@@ -40,6 +41,7 @@ export class BackpressureController implements IBackpressureController {
   constructor(controllerConfig: BackpressureControllerConfig) {
     this.config = controllerConfig.config;
     this.opLog = controllerConfig.opLog; // Shared reference, not a copy
+    this.onOpDropped = controllerConfig.onOpDropped;
   }
 
   // ============================================
@@ -242,6 +244,11 @@ export class BackpressureController implements IBackpressureController {
     if (oldestIndex !== -1) {
       const dropped = this.opLog[oldestIndex];
       this.opLog.splice(oldestIndex, 1);
+
+      // Also delete from durable storage so the dropped op cannot resurrect on reload
+      // (otherwise memory and disk diverge — the op is gone from this session's sync queue
+      // but still present in IndexedDB).
+      this.onOpDropped?.(dropped.id);
 
       logger.warn(
         { opId: dropped.id, mapName: dropped.mapName, key: dropped.key },

--- a/packages/client/src/sync/ORMapSyncHandler.ts
+++ b/packages/client/src/sync/ORMapSyncHandler.ts
@@ -114,9 +114,12 @@ export class ORMapSyncHandler implements IORMapSyncHandler {
         const result = map.mergeKey(key, records, tombstones);
         totalAdded += result.added;
         totalUpdated += result.updated;
+        // Persist server-origin merge so it survives an offline reload (symmetric with LWW).
+        await this.config.persistKey(mapName, key);
       }
 
       if (totalAdded > 0 || totalUpdated > 0) {
+        await this.config.persistTombstones(mapName);
         logger.info(
           { mapName, added: totalAdded, updated: totalUpdated },
           'Synced ORMap records from server',
@@ -149,9 +152,12 @@ export class ORMapSyncHandler implements IORMapSyncHandler {
         const result = map.mergeKey(key, records, tombstones);
         totalAdded += result.added;
         totalUpdated += result.updated;
+        // Persist server-origin merge so it survives an offline reload (symmetric with LWW).
+        await this.config.persistKey(mapName, key);
       }
 
       if (totalAdded > 0 || totalUpdated > 0) {
+        await this.config.persistTombstones(mapName);
         logger.info(
           { mapName, added: totalAdded, updated: totalUpdated },
           'Merged ORMap diff from server',

--- a/packages/client/src/sync/types.ts
+++ b/packages/client/src/sync/types.ts
@@ -232,6 +232,14 @@ export interface BackpressureControllerConfig {
    * Reference to opLog array (shared state from SyncEngine).
    */
   opLog: OpLogEntry[];
+
+  /**
+   * Called when the `drop-oldest` strategy evicts an unsynced op from the in-memory opLog.
+   * SyncEngine wires this to delete the op from storage too, so a dropped op cannot resurrect
+   * on the next reload. Receives the stringified op id; the callee coerces to the numeric
+   * storage id.
+   */
+  onOpDropped?: (opId: string) => void;
 }
 
 // ============================================
@@ -1056,6 +1064,17 @@ export interface ORMapSyncHandlerConfig {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- HLC timestamp shape is opaque at the callback boundary; the callee updates the HLC directly
   onTimestampUpdate: (timestamp: any) => Promise<void>;
+
+  /**
+   * Persist the full record list for an ORMap key (server-origin merge durability).
+   * Wired by SyncEngine to its canonical `persistORMapKey` helper.
+   */
+  persistKey: (mapName: string, key: string) => Promise<void>;
+
+  /**
+   * Persist an ORMap's tombstone set. Wired by SyncEngine to `persistORMapTombstones`.
+   */
+  persistTombstones: (mapName: string) => Promise<void>;
 }
 
 // ============================================

--- a/packages/mcp-server/src/TopGunMCPServer.ts
+++ b/packages/mcp-server/src/TopGunMCPServer.ts
@@ -9,7 +9,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { TopGunClient } from '@topgunbuild/client';
-import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
+import type { IStorageAdapter, OpLogEntry, StorageMutation } from '@topgunbuild/client';
 import type { MCPServerConfig, MCPToolResult, ResolvedMCPServerConfig, ToolContext } from './types';
 import { allTools, toolHandlers } from './tools';
 import { createLogger, type Logger } from './logger';
@@ -355,10 +355,25 @@ class InMemoryStorageAdapter implements IStorageAdapter {
   }
 
   async markOpsSynced(lastId: number): Promise<void> {
-    for (const op of this.opLog) {
-      if (op.id !== undefined && op.id <= lastId) {
-        op.synced = 1;
+    // Delete acked ops — the durable KV record is the source of truth (matches IDBAdapter).
+    this.opLog = this.opLog.filter((op) => op.id === undefined || op.id > lastId);
+  }
+
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+
+  async commitWrite(mutations: StorageMutation[], op: Omit<OpLogEntry, 'id'>): Promise<number> {
+    // In-memory: apply mutations then append the op. No real transaction, but synchronous
+    // map mutations cannot partially fail, so the atomicity contract holds.
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.data;
+      if (m.type === 'remove') {
+        target.delete(m.key);
+      } else {
+        target.set(m.key, m.value);
       }
     }
+    return this.appendOpLog(op);
   }
 }

--- a/tests/integration-rust/cluster-routing.test.ts
+++ b/tests/integration-rust/cluster-routing.test.ts
@@ -70,6 +70,22 @@ class MemoryStorageAdapter implements IStorageAdapter {
     });
   }
 
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: any }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.metaStore : this.kvStore;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value as never);
+    }
+    return this.appendOpLog(op);
+  }
+
   async getAllKeys(): Promise<string[]> {
     return Array.from(this.kvStore.keys());
   }

--- a/tests/integration-rust/live-query-limit-clamp.test.ts
+++ b/tests/integration-rust/live-query-limit-clamp.test.ts
@@ -91,6 +91,22 @@ class MemoryStorageAdapter implements IStorageAdapter {
       if ((op.id ?? 0) <= lastId) op.synced = 1;
     });
   }
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: any }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.kv;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value as never);
+    }
+    return this.appendOpLog(op);
+  }
+
   async getAllKeys(): Promise<string[]> {
     return Array.from(this.kv.keys());
   }

--- a/tests/integration-rust/reconnect.test.ts
+++ b/tests/integration-rust/reconnect.test.ts
@@ -73,6 +73,22 @@ class MemoryStorageAdapter implements IStorageAdapter {
       if ((op.id ?? 0) <= lastId) op.synced = 1;
     });
   }
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: any }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.kv;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value as never);
+    }
+    return this.appendOpLog(op);
+  }
+
   async getAllKeys(): Promise<string[]> {
     return Array.from(this.kv.keys());
   }


### PR DESCRIPTION
## Summary

Closes the four Client SDK depth-audit durability findings (`DEPTH_CLIENT_SDK.md`) — the **client half of "offline writes survive"**. Bundled into one spec (SPEC-321) because all four share the offline OpLog / `IDBAdapter` op-log lifecycle / local-write commit path; splitting would re-touch the same files across four PRs. Audit (`/sf:audit`) confirmed the bundle (do not split).

| Finding | TODO | Fix |
|---|---|---|
| **F3** ORMap server-origin state never persisted → lost on offline reload | 496 | `applyServerEvent` (OR_ADD/OR_REMOVE) + `ORMapSyncHandler` leaf/diff merges now persist via canonical `SyncEngine.persistORMapKey`/`persistORMapTombstones` (symmetric with the LWW path). |
| **F4** `drop-oldest` evicted op from memory only → resurrects on reload | 499 | `BackpressureController.onOpDropped` routes the drop through SyncEngine → new `IStorageAdapter.deleteOp(id)`; memory and disk agree. |
| **F5** OpLog never compacts (memory grows per session, IDB forever) | 497 | `handleOpAck` splices acked ops from the in-memory array; `IDBAdapter.markOpsSynced` now **deletes** rows `id<=lastId` instead of flagging `synced=1`. |
| **F6** local write non-atomic (record + oplog = separate un-awaited IDB txns) | 498 | New `IStorageAdapter.commitWrite(mutations, op)` commits the KV/meta record + op-log entry in **one** IDB transaction; `recordOperation` is the single owner, **commit-first ordering** (push to in-memory oplog only on success → no op-without-record in either layer). |

`IStorageAdapter` gains `commitWrite` + `deleteOp` + `StorageMutation`; all implementers updated (IDBAdapter real single-transaction commit, EncryptedStorageAdapter encrypt-then-delegate, MCP in-memory adapter, sync-lab demo, test mocks).

**Design note (F6 rollback):** on `commitWrite` rejection the op is never pushed to the in-memory oplog and the error is surfaced; the optimistic in-memory *map* value is intentionally retained (matching Zero/Automerge optimistic-UI — reverting CRDT state would silently discard the user's write and needs a core force-restore API out of this spec's scope). Crash-consistency is delivered at the durable layer.

## Tests

- `packages/client/src/__tests__/offline-durability.test.ts` — **7** behavioral tests (F3/F4/F5/F6) each with a negative control; promotes the audit repro controls (`C-ORMAP-PERSIST`, `C-DROP-OLDEST`) to permanent inverted regressions.
- `packages/adapters/src/__tests__/IDBAdapter.test.ts` — **5** adapter tests: `commitWrite` single-txn atomicity (mid-commit abort leaves neither store), `markOpsSynced` deletes rows, `deleteOp`, and a `(record, op)` pair surviving a real fake-indexeddb reload.

## Local gate

- `pnpm -r build` ✅ · `pnpm lint` ✅ (0 errors) · `pnpm format:check` ✅
- client **649** / adapters **44** / mcp **94** / better-auth **23** tests green
- `pnpm test:integration-rust` (blocking): **11/12 suites green** incl. all CRDT/offline/reconnect round-trips. `cluster-routing` flaked under full-suite contention but **passes 7/7 in isolation** — the known cold join-race flake (TODO-504, carved non-blocking), not a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)