### PR TITLE
fix(mcp): make topgun_subscribe a real poll-based change feed (F3/TODO-519)

### DIFF
--- a/apps/docs-astro/public/llms-full.txt
+++ b/apps/docs-astro/public/llms-full.txt
@@ -1377,6 +1377,20 @@ TopGun reads only the `sub` and `roles` claims from the JWT payload:
 
 TopGun enforces **per-collection, per-operation** access control on the server. A Tower middleware layer checks every client read, write, and remove against a policy store before the operation reaches the domain services. This is shipped and active today — you do **not** need to re-implement authorization in your application code. App-layer claim checks are fine as optional defense-in-depth, but server-side enforcement is the authoritative gate.
 
+## Two server-side gates: admission, then authorization
+
+Every client operation passes through two distinct server-side gates, in order. They answer different questions, and only the second one is authorization:
+
+1. **Admission** — a cheap, identity-agnostic integrity and quota gate at the edge. It does not decide *who may touch which collection*; it only rejects malformed or unauthenticated traffic before any policy is consulted. Its responsibilities are: enforce the authentication baseline (`require_auth`), deny anonymous writes, cap payloads at the value-size limit (`max_value_bytes`), sanitize incoming HLC timestamps, and route by trusted origin.
+2. **Authorization** — **RBAC is the sole authorization layer**, and it is the policy engine described in the rest of this page. Once a request clears admission, RBAC is the only thing that decides whether a given principal may `read`, `write`, or `remove` a given collection.
+
+| Gate | Question it answers | Identity-aware? | Mechanism |
+|------|---------------------|-----------------|-----------|
+| Admission | Is this request well-formed, authenticated, and within limits? | No | `require_auth`, deny-anonymous-writes, `max_value_bytes`, HLC sanitization, trusted-origin routing |
+| Authorization | May *this principal* perform *this action* on *this collection*? | Yes | RBAC policies (this page) |
+
+There is exactly one authorization layer — RBAC. Admission is a guard, not a second set of permissions, so there is no per-map ACL or any other authorization mechanism to configure alongside it.
+
 ## How evaluation works
 
 Authorization runs on every client operation (`read`, `write`, `remove`):
@@ -1536,7 +1550,7 @@ new TopGunClient<TSchema>(config: TopGunClientConfig)
 | `serverUrl` | `string` | Optional. WebSocket URL for single-server mode. Mutually exclusive with `cluster`. |
 | `cluster` | `TopGunClusterConfig` | Optional. Cluster configuration. Mutually exclusive with `serverUrl`. |
 | `nodeId` | `string` | Optional. Auto-generated UUID if omitted. |
