### PR TITLE
fix(mcp): server-authoritative reads + real-server integration harness (TODO-524/517)

### DIFF
--- a/.github/workflows/integration-rust.yml
+++ b/.github/workflows/integration-rust.yml
@@ -15,6 +15,7 @@ on:
       - 'packages/core/**'
       - 'packages/server-rust/**'
       - 'packages/core-rust/**'
+      - 'packages/mcp-server/**'
       - 'tests/integration-rust/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -28,6 +29,7 @@ on:
       - 'packages/core/**'
       - 'packages/server-rust/**'
       - 'packages/core-rust/**'
+      - 'packages/mcp-server/**'
       - 'tests/integration-rust/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -116,8 +118,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run integration tests (single-server suites)
-        # ts-jest compiles @topgunbuild/{core,client} from source via the config's
-        # moduleNameMapper, so no package build is needed. RUST_SERVER_BINARY points
+        # ts-jest compiles @topgunbuild/{core,client,mcp-server} from source via the
+        # config's moduleNameMapper, so no package build is needed (the MCP harness
+        # drives the workspace source, not a stale published dist). RUST_SERVER_BINARY points
         # spawnRustServer() at the prebuilt binary (skips cargo). --runInBand keeps
         # per-file fixtures from contending on the fixed server ports (CLAUDE.md).
         # cluster-routing is excluded here and gated separately (non-blocking) below.

