### PR TITLE
fix(server): connection reaper + Phase-1 auth deadline (idle/half-open/slowloris leak)

### DIFF
--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -944,6 +944,14 @@ async fn main() -> anyhow::Result<()> {
     // All routes that admin_routes() already provides (/ws, /health, /sync,
     // /api/admin/*, /api/auth/*, /api/status) MUST NOT be re-declared here —
     // axum panics at startup on duplicate paths.
+    // Capture reaper inputs before `state` is moved into `.with_state()`.
+    // This binary hand-builds its own router (it does NOT go through
+    // NetworkModule::serve), so the connection reaper must be spawned here too —
+    // otherwise idle/half-open and never-authed connections leak in the real
+    // server while only the NetworkModule path is protected.
+    let reaper_registry = Arc::clone(&state.registry);
+    let reaper_config = topgun_server::network::ReaperConfig::from(&state.config.connection);
+
     let app = topgun_server::network::module::admin_routes(
         state.config.rate_limit_per_ip,
         state.config.rate_limit_burst,
@@ -965,6 +973,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Mark the server as ready
     shutdown.set_ready();
+
+    // Start the connection reaper: closes idle/half-open connections (by
+    // last-heartbeat) and never-authenticated connections past the auth
+    // deadline (slowloris), so connection slots and per-connection resources do
+    // not leak. Aborted after the serve loop returns so it never outlives the
+    // server.
+    let reaper_handle =
+        topgun_server::network::spawn_connection_reaper(reaper_registry, reaper_config);
 
     // Hand the controller a second handle so the graceful-shutdown closure
     // can flip /health to draining the moment SIGTERM lands, while the
@@ -992,6 +1008,9 @@ async fn main() -> anyhow::Result<()> {
         let _ = shutdown_tx.send(true);
     })
     .await?;
+
+    // The HTTP server has stopped accepting; stop the reaper before draining.
+    reaper_handle.abort();
 
     // After Hyper graceful shutdown returns, wait for any still-running
     // request handlers (tracked via ShutdownController::in_flight_guard) to

--- a/packages/server-rust/src/network/config.rs
+++ b/packages/server-rust/src/network/config.rs
@@ -95,7 +95,24 @@ pub struct ConnectionConfig {
     /// Maximum time to wait when sending a message to a connection.
     pub send_timeout: Duration,
     /// Duration after which an idle connection is considered stale.
+    ///
+    /// Enforced by the connection reaper: an authenticated connection whose
+    /// last heartbeat (client `PING`) is older than this is closed. The
+    /// `TopGun` client pings every 5 s, so the 60 s default tolerates many
+    /// missed pings before reaping a half-open or dead peer.
     pub idle_timeout: Duration,
+    /// Maximum time an unauthenticated connection may exist before it is
+    /// closed.
+    ///
+    /// Bounds the Phase-1 auth window so a client that connects and never
+    /// completes authentication (or dribbles malformed frames) cannot hold a
+    /// connection slot indefinitely (slowloris). Enforced both by a per-frame
+    /// deadline in the WebSocket auth loop and as a reaper backstop.
+    pub auth_timeout: Duration,
+    /// How often the connection reaper scans the registry for stale
+    /// connections. Should be well below `idle_timeout` so reaping latency is
+    /// bounded by roughly `idle_timeout + reaper_interval`.
+    pub reaper_interval: Duration,
     /// WebSocket write buffer size in bytes.
     pub ws_write_buffer_size: usize,
     /// Maximum WebSocket write buffer size in bytes.
@@ -117,6 +134,8 @@ impl Default for ConnectionConfig {
             outbound_channel_capacity: 256,
             send_timeout: Duration::from_secs(5),
             idle_timeout: Duration::from_secs(60),
+            auth_timeout: Duration::from_secs(10),
+            reaper_interval: Duration::from_secs(10),
             ws_write_buffer_size: 131_072,        // 128 KB
             ws_max_write_buffer_size: 524_288,    // 512 KB
             ws_max_message_size: 2 * 1024 * 1024, // 2 MB — matches HTTP /sync body limit
@@ -155,6 +174,8 @@ mod tests {
         assert_eq!(config.outbound_channel_capacity, 256);
         assert_eq!(config.send_timeout, Duration::from_secs(5));
         assert_eq!(config.idle_timeout, Duration::from_secs(60));
+        assert_eq!(config.auth_timeout, Duration::from_secs(10));
+        assert_eq!(config.reaper_interval, Duration::from_secs(10));
         assert_eq!(config.ws_write_buffer_size, 131_072);
         assert_eq!(config.ws_max_write_buffer_size, 524_288);
         assert_eq!(config.ws_max_message_size, 2 * 1024 * 1024);

--- a/packages/server-rust/src/network/connection.rs
+++ b/packages/server-rust/src/network/connection.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use tokio::sync::{mpsc, RwLock};
+use tokio_util::sync::CancellationToken;
 use topgun_core::{Principal, Timestamp};
 
 use super::config::ConnectionConfig;
@@ -64,6 +65,13 @@ pub struct ConnectionHandle {
     pub connected_at: Instant,
     /// Whether this is a client or cluster peer connection.
     pub kind: ConnectionKind,
+    /// Cancellation signal for forced teardown.
+    ///
+    /// The connection's read loop selects on this token, so cancelling it
+    /// unblocks a reader parked on a half-open socket and lets the connection
+    /// run its normal cleanup path. The reaper cancels this to evict stale or
+    /// never-authenticated connections.
+    pub cancel: CancellationToken,
 }
 
 impl ConnectionHandle {
@@ -103,6 +111,22 @@ impl ConnectionHandle {
     pub fn is_connected(&self) -> bool {
         !self.tx.is_closed()
     }
+
+    /// Signals the connection's read loop to tear down.
+    ///
+    /// Idempotent: cancelling an already-cancelled connection is a no-op, so
+    /// the reaper can call this on every tick without coordinating with the
+    /// read loop. The actual resource cleanup (subscriptions, registry slot)
+    /// still runs once, in the read loop's normal disconnect path.
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+    }
+
+    /// Returns `true` once `cancel()` has been called on this connection.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
 }
 
 /// Mutable metadata associated with a connection.
@@ -116,6 +140,17 @@ impl ConnectionHandle {
 pub struct ConnectionMetadata {
     /// Whether this connection has completed authentication.
     pub authenticated: bool,
+    /// Whether this connection has finished the auth handshake and entered the
+    /// steady-state (Phase 2) read loop.
+    ///
+    /// Set once when the connection enters Phase 2 — true for both
+    /// JWT-authenticated connections and connections on a no-auth server (where
+    /// Phase 1 is skipped). The reaper uses this to decide which timeout
+    /// applies: connections still in the handshake are bounded by the auth
+    /// deadline; steady-state connections are bounded by the idle (heartbeat)
+    /// timeout. Distinct from `authenticated`, which is false on a no-auth
+    /// server even in steady state.
+    pub handshake_complete: bool,
     /// The authenticated principal, if any.
     pub principal: Option<Principal>,
     /// Active query subscriptions for this connection.
@@ -134,6 +169,7 @@ impl Default for ConnectionMetadata {
     fn default() -> Self {
         Self {
             authenticated: false,
+            handshake_complete: false,
             principal: None,
             subscriptions: HashSet::new(),
             topics: HashSet::new(),
@@ -184,6 +220,7 @@ impl ConnectionRegistry {
             metadata: Arc::new(RwLock::new(ConnectionMetadata::default())),
             connected_at: Instant::now(),
             kind,
+            cancel: CancellationToken::new(),
         });
 
         self.connections.insert(id, Arc::clone(&handle));

--- a/packages/server-rust/src/network/handlers/websocket.rs
+++ b/packages/server-rust/src/network/handlers/websocket.rs
@@ -112,11 +112,48 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
     // Closed on shutdown to unblock any pending acquire.
     let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_IN_FLIGHT));
 
+    // Cancellation signal for forced teardown by the reaper. Cloned (cheap —
+    // Arc inside) so both read phases can select on it without borrowing the
+    // handle across the moves they perform on the disconnect path.
+    let cancel = handle.cancel.clone();
+
     // Phase 1: sequential auth — only proceed when JWT secret is configured.
     // If no secret is set, every connection is pre-authenticated.
     if state.jwt_secret.is_some() {
+        // Bound the auth handshake: a client that connects and never finishes
+        // authenticating (slowloris) must not hold a connection slot forever.
+        // The deadline is enforced per read; malformed frames `continue` the
+        // loop but do not reset it.
+        let auth_deadline = tokio::time::Instant::now() + state.config.connection.auth_timeout;
         'auth: loop {
-            match receiver.next().await {
+            let next = tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    debug!("connection {:?} reaped during auth phase", conn_id);
+                    semaphore.close();
+                    drop(handle);
+                    join_outbound_with_timeout(outbound_handle).await;
+                    release_session_state(&state, conn_id);
+                    state.registry.remove(conn_id);
+                    debug!("WebSocket disconnected: {:?}", conn_id);
+                    return;
+                }
+                () = tokio::time::sleep_until(auth_deadline) => {
+                    debug!(
+                        "connection {:?} exceeded auth deadline; closing (slowloris guard)",
+                        conn_id
+                    );
+                    semaphore.close();
+                    drop(handle);
+                    join_outbound_with_timeout(outbound_handle).await;
+                    release_session_state(&state, conn_id);
+                    state.registry.remove(conn_id);
+                    debug!("WebSocket disconnected: {:?}", conn_id);
+                    return;
+                }
+                msg = receiver.next() => msg,
+            };
+            match next {
                 Some(Ok(Message::Binary(data))) => {
                     // Depth-checked decode BEFORE auth: a deeply-nested frame would
                     // otherwise recurse `rmp_serde` to a stack-overflow abort,
@@ -178,12 +215,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                                     // Drain semaphore and drop before returning
                                     semaphore.close();
                                     drop(handle);
-                                    tokio::time::timeout(
-                                        std::time::Duration::from_secs(2),
-                                        outbound_handle,
-                                    )
-                                    .await
-                                    .ok();
+                                    join_outbound_with_timeout(outbound_handle).await;
                                     release_session_state(&state, conn_id);
                                     state.registry.remove(conn_id);
                                     debug!("WebSocket disconnected: {:?}", conn_id);
@@ -203,9 +235,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                     debug!("connection {:?} closed during auth phase", conn_id);
                     semaphore.close();
                     drop(handle);
-                    tokio::time::timeout(std::time::Duration::from_secs(2), outbound_handle)
-                        .await
-                        .ok();
+                    join_outbound_with_timeout(outbound_handle).await;
                     release_session_state(&state, conn_id);
                     state.registry.remove(conn_id);
                     debug!("WebSocket disconnected: {:?}", conn_id);
@@ -227,9 +257,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                     );
                     semaphore.close();
                     drop(handle);
-                    tokio::time::timeout(std::time::Duration::from_secs(2), outbound_handle)
-                        .await
-                        .ok();
+                    join_outbound_with_timeout(outbound_handle).await;
                     release_session_state(&state, conn_id);
                     state.registry.remove(conn_id);
                     debug!("WebSocket disconnected: {:?}", conn_id);
@@ -242,8 +270,12 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
     // Resolve principal once for this connection so the authorization middleware
     // can read ctx.principal without performing a registry lookup per operation.
     // This is done after Phase 1 completes so the metadata is guaranteed to be set.
+    // Also mark the handshake complete so the reaper switches this connection
+    // from the auth-deadline bound to the idle (heartbeat) bound — true for
+    // no-auth connections too, which skip Phase 1 entirely.
     let principal: Option<Principal> = {
-        let meta = handle.metadata.read().await;
+        let mut meta = handle.metadata.write().await;
+        meta.handshake_complete = true;
         meta.principal.clone()
     };
 
@@ -251,7 +283,18 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
     // The reader continues immediately after spawning, so multiple frames
     // can be in-flight simultaneously up to MAX_IN_FLIGHT.
     loop {
-        match receiver.next().await {
+        // Select on the cancel token too, so the reaper can unblock a reader
+        // parked on a half-open socket (no FIN, no client traffic). On cancel
+        // we fall through to the shared cleanup below.
+        let next = tokio::select! {
+            biased;
+            () = cancel.cancelled() => {
+                debug!("connection {:?} reaped (idle/half-open)", conn_id);
+                break;
+            }
+            msg = receiver.next() => msg,
+        };
+        match next {
             Some(Ok(Message::Binary(data))) => {
                 let tg_msg = match decode::decode_depth_checked::<TopGunMessage>(&data) {
                     Ok(msg) => msg,
@@ -312,11 +355,9 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
     // The outbound task will drain remaining buffered messages before exiting.
     drop(handle);
 
-    // Wait for the outbound task to finish flushing, with a timeout to
-    // prevent hanging if the writer is stuck.
-    tokio::time::timeout(std::time::Duration::from_secs(2), outbound_handle)
-        .await
-        .ok();
+    // Wait for the outbound task to finish flushing, then abort it if it is
+    // wedged so a stuck writer cannot linger holding the socket.
+    join_outbound_with_timeout(outbound_handle).await;
 
     release_session_state(&state, conn_id);
     state.registry.remove(conn_id);
@@ -750,6 +791,22 @@ async fn send_operation_response(resp: OperationResponse, tx: &mpsc::Sender<Outb
 /// checks `try_recv()` for additional ready messages and sends them all
 /// before waiting again. This reduces the number of individual write
 /// syscalls under load.
+/// Awaits the outbound task's clean exit, then aborts it if it is wedged.
+///
+/// The outbound task can stall on a writer whose TCP send-buffer is full (a
+/// slow or dead client). We give it a bounded window to drain and close
+/// gracefully; if it does not, `abort()` reclaims the task so it cannot linger
+/// holding the socket sender and receiver until the OS TCP layer errors.
+async fn join_outbound_with_timeout(handle: tokio::task::JoinHandle<()>) {
+    let mut handle = handle;
+    if tokio::time::timeout(std::time::Duration::from_secs(2), &mut handle)
+        .await
+        .is_err()
+    {
+        handle.abort();
+    }
+}
+
 async fn outbound_task(
     mut sender: SplitSink<WebSocket, Message>,
     mut rx: mpsc::Receiver<OutboundMessage>,

--- a/packages/server-rust/src/network/mod.rs
+++ b/packages/server-rust/src/network/mod.rs
@@ -6,10 +6,12 @@ pub mod handlers;
 pub mod middleware;
 pub mod module;
 pub mod openapi;
+pub mod reaper;
 pub mod shutdown;
 
 pub use config::*;
 pub use connection::*;
 pub use handlers::AppState;
 pub use module::NetworkModule;
+pub use reaper::{spawn_connection_reaper, ReaperConfig};
 pub use shutdown::*;

--- a/packages/server-rust/src/network/module.rs
+++ b/packages/server-rust/src/network/module.rs
@@ -345,6 +345,9 @@ impl NetworkModule {
         let tls = config.tls.take();
         let observability = self.observability.clone();
 
+        // Capture reaper tunables before `config` is moved into `build_app`.
+        let reaper_config = super::reaper::ReaperConfig::from(&config.connection);
+
         // Allocate the backfill progress map BEFORE rebuild_from_store so that
         // progress entries written during startup rebuild are visible immediately
         // after set_ready(). The same Arc is threaded into AppState below.
@@ -463,7 +466,14 @@ impl NetworkModule {
         // Transition to Ready so readiness probes pass.
         shutdown_ctrl.set_ready();
 
-        if let Some(ref tls_config) = tls {
+        // Start the connection reaper: evicts idle/half-open and never-authed
+        // connections so slots and per-connection resources do not leak. Aborted
+        // after the serve future returns (post-drain), so it never outlives the
+        // server. Scanning a drained registry is harmless if it ticks first.
+        let reaper_handle =
+            super::reaper::spawn_connection_reaper(Arc::clone(&registry), reaper_config);
+
+        let result = if let Some(ref tls_config) = tls {
             serve_tls(
                 listener,
                 router,
@@ -475,7 +485,10 @@ impl NetworkModule {
             .await
         } else {
             serve_plain(listener, router, registry, shutdown_ctrl, shutdown).await
-        }
+        };
+
+        reaper_handle.abort();
+        result
     }
 }
 

--- a/packages/server-rust/src/network/reaper.rs
+++ b/packages/server-rust/src/network/reaper.rs
@@ -1,0 +1,291 @@
+//! Connection reaper: a background task that evicts stale and abandoned
+//! WebSocket connections so connection slots and per-connection resources do
+//! not leak.
+//!
+//! Without a reaper the server has two lifecycle leaks:
+//! - **Slowloris / never-authed:** a client that connects but never completes
+//!   authentication (or dribbles malformed frames) parks the Phase-1 auth loop
+//!   forever, holding a connection slot and a spawned outbound task.
+//! - **Half-open:** a peer whose TCP died without a FIN is never detected; the
+//!   read loop stays parked on `receiver.next()` until the OS TCP stack times
+//!   out (which can be hours, or never behind a middlebox).
+//!
+//! The reaper closes the gap by periodically scanning the registry and
+//! cancelling connections that have exceeded their timeout. Cancellation only
+//! *signals* teardown — the read loop performs the actual resource cleanup via
+//! its normal disconnect path, so a reaped connection releases exactly the same
+//! lock/topic/counter/query/journal/search subscriptions as a cleanly
+//! disconnected one.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::task::JoinHandle;
+use tracing::{debug, info};
+
+use super::config::ConnectionConfig;
+use super::connection::{ConnectionKind, ConnectionRegistry, OutboundMessage};
+
+/// Tunables for the connection reaper, derived from [`ConnectionConfig`].
+#[derive(Debug, Clone, Copy)]
+pub struct ReaperConfig {
+    /// Steady-state connections idle (no heartbeat) longer than this are reaped.
+    pub idle_timeout: std::time::Duration,
+    /// Connections still in the auth handshake older than this are reaped
+    /// (slowloris guard).
+    pub auth_timeout: std::time::Duration,
+    /// Interval between registry scans.
+    pub interval: std::time::Duration,
+}
+
+impl From<&ConnectionConfig> for ReaperConfig {
+    fn from(c: &ConnectionConfig) -> Self {
+        Self {
+            idle_timeout: c.idle_timeout,
+            auth_timeout: c.auth_timeout,
+            interval: c.reaper_interval,
+        }
+    }
+}
+
+/// Spawns the connection reaper as a background task.
+///
+/// The returned [`JoinHandle`] should be aborted on server shutdown; the task
+/// otherwise loops until aborted. Scanning an empty (drained) registry is
+/// harmless, so abort ordering relative to connection drain does not matter.
+#[must_use]
+pub fn spawn_connection_reaper(
+    registry: Arc<ConnectionRegistry>,
+    config: ReaperConfig,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        info!(
+            idle_timeout_ms = config.idle_timeout.as_millis(),
+            auth_timeout_ms = config.auth_timeout.as_millis(),
+            interval_ms = config.interval.as_millis(),
+            "connection reaper started"
+        );
+        let mut ticker = tokio::time::interval(config.interval);
+        // Skip the immediate first tick so the first scan happens one interval
+        // in, not at startup when nothing is stale yet.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let reaped = reap_stale_once(&registry, config.idle_timeout, config.auth_timeout).await;
+            if reaped > 0 {
+                debug!(reaped, "connection reaper evicted stale connections");
+            }
+        }
+    })
+}
+
+/// Scans the registry once and cancels every stale client connection.
+///
+/// A client connection is stale when either:
+/// - it has **completed the handshake** (steady state) and its last heartbeat
+///   is older than `idle_timeout` (half-open / dead peer), or
+/// - it is **still in the handshake** and has existed longer than `auth_timeout`
+///   (slowloris / abandoned handshake).
+///
+/// `handshake_complete` rather than `authenticated` is the discriminator so a
+/// no-auth server (where connections are never `authenticated`) still applies
+/// the idle bound to active connections instead of reaping them all at the
+/// auth deadline.
+///
+/// Cluster-peer connections are skipped: their liveness is governed by the
+/// cluster failure detector, not the client idle timeout.
+///
+/// Cancellation is idempotent, so a connection that was already cancelled (and
+/// is still finishing its cleanup) is skipped rather than re-signalled. Returns
+/// the number of connections newly cancelled by this scan.
+pub async fn reap_stale_once(
+    registry: &ConnectionRegistry,
+    idle_timeout: std::time::Duration,
+    auth_timeout: std::time::Duration,
+) -> usize {
+    let now = Instant::now();
+    let mut reaped = 0;
+
+    for handle in registry.connections() {
+        if handle.kind != ConnectionKind::Client || handle.is_cancelled() {
+            continue;
+        }
+
+        let (handshake_complete, last_heartbeat) = {
+            let meta = handle.metadata.read().await;
+            (meta.handshake_complete, meta.last_heartbeat)
+        };
+
+        let stale = if handshake_complete {
+            now.duration_since(last_heartbeat) > idle_timeout
+        } else {
+            now.duration_since(handle.connected_at) > auth_timeout
+        };
+
+        if stale {
+            // Best-effort Close so a still-reachable-but-idle client gets a
+            // clean reason; the read-loop teardown (triggered by cancel) does
+            // the authoritative socket close and resource release.
+            let reason = if handshake_complete {
+                "idle timeout"
+            } else {
+                "authentication timeout"
+            };
+            let _ = handle.try_send(OutboundMessage::Close(Some(reason.to_string())));
+            handle.cancel();
+            debug!(
+                conn_id = ?handle.id,
+                handshake_complete,
+                "reaping stale connection: {reason}"
+            );
+            reaped += 1;
+        }
+    }
+
+    reaped
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::network::config::ConnectionConfig;
+
+    fn client_config() -> ConnectionConfig {
+        ConnectionConfig::default()
+    }
+
+    /// An authenticated connection whose heartbeat is older than `idle_timeout`
+    /// is cancelled.
+    #[tokio::test]
+    async fn reaps_idle_authenticated_connection() {
+        let registry = ConnectionRegistry::new();
+        let (handle, _rx) = registry.register(ConnectionKind::Client, &client_config());
+        {
+            let mut meta = handle.metadata.write().await;
+            meta.handshake_complete = true;
+            meta.last_heartbeat = Instant::now().checked_sub(Duration::from_secs(2)).unwrap();
+        }
+
+        let reaped = reap_stale_once(
+            &registry,
+            Duration::from_millis(500),
+            Duration::from_secs(60),
+        )
+        .await;
+
+        assert_eq!(reaped, 1);
+        assert!(
+            handle.is_cancelled(),
+            "idle authed connection should be cancelled"
+        );
+    }
+
+    /// Negative control: an authenticated connection with a fresh heartbeat is
+    /// NOT reaped.
+    #[tokio::test]
+    async fn does_not_reap_active_authenticated_connection() {
+        let registry = ConnectionRegistry::new();
+        let (handle, _rx) = registry.register(ConnectionKind::Client, &client_config());
+        {
+            let mut meta = handle.metadata.write().await;
+            meta.handshake_complete = true;
+            meta.last_heartbeat = Instant::now();
+        }
+
+        let reaped = reap_stale_once(
+            &registry,
+            Duration::from_millis(500),
+            Duration::from_secs(60),
+        )
+        .await;
+
+        assert_eq!(reaped, 0);
+        assert!(
+            !handle.is_cancelled(),
+            "fresh authed connection must survive"
+        );
+    }
+
+    /// A never-authenticated connection older than `auth_timeout` is reaped
+    /// (slowloris guard). `auth_timeout = 0` makes any non-zero age stale.
+    #[tokio::test]
+    async fn reaps_never_authenticated_past_auth_deadline() {
+        let registry = ConnectionRegistry::new();
+        let (handle, _rx) = registry.register(ConnectionKind::Client, &client_config());
+        // Leave authenticated = false (default). Tiny sleep so connected_at is
+        // strictly in the past relative to the scan.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        let reaped =
+            reap_stale_once(&registry, Duration::from_secs(60), Duration::from_millis(1)).await;
+
+        assert_eq!(reaped, 1);
+        assert!(
+            handle.is_cancelled(),
+            "stale unauthed connection should be reaped"
+        );
+    }
+
+    /// Negative control: a never-authenticated connection within `auth_timeout`
+    /// is NOT reaped.
+    #[tokio::test]
+    async fn does_not_reap_unauthenticated_within_auth_deadline() {
+        let registry = ConnectionRegistry::new();
+        let (handle, _rx) = registry.register(ConnectionKind::Client, &client_config());
+
+        let reaped =
+            reap_stale_once(&registry, Duration::from_secs(60), Duration::from_secs(60)).await;
+
+        assert_eq!(reaped, 0);
+        assert!(
+            !handle.is_cancelled(),
+            "young unauthed connection must survive"
+        );
+    }
+
+    /// Cluster-peer connections are never reaped by the client idle reaper.
+    #[tokio::test]
+    async fn does_not_reap_cluster_peer() {
+        let registry = ConnectionRegistry::new();
+        let (handle, _rx) = registry.register(ConnectionKind::ClusterPeer, &client_config());
+        // Make it look maximally stale: unauthenticated and old.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        let reaped = reap_stale_once(
+            &registry,
+            Duration::from_millis(1),
+            Duration::from_millis(1),
+        )
+        .await;
+
+        assert_eq!(reaped, 0);
+        assert!(!handle.is_cancelled(), "cluster peer must not be reaped");
+    }
+
+    /// A connection already cancelled (mid-cleanup) is not counted again.
+    #[tokio::test]
+    async fn skips_already_cancelled_connection() {
+        let registry = ConnectionRegistry::new();
+        let (handle, _rx) = registry.register(ConnectionKind::Client, &client_config());
+        {
+            let mut meta = handle.metadata.write().await;
+            meta.handshake_complete = true;
+            meta.last_heartbeat = Instant::now().checked_sub(Duration::from_secs(2)).unwrap();
+        }
+        handle.cancel();
+
+        let reaped = reap_stale_once(
+            &registry,
+            Duration::from_millis(500),
+            Duration::from_secs(60),
+        )
+        .await;
+
+        assert_eq!(
+            reaped, 0,
+            "already-cancelled connection must not be re-counted"
+        );
+    }
+}

--- a/packages/server-rust/src/service/security.rs
+++ b/packages/server-rust/src/service/security.rs
@@ -197,6 +197,7 @@ mod tests {
     fn make_metadata(authenticated: bool) -> ConnectionMetadata {
         ConnectionMetadata {
             authenticated,
+            handshake_complete: authenticated,
             principal: None,
             subscriptions: Default::default(),
             topics: Default::default(),

--- a/packages/server-rust/tests/connection_reaper_integration.rs
+++ b/packages/server-rust/tests/connection_reaper_integration.rs
@@ -1,0 +1,361 @@
+//! Integration test: the connection reaper evicts idle/half-open and
+//! never-authenticated WebSocket connections, and the read loop runs its full
+//! cleanup path when reaped, so connection slots and per-connection resources
+//! return to zero.
+//!
+//! Strategy mirrors `disconnect_cleanup_integration.rs`: boot a minimal axum
+//! server with real registries wired into `AppState`, connect real WebSocket
+//! clients, and observe registry state. The difference is that here the client
+//! never disconnects — the *server-side reaper* is what closes the connection.
+//!
+//! Coverage:
+//! - idle connection is reaped after the idle timeout, and its seeded session
+//!   state (lock/topic/counter) is released → resources freed (AC: reaped
+//!   connection cleans up all per-connection resources, per SPEC-318).
+//! - negative control: with a long idle timeout the same idle connection
+//!   survives the observation window (reaper does not kill healthy connections).
+//! - negative control: with no reaper running, an idle connection hangs forever
+//!   (the leak this fix closes).
+//! - slowloris: with auth required and a short auth deadline, a client that
+//!   connects but never authenticates is closed by the Phase-1 deadline.
+//! - churn: N connect-then-idle connections all return the connection count to
+//!   zero after the timeout.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use tokio::net::TcpListener;
+use tokio_tungstenite::connect_async;
+use topgun_server::network::config::{ConnectionConfig, NetworkConfig};
+use topgun_server::network::connection::ConnectionRegistry;
+use topgun_server::network::handlers::AppState;
+use topgun_server::network::reaper::{spawn_connection_reaper, ReaperConfig};
+use topgun_server::service::domain::coordination_lock::LockRegistry;
+use topgun_server::service::domain::counter::CounterRegistry;
+use topgun_server::service::domain::messaging::TopicRegistry;
+
+/// Knobs for booting a test server.
+struct BootOpts {
+    /// When set, the server requires JWT auth (Phase 1 runs) with this secret.
+    jwt_secret: Option<String>,
+    /// Per-connection auth deadline (Phase-1 slowloris bound).
+    auth_timeout: Duration,
+    /// When `Some`, spawn the reaper with these tunables.
+    reaper: Option<ReaperConfig>,
+}
+
+struct Booted {
+    port: u16,
+    conn_reg: Arc<ConnectionRegistry>,
+    lock_reg: Arc<LockRegistry>,
+    topic_reg: Arc<TopicRegistry>,
+    counter_reg: Arc<CounterRegistry>,
+    shutdown_tx: tokio::sync::oneshot::Sender<()>,
+    reaper_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+async fn boot(opts: BootOpts) -> Booted {
+    let connection_registry = Arc::new(ConnectionRegistry::new());
+    let lock_reg = Arc::new(LockRegistry::new());
+    let topic_reg = Arc::new(TopicRegistry::new());
+    let counter_reg = Arc::new(CounterRegistry::new("test-node".to_string()));
+
+    let net_config = NetworkConfig {
+        connection: ConnectionConfig {
+            auth_timeout: opts.auth_timeout,
+            ..ConnectionConfig::default()
+        },
+        ..NetworkConfig::default()
+    };
+
+    let state = AppState {
+        registry: Arc::clone(&connection_registry),
+        config: Arc::new(net_config),
+        jwt_secret: opts.jwt_secret,
+        lock_registry: Some(Arc::clone(&lock_reg)),
+        topic_registry: Some(Arc::clone(&topic_reg)),
+        counter_registry: Some(Arc::clone(&counter_reg)),
+        ..AppState::for_test()
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind should succeed");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    let shutdown_ctrl = Arc::clone(&state.shutdown);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let app = axum::Router::new()
+        .route(
+            "/ws",
+            axum::routing::get(topgun_server::network::handlers::ws_upgrade_handler),
+        )
+        .with_state(state);
+
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+                shutdown_ctrl.trigger_shutdown();
+            })
+            .await
+            .expect("serve should not fail");
+    });
+
+    let reaper_handle = opts
+        .reaper
+        .map(|cfg| spawn_connection_reaper(Arc::clone(&connection_registry), cfg));
+
+    // Give the server a moment to start.
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    Booted {
+        port,
+        conn_reg: connection_registry,
+        lock_reg,
+        topic_reg,
+        counter_reg,
+        shutdown_tx,
+        reaper_handle,
+    }
+}
+
+/// Connect a WebSocket client and wait until the server registers it, returning
+/// the live stream (which the caller must hold to keep the connection open).
+async fn connect_and_register(
+    port: u16,
+    conn_reg: &ConnectionRegistry,
+    expected_count: usize,
+) -> impl StreamExt {
+    let url = format!("ws://127.0.0.1:{port}/ws");
+    let (ws_stream, _) = connect_async(&url)
+        .await
+        .expect("WebSocket connect should succeed");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while conn_reg.count() < expected_count {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "server did not register connection(s) within 2 s (have {}, want {})",
+            conn_reg.count(),
+            expected_count
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    ws_stream
+}
+
+async fn poll_until<F: Fn() -> bool>(cond: F, within: Duration, msg: &str) {
+    let deadline = tokio::time::Instant::now() + within;
+    while !cond() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "condition not met within {within:?}: {msg}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: idle connection reaped + seeded session state released
+// ---------------------------------------------------------------------------
+
+/// An idle connection (no app traffic, no heartbeat) is reaped once it exceeds
+/// the idle timeout, and the reaper-triggered teardown releases all seeded
+/// lock/topic/counter state and removes the connection from the registry.
+#[tokio::test(flavor = "multi_thread")]
+async fn idle_connection_reaped_and_resources_freed() {
+    // No JWT → connections reach steady state immediately (handshake_complete),
+    // so the idle (heartbeat) timeout governs. Short timeouts for a fast test.
+    let booted = boot(BootOpts {
+        jwt_secret: None,
+        auth_timeout: Duration::from_secs(30),
+        reaper: Some(ReaperConfig {
+            idle_timeout: Duration::from_millis(250),
+            auth_timeout: Duration::from_millis(250),
+            interval: Duration::from_millis(40),
+        }),
+    })
+    .await;
+
+    let _ws = connect_and_register(booted.port, &booted.conn_reg, 1).await;
+
+    let conn_id = booted.conn_reg.connections()[0].id;
+
+    // Seed session state as if the connection holds locks/topics/counters.
+    booted
+        .lock_reg
+        .try_acquire("L1", conn_id, Some(60_000))
+        .expect("lock acquire");
+    booted
+        .topic_reg
+        .subscribe("T1", conn_id)
+        .expect("subscribe");
+    booted.counter_reg.subscribe("C1", conn_id);
+
+    // The reaper should evict the idle connection and its cleanup should remove
+    // it from the registry AND release all seeded state.
+    poll_until(
+        || booted.conn_reg.count() == 0,
+        Duration::from_secs(5),
+        "idle connection should be reaped from the registry",
+    )
+    .await;
+
+    poll_until(
+        || {
+            booted.lock_reg.holder("L1").is_none()
+                && !booted.topic_reg.subscribers("T1").contains(&conn_id)
+                && !booted.counter_reg.subscribers("C1").contains(&conn_id)
+        },
+        Duration::from_secs(3),
+        "reaped connection must release lock/topic/counter state",
+    )
+    .await;
+
+    if let Some(h) = booted.reaper_handle {
+        h.abort();
+    }
+    let _ = booted.shutdown_tx.send(());
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: negative control — healthy connection survives a long idle timeout
+// ---------------------------------------------------------------------------
+
+/// With a long idle timeout, the reaper running on its normal cadence does NOT
+/// reap a connection that is merely young. Guards against the reaper killing
+/// healthy connections.
+#[tokio::test(flavor = "multi_thread")]
+async fn reaper_does_not_kill_young_connection() {
+    let booted = boot(BootOpts {
+        jwt_secret: None,
+        auth_timeout: Duration::from_secs(30),
+        reaper: Some(ReaperConfig {
+            idle_timeout: Duration::from_secs(30),
+            auth_timeout: Duration::from_secs(30),
+            interval: Duration::from_millis(40),
+        }),
+    })
+    .await;
+
+    let _ws = connect_and_register(booted.port, &booted.conn_reg, 1).await;
+
+    // Let several reaper ticks elapse; the connection must persist.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    assert_eq!(
+        booted.conn_reg.count(),
+        1,
+        "young connection must survive multiple reaper ticks"
+    );
+
+    if let Some(h) = booted.reaper_handle {
+        h.abort();
+    }
+    let _ = booted.shutdown_tx.send(());
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: negative control — without a reaper, an idle connection hangs
+// ---------------------------------------------------------------------------
+
+/// Without the reaper, an idle connection is never closed server-side — this is
+/// the leak the fix addresses. Demonstrates the reaper is load-bearing.
+#[tokio::test(flavor = "multi_thread")]
+async fn without_reaper_idle_connection_hangs() {
+    let booted = boot(BootOpts {
+        jwt_secret: None,
+        auth_timeout: Duration::from_secs(30),
+        reaper: None, // no reaper
+    })
+    .await;
+
+    let _ws = connect_and_register(booted.port, &booted.conn_reg, 1).await;
+
+    // Even after a generous wait, the idle connection is still registered.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert_eq!(
+        booted.conn_reg.count(),
+        1,
+        "without a reaper, an idle connection must hang (leak the slot)"
+    );
+
+    let _ = booted.shutdown_tx.send(());
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: slowloris — never-authenticated connection closed by auth deadline
+// ---------------------------------------------------------------------------
+
+/// With auth required and a short auth deadline, a client that connects but
+/// never sends AUTH is closed by the Phase-1 deadline (independent of the
+/// reaper), returning the connection count to zero.
+#[tokio::test(flavor = "multi_thread")]
+async fn slowloris_closed_by_auth_deadline() {
+    let booted = boot(BootOpts {
+        jwt_secret: Some("test-secret".to_string()),
+        auth_timeout: Duration::from_millis(250),
+        reaper: None, // prove the per-connection Phase-1 deadline alone suffices
+    })
+    .await;
+
+    // Connect but never send an AUTH message. The server's Phase-1 deadline
+    // should close it.
+    let _ws = connect_and_register(booted.port, &booted.conn_reg, 1).await;
+
+    poll_until(
+        || booted.conn_reg.count() == 0,
+        Duration::from_secs(5),
+        "never-authenticated connection should be closed by the auth deadline",
+    )
+    .await;
+
+    let _ = booted.shutdown_tx.send(());
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: churn — N connect-then-idle connections all return count to zero
+// ---------------------------------------------------------------------------
+
+/// A burst of connect-then-idle connections is fully reaped: the registry count
+/// returns to zero after the idle timeout. This is the mini soak/churn signal —
+/// no monotonic connection growth.
+#[tokio::test(flavor = "multi_thread")]
+async fn churn_idle_connections_return_count_to_zero() {
+    const N: usize = 20;
+
+    let booted = boot(BootOpts {
+        jwt_secret: None,
+        auth_timeout: Duration::from_secs(30),
+        reaper: Some(ReaperConfig {
+            idle_timeout: Duration::from_millis(250),
+            auth_timeout: Duration::from_millis(250),
+            interval: Duration::from_millis(40),
+        }),
+    })
+    .await;
+
+    // Hold the streams so the clients don't close from the client side; the
+    // server-side reaper is what must close them.
+    let mut streams = Vec::new();
+    for i in 1..=N {
+        let ws = connect_and_register(booted.port, &booted.conn_reg, i).await;
+        streams.push(ws);
+    }
+    assert_eq!(booted.conn_reg.count(), N, "all N connections registered");
+
+    poll_until(
+        || booted.conn_reg.count() == 0,
+        Duration::from_secs(6),
+        "all idle connections should be reaped back to zero",
+    )
+    .await;
+
+    if let Some(h) = booted.reaper_handle {
+        h.abort();
+    }
+    let _ = booted.shutdown_tx.send(());
+    drop(streams);
+}


### PR DESCRIPTION
## Summary

Closes the **F2 (HIGH)** lifecycle/DoS finding from the G9 network/transport depth-audit (TODO-507), and folds in **F7 (LOW, TODO-512)**.

`ConnectionConfig.idle_timeout` was **dead config** — nothing scanned the registry for staleness, `last_heartbeat` was written on `Ping` but never reaped on, and the Phase-1 auth loop had **no timeout**. Consequences:
- **slowloris** — an unauthenticated client that never sends `AUTH` (or dribbles malformed frames) held a connection slot + outbound task forever;
- **half-open** — a peer whose TCP died without a FIN was never detected (slot leaks until the OS TCP stack times out, or never behind a middlebox);
- **soak (G4b)** would show monotonic connection growth.

## What changed

- **`ConnectionConfig`**: add `auth_timeout` (10 s) + `reaper_interval` (10 s); `idle_timeout` finally has a consumer.
- **`ConnectionHandle`**: add a `CancellationToken` (`cancel()` / `is_cancelled()`). Both read-loop phases `select!` on it, so the reaper can unblock a reader parked on a half-open socket. Teardown runs the **same** `release_session_state` path as a clean disconnect — a reaped connection releases exactly the same lock/topic/counter/query/journal/search subscriptions (SPEC-318 lifecycle cleanup honoured).
- **`ConnectionMetadata`**: add `handshake_complete`, set when entering Phase 2 (true for no-auth connections too). The reaper keys idle-vs-auth on this rather than `authenticated`, so a **no-auth server** applies the idle bound to active connections instead of reaping them all at the auth deadline.
- **`network/reaper.rs`** (new): periodic `spawn_connection_reaper` + a testable `reap_stale_once`. Reaps steady-state connections idle past `idle_timeout` (by `last_heartbeat`) and handshake connections past `auth_timeout`. Cluster peers are skipped (the failure detector owns their liveness).
- **`websocket.rs`**: Phase-1 auth loop bounded by a per-connection `sleep_until(auth_deadline)` — a precise slowloris cut independent of the reaper tick.
- Reaper is spawned in **both** serve paths — `NetworkModule::serve()` **and** the hand-built `topgun-server` binary router (the dual-router trap) — and aborted on shutdown.
- **TODO-512/F7**: `outbound_handle` is now `abort()`-ed after the 2 s join timeout via a shared `join_outbound_with_timeout` helper at all four teardown sites, instead of being abandoned.

## Tests

- 6 reaper unit tests: idle-reaped / active-survives (neg. control) / never-authed past deadline / within-deadline (neg. control) / cluster-peer-skipped / already-cancelled-not-double-counted.
- `tests/connection_reaper_integration.rs` (real WS clients): idle connection reaped **and seeded lock/topic/counter state released + registry count → 0**; young connection survives (reaper doesn't kill healthy conns); **no-reaper negative control** (idle connection hangs — the leak this closes); slowloris closed by the auth deadline; **N=20 churn → count returns to 0** (mini-soak signal).

## Local gate (all green)

- `cargo test --release -p topgun-server --lib` → 1381 passed
- reaper unit (6) + `connection_reaper_integration` (5) passed
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --check` clean
- `pnpm test:integration-rust` → 83 passed / 12 suites (incl. reconnect + cluster-routing)