-| `backoff` | `Partial<BackoffConfig>` | Optional. Reconnect backoff tuning. |
+| `backoff` | `Partial<BackoffConfig>` | Optional. Reconnect backoff tuning (see [Reconnection & offline recovery](#reconnection--offline-recovery)). |
 | `backpressure` | `Partial<BackpressureConfig>` | Optional. Backpressure thresholds and strategy. |
 | `auth` | `AuthProvider` | Optional. Pluggable auth provider (Clerk, Firebase, BetterAuth, Custom). |
 
@@ -2005,7 +2019,12 @@ const handle = client.hybridQuery<Article>('articles', {
 public getConnectionState(): SyncState
 ```
 
-Returns the current state from the connection state machine (e.g., `OFFLINE`, `CONNECTING`, `AUTHENTICATING`, `READY`).
+Returns the current state from the connection state machine. `SyncState` is one of
+`INITIAL`, `CONNECTING`, `AUTHENTICATING`, `SYNCING`, `CONNECTED`, `DISCONNECTED`, `BACKOFF`, or
+`ERROR`. During a network outage the client cycles through `DISCONNECTED` (and reconnect backoff),
+returning to `CONNECTED` when the server is reachable again — see
+[Reconnection & offline recovery](#reconnection--offline-recovery). `ERROR` is reached only when a
+caller opted into a finite reconnect budget (`backoff.maxRetries`) and it was exhausted.
 
 ### `onConnectionStateChange(listener)`
 
@@ -2036,6 +2055,54 @@ public resetConnection(): void
 ```
 
 Reset the connection and state machine. Use after fatal errors to start fresh.
+
+## Reconnection & offline recovery
+
+TopGun is offline-first: a server that is briefly gone — a deploy window, a laptop waking from
+sleep, or even a client that starts *before* the server — is the normal case, not a terminal one.
+
+**By default the client reconnects indefinitely.** When the connection drops (or never came up), the
+client retries with exponential backoff and jitter, capped at a maximum interval, **forever**, until
+the server is reachable again. It never silently gives up. The capped interval bounds the retry rate
+(roughly one attempt per `maxDelayMs`), so unbounded retries do not hammer the server. This holds in
+both the browser and Node/SSR; in the browser a network-return (`online`) event additionally triggers
+an immediate reconnect instead of waiting for the next backoff tick.
+
+Tune it with the `backoff` config:
+
+```typescript
+const client = new TopGunClient({
+  serverUrl: 'ws://localhost:8080',
+  storage: new IDBAdapter(),
+  backoff: {
+    initialDelayMs: 1000, // first retry delay (default 1000)
+    maxDelayMs: 30000,    // backoff cap (default 30000)
+    multiplier: 2,        // exponential factor (default 2)
+    jitter: true,         // randomize delay 0.5x–1.5x (default true)
+    maxRetries: Infinity, // give-up budget (default Infinity = never give up)
+  },
+});
+```
+
+### Bounded retry (opt-in)
+
+Set `backoff.maxRetries` to a finite number if you want the client to stop after a fixed number of
+failed attempts. On exhaustion the client transitions to `SyncState.ERROR` and fires
+`onConnectionStateChange` with that terminal state — an explicit, honest "I have stopped trying"
+signal (never a silent stall). Recover from `ERROR` by calling [`resetConnection()`](#resetconnection),
+which starts a fresh connection with a full retry budget.
+
+```typescript
+client.onConnectionStateChange((event) => {
+  if (event.to === 'ERROR') {
+    // Reconnect budget exhausted — surface to the user and/or retry.
+    client.resetConnection();
+  }
+});
+```
+
+With the default `maxRetries: Infinity`, `SyncState.ERROR` is never reached for transient/network
+failures — the client simply keeps cycling through `DISCONNECTED` and reconnecting.
 
 ## Backpressure
 

--- a/apps/docs-astro/src/content/docs/guides/mcp-server.mdx
+++ b/apps/docs-astro/src/content/docs/guides/mcp-server.mdx
@@ -78,7 +78,7 @@ Cursor's MCP config lives at `~/.cursor/mcp.json` (project-scoped: `.cursor/mcp.
 | `topgun_query` | Run a query (filter + sort + limit) over a map. |
 | `topgun_mutate` | Set or delete records. |
 | `topgun_search` | BM25 full-text search across indexed maps. |
-| `topgun_subscribe` | Streaming subscription to map changes. |
+| `topgun_subscribe` | Poll-based change feed: `start` a live watch, `poll` for typed add/update/remove deltas, `stop` when done. |
 | `topgun_schema` | Read the Zod-derived schema for a map. |
 | `topgun_stats` | Map size, record count, last-modified. |
 | `topgun_explain` | Show the query plan for a given filter. |

--- a/apps/docs-astro/src/content/docs/reference/mcp.mdx
+++ b/apps/docs-astro/src/content/docs/reference/mcp.mdx
@@ -190,8 +190,9 @@ re-reported as "changes".
 - **Parameters:** `{ action: 'start' | 'poll' | 'stop' | 'list', map?, filter?, subscriptionId?, ttlSeconds? }`
 - **Usage:**
   - `action: 'start'` `{ map, filter? }` — opens a server-backed live query and returns a
-    `subscriptionId` immediately (it does **not** block). Errors if the server cannot deliver
-    an initial baseline (offline / unreachable).
+    `subscriptionId` as soon as the server confirms the watch (it does **not** hold the call open
+    for the watch window). Errors if the server cannot deliver an initial baseline (offline /
+    unreachable).
   - `action: 'poll'` `{ subscriptionId }` — returns the changes observed since the last poll
     as `{ type, key, value? }`. Refreshes the subscription's idle timer. Reports if the buffer
     overflowed (changes dropped).

--- a/apps/docs-astro/src/content/docs/reference/mcp.mdx
+++ b/apps/docs-astro/src/content/docs/reference/mcp.mdx
@@ -107,7 +107,7 @@ await server.start();
 | `enableSubscriptions` | `true` | If `false`, `topgun_subscribe` is unavailable. |
 | `defaultLimit` | `10` | Default page size for `topgun_query`. |
 | `maxLimit` | `100` | Hard cap on requested page size. |
-| `subscriptionTimeoutSeconds` | `60` | Maximum lifetime of a `topgun_subscribe` call. |
+| `subscriptionTimeoutSeconds` | `60` | Default idle lifetime of a `topgun_subscribe` feed; auto-stops after this long without a poll (refreshed on each poll). |
 | `debug` | `false` | Verbose logging. |
 | `client` | none | Pre-built `TopGunClient` instance (overrides `topgunUrl` + `authToken`). |
 
@@ -181,11 +181,25 @@ BM25 full-text search across a map.
 
 ### topgun_subscribe
 
-Subscribe to live updates on a map for a bounded time window. Useful for the assistant to watch for changes during a conversation.
+Watch a map for real-time changes via a **poll cursor**. MCP is a request/response
+protocol, so a tool call cannot stream changes into the assistant's turn; instead the
+feed is drained on demand. Each reported change is a genuine, typed delta (`add` /
+`update` / `remove`) — removals are first-class, and the existing snapshot is never
+re-reported as "changes".
 
-- **Parameters:** `{ map, filter?, durationSeconds? }`
-- **Response:** stream of `{ type: 'add' | 'update' | 'remove', key, value }` until timeout
-- **Security:** requires `enableSubscriptions: true`; capped by `subscriptionTimeoutSeconds`
+- **Parameters:** `{ action: 'start' | 'poll' | 'stop' | 'list', map?, filter?, subscriptionId?, ttlSeconds? }`
+- **Usage:**
+  - `action: 'start'` `{ map, filter? }` — opens a server-backed live query and returns a
+    `subscriptionId` immediately (it does **not** block). Errors if the server cannot deliver
+    an initial baseline (offline / unreachable).
+  - `action: 'poll'` `{ subscriptionId }` — returns the changes observed since the last poll
+    as `{ type, key, value? }`. Refreshes the subscription's idle timer. Reports if the buffer
+    overflowed (changes dropped).
+  - `action: 'stop'` `{ subscriptionId }` — ends the subscription.
+  - `action: 'list'` — shows active subscriptions.
+- **Lifetime:** an unpolled subscription auto-stops after `ttlSeconds` (defaults to
+  `subscriptionTimeoutSeconds`); each poll refreshes it.
+- **Security:** requires `enableSubscriptions: true`
 
 ### topgun_schema
 

--- a/packages/mcp-server/src/TopGunMCPServer.ts
+++ b/packages/mcp-server/src/TopGunMCPServer.ts
@@ -89,18 +89,20 @@ export class TopGunMCPServer {
       }
     }
 
-    // Create tool context
-    this.toolContext = {
-      client: this.client,
-      config: this.config,
-      subscriptions: new SubscriptionRegistry(this.client),
-    };
-
     // Initialize logger
     this.logger = createLogger({
       debug: this.config.debug,
       name: this.config.name,
     });
+
+    // Create tool context
+    this.toolContext = {
+      client: this.client,
+      config: this.config,
+      subscriptions: new SubscriptionRegistry(this.client, (err, subscriptionId) =>
+        this.logger.warn({ err, subscriptionId }, 'subscription teardown failed'),
+      ),
+    };
 
     // Initialize MCP server
     this.server = new Server(

--- a/packages/mcp-server/src/TopGunMCPServer.ts
+++ b/packages/mcp-server/src/TopGunMCPServer.ts
@@ -13,6 +13,7 @@ import type { IStorageAdapter, OpLogEntry, StorageMutation } from '@topgunbuild/
 import type { MCPServerConfig, MCPToolResult, ResolvedMCPServerConfig, ToolContext } from './types';
 import { allTools, toolHandlers } from './tools';
 import { createLogger, type Logger } from './logger';
+import { SubscriptionRegistry } from './subscriptions';
 
 /**
  * Default configuration values
@@ -92,6 +93,7 @@ export class TopGunMCPServer {
     this.toolContext = {
       client: this.client,
       config: this.config,
+      subscriptions: new SubscriptionRegistry(this.client),
     };
 
     // Initialize logger
@@ -249,6 +251,10 @@ export class TopGunMCPServer {
    */
   async stop(): Promise<void> {
     if (!this.isStarted) return;
+
+    // Tear down live change-feed subscriptions first so no handle or expiry
+    // timer outlives the server.
+    this.toolContext.subscriptions.teardownAll();
 
     await this.server.close();
 

--- a/packages/mcp-server/src/__tests__/mcp-integration.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-integration.test.ts
@@ -215,14 +215,51 @@ describe('MCP Integration', () => {
       expect(result.content[0].text).toBeDefined();
     });
 
-    it('should execute topgun_subscribe', async () => {
-      const result = await server.callTool('topgun_subscribe', {
-        map: 'tasks',
-        timeout: 1,
-      });
+    // topgun_subscribe is now a poll-cursor change feed (action: start/poll/stop/
+    // list), not a blocking wait. The session-management actions (list/poll/stop)
+    // are server-independent, so they are exercised here against the mock; the
+    // start → live-delta path needs a real server and is covered by the
+    // integration-rust harness (F3).
+    it('topgun_subscribe action:list reports no active subscriptions', async () => {
+      const result = await server.callTool('topgun_subscribe', { action: 'list' });
 
       expect(result).toBeDefined();
       expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('No active subscriptions');
+    });
+
+    it('topgun_subscribe action:poll requires a subscriptionId', async () => {
+      const result = await server.callTool('topgun_subscribe', { action: 'poll' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('subscriptionId');
+    });
+
+    it('topgun_subscribe action:poll on an unknown id is an explicit error', async () => {
+      const result = await server.callTool('topgun_subscribe', {
+        action: 'poll',
+        subscriptionId: 'does-not-exist',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/no active subscription/i);
+    });
+
+    it('topgun_subscribe action:stop on an unknown id reports nothing to stop', async () => {
+      const result = await server.callTool('topgun_subscribe', {
+        action: 'stop',
+        subscriptionId: 'does-not-exist',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toMatch(/no active subscription/i);
+    });
+
+    it('topgun_subscribe action:start requires a map', async () => {
+      const result = await server.callTool('topgun_subscribe', { action: 'start' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("'map' is required");
     });
 
     it('should return error for invalid arguments', async () => {

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ToolContext, ResolvedMCPServerConfig } from '../types';
+import { SubscriptionRegistry } from '../subscriptions';
 import { QueryOnceUnsettledError } from '@topgunbuild/client';
 import { handleQuery } from '../tools/query';
 import { handleMutate } from '../tools/mutate';
@@ -182,8 +183,10 @@ class MockTopGunClient {
 }
 
 function createTestContext(config?: Partial<ResolvedMCPServerConfig>): ToolContext {
+  const client = new MockTopGunClient() as unknown as ToolContext['client'];
   return {
-    client: new MockTopGunClient() as unknown as ToolContext['client'],
+    client,
+    subscriptions: new SubscriptionRegistry(client),
     config: {
       name: 'topgun-server',
       version: '1.0.0',

--- a/packages/mcp-server/src/schemas.ts
+++ b/packages/mcp-server/src/schemas.ts
@@ -95,9 +95,10 @@ export const SubscribeArgsSchema = z.object({
     .optional()
     .default('start')
     .describe(
-      "What to do: 'start' opens a live change-feed on a map and returns a subscriptionId " +
-        "immediately (does NOT block); 'poll' drains the changes buffered since the last poll; " +
-        "'stop' ends a subscription; 'list' shows active subscriptions.",
+      "What to do: 'start' opens a live change-feed on a map and returns a subscriptionId as " +
+        'soon as the server confirms the watch (it does NOT hold the call open for the watch ' +
+        "window); 'poll' drains the changes buffered since the last poll; 'stop' ends a " +
+        "subscription; 'list' shows active subscriptions.",
     ),
   map: z.string().optional().describe("Name of the map to watch (required for action 'start')"),
   filter: z
@@ -110,6 +111,7 @@ export const SubscribeArgsSchema = z.object({
     .describe("Subscription id returned by 'start' (required for 'poll' and 'stop')"),
   ttlSeconds: z
     .number()
+    .positive()
     .optional()
     .describe(
       'Idle lifetime of the subscription in seconds; refreshed on each poll. ' +
@@ -271,8 +273,8 @@ export const toolSchemas = {
         enum: ['start', 'poll', 'stop', 'list'],
         description:
           "What to do: 'start' opens a live change-feed on a map and returns a subscriptionId " +
-          'immediately (does NOT block); ' +
-          "'poll' drains the changes buffered since the last poll; " +
+          'as soon as the server confirms the watch (it does NOT hold the call open for the watch ' +
+          "window); 'poll' drains the changes buffered since the last poll; " +
           "'stop' ends a subscription; 'list' shows active subscriptions. Defaults to 'start'.",
         default: 'start',
       },

--- a/packages/mcp-server/src/schemas.ts
+++ b/packages/mcp-server/src/schemas.ts
@@ -90,12 +90,32 @@ export type SearchArgs = z.infer<typeof SearchArgsSchema>;
 // ============================================
 
 export const SubscribeArgsSchema = z.object({
-  map: z.string().describe("Name of the map to watch (e.g., 'tasks', 'notifications')"),
+  action: z
+    .enum(['start', 'poll', 'stop', 'list'])
+    .optional()
+    .default('start')
+    .describe(
+      "What to do: 'start' opens a live change-feed on a map and returns a subscriptionId " +
+        "immediately (does NOT block); 'poll' drains the changes buffered since the last poll; " +
+        "'stop' ends a subscription; 'list' shows active subscriptions.",
+    ),
+  map: z.string().optional().describe("Name of the map to watch (required for action 'start')"),
   filter: z
     .record(z.string(), z.unknown())
     .optional()
-    .describe('Filter criteria - only report changes matching these conditions'),
-  timeout: z.number().optional().default(60).describe('How long to watch for changes (in seconds)'),
+    .describe('Filter criteria - only report changes to records matching these conditions'),
+  subscriptionId: z
+    .string()
+    .optional()
+    .describe("Subscription id returned by 'start' (required for 'poll' and 'stop')"),
+  ttlSeconds: z
+    .number()
+    .optional()
+    .describe(
+      'Idle lifetime of the subscription in seconds; refreshed on each poll. ' +
+        'Defaults to the server subscriptionTimeoutSeconds. After it elapses with no poll, ' +
+        'the subscription auto-stops.',
+    ),
 });
 
 export type SubscribeArgs = z.infer<typeof SubscribeArgsSchema>;
@@ -246,22 +266,37 @@ export const toolSchemas = {
   subscribe: {
     type: 'object',
     properties: {
+      action: {
+        type: 'string',
+        enum: ['start', 'poll', 'stop', 'list'],
+        description:
+          "What to do: 'start' opens a live change-feed on a map and returns a subscriptionId " +
+          'immediately (does NOT block); ' +
+          "'poll' drains the changes buffered since the last poll; " +
+          "'stop' ends a subscription; 'list' shows active subscriptions. Defaults to 'start'.",
+        default: 'start',
+      },
       map: {
         type: 'string',
-        description: "Name of the map to watch (e.g., 'tasks', 'notifications')",
+        description: "Name of the map to watch (required for action 'start')",
       },
       filter: {
         type: 'object',
-        description: 'Filter criteria - only report changes matching these conditions',
+        description: 'Filter criteria - only report changes to records matching these conditions',
         additionalProperties: true,
       },
-      timeout: {
+      subscriptionId: {
+        type: 'string',
+        description: "Subscription id returned by 'start' (required for 'poll' and 'stop')",
+      },
+      ttlSeconds: {
         type: 'number',
-        description: 'How long to watch for changes (in seconds)',
-        default: 60,
+        description:
+          'Idle lifetime of the subscription in seconds; refreshed on each poll. Defaults to the ' +
+          'server subscriptionTimeoutSeconds. After it elapses with no poll, the subscription auto-stops.',
       },
     },
-    required: ['map'],
+    required: [],
   },
   schema: {
     type: 'object',

--- a/packages/mcp-server/src/subscriptions.ts
+++ b/packages/mcp-server/src/subscriptions.ts
@@ -8,8 +8,9 @@
  * which mis-reported every snapshot row as a change and made removals invisible.
  *
  * The honest design for a request/response transport is an explicit poll cursor:
- * `start` opens a long-lived live query in the MCP process (returning at once),
- * the genuine per-record deltas it receives buffer here, and `poll` drains them.
+ * `start` opens a long-lived live query in the MCP process (returning as soon as
+ * the server confirms the baseline, not after the watch window), the genuine
+ * per-record deltas it receives buffer here, and `poll` drains them.
  * Deltas are computed by the client's `ChangeTracker` (via `QueryHandle.onDelta`),
  * so each one carries a real `add | update | remove` type and removals are
  * first-class — never a row that silently vanishes from a re-emitted snapshot.
@@ -55,6 +56,15 @@ export interface ActiveSubscription {
   totalObserved: number;
 }
 
+/**
+ * Outcome of `start`: the subscription, or a typed reason it could not open, so
+ * the tool can tell the agent precisely what happened (offline vs. at capacity)
+ * rather than collapsing both into one vague error.
+ */
+export type StartResult =
+  | { ok: true; sub: ActiveSubscription }
+  | { ok: false; reason: 'offline' | 'capacity' };
+
 interface InternalSubscription extends ActiveSubscription {
   handle: QueryHandle<Record<string, unknown>>;
   /** Set true only after the server baseline settles, so the initial snapshot's
@@ -76,7 +86,16 @@ function nowIso(): string {
 export class SubscriptionRegistry {
   private readonly subs = new Map<string, InternalSubscription>();
 
-  constructor(private readonly client: TopGunClient) {}
+  /**
+   * @param client TopGun client whose live queries back the feeds.
+   * @param onTeardownError optional sink for cleanup failures so a throwing
+   *   unsubscribe (which could leave a server-side live query open) is surfaced
+   *   rather than silently swallowed.
+   */
+  constructor(
+    private readonly client: TopGunClient,
+    private readonly onTeardownError?: (err: unknown, subscriptionId: string) => void,
+  ) {}
 
   get size(): number {
     return this.subs.size;
@@ -88,15 +107,17 @@ export class SubscriptionRegistry {
 
   /**
    * Open a live query, wait for the server to deliver its authoritative baseline,
-   * then begin recording genuine deltas. Resolves to the subscription, or `null`
-   * if the server never settled the query within the timeout (offline /
-   * unreachable) — in which case nothing is registered and no handle leaks.
+   * then begin recording genuine deltas. Returns `{ ok: false }` (registering
+   * nothing, leaking no handle) when the server never settles the query within
+   * the timeout (`offline`) or the active-subscription cap is reached
+   * (`capacity`). The cap is re-checked AFTER the await so concurrent starts can
+   * never push the registry past MAX_ACTIVE_SUBSCRIPTIONS.
    */
-  async start(
-    map: string,
-    filter: Record<string, unknown>,
-    ttlMs: number,
-  ): Promise<ActiveSubscription | null> {
+  async start(map: string, filter: Record<string, unknown>, ttlMs: number): Promise<StartResult> {
+    if (this.subs.size >= MAX_ACTIVE_SUBSCRIPTIONS) {
+      return { ok: false, reason: 'capacity' };
+    }
+
     const id = randomUUID();
     const handle = this.client.query<Record<string, unknown>>(map, filter);
 
@@ -145,15 +166,22 @@ export class SubscriptionRegistry {
     if (!settled) {
       // Could not establish a server baseline — do not register a half-open
       // subscription that would feed the agent local-only or empty data.
-      sub.offDelta();
-      sub.unsubscribe();
-      return null;
+      this.teardown(sub);
+      return { ok: false, reason: 'offline' };
+    }
+
+    // Re-check the cap after awaiting: a burst of concurrent starts each passed
+    // the synchronous fast-path check before any of them registered, so enforce
+    // the ceiling here where the registration actually happens.
+    if (this.subs.size >= MAX_ACTIVE_SUBSCRIPTIONS) {
+      this.teardown(sub);
+      return { ok: false, reason: 'capacity' };
     }
 
     sub.recording = true;
     this.subs.set(id, sub);
     this.resetExpiry(sub, ttlMs);
-    return sub;
+    return { ok: true, sub };
   }
 
   /**
@@ -183,14 +211,16 @@ export class SubscriptionRegistry {
     return true;
   }
 
-  /** Snapshot of the active subscriptions (no internal handles exposed). */
+  /** Snapshot of the active subscriptions (no internal handles or live state
+   *  exposed — `buffer`/`filter` are copied so callers cannot mutate registry
+   *  internals or race a concurrent delta callback). */
   list(): ActiveSubscription[] {
     return Array.from(this.subs.values()).map((s) => ({
       id: s.id,
       map: s.map,
-      filter: s.filter,
+      filter: { ...s.filter },
       createdAt: s.createdAt,
-      buffer: s.buffer,
+      buffer: [...s.buffer],
       dropped: s.dropped,
       totalObserved: s.totalObserved,
     }));
@@ -233,15 +263,18 @@ export class SubscriptionRegistry {
       clearTimeout(sub.expiryTimer);
       sub.expiryTimer = null;
     }
+    // Teardown must never throw (it runs in stop / expiry / error paths), but a
+    // cleanup failure is reported, not swallowed: a throwing unsubscribe can
+    // leave a server-side live query open, which the operator needs to see.
     try {
       sub.offDelta();
-    } catch {
-      // listener removal must never throw out of teardown
+    } catch (err) {
+      this.onTeardownError?.(err, sub.id);
     }
     try {
       sub.unsubscribe();
-    } catch {
-      // unsubscribe must never throw out of teardown
+    } catch (err) {
+      this.onTeardownError?.(err, sub.id);
     }
   }
 }

--- a/packages/mcp-server/src/subscriptions.ts
+++ b/packages/mcp-server/src/subscriptions.ts
@@ -1,0 +1,247 @@
+/**
+ * Persistent change-feed subscriptions for the MCP server.
+ *
+ * WHY A POLL CONTRACT — the MCP protocol is request/response: a single
+ * `tools/call` cannot stream incremental results into the agent's turn. The old
+ * `topgun_subscribe` worked around this by BLOCKING the tool for the whole
+ * timeout (≤60 s) and then dumping the full result set as `UPDATE` "changes",
+ * which mis-reported every snapshot row as a change and made removals invisible.
+ *
+ * The honest design for a request/response transport is an explicit poll cursor:
+ * `start` opens a long-lived live query in the MCP process (returning at once),
+ * the genuine per-record deltas it receives buffer here, and `poll` drains them.
+ * Deltas are computed by the client's `ChangeTracker` (via `QueryHandle.onDelta`),
+ * so each one carries a real `add | update | remove` type and removals are
+ * first-class — never a row that silently vanishes from a re-emitted snapshot.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import type { ChangeEvent, QueryHandle, TopGunClient } from '@topgunbuild/client';
+
+/** Upper bound on buffered deltas per subscription; oldest are dropped first. */
+export const MAX_BUFFERED_DELTAS = 1000;
+
+/** Maximum number of concurrently active subscriptions per MCP process. */
+export const MAX_ACTIVE_SUBSCRIPTIONS = 50;
+
+/**
+ * How long to wait for the server's first authoritative QUERY_RESP (the baseline
+ * snapshot) before declaring the subscription un-startable. Mirrors the mutate
+ * tool's confirm timeout — a subscription we cannot baseline against the server
+ * is reported as an error rather than silently feeding the agent local-only data.
+ */
+export const SUBSCRIBE_SETTLE_TIMEOUT_MS = 5000;
+
+export interface DeltaRecord {
+  /** 'add' = entered the result set, 'update' = changed, 'remove' = left it. */
+  type: ChangeEvent<Record<string, unknown>>['type'];
+  key: string;
+  value?: Record<string, unknown>;
+  /** Wall-clock time the delta was observed by the MCP process. */
+  at: string;
+}
+
+export interface ActiveSubscription {
+  id: string;
+  map: string;
+  filter: Record<string, unknown>;
+  createdAt: string;
+  /** Genuine post-baseline deltas awaiting drain by `poll`. */
+  buffer: DeltaRecord[];
+  /** Count of deltas evicted because the buffer hit MAX_BUFFERED_DELTAS. */
+  dropped: number;
+  /** Total deltas observed since `start` (for the agent's situational awareness). */
+  totalObserved: number;
+}
+
+interface InternalSubscription extends ActiveSubscription {
+  handle: QueryHandle<Record<string, unknown>>;
+  /** Set true only after the server baseline settles, so the initial snapshot's
+   *  add-deltas are never reported as "changes". */
+  recording: boolean;
+  offDelta: () => void;
+  unsubscribe: () => void;
+  expiryTimer: ReturnType<typeof setTimeout> | null;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Owns the live-query handles backing `topgun_subscribe`. One instance per
+ * `TopGunMCPServer`; torn down with the server so no handle or timer leaks.
+ */
+export class SubscriptionRegistry {
+  private readonly subs = new Map<string, InternalSubscription>();
+
+  constructor(private readonly client: TopGunClient) {}
+
+  get size(): number {
+    return this.subs.size;
+  }
+
+  atCapacity(): boolean {
+    return this.subs.size >= MAX_ACTIVE_SUBSCRIPTIONS;
+  }
+
+  /**
+   * Open a live query, wait for the server to deliver its authoritative baseline,
+   * then begin recording genuine deltas. Resolves to the subscription, or `null`
+   * if the server never settled the query within the timeout (offline /
+   * unreachable) — in which case nothing is registered and no handle leaks.
+   */
+  async start(
+    map: string,
+    filter: Record<string, unknown>,
+    ttlMs: number,
+  ): Promise<ActiveSubscription | null> {
+    const id = randomUUID();
+    const handle = this.client.query<Record<string, unknown>>(map, filter);
+
+    const sub: InternalSubscription = {
+      id,
+      map,
+      filter,
+      createdAt: nowIso(),
+      buffer: [],
+      dropped: 0,
+      totalObserved: 0,
+      handle,
+      recording: false,
+      offDelta: () => {},
+      unsubscribe: () => {},
+      expiryTimer: null,
+    };
+
+    // Record deltas only once the baseline has settled. The initial snapshot is
+    // delivered as a burst of `add` deltas BEFORE `recording` flips, so it is
+    // intentionally ignored — only changes that happen AFTER the baseline are
+    // real changes for the agent.
+    sub.offDelta = handle.onDelta((changes) => {
+      if (!sub.recording) return;
+      for (const change of changes) {
+        sub.totalObserved += 1;
+        if (sub.buffer.length >= MAX_BUFFERED_DELTAS) {
+          sub.buffer.shift();
+          sub.dropped += 1;
+        }
+        sub.buffer.push({
+          type: change.type,
+          key: change.key,
+          value: change.value,
+          at: nowIso(),
+        });
+      }
+    });
+
+    // A no-op result listener is what actually activates the server-side live
+    // query (onDelta alone does not). We drive the feed off the deltas, not the
+    // full result set, so the callback body is intentionally empty.
+    sub.unsubscribe = handle.subscribe(() => {});
+
+    const settled = await this.waitForBaseline(handle, SUBSCRIBE_SETTLE_TIMEOUT_MS);
+    if (!settled) {
+      // Could not establish a server baseline — do not register a half-open
+      // subscription that would feed the agent local-only or empty data.
+      sub.offDelta();
+      sub.unsubscribe();
+      return null;
+    }
+
+    sub.recording = true;
+    this.subs.set(id, sub);
+    this.resetExpiry(sub, ttlMs);
+    return sub;
+  }
+
+  /**
+   * Drain and clear the buffered deltas for a subscription, refreshing its idle
+   * expiry. Returns `null` if the id is unknown (stopped or expired).
+   */
+  poll(
+    id: string,
+    ttlMs: number,
+  ): { deltas: DeltaRecord[]; dropped: number; sub: ActiveSubscription } | null {
+    const sub = this.subs.get(id);
+    if (!sub) return null;
+    const deltas = sub.buffer;
+    const dropped = sub.dropped;
+    sub.buffer = [];
+    sub.dropped = 0;
+    this.resetExpiry(sub, ttlMs);
+    return { deltas, dropped, sub };
+  }
+
+  /** Tear down one subscription. Returns false if the id was already gone. */
+  stop(id: string): boolean {
+    const sub = this.subs.get(id);
+    if (!sub) return false;
+    this.teardown(sub);
+    this.subs.delete(id);
+    return true;
+  }
+
+  /** Snapshot of the active subscriptions (no internal handles exposed). */
+  list(): ActiveSubscription[] {
+    return Array.from(this.subs.values()).map((s) => ({
+      id: s.id,
+      map: s.map,
+      filter: s.filter,
+      createdAt: s.createdAt,
+      buffer: s.buffer,
+      dropped: s.dropped,
+      totalObserved: s.totalObserved,
+    }));
+  }
+
+  /** Tear down every subscription. Called on server stop so nothing leaks. */
+  teardownAll(): void {
+    for (const sub of this.subs.values()) {
+      this.teardown(sub);
+    }
+    this.subs.clear();
+  }
+
+  private async waitForBaseline(
+    handle: QueryHandle<Record<string, unknown>>,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, timeoutMs);
+    });
+    try {
+      await Promise.race([handle.whenSettled(), timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+    return handle.isSettled;
+  }
+
+  private resetExpiry(sub: InternalSubscription, ttlMs: number): void {
+    if (sub.expiryTimer) clearTimeout(sub.expiryTimer);
+    const timer = setTimeout(() => this.stop(sub.id), ttlMs);
+    // Do not keep the Node process alive solely for a forgotten subscription.
+    if (typeof timer.unref === 'function') timer.unref();
+    sub.expiryTimer = timer;
+  }
+
+  private teardown(sub: InternalSubscription): void {
+    if (sub.expiryTimer) {
+      clearTimeout(sub.expiryTimer);
+      sub.expiryTimer = null;
+    }
+    try {
+      sub.offDelta();
+    } catch {
+      // listener removal must never throw out of teardown
+    }
+    try {
+      sub.unsubscribe();
+    } catch {
+      // unsubscribe must never throw out of teardown
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/subscribe.ts
+++ b/packages/mcp-server/src/tools/subscribe.ts
@@ -19,12 +19,16 @@ import { SubscribeArgsSchema, toolSchemas } from '../schemas';
 import type { ActiveSubscription, DeltaRecord } from '../subscriptions';
 import { MAX_BUFFERED_DELTAS } from '../subscriptions';
 
+/** Lower bound on a subscription's idle TTL, so it always outlives a poll cycle. */
+const MIN_TTL_MS = 1000;
+
 export const subscribeTool: MCPTool = {
   name: 'topgun_subscribe',
   description:
     'Watch a TopGun map for real-time changes. This is a poll-based change feed, not a ' +
     'blocking wait: call with action:"start" {map} to open a feed (returns a subscriptionId ' +
-    'right away), then call action:"poll" {subscriptionId} as often as you like to receive the ' +
+    'as soon as the server confirms the watch — it does not hold the call open for the watch ' +
+    'window), then call action:"poll" {subscriptionId} as often as you like to receive the ' +
     'changes that happened since your last poll. Each change is typed (add = entered the result ' +
     'set, update = changed, remove = deleted / left the result set) — only real changes are ' +
     'reported, never the existing snapshot. Call action:"stop" {subscriptionId} when done.',
@@ -86,7 +90,9 @@ export async function handleSubscribe(rawArgs: unknown, ctx: ToolContext): Promi
   }
 
   const { action, map, filter, subscriptionId, ttlSeconds } = parseResult.data;
-  const ttlMs = (ttlSeconds ?? ctx.config.subscriptionTimeoutSeconds) * 1000;
+  // Floor the idle TTL so a tiny value (the schema rejects <= 0, but e.g. 0.1s is
+  // valid) cannot expire the subscription before the agent can poll it.
+  const ttlMs = Math.max((ttlSeconds ?? ctx.config.subscriptionTimeoutSeconds) * 1000, MIN_TTL_MS);
 
   switch (action) {
     case 'start':
@@ -120,17 +126,16 @@ async function handleStart(
     );
   }
 
-  if (ctx.subscriptions.atCapacity()) {
-    return textResult(
-      `Error: too many active subscriptions (${ctx.subscriptions.size}). ` +
-        `Stop one with action:'stop' before starting another.`,
-      true,
-    );
-  }
-
   try {
-    const sub = await ctx.subscriptions.start(map, filter ?? {}, ttlMs);
-    if (!sub) {
+    const result = await ctx.subscriptions.start(map, filter ?? {}, ttlMs);
+    if (!result.ok && result.reason === 'capacity') {
+      return textResult(
+        `Error: too many active subscriptions (${ctx.subscriptions.size}). ` +
+          `Stop one with action:'stop' before starting another.`,
+        true,
+      );
+    }
+    if (!result.ok) {
       // The server never delivered the baseline snapshot — do not pretend to be
       // watching. Mirrors the mutate tool's honesty about an unconfirmed write.
       return textResult(
@@ -140,6 +145,7 @@ async function handleStart(
         true,
       );
     }
+    const { sub } = result;
     return textResult(
       `Started change feed on map '${map}' (subscriptionId: ${sub.id}).\n` +
         `Call topgun_subscribe with action:'poll' and this subscriptionId to receive changes ` +

--- a/packages/mcp-server/src/tools/subscribe.ts
+++ b/packages/mcp-server/src/tools/subscribe.ts
@@ -1,147 +1,218 @@
 /**
- * topgun_subscribe - Watch a map for real-time changes
+ * topgun_subscribe - Watch a map for real-time changes via a poll cursor.
+ *
+ * The MCP transport is request/response, so a tool call cannot stream changes
+ * into the agent's turn. Instead of blocking for a timeout and dumping the whole
+ * snapshot as "changes" (the old, broken behaviour), this tool exposes an
+ * explicit poll contract:
+ *
+ *   1. action:'start' opens a server-backed live query and returns a
+ *      subscriptionId at once (after the server baseline settles).
+ *   2. action:'poll' drains the genuine per-record deltas observed since the
+ *      last poll — each typed add / update / remove, removals included.
+ *   3. action:'stop' tears the subscription down.
+ *   4. action:'list' shows what is currently active.
  */
 
 import type { MCPTool, MCPToolResult, ToolContext } from '../types';
-import { SubscribeArgsSchema, toolSchemas, type SubscribeArgs } from '../schemas';
+import { SubscribeArgsSchema, toolSchemas } from '../schemas';
+import type { ActiveSubscription, DeltaRecord } from '../subscriptions';
+import { MAX_BUFFERED_DELTAS } from '../subscriptions';
 
 export const subscribeTool: MCPTool = {
   name: 'topgun_subscribe',
   description:
-    'Subscribe to real-time changes in a TopGun map. ' +
-    'Returns changes that occur within the timeout period. ' +
-    'Use this to watch for new or updated data.',
+    'Watch a TopGun map for real-time changes. This is a poll-based change feed, not a ' +
+    'blocking wait: call with action:"start" {map} to open a feed (returns a subscriptionId ' +
+    'right away), then call action:"poll" {subscriptionId} as often as you like to receive the ' +
+    'changes that happened since your last poll. Each change is typed (add = entered the result ' +
+    'set, update = changed, remove = deleted / left the result set) — only real changes are ' +
+    'reported, never the existing snapshot. Call action:"stop" {subscriptionId} when done.',
   inputSchema: toolSchemas.subscribe as MCPTool['inputSchema'],
 };
 
+function textResult(text: string, isError = false): MCPToolResult {
+  return { content: [{ type: 'text', text }], isError: isError || undefined };
+}
+
+/** Label a delta with the agent-facing change kind. */
+function deltaKind(type: DeltaRecord['type']): string {
+  switch (type) {
+    case 'add':
+      return 'ADD (entered result set)';
+    case 'update':
+      return 'UPDATE';
+    case 'remove':
+      return 'REMOVE (deleted / left result set)';
+  }
+}
+
+function formatDeltas(deltas: DeltaRecord[]): string {
+  return deltas
+    .map((d, idx) => {
+      const head = `${idx + 1}. [${d.at}] ${deltaKind(d.type)} - ${d.key}`;
+      // Removals carry no current value (the record is gone); show only the key.
+      if (d.type === 'remove' || d.value === undefined) return head;
+      const body = JSON.stringify(d.value, null, 2).split('\n').join('\n   ');
+      return `${head}\n   ${body}`;
+    })
+    .join('\n\n');
+}
+
+function describeSub(sub: ActiveSubscription): string {
+  const filter =
+    sub.filter && Object.keys(sub.filter).length > 0 ? JSON.stringify(sub.filter) : '(none)';
+  return (
+    `- subscriptionId: ${sub.id}\n` +
+    `  map: ${sub.map}\n` +
+    `  filter: ${filter}\n` +
+    `  started: ${sub.createdAt}\n` +
+    `  buffered changes (not yet polled): ${sub.buffer.length}\n` +
+    `  total changes observed: ${sub.totalObserved}`
+  );
+}
+
 export async function handleSubscribe(rawArgs: unknown, ctx: ToolContext): Promise<MCPToolResult> {
-  // Validate arguments with Zod
   const parseResult = SubscribeArgsSchema.safeParse(rawArgs);
   if (!parseResult.success) {
     const errors = parseResult.error.issues
       .map((e) => `${e.path.join('.')}: ${e.message}`)
       .join(', ');
-    return {
-      content: [{ type: 'text', text: `Invalid arguments: ${errors}` }],
-      isError: true,
-    };
+    return textResult(`Invalid arguments: ${errors}`, true);
   }
 
-  const args: SubscribeArgs = parseResult.data;
-  const { map, filter, timeout } = args;
-
-  // Check if subscriptions are enabled
   if (!ctx.config.enableSubscriptions) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: 'Error: Subscription operations are disabled on this MCP server.',
-        },
-      ],
-      isError: true,
-    };
+    return textResult('Error: Subscription operations are disabled on this MCP server.', true);
+  }
+
+  const { action, map, filter, subscriptionId, ttlSeconds } = parseResult.data;
+  const ttlMs = (ttlSeconds ?? ctx.config.subscriptionTimeoutSeconds) * 1000;
+
+  switch (action) {
+    case 'start':
+      return handleStart(ctx, map, filter, ttlMs);
+    case 'poll':
+      return handlePoll(ctx, subscriptionId, ttlMs);
+    case 'stop':
+      return handleStop(ctx, subscriptionId);
+    case 'list':
+      return handleList(ctx);
+    default:
+      return textResult(`Error: unknown action '${action}'.`, true);
+  }
+}
+
+async function handleStart(
+  ctx: ToolContext,
+  map: string | undefined,
+  filter: Record<string, unknown> | undefined,
+  ttlMs: number,
+): Promise<MCPToolResult> {
+  if (!map) {
+    return textResult("Error: 'map' is required for action 'start'.", true);
   }
 
   // Validate map access
   if (ctx.config.allowedMaps && !ctx.config.allowedMaps.includes(map)) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Error: Access to map '${map}' is not allowed. Available maps: ${ctx.config.allowedMaps.join(', ')}`,
-        },
-      ],
-      isError: true,
-    };
+    return textResult(
+      `Error: Access to map '${map}' is not allowed. Available maps: ${ctx.config.allowedMaps.join(', ')}`,
+      true,
+    );
   }
 
-  const effectiveTimeout = Math.min(
-    timeout ?? ctx.config.subscriptionTimeoutSeconds,
-    ctx.config.subscriptionTimeoutSeconds,
-  );
+  if (ctx.subscriptions.atCapacity()) {
+    return textResult(
+      `Error: too many active subscriptions (${ctx.subscriptions.size}). ` +
+        `Stop one with action:'stop' before starting another.`,
+      true,
+    );
+  }
 
   try {
-    // Create a query handle with the filter
-    const queryHandle = ctx.client.query<Record<string, unknown>>(map, filter ?? {});
-
-    // Collect changes
-    const changes: Array<{
-      type: 'add' | 'update' | 'remove';
-      key: string;
-      value?: Record<string, unknown>;
-      timestamp: string;
-    }> = [];
-
-    let isInitialLoad = true;
-
-    // Subscribe to changes
-    const unsubscribe = queryHandle.subscribe(
-      (results: Array<Record<string, unknown> & { _key: string }>) => {
-        // Skip initial load
-        if (isInitialLoad) {
-          isInitialLoad = false;
-          return;
-        }
-
-        // Record the change
-        for (const result of results) {
-          changes.push({
-            type: 'update',
-            key: result._key ?? 'unknown',
-            value: result,
-            timestamp: new Date().toISOString(),
-          });
-        }
-      },
-    );
-
-    // Wait for the timeout period
-    await new Promise((resolve) => setTimeout(resolve, effectiveTimeout * 1000));
-
-    // Cleanup
-    unsubscribe();
-
-    // Format results
-    if (changes.length === 0) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `No changes detected in map '${map}' during the ${effectiveTimeout} second watch period.`,
-          },
-        ],
-      };
+    const sub = await ctx.subscriptions.start(map, filter ?? {}, ttlMs);
+    if (!sub) {
+      // The server never delivered the baseline snapshot — do not pretend to be
+      // watching. Mirrors the mutate tool's honesty about an unconfirmed write.
+      return textResult(
+        `Error: could not start a change feed on map '${map}' — the server did not deliver an ` +
+          `initial snapshot (the client may be offline or the server unreachable). ` +
+          `Connection state: ${ctx.client.getConnectionState()}. Retry once connected.`,
+        true,
+      );
     }
-
-    const formatted = changes
-      .map(
-        (change, idx) =>
-          `${idx + 1}. [${change.timestamp}] ${change.type.toUpperCase()} - ${change.key}\n` +
-          (change.value
-            ? `   ${JSON.stringify(change.value, null, 2).split('\n').join('\n   ')}`
-            : ''),
-      )
-      .join('\n\n');
-
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Detected ${changes.length} change(s) in map '${map}' during ${effectiveTimeout} seconds:\n\n${formatted}`,
-        },
-      ],
-    };
+    return textResult(
+      `Started change feed on map '${map}' (subscriptionId: ${sub.id}).\n` +
+        `Call topgun_subscribe with action:'poll' and this subscriptionId to receive changes ` +
+        `as they happen. The feed auto-stops after ${Math.round(ttlMs / 1000)}s without a poll; ` +
+        `each poll refreshes it. Call action:'stop' when finished.`,
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Error subscribing to map '${map}': ${message}`,
-        },
-      ],
-      isError: true,
-    };
+    return textResult(`Error starting change feed on map '${map}': ${message}`, true);
   }
+}
+
+function handlePoll(
+  ctx: ToolContext,
+  subscriptionId: string | undefined,
+  ttlMs: number,
+): MCPToolResult {
+  if (!subscriptionId) {
+    return textResult("Error: 'subscriptionId' is required for action 'poll'.", true);
+  }
+
+  const result = ctx.subscriptions.poll(subscriptionId, ttlMs);
+  if (!result) {
+    return textResult(
+      `Error: no active subscription '${subscriptionId}' (it may have been stopped or expired ` +
+        `after its idle timeout). Start a new one with action:'start'.`,
+      true,
+    );
+  }
+
+  const { deltas, dropped, sub } = result;
+  if (deltas.length === 0) {
+    return textResult(
+      `No changes on map '${sub.map}' since the last poll (subscriptionId: ${sub.id}). ` +
+        `Poll again later.`,
+    );
+  }
+
+  // Surface buffer truncation honestly: when the change rate outran polling, the
+  // oldest deltas were evicted at the MAX_BUFFERED_DELTAS cap rather than silently
+  // dropped — tell the agent how many it lost so it never reads a partial feed
+  // as complete.
+  const truncated =
+    dropped > 0
+      ? `\n\nNote: ${dropped} earlier change(s) were dropped because the buffer was capped at ` +
+        `${MAX_BUFFERED_DELTAS}. Poll more frequently to avoid loss.`
+      : '';
+
+  return textResult(
+    `${deltas.length} change(s) on map '${sub.map}' since the last poll ` +
+      `(subscriptionId: ${sub.id}):\n\n${formatDeltas(deltas)}${truncated}`,
+  );
+}
+
+function handleStop(ctx: ToolContext, subscriptionId: string | undefined): MCPToolResult {
+  if (!subscriptionId) {
+    return textResult("Error: 'subscriptionId' is required for action 'stop'.", true);
+  }
+  const stopped = ctx.subscriptions.stop(subscriptionId);
+  if (!stopped) {
+    return textResult(
+      `No active subscription '${subscriptionId}' to stop (already stopped or expired).`,
+    );
+  }
+  return textResult(`Stopped subscription '${subscriptionId}'.`);
+}
+
+function handleList(ctx: ToolContext): MCPToolResult {
+  const subs = ctx.subscriptions.list();
+  if (subs.length === 0) {
+    return textResult("No active subscriptions. Start one with action:'start' {map}.");
+  }
+  return textResult(
+    `${subs.length} active subscription(s):\n\n${subs.map(describeSub).join('\n\n')}`,
+  );
 }

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { TopGunClient } from '@topgunbuild/client';
+import type { SubscriptionRegistry } from './subscriptions';
 
 /**
  * Configuration for the MCP server
@@ -162,9 +163,11 @@ export interface SearchToolArgs {
  * Subscribe tool arguments
  */
 export interface SubscribeToolArgs {
-  map: string;
+  action?: 'start' | 'poll' | 'stop' | 'list';
+  map?: string;
   filter?: Record<string, unknown>;
-  timeout?: number;
+  subscriptionId?: string;
+  ttlSeconds?: number;
 }
 
 /**
@@ -200,4 +203,6 @@ export type ListMapsToolArgs = Record<never, never>;
 export interface ToolContext {
   client: TopGunClient;
   config: ResolvedMCPServerConfig;
+  /** Live change-feed subscriptions backing `topgun_subscribe` (poll contract). */
+  subscriptions: SubscriptionRegistry;
 }

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -125,6 +125,20 @@ function text(result: { content: Array<{ text?: string }> }): string {
   return (result.content || []).map((c) => c.text ?? '').join('\n');
 }
 
+// Parse the head line of each change the subscribe feed renders, e.g.
+//   "1. [2026-...Z] ADD (entered result set) - live1"
+//   "2. [2026-...Z] REMOVE (deleted / left result set) - k0"
+// JSON body lines (indented) never match, so only one record per delta is counted.
+function parseDeltas(out: string): Array<{ kind: string; key: string }> {
+  const re = /^\s*\d+\.\s+\[[^\]]+\]\s+(ADD|UPDATE|REMOVE)\b.*?-\s+(\S+)\s*$/gm;
+  const deltas: Array<{ kind: string; key: string }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(out)) !== null) {
+    deltas.push({ kind: m[1], key: m[2] });
+  }
+  return deltas;
+}
+
 // Both clients authenticate with a JWT (same pattern the other single-server
 // integration suites use), rather than relying on a NO_AUTH server. The tokenless
 // NO_AUTH path is racy for a second connecting client under CI load (the WS
@@ -400,4 +414,141 @@ describe('Integration: MCP tools against a real Rust server (cold cache)', () =>
       await mcpClient.close().catch(() => {});
     }
   }, 30_000);
+
+  // F3 — topgun_subscribe must be a REAL change feed: one correctly-typed delta
+  // per genuine change, removals included, and NOT a re-dump of the whole
+  // snapshot. The pre-fix tool blocked for the timeout and emitted the full
+  // result set as `UPDATE` "changes" on every membership re-delivery (a 2-record
+  // scenario produced 103 changes, all UPDATE; the real removal was invisible).
+  //
+  // We seed N rows, open the feed (action:'start' — returns at once), then make
+  // exactly two concurrent changes via a SEPARATE client over the wire: one
+  // brand-new key (an ADD) and one removal of a pre-existing key (a REMOVE).
+  // Draining the feed (action:'poll') must yield EXACTLY those two deltas with
+  // the correct types — never the untouched pre-existing rows.
+  test('subscribe is a real change feed: one typed delta per change, removals visible (F3)', async () => {
+    const server = await spawnRustServer();
+    const seeder = await createRustTestClient(server.port, {
+      userId: 'mcp-seeder',
+      roles: ['ADMIN'],
+    });
+    const mcpClient = makeClient(server.port, 'mcp-watcher');
+    const mcp = new TopGunMCPServer({ client: mcpClient });
+
+    try {
+      await seeder.waitForMessage('AUTH_ACK', 10_000);
+      await mcpClient.start();
+      await waitForState(mcpClient, SyncState.CONNECTED);
+
+      // Seed a pre-existing dataset (k0..k9) and wait for each server ACK so the
+      // feed's baseline snapshot already contains all of them — none must later
+      // surface as a "change".
+      const mapName = `mcp_sub_${Date.now()}`;
+      const PRE_COUNT = 10;
+      for (let i = 0; i < PRE_COUNT; i++) {
+        seeder.messages.length = 0;
+        seeder.send({
+          type: 'CLIENT_OP',
+          payload: {
+            id: `seed-${i}`,
+            mapName,
+            opType: 'PUT',
+            key: `k${i}`,
+            record: createLWWRecord({ id: `k${i}`, title: `doc ${i}`, n: i }),
+          },
+        });
+        await seeder.waitForMessage('OP_ACK', 10_000);
+      }
+
+      // Open the change feed. Returns immediately with a subscriptionId (does NOT
+      // block for a timeout) once the server baseline settles.
+      const startRes = await callStable(mcp, 'topgun_subscribe', {
+        action: 'start',
+        map: mapName,
+      });
+      expect(startRes.isError).toBeFalsy();
+      const idMatch = text(startRes).match(/subscriptionId:\s*([0-9a-f-]+)\)/i);
+      expect(idMatch).toBeTruthy();
+      const subscriptionId = idMatch![1];
+
+      // An immediate poll before any change must report nothing — the baseline
+      // snapshot is NOT reported as changes (the core pre-fix defect).
+      const emptyPoll = await mcp.callTool('topgun_subscribe', {
+        action: 'poll',
+        subscriptionId,
+      });
+      expect(emptyPoll.isError).toBeFalsy();
+      expect(text(emptyPoll)).toMatch(/no changes/i);
+
+      // Make EXACTLY two concurrent changes over the wire:
+      //   1. a brand-new key 'live1'  → ADD
+      //   2. a removal of existing 'k0' → REMOVE
+      seeder.messages.length = 0;
+      seeder.send({
+        type: 'CLIENT_OP',
+        payload: {
+          id: 'live-add',
+          mapName,
+          opType: 'PUT',
+          key: 'live1',
+          record: createLWWRecord({ id: 'live1', title: 'fresh', n: 999 }),
+        },
+      });
+      await seeder.waitForMessage('OP_ACK', 10_000);
+
+      seeder.messages.length = 0;
+      seeder.send({
+        type: 'CLIENT_OP',
+        payload: {
+          id: 'live-remove',
+          mapName,
+          opType: 'REMOVE',
+          key: 'k0',
+          record: createLWWRecord(null),
+        },
+      });
+      await seeder.waitForMessage('OP_ACK', 10_000);
+
+      // Drain the feed. Deltas may arrive across more than one server push, so we
+      // poll until both expected changes are seen, then poll a few more times to
+      // prove no EXTRA deltas (e.g. a re-dumped snapshot row) follow.
+      const collected: Array<{ kind: string; key: string }> = [];
+      const deadline = Date.now() + 15_000;
+      let extraPollsAfterComplete = 0;
+      while (Date.now() < deadline) {
+        const poll = await mcp.callTool('topgun_subscribe', { action: 'poll', subscriptionId });
+        expect(poll.isError).toBeFalsy();
+        collected.push(...parseDeltas(text(poll)));
+        if (collected.length >= 2) {
+          // Got the two we expect — confirm the feed is now quiet (no snapshot dump).
+          if (++extraPollsAfterComplete >= 3) break;
+        }
+        await waitMs(400);
+      }
+
+      // EXACTLY two deltas — not 103, not the pre-existing rows re-reported.
+      expect(collected).toHaveLength(2);
+
+      const add = collected.find((c) => c.key === 'live1');
+      const remove = collected.find((c) => c.key === 'k0');
+      expect(add?.kind).toBe('ADD'); // new record entered the result set
+      expect(remove?.kind).toBe('REMOVE'); // removal is VISIBLE as its own delta
+
+      // Negative control: none of the untouched pre-existing rows (k1..k9) are
+      // ever reported — the snapshot is not dumped as "changes".
+      for (let i = 1; i < PRE_COUNT; i++) {
+        expect(collected.some((c) => c.key === `k${i}`)).toBe(false);
+      }
+
+      // Tearing down is explicit and acknowledged.
+      const stopRes = await mcp.callTool('topgun_subscribe', { action: 'stop', subscriptionId });
+      expect(stopRes.isError).toBeFalsy();
+      expect(text(stopRes)).toMatch(/stopped/i);
+    } finally {
+      await mcp.stop().catch(() => {});
+      await mcpClient.close().catch(() => {});
+      seeder.close();
+      await server.cleanup().catch(() => {});
+    }
+  }, 60_000);
 });


### PR DESCRIPTION
## Problem (DEPTH_MCP F3 / TODO-519, HIGH)

`topgun_subscribe` was not a change feed. It attached `QueryHandle.subscribe` (full result set per emission), skipped only the *first* emission, and pushed every row of every later snapshot as `type:'update'`. Reproduced in the audit: a 2-second window over **1 insert + 1 remove emitted 103 "changes", all `UPDATE`**; the whole pre-existing dataset was reported as changed and the real removal was **invisible**. It also **blocked the tool for the full timeout (≤60s)** with no streaming. Docs claimed "Streaming subscription" — false.

## Fix — explicit poll-cursor change feed

MCP is request/response, so a tool call cannot stream into the agent's turn. The honest design is a poll cursor backed by the client's real delta tracker (`QueryHandle.onDelta` / `ChangeTracker`):

- **`action:'start'`** `{map, filter?}` — opens a server-backed live query, waits for the server baseline to settle, returns a `subscriptionId` **immediately (no blocking)**. If the server can't deliver a baseline (offline/unreachable), it **errors honestly** instead of feeding local-only data (mirrors the mutate-tool durability honesty).
- **`action:'poll'`** `{subscriptionId}` — drains the genuine per-record deltas (`add`/`update`/`remove`) since the last poll. **Removals are first-class**; the initial snapshot is **never** reported as changes. Buffer is bounded (`MAX_BUFFERED_DELTAS`) and reports drops honestly.
- **`action:'stop'` / `action:'list'`** — session management. Idle subscriptions auto-expire (TTL refreshed on each poll) and are torn down on server stop, so no handle/timer leaks.

New `SubscriptionRegistry` owns the live-query handles; wired into `ToolContext` and torn down in `TopGunMCPServer.stop()`.

## Tests (no green without proof)

- **Real-server harness** (`tests/integration-rust/mcp-server.test.ts`, blocking CI gate): seed N rows → `start` → **1 set (new key) + 1 remove (existing key) over the wire → exactly 2 correctly-typed deltas** (ADD `live1`, REMOVE `k0`), removal visible, pre-existing rows never reported. Includes the negative control (an immediate poll reports *no changes* — baseline isn't dumped). ✅ passes against the real Rust server.
- **Unit** (`mcp-integration.test.ts`): session-management actions (start-requires-map, poll-requires-id, poll-unknown-id, stop-unknown-id, list-empty). All 101 mcp-server unit tests pass.

## Docs

Dropped the false "Streaming subscription" claim; `reference/mcp.mdx` + `guides/mcp-server.mdx` now describe the start/poll/stop/list poll contract and the idle-TTL semantics. `llms-full.txt` regenerated.

Closes TODO-519.