### PR TITLE
fix(server): bound inbound MsgPack decode depth + WS frame size (pre-auth DoS, F1/F3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4966,6 +4966,7 @@ dependencies = [
  "redb",
  "regex",
  "reqwest",
+ "rmp",
  "rmp-serde",
  "rmpv",
  "serde",

--- a/packages/server-rust/Cargo.toml
+++ b/packages/server-rust/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = "2"
 arc-swap = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+rmp = "0.8"
 rmp-serde = "1"
 rmpv = { version = "1", features = ["with-serde"] }
 tracing = "0.1"

--- a/packages/server-rust/src/network/config.rs
+++ b/packages/server-rust/src/network/config.rs
@@ -100,6 +100,15 @@ pub struct ConnectionConfig {
     pub ws_write_buffer_size: usize,
     /// Maximum WebSocket write buffer size in bytes.
     pub ws_max_write_buffer_size: usize,
+    /// Maximum size in bytes of a complete inbound WebSocket message. Frames
+    /// exceeding this are rejected by the transport before the handler decodes
+    /// them, bounding the unauthenticated memory-spike surface and capping the
+    /// input to the depth-checked decoder. Defaults to 2 MB to match the HTTP
+    /// `/sync` body limit.
+    pub ws_max_message_size: usize,
+    /// Maximum size in bytes of a single inbound WebSocket frame (a message may
+    /// span multiple frames). Defaults to 2 MB.
+    pub ws_max_frame_size: usize,
 }
 
 impl Default for ConnectionConfig {
@@ -108,8 +117,10 @@ impl Default for ConnectionConfig {
             outbound_channel_capacity: 256,
             send_timeout: Duration::from_secs(5),
             idle_timeout: Duration::from_secs(60),
-            ws_write_buffer_size: 131_072,     // 128 KB
-            ws_max_write_buffer_size: 524_288, // 512 KB
+            ws_write_buffer_size: 131_072,        // 128 KB
+            ws_max_write_buffer_size: 524_288,    // 512 KB
+            ws_max_message_size: 2 * 1024 * 1024, // 2 MB — matches HTTP /sync body limit
+            ws_max_frame_size: 2 * 1024 * 1024,   // 2 MB
         }
     }
 }
@@ -146,6 +157,8 @@ mod tests {
         assert_eq!(config.idle_timeout, Duration::from_secs(60));
         assert_eq!(config.ws_write_buffer_size, 131_072);
         assert_eq!(config.ws_max_write_buffer_size, 524_288);
+        assert_eq!(config.ws_max_message_size, 2 * 1024 * 1024);
+        assert_eq!(config.ws_max_frame_size, 2 * 1024 * 1024);
     }
 
     #[test]

--- a/packages/server-rust/src/network/handlers/decode.rs
+++ b/packages/server-rust/src/network/handlers/decode.rs
@@ -1,0 +1,366 @@
+//! Depth- and structure-bounded `MsgPack` decoding for untrusted inbound frames.
+//!
+//! Every inbound WebSocket frame (and the HTTP `/sync` body) is `MsgPack`, decoded
+//! with `rmp_serde` — and on `/ws` the decode happens in Phase 1, BEFORE the
+//! connection is authenticated. `rmp_serde` applies no recursion-depth limit,
+//! and the message types are internally tagged (`#[serde(tag = "type")]`, which
+//! buffers the whole frame into serde's recursive `Content` type) and embed
+//! `rmpv::Value` — itself a recursive enum. A deeply-nested frame therefore
+//! recurses one native stack frame per nesting level during deserialization, and
+//! a stack overflow in safe Rust aborts the whole process (uncatchable: no
+//! `catch_unwind`, no per-task isolation). One small unauthenticated frame would
+//! kill every connection on the node.
+//!
+//! [`decode_depth_checked`] closes this by scanning the raw `MsgPack` bytes
+//! iteratively — an explicit heap stack, so the scanner itself never recurses and
+//! cannot overflow — and rejecting any frame whose container nesting exceeds
+//! [`MAX_DECODE_DEPTH`] before the bytes ever reach `rmp_serde`. Paired with the
+//! inbound frame-size cap on the WebSocket upgrade, this bounds the decoder's
+//! input to well-formed, shallow frames.
+
+use rmp::Marker;
+use serde::de::DeserializeOwned;
+
+/// Maximum container-nesting depth accepted for an inbound `MsgPack` frame.
+///
+/// Legitimate `TopGun` payloads (operation envelopes carrying `rmpv::Value`
+/// records and `where` predicates) nest only a handful of levels deep; 128 is
+/// far above any real document while still well below the thousands of levels it
+/// takes to exhaust a worker thread's stack during `rmp_serde` recursion.
+pub const MAX_DECODE_DEPTH: usize = 128;
+
+/// Why an inbound frame was rejected before or during decode.
+#[derive(Debug)]
+pub enum DecodeError {
+    /// Container nesting exceeded the allowed depth — rejected before `rmp_serde`
+    /// ever ran, so the recursive decoder cannot overflow the stack.
+    TooDeep,
+    /// The byte stream is not well-formed `MsgPack` (truncated, or a reserved
+    /// marker), detected by the pre-scan.
+    Malformed,
+    /// Structurally valid and within depth, but failed to deserialize into the
+    /// target type.
+    Decode(rmp_serde::decode::Error),
+}
+
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooDeep => write!(
+                f,
+                "frame rejected: MsgPack nesting exceeds {MAX_DECODE_DEPTH} levels"
+            ),
+            Self::Malformed => write!(f, "frame rejected: malformed MsgPack"),
+            Self::Decode(e) => write!(f, "decode error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decode(e) => Some(e),
+            Self::TooDeep | Self::Malformed => None,
+        }
+    }
+}
+
+/// Reads `n` big-endian length bytes at `*pos`, advancing the cursor.
+/// Bounds-checked: returns [`DecodeError::Malformed`] on truncation.
+fn read_uint(data: &[u8], pos: &mut usize, n: usize) -> Result<u64, DecodeError> {
+    let end = pos.checked_add(n).ok_or(DecodeError::Malformed)?;
+    let slice = data.get(*pos..end).ok_or(DecodeError::Malformed)?;
+    let mut v = 0u64;
+    for &b in slice {
+        v = (v << 8) | u64::from(b);
+    }
+    *pos = end;
+    Ok(v)
+}
+
+/// Advances `*pos` past `n` payload bytes (str/bin/ext/scalar bodies) without
+/// reading them. Bounds-checked: returns [`DecodeError::Malformed`] on truncation.
+fn skip(data: &[u8], pos: &mut usize, n: u64) -> Result<(), DecodeError> {
+    let n = usize::try_from(n).map_err(|_| DecodeError::Malformed)?;
+    let end = pos.checked_add(n).ok_or(DecodeError::Malformed)?;
+    if end > data.len() {
+        return Err(DecodeError::Malformed);
+    }
+    *pos = end;
+    Ok(())
+}
+
+/// Scans `data` as `MsgPack` iteratively, bounding container nesting to `max_depth`.
+///
+/// Returns `Err(TooDeep)` the moment nesting would exceed `max_depth`, and
+/// `Err(Malformed)` on a truncated stream or reserved marker. The scan uses an
+/// explicit heap stack and **never recurses**, so it cannot itself overflow on
+/// adversarial input — that is the whole point: it runs before the recursive
+/// `rmp_serde` decoder and rejects frames that would overflow it.
+///
+/// Trailing bytes after the first complete top-level value are ignored here;
+/// `rmp_serde` rejects them downstream if it cares.
+///
+/// # Errors
+///
+/// Returns [`DecodeError::TooDeep`] if container nesting would exceed
+/// `max_depth`, or [`DecodeError::Malformed`] on a truncated stream or a
+/// reserved marker byte.
+// One match arm per MsgPack marker keeps the scanner auditable; merging arms or
+// splitting the function would obscure the byte-advance accounting that makes it
+// safe, so the length and a few same-bodied arms are intentional.
+#[allow(clippy::too_many_lines, clippy::match_same_arms)]
+pub fn check_msgpack_depth(data: &[u8], max_depth: usize) -> Result<(), DecodeError> {
+    let mut pos = 0usize;
+
+    // `stack[i]` = number of child values still to read at nesting level `i`.
+    // `pending` is the count at the current (deepest open) level. The scanner
+    // expects exactly one top-level value.
+    let mut stack: Vec<u64> = Vec::new();
+    let mut pending: u64 = 1;
+
+    loop {
+        // Pop levels whose child count has been fully consumed.
+        while pending == 0 {
+            match stack.pop() {
+                Some(parent_remaining) => pending = parent_remaining,
+                None => return Ok(()), // all values consumed
+            }
+        }
+        // Consume one value at the current level.
+        pending -= 1;
+
+        let marker_byte = *data.get(pos).ok_or(DecodeError::Malformed)?;
+        pos += 1;
+        let marker = Marker::from_u8(marker_byte);
+
+        // For containers, how many child values we must descend into.
+        let children: u64 = match marker {
+            Marker::FixPos(_) | Marker::FixNeg(_) | Marker::Null | Marker::True | Marker::False => {
+                0
+            }
+            Marker::U8 | Marker::I8 => {
+                skip(data, &mut pos, 1)?;
+                0
+            }
+            Marker::U16 | Marker::I16 => {
+                skip(data, &mut pos, 2)?;
+                0
+            }
+            Marker::U32 | Marker::I32 | Marker::F32 => {
+                skip(data, &mut pos, 4)?;
+                0
+            }
+            Marker::U64 | Marker::I64 | Marker::F64 => {
+                skip(data, &mut pos, 8)?;
+                0
+            }
+            Marker::FixStr(n) => {
+                skip(data, &mut pos, u64::from(n))?;
+                0
+            }
+            Marker::Str8 | Marker::Bin8 => {
+                let len = read_uint(data, &mut pos, 1)?;
+                skip(data, &mut pos, len)?;
+                0
+            }
+            Marker::Str16 | Marker::Bin16 => {
+                let len = read_uint(data, &mut pos, 2)?;
+                skip(data, &mut pos, len)?;
+                0
+            }
+            Marker::Str32 | Marker::Bin32 => {
+                let len = read_uint(data, &mut pos, 4)?;
+                skip(data, &mut pos, len)?;
+                0
+            }
+            // ext = 1 type byte + payload.
+            Marker::FixExt1 => {
+                skip(data, &mut pos, 1 + 1)?;
+                0
+            }
+            Marker::FixExt2 => {
+                skip(data, &mut pos, 1 + 2)?;
+                0
+            }
+            Marker::FixExt4 => {
+                skip(data, &mut pos, 1 + 4)?;
+                0
+            }
+            Marker::FixExt8 => {
+                skip(data, &mut pos, 1 + 8)?;
+                0
+            }
+            Marker::FixExt16 => {
+                skip(data, &mut pos, 1 + 16)?;
+                0
+            }
+            Marker::Ext8 => {
+                let len = read_uint(data, &mut pos, 1)?;
+                skip(data, &mut pos, len + 1)?;
+                0
+            }
+            Marker::Ext16 => {
+                let len = read_uint(data, &mut pos, 2)?;
+                skip(data, &mut pos, len + 1)?;
+                0
+            }
+            Marker::Ext32 => {
+                let len = read_uint(data, &mut pos, 4)?;
+                skip(data, &mut pos, len + 1)?;
+                0
+            }
+            Marker::FixArray(n) => u64::from(n),
+            Marker::Array16 => read_uint(data, &mut pos, 2)?,
+            Marker::Array32 => read_uint(data, &mut pos, 4)?,
+            // Each map entry is a key + a value, so two child values per pair.
+            Marker::FixMap(n) => u64::from(n) * 2,
+            Marker::Map16 => read_uint(data, &mut pos, 2)? * 2,
+            Marker::Map32 => read_uint(data, &mut pos, 4)? * 2,
+            Marker::Reserved => return Err(DecodeError::Malformed),
+        };
+
+        if children > 0 {
+            // Opening a new container increases nesting by one level. Reject
+            // before descending so the recursive decoder is never handed a
+            // frame deeper than it can safely process.
+            if stack.len() + 1 > max_depth {
+                return Err(DecodeError::TooDeep);
+            }
+            stack.push(pending);
+            pending = children;
+        }
+    }
+}
+
+/// Depth-checks `data` and then decodes it into `T` with `rmp_serde`.
+///
+/// The pre-scan guarantees `rmp_serde`'s recursive deserialization can never be
+/// driven deeper than [`MAX_DECODE_DEPTH`], so a malicious deeply-nested frame is
+/// rejected as `Err(TooDeep)` instead of overflowing the stack and aborting the
+/// process. Callers should treat any `Err` as "drop this frame" (log + continue),
+/// never panic.
+///
+/// # Errors
+///
+/// Returns [`DecodeError::TooDeep`] or [`DecodeError::Malformed`] if the pre-scan
+/// rejects the frame, or [`DecodeError::Decode`] if `rmp_serde` fails to
+/// deserialize a structurally-valid, in-depth frame into `T`.
+pub fn decode_depth_checked<T: DeserializeOwned>(data: &[u8]) -> Result<T, DecodeError> {
+    check_msgpack_depth(data, MAX_DECODE_DEPTH)?;
+    rmp_serde::from_slice(data).map_err(DecodeError::Decode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use topgun_core::messages::{Message as TopGunMessage, PingData};
+
+    /// Builds `depth`-deep nested 1-element arrays (`0x91` repeated) terminated
+    /// by nil (`0xc0`): a `depth + 1`-byte payload forcing `depth`-deep recursion.
+    /// This is the exact shape from the audit repro harness.
+    fn nested_msgpack(depth: usize) -> Vec<u8> {
+        let mut buf = vec![0x91u8; depth];
+        buf.push(0xc0);
+        buf
+    }
+
+    #[test]
+    fn shallow_nesting_passes_depth_check() {
+        // Negative control: 64-deep is valid `MsgPack` and within the limit.
+        assert!(check_msgpack_depth(&nested_msgpack(64), MAX_DECODE_DEPTH).is_ok());
+    }
+
+    #[test]
+    fn at_limit_passes_over_limit_rejected() {
+        assert!(check_msgpack_depth(&nested_msgpack(MAX_DECODE_DEPTH), MAX_DECODE_DEPTH).is_ok());
+        assert!(matches!(
+            check_msgpack_depth(&nested_msgpack(MAX_DECODE_DEPTH + 1), MAX_DECODE_DEPTH),
+            Err(DecodeError::TooDeep)
+        ));
+    }
+
+    #[test]
+    fn deeply_nested_frame_rejected_not_overflowed() {
+        // The DoS payload: ~512k-deep. The OLD path fed this straight to
+        // `rmp_serde::from_slice`, recursing ~512k native frames → stack overflow
+        // → SIGABRT. The pre-scan rejects it in O(MAX_DECODE_DEPTH) memory with
+        // zero recursion, so this test returns an Err instead of aborting.
+        let bytes = nested_msgpack(512_000);
+        assert!(matches!(
+            check_msgpack_depth(&bytes, MAX_DECODE_DEPTH),
+            Err(DecodeError::TooDeep)
+        ));
+    }
+
+    #[test]
+    fn decode_depth_checked_rejects_deep_topgun_message() {
+        // End-to-end: the exact call Phase 1 makes pre-auth. A deep frame must
+        // come back as Err (dropped), never panic/abort.
+        let bytes = nested_msgpack(512_000);
+        let result: Result<TopGunMessage, _> = decode_depth_checked(&bytes);
+        assert!(matches!(result, Err(DecodeError::TooDeep)));
+    }
+
+    #[test]
+    fn deep_nesting_inside_map_value_rejected() {
+        // Realistic attack shape: a 1-entry map whose value is deeply nested,
+        // mimicking an operation envelope carrying a hostile `record`/`where`.
+        // fixmap(1) + fixstr "k" + <deep array chain>.
+        let mut bytes = vec![0x81u8, 0xa1, b'k'];
+        bytes.extend(std::iter::repeat_n(0x91u8, 512_000));
+        bytes.push(0xc0);
+        assert!(matches!(
+            check_msgpack_depth(&bytes, MAX_DECODE_DEPTH),
+            Err(DecodeError::TooDeep)
+        ));
+    }
+
+    #[test]
+    fn truncated_frame_is_malformed_not_panic() {
+        // Array claims 4 elements but the stream ends — must be a graceful Err.
+        assert!(matches!(
+            check_msgpack_depth(&[0x94], MAX_DECODE_DEPTH),
+            Err(DecodeError::Malformed)
+        ));
+        // str8 claims 200 bytes that aren't there.
+        assert!(matches!(
+            check_msgpack_depth(&[0xd9, 0xc8, 0x00], MAX_DECODE_DEPTH),
+            Err(DecodeError::Malformed)
+        ));
+        // Empty input.
+        assert!(matches!(
+            check_msgpack_depth(&[], MAX_DECODE_DEPTH),
+            Err(DecodeError::Malformed)
+        ));
+        // Reserved marker 0xc1.
+        assert!(matches!(
+            check_msgpack_depth(&[0xc1], MAX_DECODE_DEPTH),
+            Err(DecodeError::Malformed)
+        ));
+    }
+
+    #[test]
+    fn wide_but_shallow_frame_passes() {
+        // A flat array of 1000 small ints is wide, not deep — must pass.
+        let mut bytes = vec![0xdd, 0x00, 0x00, 0x03, 0xe8]; // array32, len 1000
+        bytes.extend(std::iter::repeat_n(0x01u8, 1000));
+        assert!(check_msgpack_depth(&bytes, MAX_DECODE_DEPTH).is_ok());
+    }
+
+    #[test]
+    fn scalars_and_strings_advance_correctly() {
+        // map { "a": 1, "b": "hi" } — exercises fixmap/fixstr/fixint cursor math.
+        let bytes = vec![0x82, 0xa1, b'a', 0x01, 0xa1, b'b', 0xa2, b'h', b'i'];
+        assert!(check_msgpack_depth(&bytes, MAX_DECODE_DEPTH).is_ok());
+    }
+
+    #[test]
+    fn valid_message_round_trips_through_decode_depth_checked() {
+        // A real, shallow TopGunMessage must still decode normally.
+        let msg = TopGunMessage::Ping(PingData { timestamp: 0 });
+        let bytes = rmp_serde::to_vec_named(&msg).expect("encode");
+        let decoded: TopGunMessage = decode_depth_checked(&bytes).expect("decode");
+        assert!(matches!(decoded, TopGunMessage::Ping(_)));
+    }
+}

--- a/packages/server-rust/src/network/handlers/http_sync.rs
+++ b/packages/server-rust/src/network/handlers/http_sync.rs
@@ -630,7 +630,7 @@ pub async fn http_sync_handler(
     let request: HttpSyncRequest = if body.is_empty() {
         HttpSyncRequest::default()
     } else {
-        match rmp_serde::from_slice::<HttpSyncRequest>(&body) {
+        match super::decode::decode_depth_checked::<HttpSyncRequest>(&body) {
             Ok(req) => req,
             Err(e) => {
                 let json = format!(r#"{{"code":400,"message":"invalid MsgPack body: {e}"}}"#);

--- a/packages/server-rust/src/network/handlers/mod.rs
+++ b/packages/server-rust/src/network/handlers/mod.rs
@@ -10,6 +10,7 @@ pub mod admin_types;
 pub mod auth;
 pub mod auth_provider;
 pub mod auth_validator;
+pub mod decode;
 pub mod health;
 pub mod http_sync;
 pub mod metrics_endpoint;

--- a/packages/server-rust/src/network/handlers/websocket.rs
+++ b/packages/server-rust/src/network/handlers/websocket.rs
@@ -28,6 +28,7 @@ use topgun_core::messages::{
 use tracing::{debug, warn};
 
 use super::auth::AuthHandler;
+use super::decode;
 use super::AppState;
 use crate::network::connection::ConnectionId;
 use crate::network::{ConnectionKind, OutboundMessage};
@@ -54,6 +55,11 @@ pub async fn ws_upgrade_handler(
 ) -> Response {
     ws.write_buffer_size(state.config.connection.ws_write_buffer_size)
         .max_write_buffer_size(state.config.connection.ws_max_write_buffer_size)
+        // Cap inbound message/frame size so an unauthenticated client cannot force
+        // a large allocation (tungstenite defaults are 64 MiB / 16 MiB) and so the
+        // depth-checked decoder only ever sees bounded frames.
+        .max_message_size(state.config.connection.ws_max_message_size)
+        .max_frame_size(state.config.connection.ws_max_frame_size)
         .on_upgrade(|socket| handle_socket(socket, state))
 }
 
@@ -112,7 +118,11 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
         'auth: loop {
             match receiver.next().await {
                 Some(Ok(Message::Binary(data))) => {
-                    let tg_msg = match rmp_serde::from_slice::<TopGunMessage>(&data) {
+                    // Depth-checked decode BEFORE auth: a deeply-nested frame would
+                    // otherwise recurse `rmp_serde` to a stack-overflow abort,
+                    // killing every connection on the node from an unauthenticated
+                    // client. Over-deep/malformed frames are dropped, not fatal.
+                    let tg_msg = match decode::decode_depth_checked::<TopGunMessage>(&data) {
                         Ok(msg) => msg,
                         Err(e) => {
                             debug!("failed to deserialize message from {:?}: {}", conn_id, e);
@@ -243,7 +253,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
     loop {
         match receiver.next().await {
             Some(Ok(Message::Binary(data))) => {
-                let tg_msg = match rmp_serde::from_slice::<TopGunMessage>(&data) {
+                let tg_msg = match decode::decode_depth_checked::<TopGunMessage>(&data) {
                     Ok(msg) => msg,
                     Err(e) => {
                         debug!("failed to deserialize message from {:?}: {}", conn_id, e);

--- a/packages/server-rust/tests/network_decode_dos_integration.rs
+++ b/packages/server-rust/tests/network_decode_dos_integration.rs
@@ -1,0 +1,174 @@
+//! Behavioral integration tests for the pre-auth inbound-frame `DoS` hardening
+//! (network audit F1 + F3).
+//!
+//! F1: the WS reader decoded every inbound frame with `rmp_serde` BEFORE auth.
+//! `rmp_serde` has no recursion-depth limit and the message types are recursive,
+//! so a deeply-nested frame recursed to a stack-overflow `abort()` — uncatchable,
+//! killing the whole process (and every connection on it) from an unauthenticated
+//! client. The fix depth-checks the raw bytes before decoding.
+//!
+//! F3: inbound WS frames had no size cap (tungstenite default 64 MiB). The fix
+//! caps inbound message/frame size on the upgrade.
+//!
+//! These tests boot a real server IN-PROCESS. If the F1 fix regressed, the deep
+//! frame would `SIGABRT` the test runner itself — so "the test completes and the
+//! server stays responsive" *is* the proof the crash is fixed. Each test asserts
+//! the process survives a hostile frame and unrelated connections are unaffected.
+
+use std::time::Duration;
+
+use futures_util::SinkExt;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use topgun_server::network::{NetworkConfig, NetworkModule};
+
+/// Boots a minimal server on an OS-assigned port (no JWT → unauthenticated).
+/// Returns `(port, shutdown_tx, serve_handle)`.
+async fn start_server() -> (
+    u16,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    let mut module = NetworkModule::new(NetworkConfig::default());
+    let port = module.start().await.expect("start should succeed");
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let serve_handle = tokio::spawn(async move {
+        module
+            .serve(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("serve should not fail");
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (port, shutdown_tx, serve_handle)
+}
+
+type Ws = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn connect(port: u16) -> Ws {
+    let url = format!("ws://127.0.0.1:{port}/ws");
+    let (ws, _) = connect_async(&url)
+        .await
+        .expect("WebSocket connect should succeed");
+    ws
+}
+
+/// `depth`-deep nested 1-element arrays (`0x91`) terminated by nil (`0xc0`) — the
+/// audit repro payload. A `depth + 1`-byte frame that forces `depth`-deep decode
+/// recursion. At 200k deep it is far over the 128-level cap yet well under the
+/// 2 MB size cap, so it reaches (and must be rejected by) the decoder.
+fn nested_frame(depth: usize) -> Vec<u8> {
+    let mut buf = vec![0x91u8; depth];
+    buf.push(0xc0);
+    buf
+}
+
+/// Confirms the server process is alive and responsive via the health endpoint.
+async fn assert_server_alive(port: u16) {
+    let resp = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/health"))
+        .timeout(Duration::from_secs(2))
+        .send()
+        .await
+        .expect("server must still answer /health (process survived)");
+    assert!(
+        resp.status().is_success(),
+        "/health returned {}",
+        resp.status()
+    );
+}
+
+/// F1: a deeply-nested pre-auth frame must NOT crash the server. The connection
+/// that sent it is dropped harmlessly; every other connection and the process
+/// itself survive.
+#[tokio::test(flavor = "multi_thread")]
+async fn deeply_nested_frame_does_not_crash_server() {
+    let (port, shutdown_tx, _serve) = start_server().await;
+
+    // A bystander connection that must survive the attack untouched.
+    let mut bystander = connect(port).await;
+
+    // The attacker sends one deeply-nested frame. Pre-fix this aborts the whole
+    // process (SIGABRT) — which would also kill this test runner.
+    let mut attacker = connect(port).await;
+    attacker
+        .send(WsMessage::binary(nested_frame(200_000)))
+        .await
+        .expect("send of hostile frame should leave the socket usable");
+
+    // Give the server time to read + reject the frame.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Proof 1: the process is alive and serving.
+    assert_server_alive(port).await;
+
+    // Proof 2: the bystander connection is untouched — it can still send.
+    bystander
+        .send(WsMessage::binary(nested_frame(8)))
+        .await
+        .expect("bystander connection must remain usable after the attack");
+
+    // Proof 3: new connections are still accepted.
+    let mut latecomer = connect(port).await;
+    latecomer
+        .send(WsMessage::binary(nested_frame(8)))
+        .await
+        .expect("server must still accept new connections after the attack");
+
+    let _ = shutdown_tx.send(());
+}
+
+/// Negative control: a SHALLOW nested frame (within the depth cap) is handled
+/// gracefully — proving the rejection is depth-driven, not a blanket refusal of
+/// all nested input, and the server stays up either way.
+#[tokio::test(flavor = "multi_thread")]
+async fn shallow_frame_is_handled_gracefully() {
+    let (port, shutdown_tx, _serve) = start_server().await;
+
+    let mut conn = connect(port).await;
+    // 64-deep is valid MsgPack and under the 128 cap. It is not a valid
+    // TopGunMessage, so the server drops it — but without crashing or closing.
+    conn.send(WsMessage::binary(nested_frame(64)))
+        .await
+        .expect("send should succeed");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_server_alive(port).await;
+
+    // The connection should still be usable.
+    conn.send(WsMessage::binary(nested_frame(8)))
+        .await
+        .expect("connection should remain usable after a shallow frame");
+
+    let _ = shutdown_tx.send(());
+}
+
+/// F3: an oversized frame (> the 2 MB inbound cap) is rejected by the transport;
+/// the process survives and other connections are unaffected.
+#[tokio::test(flavor = "multi_thread")]
+async fn oversized_frame_is_rejected_process_survives() {
+    let (port, shutdown_tx, _serve) = start_server().await;
+
+    let mut bystander = connect(port).await;
+
+    let mut attacker = connect(port).await;
+    // 3 MB of payload — over the 2 MB cap. The server's transport rejects the
+    // frame and closes that connection; it must not buffer it or crash.
+    let oversized = vec![0u8; 3 * 1024 * 1024];
+    // The send itself may or may not error depending on when the server closes;
+    // either way the process must survive, which is what we assert.
+    let _ = attacker.send(WsMessage::binary(oversized)).await;
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_server_alive(port).await;
+
+    bystander
+        .send(WsMessage::binary(nested_frame(8)))
+        .await
+        .expect("bystander must survive an oversized frame on another connection");
+
+    let _ = shutdown_tx.send(());
+}


### PR DESCRIPTION
## Summary

Closes the network-audit **F1 (CRITICAL, TODO-506)** and **F3 (TODO-508)** findings: an unauthenticated single-frame whole-process crash and the missing inbound WS size cap.

The WS reader decoded **every** inbound frame with `rmp_serde` **before authentication** (`websocket.rs` Phase 1). `rmp_serde` applies no recursion-depth limit; the message envelope is internally tagged (`#[serde(tag="type")]`, which buffers into serde's recursive `Content`) and op payloads are `rmpv::Value` (a recursive enum). A deeply-nested frame recursed one native stack frame per nesting level → **stack overflow → `SIGABRT`** (uncatchable in safe Rust), killing every connection on the node from one unauthenticated client and dropping ~1 s of acked write-behind data. The repro: a ~512 KB frame (`0x91`×512 000 + `0xc0`), far under the 64 MiB tungstenite default, reached the decoder.

## Fix

**F1 — depth-bounded decode.** New `network/handlers/decode.rs`:
- `check_msgpack_depth` scans raw MsgPack bytes **iteratively** (explicit heap stack — never recurses, so the scanner itself cannot overflow on adversarial input) and rejects any frame nesting deeper than `MAX_DECODE_DEPTH` (128) **before** `rmp_serde` runs.
- `decode_depth_checked<T>` = depth-check then `from_slice`; any `Err` ⇒ drop the frame (log + continue), never panic.
- Wired at all three decode sites: WS Phase 1 (pre-auth), WS Phase 2, HTTP `/sync`.

**F3 — inbound size cap.** `ws_upgrade_handler` now sets `.max_message_size()` / `.max_frame_size()` from new `ConnectionConfig` fields `ws_max_message_size` / `ws_max_frame_size` (default **2 MB**, matching the HTTP `/sync` body limit), replacing the tungstenite 64 MiB / 16 MiB defaults.

## Tests

- **`decode.rs` unit suite (9):** shallow ok, at-limit ok / over-limit `TooDeep`, 512k-deep + deep-inside-map-value rejected as `TooDeep` (not overflow), truncated/reserved/empty → `Malformed`, wide-but-shallow ok, valid `TopGunMessage` round-trips.
- **`network_decode_dos_integration.rs` (behavioral, in-process server):** a 200k-deep **pre-decode** frame leaves the process alive + responsive, bystander and new connections unaffected; shallow frame handled gracefully (negative control); oversized (>2 MB) frame rejected, process survives. Pre-fix, these would `SIGABRT` the test runner itself.

## Gate

- `cargo test --release -p topgun-server --lib` — **1375 pass**
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `pnpm test:integration-rust` — **11/11 blocking suites pass**. The single failure is `cluster-routing.test.ts` (partition-map-after-failover), the known **non-blocking** cold join-race flake (TODO-504), unrelated to decode and passing on re-run.

Audit reference: `.specflow/reference/audits/DEPTH_NETWORK_TRANSPORT.md` §F1/F3.