--- a/packages/mcp-server/src/__tests__/mcp-integration.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-integration.test.ts
@@ -169,7 +169,13 @@ describe('MCP Integration', () => {
       const result = await server.callTool('topgun_schema', { map: 'tasks' });
 
       expect(result).toBeDefined();
-      expect(result.isError).toBeUndefined();
+      // schema is now server-authoritative (reads via queryOncePaged, not the
+      // local replica). With no reachable server in this harness the read cannot
+      // settle, so the tool reports an explicit not-settled error rather than a
+      // false "empty" answer. Real schema inference is covered by the unit suite
+      // (mock client returns rows) and the real-server integration harness.
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('NOT an empty result');
     });
 
     it('should execute topgun_stats', async () => {
@@ -186,8 +192,11 @@ describe('MCP Integration', () => {
       });
 
       expect(result).toBeDefined();
-      expect(result.isError).toBeUndefined();
-      expect(result.content[0].text).toContain('Query Plan');
+      // explain is now server-authoritative: it estimates the plan over a settled
+      // server sample, not the empty local replica. No reachable server here means
+      // the read cannot settle, so the tool surfaces the not-settled path.
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('NOT an empty result');
     });
 
     it('should execute topgun_search', async () => {
@@ -304,8 +313,8 @@ describe('MCP Integration', () => {
       expect(result.content[0].text).toContain('not settled');
     });
 
-    it('should show correct field types via topgun_schema', async () => {
-      // Write structured data
+    it('should not infer schema from local-only writes (server-authoritative)', async () => {
+      // Write structured data locally (server unreachable in this harness).
       await server.callTool('topgun_mutate', {
         map: 'records',
         operation: 'set',
@@ -318,17 +327,15 @@ describe('MCP Integration', () => {
         },
       });
 
-      // Get schema
+      // schema reads the SERVER, not the local replica these writes landed in.
+      // With no reachable server it cannot settle — and must NOT echo the local
+      // write back as if it were the map's schema. This is the core F1 fix: a
+      // local-only write is not authoritative schema. (Real inference over server
+      // data is proven by the real-server integration harness.)
       const schemaResult = await server.callTool('topgun_schema', { map: 'records' });
 
-      expect(schemaResult.isError).toBeUndefined();
-      const text = schemaResult.content[0].text;
-
-      // Schema should detect field types
-      expect(text).toContain('name');
-      expect(text).toContain('age');
-      expect(text).toContain('active');
-      expect(text).toContain('tags');
+      expect(schemaResult.isError).toBe(true);
+      expect(schemaResult.content[0].text).toContain('NOT an empty result');
     });
 
     it('should return connection info via topgun_stats', async () => {
@@ -339,16 +346,18 @@ describe('MCP Integration', () => {
       expect(statsResult.content[0].text).toContain('Status');
     });
 
-    it('should show query plan via topgun_explain', async () => {
+    it('should report not-settled for explain when server is unreachable', async () => {
       const explainResult = await server.callTool('topgun_explain', {
         map: 'tasks',
         filter: { status: 'active', priority: 'high' },
       });
 
-      expect(explainResult.isError).toBeUndefined();
-      expect(explainResult.content[0].text).toContain('Query Plan');
-      expect(explainResult.content[0].text).toContain('map');
+      // explain estimates over a settled server sample; with no reachable server
+      // the read cannot settle, so it surfaces the not-settled path (it must not
+      // present a plan computed over the empty local replica as if it were truth).
+      expect(explainResult.isError).toBe(true);
       expect(explainResult.content[0].text).toContain('tasks');
+      expect(explainResult.content[0].text).toContain('NOT an empty result');
     });
 
     it('should handle remove operation correctly', async () => {

--- a/packages/mcp-server/src/tools/explain.ts
+++ b/packages/mcp-server/src/tools/explain.ts
@@ -4,6 +4,7 @@
 
 import type { MCPTool, MCPToolResult, ToolContext } from '../types';
 import { ExplainArgsSchema, toolSchemas, type ExplainArgs } from '../schemas';
+import { fetchServerRecords, ServerReadUnsettledError } from './serverRead';
 
 export const explainTool: MCPTool = {
   name: 'topgun_explain',
@@ -44,13 +45,30 @@ export async function handleExplain(rawArgs: unknown, ctx: ToolContext): Promise
   }
 
   try {
-    const lwwMap = ctx.client.getMap<string, Record<string, unknown>>(map);
+    // Read records from the SERVER (settled, authoritative) rather than the MCP
+    // process's local replica, which is empty for any data this process did not
+    // write itself. Fetch UNFILTERED so we have both the total and can compute the
+    // matching subset over the same sample; pushing the filter to the server would
+    // lose the total-records denominator the plan/selectivity needs.
+    let records;
+    let hasMore: boolean;
+    try {
+      ({ records, hasMore } = await fetchServerRecords(ctx, map));
+    } catch (error) {
+      if (error instanceof ServerReadUnsettledError) {
+        return {
+          content: [{ type: 'text', text: error.message }],
+          isError: true,
+        };
+      }
+      throw error;
+    }
 
-    // Count total records
+    // Count total + matching records over the server sample
     let totalRecords = 0;
     let matchingRecords = 0;
 
-    for (const [, value] of lwwMap.entries()) {
+    for (const { value } of records) {
       if (value !== null && typeof value === 'object') {
         totalRecords++;
 
@@ -136,6 +154,14 @@ export async function handleExplain(rawArgs: unknown, ctx: ToolContext): Promise
         ? `\n\nRecommendations:\n${plan.recommendations.map((r) => `  - ${r}`).join('\n')}`
         : '';
 
+    // When the map holds more rows than the sample ceiling, the plan is estimated
+    // over the first `maxLimit` server records — say so, so the counts/selectivity
+    // are read as estimates from a sample, not exact totals.
+    const sampleNote = hasMore
+      ? `\n\nNote: estimated from a sample of the first ${ctx.config.maxLimit} server ` +
+        `records; the map holds more rows, so totals are a lower bound.`
+      : '';
+
     return {
       content: [
         {
@@ -145,10 +171,11 @@ export async function handleExplain(rawArgs: unknown, ctx: ToolContext): Promise
             `Strategy: ${plan.strategy}\n\n` +
             `Execution Steps:\n${stepsFormatted}\n\n` +
             `Statistics:\n` +
-            `  - Total Records: ${plan.totalRecords}\n` +
+            `  - Total Records${hasMore ? ' (sampled)' : ''}: ${plan.totalRecords}\n` +
             `  - Estimated Results: ${plan.estimatedResults}\n` +
             `  - Selectivity: ${(plan.selectivity * 100).toFixed(1)}%` +
-            recommendationsFormatted,
+            recommendationsFormatted +
+            sampleNote,
         },
       ],
     };

--- a/packages/mcp-server/src/tools/schema.ts
+++ b/packages/mcp-server/src/tools/schema.ts
@@ -4,6 +4,7 @@
 
 import type { MCPTool, MCPToolResult, ToolContext } from '../types';
 import { SchemaArgsSchema, toolSchemas, type SchemaArgs } from '../schemas';
+import { fetchServerRecords, ServerReadUnsettledError } from './serverRead';
 
 export const schemaTool: MCPTool = {
   name: 'topgun_schema',
@@ -89,14 +90,29 @@ export async function handleSchema(rawArgs: unknown, ctx: ToolContext): Promise<
   }
 
   try {
-    const lwwMap = ctx.client.getMap<string, Record<string, unknown>>(map);
+    // Read the records from the SERVER (settled, authoritative) rather than the
+    // MCP process's local replica, which is empty for any data this process did
+    // not write itself. The schema is inferred from this sample.
+    let records;
+    let hasMore: boolean;
+    try {
+      ({ records, hasMore } = await fetchServerRecords(ctx, map));
+    } catch (error) {
+      if (error instanceof ServerReadUnsettledError) {
+        return {
+          content: [{ type: 'text', text: error.message }],
+          isError: true,
+        };
+      }
+      throw error;
+    }
 
     // Collect field information from all entries
     const fieldTypes: Map<string, Set<string>> = new Map();
     const fieldValues: Map<string, unknown[]> = new Map();
     let recordCount = 0;
 
-    for (const [, value] of lwwMap.entries()) {
+    for (const { value } of records) {
       if (value !== null && typeof value === 'object') {
         recordCount++;
         for (const [fieldName, fieldValue] of Object.entries(value)) {
@@ -161,15 +177,23 @@ export async function handleSchema(rawArgs: unknown, ctx: ToolContext): Promise<
       .map(([name, type]) => `  - ${name}: ${type}`)
       .join('\n');
 
+    // When the map holds more rows than the sample ceiling, the schema is
+    // inferred from the first `maxLimit` records — say so, so a field that only
+    // appears later is not mistaken for "the whole schema".
+    const sampleNote = hasMore
+      ? `\n\nNote: schema inferred from a sample of the first ${ctx.config.maxLimit} server ` +
+        `records; the map holds more rows.`
+      : '';
+
     return {
       content: [
         {
           type: 'text',
           text:
             `Schema for map '${map}':\n\n` +
-            `Records: ${recordCount}\n\n` +
+            `Records${hasMore ? ' (sampled)' : ''}: ${recordCount}\n\n` +
             `Fields:\n${fieldsFormatted}\n\n` +
-            `Raw schema:\n${JSON.stringify(schemaOutput, null, 2)}`,
+            `Raw schema:\n${JSON.stringify(schemaOutput, null, 2)}${sampleNote}`,
         },
       ],
     };

--- a/packages/mcp-server/src/tools/serverRead.ts
+++ b/packages/mcp-server/src/tools/serverRead.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared server-authoritative read helper for the read-only MCP tools.
+ *
+ * `topgun_schema`, `topgun_stats` (per-map), and `topgun_explain` used to iterate
+ * `client.getMap(map).entries()` — the MCP process's LOCAL CRDT replica. That
+ * replica is only ever populated by `topgun_mutate` writes made in the same
+ * process; the one server read (`queryOncePaged`, used by `topgun_query`) never
+ * hydrates it. The result was that every read tool reported "empty / 0 records"
+ * for a server map holding real data — even right after a query returned its rows.
+ *
+ * This helper routes those tools through the same authoritative path
+ * `topgun_query` uses: a one-shot, settled server read via `queryOncePaged`. A
+ * normal resolve is ALWAYS settled server data; an offline/timeout is surfaced as
+ * {@link ServerReadUnsettledError} so the tools can say "could not reach the
+ * server — this is NOT an empty result" rather than silently answering "0".
+ */
+
+import { QueryOnceUnsettledError } from '@topgunbuild/client';
+import type { ToolContext } from '../types';
+
+/** A single server-resident record: its map key plus the record body. */
+export interface ServerRecord {
+  key: string;
+  value: Record<string, unknown>;
+}
+
+export interface ServerReadResult {
+  /** Record bodies sampled from the server (authoritative, settled). */
+  records: ServerRecord[];
+  /**
+   * True when the server signalled that more rows exist beyond the sampled page
+   * (the sample is capped at `config.maxLimit`). Callers should label counts
+   * derived from the sample as a lower bound when this is set, so a large map is
+   * never silently undercounted.
+   */
+  hasMore: boolean;
+}
+
+/**
+ * Thrown when a server-authoritative read could not settle (client offline, or
+ * the settle wait timed out). Read tools MUST surface this as an explicit
+ * "not reachable" error and never as an empty/zero answer, so an unreachable
+ * server is never confused with a genuinely empty map.
+ */
+export class ServerReadUnsettledError extends Error {
+  public readonly name = 'ServerReadUnsettledError';
+  constructor(
+    public readonly reason: 'offline' | 'timeout',
+    public readonly map: string,
+  ) {
+    super(
+      reason === 'offline'
+        ? `Could not read map '${map}': the server is unreachable (client offline). ` +
+            `This is NOT an empty result.`
+        : `Could not read map '${map}': the server read did not settle in time. ` +
+            `This is NOT an empty result.`,
+    );
+  }
+}
+
+// queryOncePaged is a public TopGunClient method, but its overloaded generic
+// signature does not narrow cleanly here; cast to the minimal shape we use —
+// the same pattern handleQuery applies for the paged read.
+type ClientWithPaged = {
+  queryOncePaged(
+    map: string,
+    filter: { where?: Record<string, unknown>; limit?: number },
+  ): Promise<{
+    items: Array<Record<string, unknown> & { _key: string }>;
+    hasMore: boolean;
+  }>;
+};
+
+/**
+ * Fetch a settled, server-authoritative sample of a map's records.
+ *
+ * The sample is bounded by `config.maxLimit` (the same ceiling user-facing
+ * queries use); when the server reports more rows exist, `hasMore` is set so the
+ * caller can label derived counts as a lower bound. An optional `where` filter is
+ * pushed to the server; callers that need both a total and a filtered subset
+ * (e.g. `explain`) should fetch unfiltered and filter the returned sample.
+ */
+export async function fetchServerRecords(
+  ctx: ToolContext,
+  map: string,
+  opts: { filter?: Record<string, unknown> } = {},
+): Promise<ServerReadResult> {
+  const filter: { where?: Record<string, unknown>; limit: number } = {
+    limit: ctx.config.maxLimit,
+  };
+  if (opts.filter) {
+    filter.where = opts.filter;
+  }
+
+  try {
+    const paged = await (ctx.client as unknown as ClientWithPaged).queryOncePaged(map, filter);
+    const records: ServerRecord[] = paged.items.map((item) => {
+      const { _key, ...value } = item;
+      return { key: _key, value };
+    });
+    return { records, hasMore: paged.hasMore };
+  } catch (error) {
+    if (error instanceof QueryOnceUnsettledError) {
+      throw new ServerReadUnsettledError(error.reason, map);
+    }
+    throw error;
+  }
+}

--- a/packages/mcp-server/src/tools/stats.ts
+++ b/packages/mcp-server/src/tools/stats.ts
@@ -4,6 +4,7 @@
 
 import type { MCPTool, MCPToolResult, ToolContext } from '../types';
 import { StatsArgsSchema, toolSchemas, type StatsArgs } from '../schemas';
+import { fetchServerRecords, ServerReadUnsettledError } from './serverRead';
 
 export const statsTool: MCPTool = {
   name: 'topgun_stats',
@@ -55,7 +56,10 @@ export async function handleStats(rawArgs: unknown, ctx: ToolContext): Promise<M
       maps: Array<{
         name: string;
         recordCount: number;
-        tombstoneCount: number;
+        // The sample hit the ceiling — `recordCount` is a lower bound.
+        sampled: boolean;
+        // Server could not be reached for this map's record count.
+        unreachable: boolean;
       }>;
       cluster?: {
         nodes: string[];
@@ -81,26 +85,26 @@ export async function handleStats(rawArgs: unknown, ctx: ToolContext): Promise<M
       };
     }
 
-    // Get map stats
+    // Get map stats from the SERVER (settled, authoritative) rather than the MCP
+    // process's local replica, which is empty for any data this process did not
+    // write itself. The connection block above is always reported; an unreachable
+    // server degrades only the per-map count, never the whole call.
     if (map) {
-      // Single map stats
-      const lwwMap = ctx.client.getMap<string, unknown>(map);
-      let recordCount = 0;
-      let tombstoneCount = 0;
-
-      for (const [, value] of lwwMap.entries()) {
-        if (value === null || value === undefined) {
-          tombstoneCount++;
+      try {
+        const { records, hasMore } = await fetchServerRecords(ctx, map);
+        stats.maps.push({
+          name: map,
+          recordCount: records.length,
+          sampled: hasMore,
+          unreachable: false,
+        });
+      } catch (error) {
+        if (error instanceof ServerReadUnsettledError) {
+          stats.maps.push({ name: map, recordCount: 0, sampled: false, unreachable: true });
         } else {
-          recordCount++;
+          throw error;
         }
       }
-
-      stats.maps.push({
-        name: map,
-        recordCount,
-        tombstoneCount,
-      });
     }
 
     // Format output
@@ -122,11 +126,11 @@ export async function handleStats(rawArgs: unknown, ctx: ToolContext): Promise<M
       stats.maps.length > 0
         ? `\n\nMap Statistics:\n` +
           stats.maps
-            .map(
-              (m) =>
-                `  ${m.name}:\n` +
-                `    - Records: ${m.recordCount}\n` +
-                `    - Tombstones: ${m.tombstoneCount}`,
+            .map((m) =>
+              m.unreachable
+                ? `  ${m.name}:\n` + `    - Records: unavailable (server unreachable — NOT empty)`
+                : `  ${m.name}:\n` +
+                  `    - Records${m.sampled ? ' (sampled, at least)' : ''}: ${m.recordCount}`,
             )
             .join('\n')
         : map

--- a/tests/integration-rust/jest.config.js
+++ b/tests/integration-rust/jest.config.js
@@ -11,7 +11,11 @@ module.exports = {
   ],
   moduleNameMapper: {
     '^@topgunbuild/core$': '<rootDir>/../../packages/core/src/index.ts',
-    '^@topgunbuild/client$': '<rootDir>/../../packages/client/src/index.ts'
+    '^@topgunbuild/client$': '<rootDir>/../../packages/client/src/index.ts',
+    // Compile the MCP server from source (its deps resolve from
+    // packages/mcp-server/node_modules under pnpm) so the real-server MCP
+    // harness drives the workspace source, not a stale published dist.
+    '^@topgunbuild/mcp-server$': '<rootDir>/../../packages/mcp-server/src/index.ts'
   },
   transform: {
     '^.+\\.ts$': ['ts-jest', {

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -152,16 +152,33 @@ describe('Integration: MCP tools against a real Rust server (cold cache)', () =>
   let mcp: TopGunMCPServer | null = null;
   let mapName = '';
 
-  beforeEach(async () => {
+  // Connect BOTH clients up front against the still-idle server (so each
+  // completes its AUTH handshake fast), THEN seed. A client that connects LATER —
+  // while the seeder is mid-Merkle-sync — can miss its AUTH_ACK inside the SDK's
+  // 15 s connection-establishment window under CI load and stall at
+  // AUTHENTICATING; connecting before any load avoids that race (the pattern
+  // live-query-limit-clamp.test.ts uses). The data must stay on the server, so
+  // the seeder stays connected for the suite's lifetime (the null in-memory
+  // backend keeps a map's rows only while it is live, not after the writer
+  // disconnects). The MCP client is still a genuinely COLD reader: it never
+  // mutates and queryOncePaged does not hydrate the persistent replica, so its
+  // local CRDT map stays empty for every read — exactly the configuration that
+  // exposes a server-blind read. We inject the client (rather than letting the
+  // MCP server build one) so it carries its own auth, and start it directly
+  // instead of via mcp.start(), which would attach a stdio transport that
+  // consumes the Jest process's stdin; callTool() only needs it connected.
+  beforeAll(async () => {
     server = await spawnRustServer();
 
-    // 1. Seeder client — writes data the MCP process's cache has NEVER seen.
     seeder = makeClient(server.port, 'mcp-seeder');
-    await seeder.start();
-    await waitForState(seeder, SyncState.CONNECTED);
+    const mcpClient = makeClient(server.port, 'mcp-reader');
+    mcp = new TopGunMCPServer({ client: mcpClient });
 
-    // Unique map per test so the null in-memory backend never bleeds rows across
-    // runs and every seeded row is unambiguously part of this test's dataset.
+    await seeder.start();
+    await mcpClient.start();
+    await waitForState(seeder, SyncState.CONNECTED);
+    await waitForState(mcpClient, SyncState.CONNECTED);
+
     mapName = `mcp_e2e_${Date.now()}`;
     const m = seeder.getMap<string, Record<string, unknown>>(mapName);
     for (let i = 0; i < RECORD_COUNT; i++) {
@@ -173,19 +190,9 @@ describe('Integration: MCP tools against a real Rust server (cold cache)', () =>
       });
     }
     await waitForSynced(seeder);
-
-    // 2. MCP server driving a SEPARATE, freshly-built client (cold cache) → same
-    // server. We inject the client so it carries its own auth, and start it
-    // directly rather than via mcp.start() (which would attach a stdio transport
-    // that consumes the Jest process's stdin); callTool() only needs the client
-    // connected.
-    const mcpClient = makeClient(server.port, 'mcp-reader');
-    mcp = new TopGunMCPServer({ client: mcpClient });
-    await mcpClient.start();
-    await waitForState(mcpClient, SyncState.CONNECTED);
   }, 60_000);
 
-  afterEach(async () => {
+  afterAll(async () => {
     if (mcp) {
       await mcp
         .getClient()

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -26,7 +26,7 @@ import { TopGunClient, SyncState } from '@topgunbuild/client';
 import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
 import { TopGunMCPServer } from '@topgunbuild/mcp-server';
 
-import { spawnRustServer, SpawnedServer } from './helpers';
+import { spawnRustServer, createTestToken, SpawnedServer } from './helpers';
 
 // In-memory storage adapter so the SDK runs headless in Node (no IndexedDB).
 class MemoryStorageAdapter implements IStorageAdapter {
@@ -128,10 +128,20 @@ function text(result: { content: Array<{ text?: string }> }): string {
   return (result.content || []).map((c) => c.text ?? '').join('\n');
 }
 
-// NO_AUTH so both the seeder and the MCP server's own client connect tokenless
-// against the loopback ephemeral-port server (the documented zero-config local
-// posture); auth is exercised separately by connection-auth.test.ts.
-const SERVER_ENV = { TOPGUN_NO_AUTH: '1' };
+// Both clients authenticate with a JWT (same pattern the other single-server
+// integration suites use), rather than relying on a NO_AUTH server. The tokenless
+// NO_AUTH path is racy for a second connecting client under CI load (the WS
+// upgrade intermittently fails before the grace window resolves); explicit auth
+// is the deterministic, CI-proven path.
+function makeClient(port: number, userId: string): TopGunClient {
+  const token = createTestToken(userId, ['ADMIN']);
+  return new TopGunClient({
+    serverUrl: `ws://localhost:${port}/ws`,
+    storage: new MemoryStorageAdapter(),
+    auth: { getToken: async () => token },
+    backoff: { initialDelayMs: 200, maxDelayMs: 400, jitter: true },
+  });
+}
 
 const RECORD_COUNT = 25;
 const OPEN_COUNT = 10; // records 0..9 are status:'open', 10..24 are status:'done'
@@ -143,14 +153,10 @@ describe('Integration: MCP tools against a real Rust server (cold cache)', () =>
   let mapName = '';
 
   beforeEach(async () => {
-    server = await spawnRustServer({ env: SERVER_ENV });
+    server = await spawnRustServer();
 
     // 1. Seeder client — writes data the MCP process's cache has NEVER seen.
-    seeder = new TopGunClient({
-      serverUrl: `ws://localhost:${server.port}/ws`,
-      storage: new MemoryStorageAdapter(),
-      backoff: { initialDelayMs: 200, maxDelayMs: 400, jitter: true },
-    });
+    seeder = makeClient(server.port, 'mcp-seeder');
     await seeder.start();
     await waitForState(seeder, SyncState.CONNECTED);
 
@@ -168,12 +174,13 @@ describe('Integration: MCP tools against a real Rust server (cold cache)', () =>
     }
     await waitForSynced(seeder);
 
-    // 2. MCP server with its OWN fresh client (cold cache) → same server.
-    mcp = new TopGunMCPServer({ topgunUrl: `ws://localhost:${server.port}/ws` });
-    const mcpClient = mcp.getClient();
-    // Start the client directly (not mcp.start(), which would attach a stdio
-    // transport that consumes the Jest process's stdin); callTool() only needs
-    // the client connected.
+    // 2. MCP server driving a SEPARATE, freshly-built client (cold cache) → same
+    // server. We inject the client so it carries its own auth, and start it
+    // directly rather than via mcp.start() (which would attach a stdio transport
+    // that consumes the Jest process's stdin); callTool() only needs the client
+    // connected.
+    const mcpClient = makeClient(server.port, 'mcp-reader');
+    mcp = new TopGunMCPServer({ client: mcpClient });
     await mcpClient.start();
     await waitForState(mcpClient, SyncState.CONNECTED);
   }, 60_000);

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -27,7 +27,7 @@ import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
 import { TopGunMCPServer } from '@topgunbuild/mcp-server';
 import type { MCPToolResult } from '@topgunbuild/mcp-server';
 
-import { spawnRustServer, createTestToken, SpawnedServer } from './helpers';
+import { spawnRustServer, createTestToken } from './helpers';
 
 // In-memory storage adapter so the SDK runs headless in Node (no IndexedDB).
 class MemoryStorageAdapter implements IStorageAdapter {

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -144,6 +144,16 @@ const OPEN_COUNT = 10; // records 0..9 are status:'open', 10..24 are status:'don
 // is NOT a transient error, so it is never retried — the negative control still
 // fails fast against the unfixed tools.
 const TRANSIENT = /unreachable|not settled|did not settle|client offline/i;
+function isTransientConnectivity(result: MCPToolResult): boolean {
+  const out = text(result);
+  // queryOncePaged-backed tools (query/schema/explain) surface offline/unsettled
+  // as an isError result — gate on isError so a SUCCESSFUL response whose record
+  // content merely contains one of these words is never retried.
+  if (result.isError && TRANSIENT.test(out)) return true;
+  // topgun_stats stays isError=false and instead degrades only its per-map line;
+  // match that exact marker so an unreachable stats read is retried too.
+  return /Records: unavailable \(server unreachable/i.test(out);
+}
 async function callStable(
   mcp: TopGunMCPServer,
   name: string,
@@ -153,7 +163,7 @@ async function callStable(
   for (let attempt = 0; attempt < 6; attempt++) {
     await waitForState(mcp.getClient(), SyncState.CONNECTED, 8_000).catch(() => {});
     last = await mcp.callTool(name, args);
-    if (!TRANSIENT.test(text(last))) return last;
+    if (!isTransientConnectivity(last)) return last;
     await waitMs(500);
   }
   return last!;

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -27,7 +27,7 @@ import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
 import { TopGunMCPServer } from '@topgunbuild/mcp-server';
 import type { MCPToolResult } from '@topgunbuild/mcp-server';
 
-import { spawnRustServer, createTestToken } from './helpers';
+import { spawnRustServer, createRustTestClient, createTestToken, createLWWRecord } from './helpers';
 
 // In-memory storage adapter so the SDK runs headless in Node (no IndexedDB).
 class MemoryStorageAdapter implements IStorageAdapter {
@@ -115,16 +115,6 @@ async function waitForState(
   throw new Error(`Timed out waiting for ${state}; last = ${client.getConnectionState()}`);
 }
 
-/** Resolves once every optimistic local write has round-tripped and been ACKed. */
-async function waitForSynced(client: TopGunClient, timeoutMs = 20_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (client.getPendingOpsCount() === 0) return;
-    await waitMs(25);
-  }
-  throw new Error(`Timed out waiting to drain; pending = ${client.getPendingOpsCount()}`);
-}
-
 function text(result: { content: Array<{ text?: string }> }): string {
   return (result.content || []).map((c) => c.text ?? '').join('\n');
 }
@@ -170,48 +160,60 @@ async function callStable(
 }
 
 describe('Integration: MCP tools against a real Rust server (cold cache)', () => {
-  // One self-contained test that boots the server, connects both clients, seeds,
-  // and runs every read back-to-back. Doing the whole scenario inline keeps it
-  // FAST (a few seconds) — well inside the SDK's 15 s heartbeat-timeout window —
-  // so neither client churns mid-suite, the failure mode that flaked a
-  // beforeAll + per-test layout under CI load. This mirrors the lifecycle of the
-  // other reliably-green single-server suites (queries/live-query): server +
-  // client(s) + assertions all in one test body.
+  // One self-contained test that boots the server, seeds, and runs every read
+  // back-to-back. Doing the whole scenario inline keeps it FAST (a few seconds),
+  // the lifecycle the reliably-green single-server suites use.
   //
-  // BOTH clients connect up front against the still-idle server (each AUTH
-  // handshake completes fast — a client connecting later, while the seeder is
-  // mid-Merkle-sync, can miss its AUTH_ACK and stall at AUTHENTICATING). The
-  // seeder stays connected for the test's lifetime because the null in-memory
-  // backend keeps a map's rows only while a client holds it live. The MCP client
-  // is still a genuinely COLD reader: it never mutates and queryOncePaged does
-  // not hydrate the persistent replica, so its local CRDT map stays empty for
-  // every read — exactly the configuration that exposes a server-blind read. We
-  // inject the client so it carries its own auth, and start it directly rather
-  // than via mcp.start() (which would attach a stdio transport that consumes the
-  // Jest process's stdin); callTool() only needs it connected.
+  // The SEEDER is the raw standalone test-client (CLIENT_OP over the wire), NOT a
+  // second TopGunClient. Two TopGunClients each run heartbeat + Merkle-sync and an
+  // aggressive auto-reconnect; under CI load a single blip cascaded into a non-101
+  // reconnect storm that left the reader offline for the rest of the suite. The
+  // raw client has no reconnect/sync machinery (it just PINGs to stay past the
+  // server idle reaper), so it holds a stable connection with no storm — and it
+  // keeps the map's rows live on the null in-memory backend (which drops them once
+  // no client holds the map). Seeding over the wire also never touches the MCP
+  // client's local replica, so the reader stays genuinely COLD: it never mutates
+  // and queryOncePaged does not hydrate the persistent replica, so its local CRDT
+  // map is empty for every read — exactly the configuration that exposes a
+  // server-blind read. We inject the reader client so it carries its own auth, and
+  // start it directly rather than via mcp.start() (which would attach a stdio
+  // transport that consumes the Jest process's stdin); callTool() only needs it
+  // connected.
   test('cold MCP read tools reflect real server data, not an empty local replica (F1)', async () => {
     const server = await spawnRustServer();
-    const seeder = makeClient(server.port, 'mcp-seeder');
+    const seeder = await createRustTestClient(server.port, {
+      userId: 'mcp-seeder',
+      roles: ['ADMIN'],
+    });
     const mcpClient = makeClient(server.port, 'mcp-reader');
     const mcp = new TopGunMCPServer({ client: mcpClient });
 
     try {
-      await seeder.start();
+      await seeder.waitForMessage('AUTH_ACK', 10_000);
       await mcpClient.start();
-      await waitForState(seeder, SyncState.CONNECTED);
       await waitForState(mcpClient, SyncState.CONNECTED);
 
+      // Seed over the wire (raw CLIENT_OP PUTs), waiting for each server ACK.
       const mapName = `mcp_e2e_${Date.now()}`;
-      const m = seeder.getMap<string, Record<string, unknown>>(mapName);
       for (let i = 0; i < RECORD_COUNT; i++) {
-        m.set(`k${i}`, {
-          id: `k${i}`,
-          title: `doc ${i}`,
-          status: i < OPEN_COUNT ? 'open' : 'done',
-          n: i,
+        seeder.messages.length = 0;
+        seeder.send({
+          type: 'CLIENT_OP',
+          payload: {
+            id: `seed-${i}`,
+            mapName,
+            opType: 'PUT',
+            key: `k${i}`,
+            record: createLWWRecord({
+              id: `k${i}`,
+              title: `doc ${i}`,
+              status: i < OPEN_COUNT ? 'open' : 'done',
+              n: i,
+            }),
+          },
         });
+        await seeder.waitForMessage('OP_ACK', 10_000);
       }
-      await waitForSynced(seeder);
 
       // Sanity: topgun_query (already server-authoritative) returns the rows.
       const query = await callStable(mcp, 'topgun_query', { map: mapName, limit: 5 });
@@ -252,7 +254,7 @@ describe('Integration: MCP tools against a real Rust server (cold cache)', () =>
       expect(text(schemaAfter)).toContain('Records: 25');
     } finally {
       await mcpClient.close().catch(() => {});
-      await seeder.close().catch(() => {});
+      seeder.close();
       await server.cleanup().catch(() => {});
     }
   }, 60_000);

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -25,6 +25,7 @@
 import { TopGunClient, SyncState } from '@topgunbuild/client';
 import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
 import { TopGunMCPServer } from '@topgunbuild/mcp-server';
+import type { MCPToolResult } from '@topgunbuild/mcp-server';
 
 import { spawnRustServer, createTestToken, SpawnedServer } from './helpers';
 
@@ -146,127 +147,113 @@ function makeClient(port: number, userId: string): TopGunClient {
 const RECORD_COUNT = 25;
 const OPEN_COUNT = 10; // records 0..9 are status:'open', 10..24 are status:'done'
 
+// Retry transient connectivity failures (NOT content mismatches): the read tools
+// go through queryOncePaged, which rejects if the client is momentarily
+// reconnecting. Re-confirm CONNECTED and retry, so a brief blip never reds the
+// suite. A genuine server-blind read (the pre-fix "Map is empty" / "Records: 0")
+// is NOT a transient error, so it is never retried — the negative control still
+// fails fast against the unfixed tools.
+const TRANSIENT = /unreachable|not settled|did not settle|client offline/i;
+async function callStable(
+  mcp: TopGunMCPServer,
+  name: string,
+  args: unknown,
+): Promise<MCPToolResult> {
+  let last: MCPToolResult | undefined;
+  for (let attempt = 0; attempt < 6; attempt++) {
+    await waitForState(mcp.getClient(), SyncState.CONNECTED, 8_000).catch(() => {});
+    last = await mcp.callTool(name, args);
+    if (!TRANSIENT.test(text(last))) return last;
+    await waitMs(500);
+  }
+  return last!;
+}
+
 describe('Integration: MCP tools against a real Rust server (cold cache)', () => {
-  let server: SpawnedServer | null = null;
-  let seeder: TopGunClient | null = null;
-  let mcp: TopGunMCPServer | null = null;
-  let mapName = '';
-
-  // Connect BOTH clients up front against the still-idle server (so each
-  // completes its AUTH handshake fast), THEN seed. A client that connects LATER —
-  // while the seeder is mid-Merkle-sync — can miss its AUTH_ACK inside the SDK's
-  // 15 s connection-establishment window under CI load and stall at
-  // AUTHENTICATING; connecting before any load avoids that race (the pattern
-  // live-query-limit-clamp.test.ts uses). The data must stay on the server, so
-  // the seeder stays connected for the suite's lifetime (the null in-memory
-  // backend keeps a map's rows only while it is live, not after the writer
-  // disconnects). The MCP client is still a genuinely COLD reader: it never
-  // mutates and queryOncePaged does not hydrate the persistent replica, so its
-  // local CRDT map stays empty for every read — exactly the configuration that
-  // exposes a server-blind read. We inject the client (rather than letting the
-  // MCP server build one) so it carries its own auth, and start it directly
-  // instead of via mcp.start(), which would attach a stdio transport that
-  // consumes the Jest process's stdin; callTool() only needs it connected.
-  beforeAll(async () => {
-    server = await spawnRustServer();
-
-    seeder = makeClient(server.port, 'mcp-seeder');
-    const mcpClient = makeClient(server.port, 'mcp-reader');
-    mcp = new TopGunMCPServer({ client: mcpClient });
-
-    await seeder.start();
-    await mcpClient.start();
-    await waitForState(seeder, SyncState.CONNECTED);
-    await waitForState(mcpClient, SyncState.CONNECTED);
-
-    mapName = `mcp_e2e_${Date.now()}`;
-    const m = seeder.getMap<string, Record<string, unknown>>(mapName);
-    for (let i = 0; i < RECORD_COUNT; i++) {
-      m.set(`k${i}`, {
-        id: `k${i}`,
-        title: `doc ${i}`,
-        status: i < OPEN_COUNT ? 'open' : 'done',
-        n: i,
-      });
-    }
-    await waitForSynced(seeder);
-  }, 60_000);
-
-  afterAll(async () => {
-    if (mcp) {
-      await mcp
-        .getClient()
-        .close()
-        .catch(() => {});
-      mcp = null;
-    }
-    if (seeder) {
-      await seeder.close().catch(() => {});
-      seeder = null;
-    }
-    if (server) {
-      await server.cleanup().catch(() => {});
-      server = null;
-    }
-  });
-
-  test('topgun_query returns the seeded rows (server-authoritative sanity)', async () => {
-    const result = await mcp!.callTool('topgun_query', { map: mapName, limit: 5 });
-    expect(result.isError).toBeFalsy();
-    const out = text(result);
-    expect(out).toContain('Found 5 result(s)');
-    expect(out).toContain('doc');
-  });
-
-  // --- F1: server-blind read divergence is gone (the negative control) -------
+  // One self-contained test that boots the server, connects both clients, seeds,
+  // and runs every read back-to-back. Doing the whole scenario inline keeps it
+  // FAST (a few seconds) — well inside the SDK's 15 s heartbeat-timeout window —
+  // so neither client churns mid-suite, the failure mode that flaked a
+  // beforeAll + per-test layout under CI load. This mirrors the lifecycle of the
+  // other reliably-green single-server suites (queries/live-query): server +
+  // client(s) + assertions all in one test body.
   //
-  // Each of these reads happens on a COLD MCP client with NO prior topgun_mutate
-  // or topgun_query in this process — so the local replica is empty. A correct
-  // (server-authoritative) tool still sees all 25 seeded rows; the pre-fix
-  // local-replica reads would report empty/0 here and fail.
+  // BOTH clients connect up front against the still-idle server (each AUTH
+  // handshake completes fast — a client connecting later, while the seeder is
+  // mid-Merkle-sync, can miss its AUTH_ACK and stall at AUTHENTICATING). The
+  // seeder stays connected for the test's lifetime because the null in-memory
+  // backend keeps a map's rows only while a client holds it live. The MCP client
+  // is still a genuinely COLD reader: it never mutates and queryOncePaged does
+  // not hydrate the persistent replica, so its local CRDT map stays empty for
+  // every read — exactly the configuration that exposes a server-blind read. We
+  // inject the client so it carries its own auth, and start it directly rather
+  // than via mcp.start() (which would attach a stdio transport that consumes the
+  // Jest process's stdin); callTool() only needs it connected.
+  test('cold MCP read tools reflect real server data, not an empty local replica (F1)', async () => {
+    const server = await spawnRustServer();
+    const seeder = makeClient(server.port, 'mcp-seeder');
+    const mcpClient = makeClient(server.port, 'mcp-reader');
+    const mcp = new TopGunMCPServer({ client: mcpClient });
 
-  test('topgun_schema (cold) reflects the 25 server records, not an empty map', async () => {
-    const result = await mcp!.callTool('topgun_schema', { map: mapName });
-    expect(result.isError).toBeFalsy();
-    const out = text(result);
-    expect(out).not.toMatch(/is empty/i);
-    expect(out).toContain('Records: 25');
-    // Fields inferred from real server rows.
-    expect(out).toContain('title');
-    expect(out).toContain('status');
-    expect(out).toContain('n');
-  });
+    try {
+      await seeder.start();
+      await mcpClient.start();
+      await waitForState(seeder, SyncState.CONNECTED);
+      await waitForState(mcpClient, SyncState.CONNECTED);
 
-  test('topgun_stats (cold) reports the 25-record server count', async () => {
-    const result = await mcp!.callTool('topgun_stats', { map: mapName });
-    expect(result.isError).toBeFalsy();
-    const out = text(result);
-    expect(out).toContain(mapName);
-    expect(out).toContain('Records: 25');
-  });
+      const mapName = `mcp_e2e_${Date.now()}`;
+      const m = seeder.getMap<string, Record<string, unknown>>(mapName);
+      for (let i = 0; i < RECORD_COUNT; i++) {
+        m.set(`k${i}`, {
+          id: `k${i}`,
+          title: `doc ${i}`,
+          status: i < OPEN_COUNT ? 'open' : 'done',
+          n: i,
+        });
+      }
+      await waitForSynced(seeder);
 
-  test('topgun_explain (cold) plans over real server totals and selectivity', async () => {
-    const result = await mcp!.callTool('topgun_explain', {
-      map: mapName,
-      filter: { status: 'open' },
-    });
-    expect(result.isError).toBeFalsy();
-    const out = text(result);
-    expect(out).toContain('Total Records: 25');
-    expect(out).toContain(`Estimated Results: ${OPEN_COUNT}`);
-    expect(out).toContain('Selectivity: 40.0%');
-  });
+      // Sanity: topgun_query (already server-authoritative) returns the rows.
+      const query = await callStable(mcp, 'topgun_query', { map: mapName, limit: 5 });
+      expect(query.isError).toBeFalsy();
+      expect(text(query)).toContain('Found 5 result(s)');
+      expect(text(query)).toContain('doc');
 
-  test('cold schema sees server data BEFORE any query hydrates the local cache', async () => {
-    // The pre-fix bug persisted even AFTER a query (queryOncePaged never wrote the
-    // persistent replica). Here we prove the stronger property: the very FIRST
-    // read on a cold process already reflects the server, with no warm-up.
-    const schema = await mcp!.callTool('topgun_schema', { map: mapName });
-    expect(text(schema)).toContain('Records: 25');
+      // F1 — each read runs on a COLD MCP client (no prior mutate/query in this
+      // process, so the local replica is empty). A correct server-authoritative
+      // tool still sees all 25 seeded rows; the pre-fix local-replica reads would
+      // report "empty / 0" here and fail (the negative control).
+      const schema = await callStable(mcp, 'topgun_schema', { map: mapName });
+      expect(schema.isError).toBeFalsy();
+      expect(text(schema)).not.toMatch(/is empty/i);
+      expect(text(schema)).toContain('Records: 25');
+      expect(text(schema)).toContain('title');
+      expect(text(schema)).toContain('status');
+      expect(text(schema)).toContain('n');
 
-    // And it stays consistent after a query, too.
-    await mcp!.callTool('topgun_query', { map: mapName, limit: 5 });
-    const schemaAfter = await mcp!.callTool('topgun_schema', { map: mapName });
-    expect(text(schemaAfter)).toContain('Records: 25');
-  });
+      const stats = await callStable(mcp, 'topgun_stats', { map: mapName });
+      expect(stats.isError).toBeFalsy();
+      expect(text(stats)).toContain(mapName);
+      expect(text(stats)).toContain('Records: 25');
+
+      const explain = await callStable(mcp, 'topgun_explain', {
+        map: mapName,
+        filter: { status: 'open' },
+      });
+      expect(explain.isError).toBeFalsy();
+      expect(text(explain)).toContain('Total Records: 25');
+      expect(text(explain)).toContain(`Estimated Results: ${OPEN_COUNT}`);
+      expect(text(explain)).toContain('Selectivity: 40.0%');
+
+      // A query does not hydrate the persistent replica these tools read (that
+      // was the bug), so schema stays correct (server-derived) after one.
+      await callStable(mcp, 'topgun_query', { map: mapName, limit: 5 });
+      const schemaAfter = await callStable(mcp, 'topgun_schema', { map: mapName });
+      expect(text(schemaAfter)).toContain('Records: 25');
+    } finally {
+      await mcpClient.close().catch(() => {});
+      await seeder.close().catch(() => {});
+      await server.cleanup().catch(() => {});
+    }
+  }, 60_000);
 });

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Real-server MCP integration harness (client → Rust server, driven through the
+ * built MCP tool handlers).
+ *
+ * WHY THIS EXISTS — every one of the package's 94 unit tests runs the MCP tools
+ * against a `MockTopGunClient` (or a stubbed `WebSocket`) whose `getMap` and
+ * `queryOncePaged` read the SAME in-memory store. That unification structurally
+ * hides the entire "server-blind read" bug class: a tool that reads the local
+ * CRDT replica instead of the server looks identical to one that reads the server,
+ * because in the mock they are the same object. This harness boots a REAL Rust
+ * server, seeds it from a SEPARATE client, then drives the real
+ * `TopGunMCPServer.callTool()` against a COLD MCP client (its own cache has never
+ * seen the seeded data) — the only configuration in which a server-blind read is
+ * observably wrong.
+ *
+ * NEGATIVE CONTROL — these assertions are written for the CORRECT (server-
+ * authoritative) behavior. Against the pre-fix code, where `topgun_schema`,
+ * `topgun_stats`, and `topgun_explain` iterate `client.getMap(map).entries()`,
+ * the cold MCP cache is empty, so they report "Map is empty / Records: 0 /
+ * Total Records: 0" and every assertion below FAILS. That red is the proof the
+ * bug class is now visible to CI; the fix (reads routed through `queryOncePaged`)
+ * turns it green.
+ */
+
+import { TopGunClient, SyncState } from '@topgunbuild/client';
+import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
+import { TopGunMCPServer } from '@topgunbuild/mcp-server';
+
+import { spawnRustServer, SpawnedServer } from './helpers';
+
+// In-memory storage adapter so the SDK runs headless in Node (no IndexedDB).
+class MemoryStorageAdapter implements IStorageAdapter {
+  private kv = new Map<string, unknown>();
+  private meta = new Map<string, unknown>();
+  private opLog: OpLogEntry[] = [];
+  private pending: OpLogEntry[] = [];
+
+  async initialize(): Promise<void> {}
+  async close(): Promise<void> {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async get(key: string): Promise<any> {
+    return this.kv.get(key);
+  }
+  async put(key: string, value: unknown): Promise<void> {
+    this.kv.set(key, value);
+  }
+  async remove(key: string): Promise<void> {
+    this.kv.delete(key);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getMeta(key: string): Promise<any> {
+    return this.meta.get(key);
+  }
+  async setMeta(key: string, value: unknown): Promise<void> {
+    this.meta.set(key, value);
+  }
+  async batchPut(entries: Map<string, unknown>): Promise<void> {
+    for (const [k, v] of entries) this.kv.set(k, v);
+  }
+  async appendOpLog(entry: Omit<OpLogEntry, 'id'>): Promise<number> {
+    const id = this.opLog.length + 1;
+    const e = { ...entry, id, synced: 0 } as OpLogEntry;
+    this.opLog.push(e);
+    this.pending.push(e);
+    return id;
+  }
+  async getPendingOps(): Promise<OpLogEntry[]> {
+    return this.pending;
+  }
+  async markOpsSynced(lastId: number): Promise<void> {
+    this.pending = this.pending.filter((op) => (op.id ?? 0) > lastId);
+    this.opLog.forEach((op) => {
+      if ((op.id ?? 0) <= lastId) op.synced = 1;
+    });
+  }
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+  async commitWrite(
+    mutations: Array<{
+      store: 'kv' | 'meta';
+      type: 'put' | 'remove';
+      key: string;
+      value?: unknown;
+    }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.kv;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value as never);
+    }
+    return this.appendOpLog(op);
+  }
+  async getAllKeys(): Promise<string[]> {
+    return Array.from(this.kv.keys());
+  }
+}
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForState(
+  client: TopGunClient,
+  state: SyncState,
+  timeoutMs = 20_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (client.getConnectionState() === state) return;
+    await waitMs(50);
+  }
+  throw new Error(`Timed out waiting for ${state}; last = ${client.getConnectionState()}`);
+}
+
+/** Resolves once every optimistic local write has round-tripped and been ACKed. */
+async function waitForSynced(client: TopGunClient, timeoutMs = 20_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (client.getPendingOpsCount() === 0) return;
+    await waitMs(25);
+  }
+  throw new Error(`Timed out waiting to drain; pending = ${client.getPendingOpsCount()}`);
+}
+
+function text(result: { content: Array<{ text?: string }> }): string {
+  return (result.content || []).map((c) => c.text ?? '').join('\n');
+}
+
+// NO_AUTH so both the seeder and the MCP server's own client connect tokenless
+// against the loopback ephemeral-port server (the documented zero-config local
+// posture); auth is exercised separately by connection-auth.test.ts.
+const SERVER_ENV = { TOPGUN_NO_AUTH: '1' };
+
+const RECORD_COUNT = 25;
+const OPEN_COUNT = 10; // records 0..9 are status:'open', 10..24 are status:'done'
+
+describe('Integration: MCP tools against a real Rust server (cold cache)', () => {
+  let server: SpawnedServer | null = null;
+  let seeder: TopGunClient | null = null;
+  let mcp: TopGunMCPServer | null = null;
+  let mapName = '';
+
+  beforeEach(async () => {
+    server = await spawnRustServer({ env: SERVER_ENV });
+
+    // 1. Seeder client — writes data the MCP process's cache has NEVER seen.
+    seeder = new TopGunClient({
+      serverUrl: `ws://localhost:${server.port}/ws`,
+      storage: new MemoryStorageAdapter(),
+      backoff: { initialDelayMs: 200, maxDelayMs: 400, jitter: true },
+    });
+    await seeder.start();
+    await waitForState(seeder, SyncState.CONNECTED);
+
+    // Unique map per test so the null in-memory backend never bleeds rows across
+    // runs and every seeded row is unambiguously part of this test's dataset.
+    mapName = `mcp_e2e_${Date.now()}`;
+    const m = seeder.getMap<string, Record<string, unknown>>(mapName);
+    for (let i = 0; i < RECORD_COUNT; i++) {
+      m.set(`k${i}`, {
+        id: `k${i}`,
+        title: `doc ${i}`,
+        status: i < OPEN_COUNT ? 'open' : 'done',
+        n: i,
+      });
+    }
+    await waitForSynced(seeder);
+
+    // 2. MCP server with its OWN fresh client (cold cache) → same server.
+    mcp = new TopGunMCPServer({ topgunUrl: `ws://localhost:${server.port}/ws` });
+    const mcpClient = mcp.getClient();
+    // Start the client directly (not mcp.start(), which would attach a stdio
+    // transport that consumes the Jest process's stdin); callTool() only needs
+    // the client connected.
+    await mcpClient.start();
+    await waitForState(mcpClient, SyncState.CONNECTED);
+  }, 60_000);
+
+  afterEach(async () => {
+    if (mcp) {
+      await mcp
+        .getClient()
+        .close()
+        .catch(() => {});
+      mcp = null;
+    }
+    if (seeder) {
+      await seeder.close().catch(() => {});
+      seeder = null;
+    }
+    if (server) {
+      await server.cleanup().catch(() => {});
+      server = null;
+    }
+  });
+
+  test('topgun_query returns the seeded rows (server-authoritative sanity)', async () => {
+    const result = await mcp!.callTool('topgun_query', { map: mapName, limit: 5 });
+    expect(result.isError).toBeFalsy();
+    const out = text(result);
+    expect(out).toContain('Found 5 result(s)');
+    expect(out).toContain('doc');
+  });
+
+  // --- F1: server-blind read divergence is gone (the negative control) -------
+  //
+  // Each of these reads happens on a COLD MCP client with NO prior topgun_mutate
+  // or topgun_query in this process — so the local replica is empty. A correct
+  // (server-authoritative) tool still sees all 25 seeded rows; the pre-fix
+  // local-replica reads would report empty/0 here and fail.
+
+  test('topgun_schema (cold) reflects the 25 server records, not an empty map', async () => {
+    const result = await mcp!.callTool('topgun_schema', { map: mapName });
+    expect(result.isError).toBeFalsy();
+    const out = text(result);
+    expect(out).not.toMatch(/is empty/i);
+    expect(out).toContain('Records: 25');
+    // Fields inferred from real server rows.
+    expect(out).toContain('title');
+    expect(out).toContain('status');
+    expect(out).toContain('n');
+  });
+
+  test('topgun_stats (cold) reports the 25-record server count', async () => {
+    const result = await mcp!.callTool('topgun_stats', { map: mapName });
+    expect(result.isError).toBeFalsy();
+    const out = text(result);
+    expect(out).toContain(mapName);
+    expect(out).toContain('Records: 25');
+  });
+
+  test('topgun_explain (cold) plans over real server totals and selectivity', async () => {
+    const result = await mcp!.callTool('topgun_explain', {
+      map: mapName,
+      filter: { status: 'open' },
+    });
+    expect(result.isError).toBeFalsy();
+    const out = text(result);
+    expect(out).toContain('Total Records: 25');
+    expect(out).toContain(`Estimated Results: ${OPEN_COUNT}`);
+    expect(out).toContain('Selectivity: 40.0%');
+  });
+
+  test('cold schema sees server data BEFORE any query hydrates the local cache', async () => {
+    // The pre-fix bug persisted even AFTER a query (queryOncePaged never wrote the
+    // persistent replica). Here we prove the stronger property: the very FIRST
+    // read on a cold process already reflects the server, with no warm-up.
+    const schema = await mcp!.callTool('topgun_schema', { map: mapName });
+    expect(text(schema)).toContain('Records: 25');
+
+    // And it stays consistent after a query, too.
+    await mcp!.callTool('topgun_query', { map: mapName, limit: 5 });
+    const schemaAfter = await mcp!.callTool('topgun_schema', { map: mapName });
+    expect(text(schemaAfter)).toContain('Records: 25');
+  });
+});

--- a/tests/integration-rust/tsconfig.json
+++ b/tests/integration-rust/tsconfig.json
@@ -13,7 +13,8 @@
     "baseUrl": "../..",
     "paths": {
       "@topgunbuild/core": ["packages/core/src"],
-      "@topgunbuild/client": ["packages/client/src"]
+      "@topgunbuild/client": ["packages/client/src"],
+      "@topgunbuild/mcp-server": ["packages/mcp-server/src"]
     }
   },
   "include": ["./**/*.ts"],


### PR DESCRIPTION
## Summary

Closes the MCP "server-blind reads" bug class (DEPTH_MCP.md **F1/F9**) and adds the missing real-server test gate.

The MCP read tools answered from the MCP process's **local CRDT replica**, populated only by `topgun_mutate` writes in the same process — never by a server read. Against a real server holding data a *separate* client wrote, `topgun_schema` / `topgun_stats` / `topgun_explain` reported **"empty / 0 records"** even after `topgun_query` returned those exact rows. The whole class was **invisible to CI**: all 94 package tests run against a mock whose `getMap` and `queryOncePaged` share one store, so a server-blind read is indistinguishable from a server read.

## Phase A — real-server harness (TODO-524, landed first)

- New `tests/integration-rust/mcp-server.test.ts`: boots the Rust binary, seeds via a **separate** client, then drives the real `TopGunMCPServer.callTool()` against a **cold** MCP client (its cache never saw the data) — the only configuration where a server-blind read is observably wrong.
- Wired into the **blocking** `integration-rust` gate: `@topgunbuild/mcp-server` is now compiled from source via `moduleNameMapper` (drives workspace source, not a stale dist), and `packages/mcp-server/**` added to the workflow path triggers.
- **Negative control verified:** reverting only the read fix turns the harness **red** — `schema` → "Map is empty", `stats` → "Records: 0", `explain` → "Total Records: 0". With the fix, all 5 cases pass. Proof the bug class is now CI-visible.

## Phase B — server-authoritative reads (TODO-517)

- New shared `tools/serverRead.ts` (`fetchServerRecords`) routes `schema` / `stats` (per-map) / `explain` through `queryOncePaged` — the same settled-snapshot path `topgun_query` already uses.
- Offline/timeout surfaces an explicit **"could not reach the server — NOT an empty result"** error, never a false zero.
- Counts derived from a sample beyond `maxLimit` are labelled as a lower bound. The connection half of `topgun_stats` is unchanged and still reported even when the per-map read is unreachable.
- Mock-WebSocket unit tests for schema/explain updated to assert the new not-settled-under-unreachable-server behavior (mirrors how the `topgun_query` tests in the same file were already written).

Out of scope (own TODOs): `topgun_search` body hydration (TODO-522), `list_maps` discovery (TODO-520), `subscribe` change-feed (TODO-519), `mutate` ack (TODO-518/521).

## Test gate

- `pnpm --filter @topgunbuild/mcp-server test` → **94/94**
- Full non-cluster `integration-rust` suite → **12 suites / 81 tests** green (incl. the new harness)
- `pnpm --filter @topgunbuild/mcp-server build`, `pnpm lint` (0 errors), `pnpm format:check` clean