### PR TITLE
fix(mcp): server-confirm topgun_mutate writes; make remove server-authoritative (TODO-518/521)

### DIFF
--- a/packages/client/src/SyncEngine.ts
+++ b/packages/client/src/SyncEngine.ts
@@ -1409,6 +1409,47 @@ export class SyncEngine {
   }
 
   /**
+   * Wait until a specific local op has been confirmed applied by the server.
+   *
+   * Resolves `'synced'` once the op identified by `opId` is acknowledged (the
+   * server applied it). Acknowledged ops are flipped `synced=true` and then
+   * spliced out of the in-memory `opLog` (see {@link handleOpAck}); therefore an
+   * op that is **absent** from `opLog` has already been acked — that is treated
+   * as `'synced'`, not as "unknown".
+   *
+   * Resolves `'offline'` the moment the client is not online with the op still
+   * pending — so a caller (e.g. the MCP `mutate` tool) can fail fast with an
+   * honest "queued locally, not yet durable" instead of blocking for the whole
+   * timeout. Resolves `'timeout'` if the op stays pending past `timeoutMs` while
+   * online (server slow / unreachable mid-flight).
+   *
+   * This is the authoritative "did the server take my write?" signal for plain
+   * map writes. Per-op Write Concern promises only resolve when the server
+   * returns per-op `results`, which the single-server OP_BATCH path does not — so
+   * this op-log/ACK projection is the correct primitive for confirming a write.
+   */
+  public async waitForOpSynced(
+    opId: string,
+    timeoutMs: number,
+  ): Promise<'synced' | 'offline' | 'timeout'> {
+    const deadline = Date.now() + timeoutMs;
+    // Absent from opLog ⇒ already acked + compacted out. Present + synced ⇒ acked.
+    const isSynced = (): boolean => {
+      const op = this.opLog.find((o) => o.id === opId);
+      return !op || op.synced === true;
+    };
+
+    while (!isSynced()) {
+      // Fail fast when offline with the op still pending: it will only sync on a
+      // future reconnect, so there is nothing to wait for here.
+      if (!this.isOnline()) return 'offline';
+      if (Date.now() >= deadline) return 'timeout';
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return 'synced';
+  }
+
+  /**
    * Get the current backpressure status.
    * Delegates to BackpressureController.
    */

--- a/packages/client/src/SyncEngine.ts
+++ b/packages/client/src/SyncEngine.ts
@@ -1433,13 +1433,30 @@ export class SyncEngine {
     timeoutMs: number,
   ): Promise<'synced' | 'offline' | 'timeout'> {
     const deadline = Date.now() + timeoutMs;
-    // Absent from opLog ⇒ already acked + compacted out. Present + synced ⇒ acked.
-    const isSynced = (): boolean => {
-      const op = this.opLog.find((o) => o.id === opId);
-      return !op || op.synced === true;
-    };
 
-    while (!isSynced()) {
+    // Capture the op object ONCE by id, then poll ITS `synced` flag — do NOT
+    // re-find by id each tick. The distinction matters for correctness:
+    //
+    //   - On ack, handleOpAck flips `synced = true` on this exact object BEFORE
+    //     compacting it out of the array, so the captured reference observes the
+    //     ack even after the splice.
+    //   - When an op leaves opLog UNACKED — backpressure drop-oldest evicting an
+    //     unsynced op, or the opLog being cleared and rebuilt from storage on
+    //     reconnect (`opLog.length = 0`) — its `synced` flag stays false on this
+    //     captured object. So we correctly report timeout/offline, never a false
+    //     'synced'. A re-find-by-id would instead see the op ABSENT and wrongly
+    //     conclude it was acked — reporting a write as durable that the server
+    //     never confirmed.
+    //
+    // If the op is already absent at this first lookup, it was acked + compacted
+    // in the brief gap since recordOperation appended it (the fast-ack path — the
+    // only way an op leaves opLog between append and this immediate check, since
+    // drop/reset require backpressure buildup or a reconnect that cannot occur in
+    // that window). That is a genuine ack ⇒ 'synced'.
+    const op = this.opLog.find((o) => o.id === opId);
+    if (!op) return 'synced';
+
+    while (op.synced !== true) {
       // Fail fast when offline with the op still pending: it will only sync on a
       // future reconnect, so there is nothing to wait for here.
       if (!this.isOnline()) return 'offline';

--- a/packages/client/src/TopGunClient.ts
+++ b/packages/client/src/TopGunClient.ts
@@ -1002,7 +1002,8 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
    *   will sync on reconnect, but is NOT yet durable on the server.
    * - `'timeout'` — connected, but the server did not acknowledge within
    *   `timeoutMs`; the write is not yet confirmed durable.
-   * - `'failed'` — the local op could not be recorded (commit/storage failure).
+   * - `'failed'` — there was no recordable write to confirm (no tracked op, or
+   *   the local op could not be committed).
    *
    * This is the honest "did the server take my write?" answer that callers
    * mutating a database (e.g. the MCP `mutate` tool) need before reporting
@@ -1015,23 +1016,32 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
   ): Promise<WriteConfirmation> {
     const writeKey = `${name}:${key}`;
     const opPromise = this.inFlightWrites.get(writeKey);
-    // No tracked write ⇒ nothing to confirm; callers always write before
-    // confirming, so this only guards misuse.
-    if (!opPromise) return 'synced';
+    // No tracked write ⇒ we have nothing to confirm. NEVER assume success here:
+    // returning 'synced' for an unknown write would violate the core contract
+    // (report only server-confirmed state). Callers always write before
+    // confirming, so this only fires on misuse — fail closed, not open.
+    if (!opPromise) return 'failed';
 
     let opId: string;
     try {
       opId = await opPromise;
     } catch {
-      return 'failed';
-    } finally {
-      // Only clear if this is still the latest in-flight write for the key.
       if (this.inFlightWrites.get(writeKey) === opPromise) {
         this.inFlightWrites.delete(writeKey);
       }
+      return 'failed';
     }
 
-    return this.syncEngine.waitForOpSynced(opId, timeoutMs);
+    const outcome = await this.syncEngine.waitForOpSynced(opId, timeoutMs);
+    // Forget the in-flight write ONLY once the server has confirmed it. On
+    // offline/timeout we keep the entry so a later retry re-waits on the same op
+    // instead of hitting the no-tracked-write path above and reporting a false
+    // result. A subsequent write to the same key overwrites the entry, so this
+    // never grows unbounded.
+    if (outcome === 'synced' && this.inFlightWrites.get(writeKey) === opPromise) {
+      this.inFlightWrites.delete(writeKey);
+    }
+    return outcome;
   }
 
   // ============================================

--- a/packages/client/src/TopGunClient.ts
+++ b/packages/client/src/TopGunClient.ts
@@ -103,6 +103,14 @@ export const DEFAULT_CLUSTER_CONFIG: Required<Omit<TopGunClusterConfig, 'seeds'>
 export const DEFAULT_QUERY_ONCE_TIMEOUT_MS = 5000;
 
 /**
+ * Outcome of {@link TopGunClient.confirmWrite}: whether a local write was
+ * confirmed applied by the server (`'synced'`) or could not be confirmed —
+ * because the client is offline (`'offline'`), the server did not acknowledge in
+ * time (`'timeout'`), or the local op could not be recorded (`'failed'`).
+ */
+export type WriteConfirmation = 'synced' | 'offline' | 'timeout' | 'failed';
+
+/**
  * Options for {@link TopGunClient.queryOnce}, a one-shot read that resolves with
  * authoritative server data (or rejects rather than returning stale local data).
  */
@@ -176,6 +184,16 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
     seeds: string[];
   };
   private readonly authProvider?: AuthProvider;
+
+  /**
+   * Most-recent in-flight op promise per `${map}:${key}`, set synchronously by the
+   * getMap set/remove wrappers. {@link confirmWrite} awaits the op id from this
+   * promise, then waits for the server ack — letting a write be reported as durable
+   * only once the server has actually applied it. Entries are deleted once
+   * confirmed. Keyed by the latest write to a (map,key); serial callers (the MCP
+   * mutate tool) never overlap two writes to one key.
+   */
+  private readonly inFlightWrites: Map<string, Promise<string>> = new Map();
 
   constructor(config: TopGunClientConfig) {
     // Supplying both serverUrl and cluster is ambiguous — fail early
@@ -653,15 +671,14 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
       const mutations: StorageMutation[] = [
         { store: 'kv', type: 'put', key: `${name}:${key}`, value: record },
       ];
-      this.syncEngine
-        .recordOperation(
-          name,
-          'PUT',
-          String(key),
-          { record, timestamp: record.timestamp },
-          mutations,
-        )
-        .catch((err) => logger.error({ err }, 'Failed to commit PUT op'));
+      const opPromise = this.syncEngine.recordOperation(
+        name,
+        'PUT',
+        String(key),
+        { record, timestamp: record.timestamp },
+        mutations,
+      );
+      this.trackInFlightWrite(name, String(key), opPromise, 'PUT');
       return record;
     };
 
@@ -672,15 +689,14 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
       const mutations: StorageMutation[] = [
         { store: 'kv', type: 'put', key: `${name}:${key}`, value: tombstone },
       ];
-      this.syncEngine
-        .recordOperation(
-          name,
-          'REMOVE',
-          String(key),
-          { record: tombstone, timestamp: tombstone.timestamp },
-          mutations,
-        )
-        .catch((err) => logger.error({ err }, 'Failed to commit REMOVE op'));
+      const opPromise = this.syncEngine.recordOperation(
+        name,
+        'REMOVE',
+        String(key),
+        { record: tombstone, timestamp: tombstone.timestamp },
+        mutations,
+      );
+      this.trackInFlightWrite(name, String(key), opPromise, 'REMOVE');
       return tombstone;
     };
 
@@ -953,6 +969,69 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
    */
   public resetConnection(): void {
     this.syncEngine.resetConnection();
+  }
+
+  // ============================================
+  // Write confirmation API
+  // ============================================
+
+  /**
+   * Record the in-flight op promise for the latest write to a (map, key), so
+   * {@link confirmWrite} can await its server ack. Attaches a `.catch` so an
+   * unawaited commit failure never becomes an unhandled rejection, and clears the
+   * entry once the op id resolves or rejects (the ack itself is then awaited via
+   * the op id, independent of this map).
+   */
+  private trackInFlightWrite(
+    name: string,
+    key: string,
+    opPromise: Promise<string>,
+    opType: 'PUT' | 'REMOVE',
+  ): void {
+    const writeKey = `${name}:${key}`;
+    this.inFlightWrites.set(writeKey, opPromise);
+    opPromise.catch((err) => logger.error({ err, name, key }, `Failed to commit ${opType} op`));
+  }
+
+  /**
+   * Wait until the latest local write to `(map, key)` has been confirmed applied
+   * by the server, or report that it could not be confirmed.
+   *
+   * - `'synced'` — the server acknowledged the write; it is durable server-side.
+   * - `'offline'` — the client is not connected; the write is queued locally and
+   *   will sync on reconnect, but is NOT yet durable on the server.
+   * - `'timeout'` — connected, but the server did not acknowledge within
+   *   `timeoutMs`; the write is not yet confirmed durable.
+   * - `'failed'` — the local op could not be recorded (commit/storage failure).
+   *
+   * This is the honest "did the server take my write?" answer that callers
+   * mutating a database (e.g. the MCP `mutate` tool) need before reporting
+   * success — never an optimistic local-only echo.
+   */
+  public async confirmWrite(
+    name: string,
+    key: string,
+    timeoutMs = 5000,
+  ): Promise<WriteConfirmation> {
+    const writeKey = `${name}:${key}`;
+    const opPromise = this.inFlightWrites.get(writeKey);
+    // No tracked write ⇒ nothing to confirm; callers always write before
+    // confirming, so this only guards misuse.
+    if (!opPromise) return 'synced';
+
+    let opId: string;
+    try {
+      opId = await opPromise;
+    } catch {
+      return 'failed';
+    } finally {
+      // Only clear if this is still the latest in-flight write for the key.
+      if (this.inFlightWrites.get(writeKey) === opPromise) {
+        this.inFlightWrites.delete(writeKey);
+      }
+    }
+
+    return this.syncEngine.waitForOpSynced(opId, timeoutMs);
   }
 
   // ============================================

--- a/packages/client/src/__tests__/TopGunClient.test.ts
+++ b/packages/client/src/__tests__/TopGunClient.test.ts
@@ -568,4 +568,52 @@ describe('TopGunClient', () => {
       await expect(tempClient.close()).resolves.not.toThrow();
     });
   });
+
+  describe('confirmWrite — server-confirmed write contract', () => {
+    // A local-only client (no serverUrl/cluster) is deterministically offline:
+    // its NullConnectionProvider never connects, so a tracked write can never be
+    // server-acked. This is the cleanest harness for the "never report a write as
+    // durable that the server did not confirm" contract.
+    function makeLocalOnlyClient(): TopGunClient {
+      const c = new TopGunClient({ storage: new MemoryStorageAdapter() });
+      extraClients.push(c);
+      return c;
+    }
+
+    test('returns "failed" (never "synced") when there is no tracked write to confirm', async () => {
+      const c = makeLocalOnlyClient();
+      // Nothing was ever written for this (map, key): confirmWrite must fail
+      // closed, never assume success.
+      await expect(c.confirmWrite('nomap', 'nokey')).resolves.toBe('failed');
+    });
+
+    test('never reports a tracked-but-unconfirmed write as "synced" (no server ack)', async () => {
+      const c = makeLocalOnlyClient();
+      c.getMap<string, { v: number }>('m').set('k', { v: 1 });
+
+      // No server ⇒ the op is never acked. A short timeout keeps the test fast.
+      // The outcome MUST be a not-durable signal ('timeout' here; 'offline' on a
+      // truly disconnected transport) — never 'synced', and never 'failed' (a
+      // write WAS recorded).
+      const outcome = await c.confirmWrite('m', 'k', 100);
+      expect(['offline', 'timeout']).toContain(outcome);
+      expect(outcome).not.toBe('synced');
+      expect(outcome).not.toBe('failed');
+    });
+
+    test('retains the in-flight write on a non-synced outcome so a retry re-waits (not a false "synced"/"failed")', async () => {
+      const c = makeLocalOnlyClient();
+      c.getMap<string, { v: number }>('m').set('k', { v: 1 });
+
+      const first = await c.confirmWrite('m', 'k', 100);
+      // Retry WITHOUT a new write: the entry must still be tracked, so we re-wait
+      // on the SAME op and return the same not-durable signal — crucially NOT
+      // 'synced' (the pre-fix no-tracked-write default) and NOT 'failed' (which
+      // would mean the entry had been dropped).
+      const second = await c.confirmWrite('m', 'k', 100);
+      expect(second).toBe(first);
+      expect(second).not.toBe('synced');
+      expect(second).not.toBe('failed');
+    });
+  });
 });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -150,6 +150,7 @@ export type {
   TopGunClientConfig,
   QueryOnceOptions,
   QueryOncePagedResult,
+  WriteConfirmation,
 } from './TopGunClient';
 export { DEFAULT_QUERY_ONCE_TIMEOUT_MS } from './TopGunClient';
 

--- a/packages/mcp-server/src/__tests__/mcp-integration.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-integration.test.ts
@@ -153,7 +153,7 @@ describe('MCP Integration', () => {
       expect(result.content[0].text).not.toContain('No results found');
     });
 
-    it('should execute topgun_mutate', async () => {
+    it('should execute topgun_mutate (unconfirmed without a reachable server)', async () => {
       const result = await server.callTool('topgun_mutate', {
         map: 'tasks',
         operation: 'set',
@@ -161,8 +161,11 @@ describe('MCP Integration', () => {
         data: { title: 'Test Task' },
       });
 
-      expect(result.isError).toBeUndefined();
-      expect(result.content[0].text).toContain('Successfully created');
+      // mutate now confirms the write against the server before reporting success.
+      // No reachable server here ⇒ honest not-durable error, never a false success.
+      // Server-confirmed success is proven by the real-server integration harness.
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/not yet.*durable/i);
     });
 
     it('should execute topgun_schema', async () => {
@@ -267,8 +270,10 @@ describe('MCP Integration', () => {
       await server.getClient().start();
     });
 
-    it('should write data via topgun_mutate; offline read is not-settled, not silent empty', async () => {
-      // Write data (local write succeeds even while the server is unreachable).
+    it('should write data via topgun_mutate; offline write/read are honest errors, not silent success/empty', async () => {
+      // The write is queued locally, but with no reachable server it cannot be
+      // confirmed durable — so mutate reports a not-durable error rather than a
+      // false "Successfully created".
       const writeResult = await server.callTool('topgun_mutate', {
         map: 'products',
         operation: 'set',
@@ -276,8 +281,8 @@ describe('MCP Integration', () => {
         data: { name: 'Widget', price: 9.99 },
       });
 
-      expect(writeResult.isError).toBeUndefined();
-      expect(writeResult.content[0].text).toContain('Successfully created');
+      expect(writeResult.isError).toBe(true);
+      expect(writeResult.content[0].text).toMatch(/not yet.*durable/i);
 
       // Read back. queryOnce is server-truth: with no reachable server it cannot
       // settle, so the tool reports an explicit not-settled message and never
@@ -289,23 +294,9 @@ describe('MCP Integration', () => {
       expect(readResult.content[0].text).not.toContain('No results found');
     });
 
-    it('should accept multiple local mutations; offline query is not-settled', async () => {
-      // Create
-      await server.callTool('topgun_mutate', {
-        map: 'items',
-        operation: 'set',
-        key: 'item1',
-        data: { title: 'First' },
-      });
-
-      // Update
-      await server.callTool('topgun_mutate', {
-        map: 'items',
-        operation: 'set',
-        key: 'item1',
-        data: { title: 'Updated' },
-      });
-
+    it('offline query is not-settled, never silent stale local data', async () => {
+      // No seeding mutations: without a reachable server they cannot be confirmed
+      // (each would block the confirm timeout) and add nothing to this assertion.
       // Query — offline, so server-truth queryOnce cannot settle.
       const result = await server.callTool('topgun_query', { map: 'items' });
 
@@ -373,15 +364,15 @@ describe('MCP Integration', () => {
       let queryResult = await server.callTool('topgun_query', { map: 'temp' });
       expect(queryResult.content[0].text).toContain('not settled');
 
-      // Remove
+      // Remove — server-authoritative, but unconfirmed without a reachable server.
       const removeResult = await server.callTool('topgun_mutate', {
         map: 'temp',
         operation: 'remove',
         key: 'temp1',
       });
 
-      expect(removeResult.isError).toBeUndefined();
-      expect(removeResult.content[0].text).toContain('Successfully removed');
+      expect(removeResult.isError).toBe(true);
+      expect(removeResult.content[0].text).toMatch(/not yet.*durable/i);
 
       // Offline read-back cannot settle under server-truth queryOnce.
       queryResult = await server.callTool('topgun_query', { map: 'temp' });
@@ -421,19 +412,11 @@ describe('MCP Integration', () => {
     it('should respect defaultLimit configuration', async () => {
       server = new TopGunMCPServer({ defaultLimit: 5 });
 
-      // Create more records than default limit
-      for (let i = 1; i <= 10; i++) {
-        await server.callTool('topgun_mutate', {
-          map: 'limited',
-          operation: 'set',
-          key: `item${i}`,
-          data: { index: i },
-        });
-      }
-
-      // Query without specifying limit. Offline server-truth queryOnce cannot
-      // settle, so we assert the tool executes and surfaces the not-settled path
-      // rather than verifying server-applied limit counts (which require a server).
+      // No seeding loop: writes can no longer be confirmed without a reachable
+      // server (each would block the full confirm timeout), and the query below
+      // cannot settle anyway. Server-applied limit counts are covered by the
+      // real-server integration harness; here we only assert the access/not-settled
+      // path for the configured limit.
       const result = await server.callTool('topgun_query', { map: 'limited' });
 
       const text = result.content[0].text;
@@ -445,25 +428,15 @@ describe('MCP Integration', () => {
     it('should respect maxLimit configuration', async () => {
       server = new TopGunMCPServer({ maxLimit: 3 });
 
-      // Create records
-      for (let i = 1; i <= 10; i++) {
-        await server.callTool('topgun_mutate', {
-          map: 'maxed',
-          operation: 'set',
-          key: `item${i}`,
-          data: { index: i },
-        });
-      }
-
-      // Query with limit exceeding maxLimit
+      // Query with limit exceeding maxLimit. No seeding loop (see defaultLimit
+      // test): offline server-truth queryOnce cannot settle, so we assert the tool
+      // executes and surfaces the not-settled path rather than server-applied counts.
       const result = await server.callTool('topgun_query', {
         map: 'maxed',
         limit: 100,
       });
 
       const text = result.content[0].text;
-      // Offline server-truth queryOnce cannot settle; assert the tool executes and
-      // surfaces the not-settled path rather than verifying server-applied counts.
       expect(result.isError).toBe(true);
       expect(text).toContain('not settled');
       expect(text).toContain('maxed');

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -205,7 +205,7 @@ describe('TopGunMCPServer', () => {
   });
 
   describe('mutations', () => {
-    it('should allow mutations when enabled', async () => {
+    it('should allow mutations when enabled (gated on server confirmation)', async () => {
       const server = makeServer({ enableMutations: true });
 
       const result = await server.callTool('topgun_mutate', {
@@ -215,9 +215,17 @@ describe('TopGunMCPServer', () => {
         data: { title: 'Test' },
       });
 
-      expect((result as { isError?: boolean }).isError).toBeUndefined();
-      expect((result as { content: Array<{ text: string }> }).content[0].text).toContain(
-        'Successfully created',
+      // Mutations are NOT blocked (no "disabled" error) — they reach the write
+      // path. With no reachable server in this harness the write cannot be
+      // confirmed durable, so the tool honestly reports a not-durable error rather
+      // than a false "Successfully created". Server-confirmed success is proven by
+      // the real-server integration harness.
+      expect((result as { content: Array<{ text: string }> }).content[0].text).not.toContain(
+        'disabled',
+      );
+      expect((result as { isError?: boolean }).isError).toBe(true);
+      expect((result as { content: Array<{ text: string }> }).content[0].text).toMatch(
+        /not yet.*durable/i,
       );
     });
 

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -64,12 +64,26 @@ class MockTopGunClient {
   // Override hasMore/cursor returned by queryOncePaged for pagination tests.
   queryOncePagedHasMore = false;
   queryOncePagedCursor: string | undefined = undefined;
+  // Outcome confirmWrite resolves with — defaults to a server-confirmed write so
+  // the happy path needs no setup; override to exercise offline/timeout/failed.
+  confirmWriteOutcome: 'synced' | 'offline' | 'timeout' | 'failed' = 'synced';
+  // Records (map, key) pairs confirmWrite was asked to confirm, for assertions.
+  confirmWriteCalls: Array<{ map: string; key: string }> = [];
 
   getMap(name: string): MockLWWMap {
     if (!this.maps.has(name)) {
       this.maps.set(name, new MockLWWMap());
     }
     return this.maps.get(name)!;
+  }
+
+  async confirmWrite(
+    map: string,
+    key: string,
+    _timeoutMs?: number,
+  ): Promise<'synced' | 'offline' | 'timeout' | 'failed'> {
+    this.confirmWriteCalls.push({ map, key });
+    return this.confirmWriteOutcome;
   }
 
   getConnectionState() {
@@ -405,8 +419,9 @@ describe('MCP Tools', () => {
   });
 
   describe('handleMutate', () => {
-    it('should create a new record', async () => {
+    it('should save a record only after the server confirms it', async () => {
       const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
 
       const result = await handleMutate(
         {
@@ -419,11 +434,15 @@ describe('MCP Tools', () => {
       );
 
       expect(result.isError).toBeUndefined();
-      expect(result.content[0].text).toContain('Successfully created');
+      // Upsert wording — never claims create-vs-update (cold cache can't tell).
+      expect(result.content[0].text).toContain('Successfully saved');
+      expect(result.content[0].text).toContain('confirmed on server');
       expect(result.content[0].text).toContain('task1');
+      // The success was gated on a server confirmation for this exact (map, key).
+      expect(mockClient.confirmWriteCalls).toEqual([{ map: 'tasks', key: 'task1' }]);
     });
 
-    it('should update an existing record', async () => {
+    it('should use upsert wording for an existing record too', async () => {
       const ctx = createTestContext();
       const map = (ctx.client as unknown as MockTopGunClient).getMap('tasks');
       map.set('task1', { title: 'Old Title', status: 'todo' });
@@ -439,10 +458,44 @@ describe('MCP Tools', () => {
       );
 
       expect(result.isError).toBeUndefined();
-      expect(result.content[0].text).toContain('Successfully updated');
+      expect(result.content[0].text).toContain('Successfully saved');
     });
 
-    it('should remove a record', async () => {
+    it('should NOT report success when a set is not confirmed (offline)', async () => {
+      const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
+      mockClient.confirmWriteOutcome = 'offline';
+
+      const result = await handleMutate(
+        {
+          map: 'tasks',
+          operation: 'set',
+          key: 'task1',
+          data: { title: 'Unsynced', status: 'todo' },
+        },
+        ctx,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('NOT yet durable');
+      expect(result.content[0].text).not.toContain('Successfully');
+    });
+
+    it('should report an error when a set times out without server confirmation', async () => {
+      const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
+      mockClient.confirmWriteOutcome = 'timeout';
+
+      const result = await handleMutate(
+        { map: 'tasks', operation: 'set', key: 'task1', data: { title: 'Slow' } },
+        ctx,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('NOT yet confirmed durable');
+    });
+
+    it('should remove a record once the server confirms it', async () => {
       const ctx = createTestContext();
       const map = (ctx.client as unknown as MockTopGunClient).getMap('tasks');
       map.set('task1', { title: 'To Delete', status: 'todo' });
@@ -458,22 +511,45 @@ describe('MCP Tools', () => {
 
       expect(result.isError).toBeUndefined();
       expect(result.content[0].text).toContain('Successfully removed');
+      expect(result.content[0].text).toContain('confirmed on server');
     });
 
-    it('should warn when removing non-existent record', async () => {
+    it('should issue a server-authoritative remove for a key absent from the local cache', async () => {
+      // F5: the record exists on the server but is NOT in the cold MCP cache. The
+      // remove must still be issued (server-authoritative) and reported as done —
+      // never silently no-op'd with a false "does not exist".
       const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
+      const removeSpy = jest.spyOn(mockClient.getMap('tasks'), 'remove');
 
       const result = await handleMutate(
         {
           map: 'tasks',
           operation: 'remove',
-          key: 'nonexistent',
+          key: 'server-only-key',
         },
         ctx,
       );
 
       expect(result.isError).toBeUndefined();
-      expect(result.content[0].text).toContain('does not exist');
+      expect(result.content[0].text).toContain('Successfully removed');
+      expect(result.content[0].text).not.toContain('does not exist');
+      // The tombstone was actually written (not short-circuited on cold cache)...
+      expect(removeSpy).toHaveBeenCalledWith('server-only-key');
+      // ...and success was gated on a server confirmation.
+      expect(mockClient.confirmWriteCalls).toEqual([{ map: 'tasks', key: 'server-only-key' }]);
+    });
+
+    it('should NOT report a remove as done when it is not confirmed (offline)', async () => {
+      const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
+      mockClient.confirmWriteOutcome = 'offline';
+
+      const result = await handleMutate({ map: 'tasks', operation: 'remove', key: 'task1' }, ctx);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('NOT yet durable');
+      expect(result.content[0].text).not.toContain('Successfully');
     });
 
     it('should error when mutations are disabled', async () => {

--- a/packages/mcp-server/src/tools/mutate.ts
+++ b/packages/mcp-server/src/tools/mutate.ts
@@ -2,6 +2,7 @@
  * topgun_mutate - Create, update, or delete data in a TopGun map
  */
 
+import type { WriteConfirmation } from '@topgunbuild/client';
 import type { MCPTool, MCPToolResult, ToolContext } from '../types';
 import { MutateArgsSchema, toolSchemas } from '../schemas';
 
@@ -9,10 +10,55 @@ export const mutateTool: MCPTool = {
   name: 'topgun_mutate',
   description:
     'Create, update, or delete data in a TopGun map. ' +
-    'Use "set" operation to create or update a record. ' +
-    'Use "remove" operation to delete a record.',
+    'Use "set" operation to create or update a record (an upsert). ' +
+    'Use "remove" operation to delete a record. ' +
+    'Both operations are confirmed against the server before reporting success — ' +
+    'an offline or unconfirmed write is reported as an error, never as success.',
   inputSchema: toolSchemas.mutate as MCPTool['inputSchema'],
 };
+
+/**
+ * How long to wait for the server to confirm a write before reporting it as
+ * not-yet-durable. Mirrors the client's queryOnce settle timeout.
+ */
+const WRITE_CONFIRM_TIMEOUT_MS = 5000;
+
+/**
+ * Map a non-`synced` write outcome to an explicit error result. A write that the
+ * server has not confirmed must NEVER be reported as success: an MCP agent that
+ * is told "saved" will not retry, so a silent loss (offline, F8 launch-order, or
+ * the MCP server's default in-memory store on process exit) becomes invisible
+ * data loss. The wording tells the agent exactly what is and isn't true.
+ */
+function unconfirmedWriteError(
+  outcome: Exclude<WriteConfirmation, 'synced'>,
+  verb: 'write' | 'removal',
+  key: string,
+  map: string,
+): MCPToolResult {
+  let text: string;
+  switch (outcome) {
+    case 'offline':
+      text =
+        `Error: the ${verb} of '${key}' in map '${map}' was queued locally but the ` +
+        `client is NOT connected to the server, so it is NOT yet durable. It will sync ` +
+        `on reconnect — but the MCP server's default in-memory store does not persist ` +
+        `across restarts, so an unsynced write can be lost. Reconnect and retry to confirm.`;
+      break;
+    case 'timeout':
+      text =
+        `Error: the ${verb} of '${key}' in map '${map}' was sent but the server did not ` +
+        `confirm it within ${WRITE_CONFIRM_TIMEOUT_MS / 1000}s, so it is NOT yet confirmed ` +
+        `durable. The server may be slow or unreachable; verify with topgun_query before retrying.`;
+      break;
+    case 'failed':
+      text =
+        `Error: the ${verb} of '${key}' in map '${map}' could not be recorded locally ` +
+        `(storage/commit failure). The ${verb} did not take effect.`;
+      break;
+  }
+  return { content: [{ type: 'text', text }], isError: true };
+}
 
 export async function handleMutate(rawArgs: unknown, ctx: ToolContext): Promise<MCPToolResult> {
   // Validate and parse args with Zod
@@ -77,43 +123,43 @@ export async function handleMutate(rawArgs: unknown, ctx: ToolContext): Promise<
         _updatedAt: new Date().toISOString(),
       };
 
-      // Check if record exists for logging
-      const existingValue = lwwMap.get(key);
-      const isCreate = existingValue === undefined;
-
+      // Apply the write locally (queues the op), then wait for the SERVER to
+      // confirm it before reporting success. `set` is an upsert (create-or-
+      // update) — we deliberately do NOT claim "created" vs "updated" because the
+      // MCP client's local cache is cold for server-resident data, so it cannot
+      // tell which one this was.
       lwwMap.set(key, recordData);
+      const outcome = await ctx.client.confirmWrite(map, key, WRITE_CONFIRM_TIMEOUT_MS);
+      if (outcome !== 'synced') {
+        return unconfirmedWriteError(outcome, 'write', key, map);
+      }
 
       return {
         content: [
           {
             type: 'text',
-            text: isCreate
-              ? `Successfully created record '${key}' in map '${map}':\n${JSON.stringify(recordData, null, 2)}`
-              : `Successfully updated record '${key}' in map '${map}':\n${JSON.stringify(recordData, null, 2)}`,
+            text: `Successfully saved record '${key}' in map '${map}' (confirmed on server):\n${JSON.stringify(recordData, null, 2)}`,
           },
         ],
       };
     } else if (operation === 'remove') {
-      // Check if record exists
-      const existingValue = lwwMap.get(key);
-      if (existingValue === undefined) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Warning: Record '${key}' does not exist in map '${map}'. No action taken.`,
-            },
-          ],
-        };
-      }
-
+      // Issue the removal to the server UNCONDITIONALLY (server-authoritative).
+      // Do NOT gate on the local cache: it is empty by default for any record the
+      // agent did not write in this process, so gating would silently no-op a real
+      // deletion of server data while telling the agent it "does not exist".
+      // LWWMap.remove writes a tombstone with a fresh timestamp regardless of
+      // local presence, so this propagates to the server even for a cold key.
       lwwMap.remove(key);
+      const outcome = await ctx.client.confirmWrite(map, key, WRITE_CONFIRM_TIMEOUT_MS);
+      if (outcome !== 'synced') {
+        return unconfirmedWriteError(outcome, 'removal', key, map);
+      }
 
       return {
         content: [
           {
             type: 'text',
-            text: `Successfully removed record '${key}' from map '${map}'.`,
+            text: `Successfully removed record '${key}' from map '${map}' (confirmed on server).`,
           },
         ],
       };

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -27,7 +27,13 @@ import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
 import { TopGunMCPServer } from '@topgunbuild/mcp-server';
 import type { MCPToolResult } from '@topgunbuild/mcp-server';
 
-import { spawnRustServer, createRustTestClient, createTestToken, createLWWRecord } from './helpers';
+import {
+  spawnRustServer,
+  createRustTestClient,
+  createTestToken,
+  createLWWRecord,
+  completeMerkleSync,
+} from './helpers';
 
 // In-memory storage adapter so the SDK runs headless in Node (no IndexedDB).
 class MemoryStorageAdapter implements IStorageAdapter {
@@ -268,4 +274,130 @@ describe('Integration: MCP tools against a real Rust server (cold cache)', () =>
       await server.cleanup().catch(() => {});
     }
   }, 60_000);
+
+  // F2 — topgun_mutate{set} must reflect SERVER-confirmed state, never an
+  // optimistic local echo. We assert the write is reported successful only after
+  // the server applied it, and prove that by reading it back from a SEPARATE
+  // client (the raw seeder, over the wire) — the MCP process's own local replica
+  // is irrelevant to whether the data is durable on the server.
+  //
+  // F5 — topgun_mutate{remove} must be server-authoritative: it deletes a record
+  // that exists on the server but is absent from the cold MCP cache, and the
+  // deletion is visible to a subsequent server read. Against the pre-fix code the
+  // remove short-circuited on the empty local cache ("does not exist, no action"),
+  // so the record survived — these assertions are the negative control for that.
+  test('mutate is server-confirmed (F2) and remove is server-authoritative (F5)', async () => {
+    const server = await spawnRustServer();
+    const seeder = await createRustTestClient(server.port, {
+      userId: 'mcp-seeder',
+      roles: ['ADMIN'],
+    });
+    const mcpClient = makeClient(server.port, 'mcp-writer');
+    const mcp = new TopGunMCPServer({ client: mcpClient });
+
+    try {
+      await seeder.waitForMessage('AUTH_ACK', 10_000);
+      await mcpClient.start();
+      await waitForState(mcpClient, SyncState.CONNECTED);
+
+      // ---- F2: set, confirmed on the server, visible to a separate client ----
+      const writeMap = `mcp_write_${Date.now()}`;
+      const setRes = await callStable(mcp, 'topgun_mutate', {
+        map: writeMap,
+        operation: 'set',
+        key: 'w1',
+        data: { title: 'hello', n: 1 },
+      });
+      expect(setRes.isError).toBeFalsy();
+      expect(text(setRes)).toContain('Successfully saved');
+      expect(text(setRes)).toContain('confirmed on server');
+
+      // A SEPARATE client pulls the map from the server via Merkle sync and sees
+      // the record — proof the write is durable server-side, not local-only.
+      const seenAfterSet = await completeMerkleSync(seeder, writeMap);
+      expect(seenAfterSet.has('w1')).toBe(true);
+      expect(seenAfterSet.get('w1')?.value?.title).toBe('hello');
+
+      // ---- F5: remove a server-resident key that is COLD to the MCP cache ----
+      const removeMap = `mcp_remove_${Date.now()}`;
+      // Seed two keys over the wire (server-resident; the MCP client never wrote
+      // them, so they are absent from its local replica). 'keep1' is a sentinel to
+      // prove the remove is targeted, not a blanket wipe.
+      for (const [k, title] of [
+        ['doomed', 'delete me'],
+        ['keep1', 'survivor'],
+      ]) {
+        seeder.messages.length = 0;
+        seeder.send({
+          type: 'CLIENT_OP',
+          payload: {
+            id: `seed-${removeMap}-${k}`,
+            mapName: removeMap,
+            opType: 'PUT',
+            key: k,
+            record: createLWWRecord({ id: k, title }),
+          },
+        });
+        await seeder.waitForMessage('OP_ACK', 10_000);
+      }
+
+      // The MCP client has never cached 'doomed' — a pre-fix remove would no-op
+      // with "does not exist". The fix issues the tombstone server-authoritatively.
+      const removeRes = await callStable(mcp, 'topgun_mutate', {
+        map: removeMap,
+        operation: 'remove',
+        key: 'doomed',
+      });
+      expect(removeRes.isError).toBeFalsy();
+      expect(text(removeRes)).toContain('Successfully removed');
+      expect(text(removeRes)).toContain('confirmed on server');
+      expect(text(removeRes)).not.toMatch(/does not exist/i);
+
+      // Server-authoritative read-back: 'doomed' is gone, 'keep1' remains.
+      const query = await callStable(mcp, 'topgun_query', { map: removeMap, limit: 50 });
+      expect(query.isError).toBeFalsy();
+      expect(text(query)).toContain('survivor');
+      expect(text(query)).not.toContain('delete me');
+    } finally {
+      await mcpClient.close().catch(() => {});
+      seeder.close();
+      await server.cleanup().catch(() => {});
+    }
+  }, 60_000);
+
+  // Negative control for F2: with no reachable server, a mutate must NOT report
+  // success. The pre-fix tool answered "Successfully created" optimistically (and
+  // the InMemory adapter then lost the write on exit); the fix returns an explicit
+  // not-durable error for both set and remove.
+  test('mutate returns an explicit not-durable error when the server is unreachable (F2 negative control)', async () => {
+    // Point at a port with nothing listening so the client never connects.
+    const deadPort = 59_237;
+    const mcpClient = makeClient(deadPort, 'mcp-offline');
+    const mcp = new TopGunMCPServer({ client: mcpClient });
+
+    try {
+      await mcpClient.start();
+
+      const setRes = await mcp.callTool('topgun_mutate', {
+        map: 'offline_map',
+        operation: 'set',
+        key: 'k1',
+        data: { x: 1 },
+      });
+      expect(setRes.isError).toBe(true);
+      expect(text(setRes)).toMatch(/not yet.*durable/i);
+      expect(text(setRes)).not.toContain('Successfully');
+
+      const removeRes = await mcp.callTool('topgun_mutate', {
+        map: 'offline_map',
+        operation: 'remove',
+        key: 'k1',
+      });
+      expect(removeRes.isError).toBe(true);
+      expect(text(removeRes)).toMatch(/not yet.*durable/i);
+      expect(text(removeRes)).not.toContain('Successfully');
+    } finally {
+      await mcpClient.close().catch(() => {});
+    }
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

Closes the two MCP mutate-path defects from the G9 MCP depth-audit (`DEPTH_MCP.md` F2/F5):

- **F2 (TODO-518)** — `topgun_mutate{set}` reported *"Successfully created"* on an optimistic local write **before any server ack** (`pending=1` immediately after). With the MCP server's non-durable in-memory adapter, a falsely-acked write was **lost on process exit**.
- **F5 (TODO-521)** — `topgun_mutate{remove}` gated the delete on the **cold local cache** and returned *"does not exist… no action"* for records that exist on the server — an agent **could not delete server data** it hadn't itself cached.

The RULE this enforces: **MCP mutate must reflect server-confirmed state, never optimistic-local.**

## Changes

**Client SDK (`@topgunbuild/client`)**
- `SyncEngine.waitForOpSynced(opId, timeoutMs)` — authoritative "did the server take my write?" signal via the op-log/ACK projection (per-op Write Concern promises don't resolve on the single-server `OP_BATCH` path). Returns `synced` / `offline` (fast-fail) / `timeout`.
- `TopGunClient.confirmWrite(map, key, timeoutMs)` + in-flight write registry; exported `WriteConfirmation` type.

**`@topgunbuild/mcp-server` — `topgun_mutate`**
- `set`: apply locally → **confirm against the server** before reporting success; offline/timeout/failed → explicit not-durable `isError` (never false success). Upsert wording (no false create-vs-update over a cold cache; fixes F5b LOW).
- `remove`: issue the tombstone **server-authoritatively** (drops the local-cache gate); confirm before success.

## Tests

- **Real-server harness** (`tests/integration-rust/mcp-server.test.ts`, the TODO-524/PR#70 harness):
  - set is server-confirmed and visible to a **separate client** (Merkle sync).
  - remove of a server-resident key **cold to the MCP cache** actually deletes it (server query read-back).
  - **negative control** — mutate against an unreachable server returns a not-durable error, never success.
- Unit tests: `confirmWrite` mock + offline/timeout negative controls; server-authoritative remove for an uncached key.
- Mock-WebSocket suites updated to assert the honest not-durable behavior.

## Verification (local)

- `pnpm -r build` ✅ · `pnpm lint` ✅ (0 errors) · `pnpm format:check` ✅
- `@topgunbuild/mcp-server` unit tests: 97 passed ✅
- `@topgunbuild/client` unit tests: 649 passed ✅
- `pnpm test:integration-rust` (blocking gate): **86 passed**, incl. the 3 MCP integration tests ✅

No Rust changes.