### PR TITLE
fix(mcp): make topgun_list_maps server-authoritative (DEPTH_MCP F4 / TODO-520)

### DIFF
--- a/packages/client/src/SyncEngine.ts
+++ b/packages/client/src/SyncEngine.ts
@@ -776,6 +776,26 @@ export class SyncEngine {
     }
   }
 
+  /**
+   * Resolve the token currently in effect: the one set directly via
+   * {@link setAuthToken}, else the value produced by the configured token
+   * provider, else `null`. Does not mutate connection state — it is a read used
+   * by callers that need to authenticate a side-channel request with the same
+   * credentials the WebSocket uses.
+   *
+   * If a token provider is configured and rejects, this rejects too: a provider
+   * failure (OAuth down, expired refresh) is distinct from "no credentials
+   * configured" (null) and callers must be able to tell them apart rather than
+   * silently degrade to an unauthenticated request.
+   */
+  public async getResolvedToken(): Promise<string | null> {
+    if (this.authToken) return this.authToken;
+    if (this.tokenProvider) {
+      return await this.tokenProvider();
+    }
+    return null;
+  }
+
   public setTokenProvider(provider: () => Promise<string | null>): void {
     this.tokenProvider = provider;
     const state = this.stateMachine.getState();

--- a/packages/client/src/TopGunClient.ts
+++ b/packages/client/src/TopGunClient.ts
@@ -186,6 +186,14 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
   private readonly authProvider?: AuthProvider;
 
   /**
+   * The single-server WebSocket URL this client was configured with, retained so
+   * callers (e.g. the MCP server's map-enumeration tool) can derive the matching
+   * HTTP control-plane base. `undefined` in cluster or local-only mode, where no
+   * single authoritative URL exists.
+   */
+  private readonly serverUrl?: string;
+
+  /**
    * Most-recent in-flight op promise per `${map}:${key}`, set synchronously by the
    * getMap set/remove wrappers. {@link confirmWrite} awaits the op id from this
    * promise, then waits for the server ack — letting a write be reported as durable
@@ -251,6 +259,9 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
       logger.info({ seeds: this.clusterConfig.seeds }, 'TopGunClient initialized in cluster mode');
     } else if (config.serverUrl) {
       // Single-server mode: create SingleServerProvider from serverUrl
+      // Retain the URL so getServerUrl() can expose it without reaching into the
+      // connection provider.
+      this.serverUrl = config.serverUrl;
       // Map BackoffConfig to SingleServerProviderConfig for unified retry behavior
       const singleServerProvider = new SingleServerProvider({
         url: config.serverUrl,
@@ -944,6 +955,28 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
    */
   public getConnectionState(): SyncState {
     return this.syncEngine.getConnectionState();
+  }
+
+  /**
+   * The single-server WebSocket URL this client was configured with, or
+   * `undefined` in cluster / local-only mode. Exposed so callers that need to
+   * reach the server's HTTP control plane (e.g. the MCP map-enumeration tool)
+   * can derive the matching base URL rather than guessing a default.
+   */
+  public getServerUrl(): string | undefined {
+    return this.serverUrl;
+  }
+
+  /**
+   * Resolve the auth token currently used to authenticate with the server,
+   * whether it was set directly via {@link setAuthToken} or supplied by a token
+   * provider (config.auth / {@link setAuthTokenProvider}). Returns `null` when no
+   * credentials are configured. Exposed for callers that must authenticate a
+   * side-channel request to the server (e.g. the MCP map-enumeration tool calling
+   * the HTTP control plane).
+   */
+  public getAuthToken(): Promise<string | null> {
+    return this.syncEngine.getResolvedToken();
   }
 
   /**

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -91,6 +91,14 @@ class MockTopGunClient {
     return 'CONNECTED';
   }
 
+  getServerUrl() {
+    return 'ws://localhost:8080/ws';
+  }
+
+  async getAuthToken() {
+    return 'mock-token';
+  }
+
   isCluster() {
     return false;
   }
@@ -204,10 +212,17 @@ function createTestContext(config?: Partial<ResolvedMCPServerConfig>): ToolConte
 
 describe('MCP Tools', () => {
   describe('handleListMaps', () => {
-    it('should list allowed maps when configured', async () => {
+    const realFetch = global.fetch;
+    afterEach(() => {
+      global.fetch = realFetch;
+    });
+
+    it('returns the configured allow-list without a server round-trip', async () => {
       const ctx = createTestContext({
         allowedMaps: ['tasks', 'users', 'products'],
       });
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy as unknown as typeof fetch;
 
       const result = await handleListMaps({}, ctx);
 
@@ -215,15 +230,73 @@ describe('MCP Tools', () => {
       expect(result.content[0].text).toContain('tasks');
       expect(result.content[0].text).toContain('users');
       expect(result.content[0].text).toContain('products');
+      // The allow-list IS the authoritative scope — no server enumeration needed.
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('should indicate no restrictions when allowedMaps not set', async () => {
+    it('returns the real server catalog from the admin endpoint, never fabricated names', async () => {
       const ctx = createTestContext();
+      const fetchSpy = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          maps: [
+            { name: 'orders', entryCount: 3 },
+            { name: 'customers', entryCount: 1 },
+          ],
+        }),
+      });
+      global.fetch = fetchSpy as unknown as typeof fetch;
 
       const result = await handleListMaps({}, ctx);
 
       expect(result.isError).toBeUndefined();
-      expect(result.content[0].text).toContain('all maps');
+      const text = result.content[0].text ?? '';
+      // Hits the derived HTTP control-plane URL with the client's bearer token.
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://localhost:8080/api/admin/maps',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer mock-token' },
+        }),
+      );
+      expect(text).toContain('orders');
+      expect(text).toContain('3 entries');
+      expect(text).toContain('customers');
+      expect(text).toContain('1 entry');
+      // Negative control: the retired fabricated "common patterns" must be gone.
+      expect(text).not.toMatch(/common (map )?pattern/i);
+      expect(text).not.toContain('Blog posts');
+    });
+
+    it('reports DISCONNECTED honestly and does not guess', async () => {
+      const ctx = createTestContext();
+      (ctx.client as unknown as { getConnectionState: () => string }).getConnectionState = () =>
+        'DISCONNECTED';
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy as unknown as typeof fetch;
+
+      const result = await handleListMaps({}, ctx);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/not connected/i);
+      expect(result.content[0].text).toMatch(/NOT an empty/i);
+      // Never fabricates and never round-trips while offline.
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('reports an explicit error when the token lacks admin access, not example names', async () => {
+      const ctx = createTestContext();
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => 'forbidden',
+      }) as unknown as typeof fetch;
+
+      const result = await handleListMaps({}, ctx);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/admin-scoped token/i);
+      expect(result.content[0].text).not.toContain('Blog posts');
     });
   });
 

--- a/packages/mcp-server/src/tools/listMaps.ts
+++ b/packages/mcp-server/src/tools/listMaps.ts
@@ -1,5 +1,13 @@
 /**
- * topgun_list_maps - List all available maps
+ * topgun_list_maps - List the maps that actually exist on the server.
+ *
+ * Server-authoritative discovery. The only map-enumeration surface TopGun exposes
+ * is the admin HTTP control plane (`GET /api/admin/maps`) — there is no
+ * data-plane (WebSocket) "list maps" message. So this tool derives the HTTP base
+ * from the client's WebSocket URL, authenticates with the same token the client
+ * uses, and returns the real catalog. It NEVER fabricates example names: a
+ * disconnected client, a non-admin token, or a server without the endpoint each
+ * yields an honest, typed error rather than cheerful guidance.
  */
 
 import type { MCPTool, MCPToolResult, ToolContext } from '../types';
@@ -8,11 +16,45 @@ import { ListMapsArgsSchema, toolSchemas } from '../schemas';
 export const listMapsTool: MCPTool = {
   name: 'topgun_list_maps',
   description:
-    'List all available TopGun maps that can be queried. ' +
-    'Returns the names of maps you have access to. ' +
-    'Use this first to discover what data is available.',
+    'Discover the maps available to this MCP server. ' +
+    'When configured with an explicit allow-list, returns that list (the maps this ' +
+    'server may access). Otherwise enumerates the real server catalog (actual map ' +
+    'names and entry counts), never examples. ' +
+    'Use this first to discover what data is available. ' +
+    'Server enumeration requires an admin-scoped token; if the server cannot be reached ' +
+    'or the token lacks admin access, this returns an explicit error rather than guessing.',
   inputSchema: toolSchemas.listMaps as MCPTool['inputSchema'],
 };
+
+/** Connection states in which a server round-trip is worth attempting. */
+const ONLINE_STATES = new Set(['CONNECTED', 'SYNCING']);
+
+interface MapEntry {
+  name: string;
+  entryCount: number;
+}
+
+/**
+ * Derive the admin map-enumeration URL from the client's WebSocket URL: same host
+ * and port, HTTP(S) scheme, fixed `/api/admin/maps` path. Returns null when the
+ * URL is absent (cluster / local-only mode) or unparseable.
+ *
+ * The server mounts `/ws` and `/api/admin/maps` as absolute routes on the same
+ * origin, so the WS pathname is intentionally discarded — only scheme + host(:port)
+ * carry over.
+ */
+function deriveAdminMapsUrl(wsUrl: string | undefined): string | null {
+  if (!wsUrl) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(wsUrl);
+  } catch {
+    return null;
+  }
+  const httpProtocol =
+    parsed.protocol === 'wss:' ? 'https:' : parsed.protocol === 'ws:' ? 'http:' : parsed.protocol;
+  return `${httpProtocol}//${parsed.host}/api/admin/maps`;
+}
 
 export async function handleListMaps(rawArgs: unknown, ctx: ToolContext): Promise<MCPToolResult> {
   // Validate arguments with Zod (no required fields, but validates structure)
@@ -26,40 +68,195 @@ export async function handleListMaps(rawArgs: unknown, ctx: ToolContext): Promis
       isError: true,
     };
   }
-  try {
-    // If allowedMaps is configured, return those
-    if (ctx.config.allowedMaps && ctx.config.allowedMaps.length > 0) {
-      const mapList = ctx.config.allowedMaps.map((name) => `  - ${name}`).join('\n');
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text:
-              `Available maps (${ctx.config.allowedMaps.length}):\n${mapList}\n\n` +
-              `Use topgun_schema to get field information for a specific map.\n` +
-              `Use topgun_query to read data from a map.`,
-          },
-        ],
-      };
-    }
-
-    // Otherwise, indicate that all maps are accessible but we don't have a directory
+  // An explicit allow-list IS the authoritative set of maps this MCP server may
+  // touch — return it directly. This is the access scope, not a server claim
+  // about which maps hold data, so no round-trip is needed.
+  if (ctx.config.allowedMaps && ctx.config.allowedMaps.length > 0) {
+    const mapList = ctx.config.allowedMaps.map((name) => `  - ${name}`).join('\n');
     return {
       content: [
         {
           type: 'text',
           text:
-            `This MCP server allows access to all maps (no restrictions configured).\n\n` +
-            `To query a map, use topgun_query with the map name.\n` +
-            `To get schema information, use topgun_schema.\n` +
-            `To search, use topgun_search.\n\n` +
-            `Common map patterns:\n` +
-            `  - 'users' - User accounts\n` +
-            `  - 'tasks' - Task items\n` +
-            `  - 'posts' - Blog posts or messages\n` +
-            `  - 'products' - E-commerce products\n\n` +
-            `Tip: Ask the user what maps are available in their application.`,
+            `Available maps (${ctx.config.allowedMaps.length}, restricted by server configuration):\n${mapList}\n\n` +
+            `Use topgun_schema to get field information for a specific map.\n` +
+            `Use topgun_query to read data from a map.`,
+        },
+      ],
+    };
+  }
+
+  try {
+    // Honest connection signal: never answer while offline, and never confuse an
+    // unreachable server with an empty catalog.
+    const state = ctx.client.getConnectionState();
+    if (!ONLINE_STATES.has(state)) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `Cannot list maps: the client is not connected to the server (state: ${state}). ` +
+              `This is NOT an empty catalog — the server was not reached. ` +
+              `Check connectivity and retry.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const url = deriveAdminMapsUrl(ctx.client.getServerUrl());
+    if (!url) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `Cannot list maps: this client has no single server URL to enumerate against ` +
+              `(cluster or local-only mode). Configure allowedMaps to declare the maps this ` +
+              `MCP server may use, or call topgun_query with a known map name.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    // A throwing token provider is a distinct failure from "no token configured"
+    // (null) — surface it as such so a crashed provider is never misreported as a
+    // 401 "not authorized".
+    let token: string | null;
+    try {
+      token = await ctx.client.getAuthToken();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `Cannot list maps: failed to obtain an auth token from the configured provider ` +
+              `(${message}). This is NOT an empty catalog.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    // Bound the request so a hung control plane can't block the MCP call.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: 'GET',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        signal: controller.signal,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `Cannot list maps: failed to reach the server's map-enumeration endpoint (${message}). ` +
+              `This is NOT an empty catalog. Check connectivity and retry.`,
+          },
+        ],
+        isError: true,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `Cannot list maps: the configured token is not authorized to enumerate maps ` +
+              `(server returned ${res.status}). Map enumeration requires an admin-scoped token. ` +
+              `Either configure this MCP server with allowedMaps (the maps it may use), supply an ` +
+              `admin token, or call topgun_query directly with a known map name.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (res.status === 404) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `Cannot list maps: this server does not expose a map-enumeration endpoint ` +
+              `(404 at ${url}). Configure allowedMaps, or call topgun_query with a known map name.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      const snippet = body.slice(0, 200);
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `Cannot list maps: the server returned ${res.status} when enumerating maps` +
+              (snippet ? ` — ${snippet}` : '') +
+              `.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const data = (await res.json().catch(() => null)) as { maps?: MapEntry[] } | null;
+    if (!data || !Array.isArray(data.maps)) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Cannot list maps: the server returned an unexpected response shape.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (data.maps.length === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `The server reports no maps yet. ` +
+              `Write data with topgun_mutate, then list again to see it appear.`,
+          },
+        ],
+      };
+    }
+
+    // Sort by name for stable, readable output.
+    const sorted = [...data.maps].sort((a, b) => a.name.localeCompare(b.name));
+    const mapList = sorted
+      .map((m) => `  - ${m.name} (${m.entryCount} entr${m.entryCount === 1 ? 'y' : 'ies'})`)
+      .join('\n');
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text:
+            `Maps on the server (${sorted.length}):\n${mapList}\n\n` +
+            `Use topgun_schema to get field information for a specific map.\n` +
+            `Use topgun_query to read data from a map.`,
         },
       ],
     };

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -144,8 +144,8 @@ function parseDeltas(out: string): Array<{ kind: string; key: string }> {
 // NO_AUTH path is racy for a second connecting client under CI load (the WS
 // upgrade intermittently fails before the grace window resolves); explicit auth
 // is the deterministic, CI-proven path.
-function makeClient(port: number, userId: string): TopGunClient {
-  const token = createTestToken(userId, ['ADMIN']);
+function makeClient(port: number, userId: string, roles: string[] = ['ADMIN']): TopGunClient {
+  const token = createTestToken(userId, roles);
   return new TopGunClient({
     serverUrl: `ws://localhost:${port}/ws`,
     storage: new MemoryStorageAdapter(),
@@ -551,4 +551,88 @@ describe('Integration: MCP tools against a real Rust server (cold cache)', () =>
       await server.cleanup().catch(() => {});
     }
   }, 60_000);
+
+  // F4 — topgun_list_maps must reflect the REAL server catalog, never fabricated
+  // "common patterns". A separate seeder creates two distinctly-named maps over
+  // the wire; list_maps (server-authoritative, via the admin map-enumeration
+  // endpoint) must return exactly those names with their entry counts — and never
+  // the retired boilerplate ('users'/'tasks'/'posts'/'products' as examples). The
+  // MCP client carries both the data-plane 'ADMIN' role (to connect) and the
+  // admin-plane 'admin' role (the HTTP control plane requires it).
+  test('list_maps reflects the real server catalog, not fabricated names (F4)', async () => {
+    const server = await spawnRustServer();
+    const seeder = await createRustTestClient(server.port, {
+      userId: 'mcp-seeder',
+      roles: ['ADMIN'],
+    });
+    const mcpClient = makeClient(server.port, 'mcp-lister', ['ADMIN', 'admin']);
+    const mcp = new TopGunMCPServer({ client: mcpClient });
+
+    try {
+      await seeder.waitForMessage('AUTH_ACK', 10_000);
+      await mcpClient.start();
+      await waitForState(mcpClient, SyncState.CONNECTED);
+
+      // Seed two distinctly-named maps (one row each) over the wire. The unique
+      // suffix keeps the assertion robust against any residue from other suites.
+      const suffix = Date.now();
+      const mapA = `mcp_catalog_a_${suffix}`;
+      const mapB = `mcp_catalog_b_${suffix}`;
+      for (const map of [mapA, mapB]) {
+        seeder.messages.length = 0;
+        seeder.send({
+          type: 'CLIENT_OP',
+          payload: {
+            id: `seed-${map}`,
+            mapName: map,
+            opType: 'PUT',
+            key: 'k0',
+            record: createLWWRecord({ id: 'k0', title: 'row' }),
+          },
+        });
+        await seeder.waitForMessage('OP_ACK', 10_000);
+      }
+
+      const result = await callStable(mcp, 'topgun_list_maps', {});
+      expect(result.isError).toBeFalsy();
+      const out = text(result);
+
+      // The real, server-resident maps are listed, with entry counts.
+      expect(out).toContain(mapA);
+      expect(out).toContain(mapB);
+      expect(out).toMatch(new RegExp(`${mapA}\\s*\\(1 entry`));
+
+      // Negative control: the pre-fix fabricated "common patterns" are gone. The
+      // server never created these names, so a server-authoritative answer for a
+      // catalog made only of mapA/mapB can never mention them.
+      expect(out).not.toMatch(/common (map )?pattern/i);
+      expect(out).not.toContain('Blog posts');
+      expect(out).not.toContain('E-commerce products');
+    } finally {
+      await mcp.stop().catch(() => {});
+      await mcpClient.close().catch(() => {});
+      seeder.close();
+      await server.cleanup().catch(() => {});
+    }
+  }, 60_000);
+
+  // F4 negative control — with no reachable server, list_maps must say so
+  // honestly (DISCONNECTED), never emit a cheerful fabricated catalog.
+  test('list_maps reports DISCONNECTED honestly when the server is unreachable (F4 negative control)', async () => {
+    const deadPort = 59_241;
+    const mcpClient = makeClient(deadPort, 'mcp-list-offline', ['ADMIN', 'admin']);
+    const mcp = new TopGunMCPServer({ client: mcpClient });
+
+    try {
+      await mcpClient.start();
+
+      const result = await mcp.callTool('topgun_list_maps', {});
+      expect(result.isError).toBe(true);
+      expect(text(result)).toMatch(/not connected|NOT an empty/i);
+      expect(text(result)).not.toContain('Blog posts');
+      expect(text(result)).not.toMatch(/common (map )?pattern/i);
+    } finally {
+      await mcpClient.close().catch(() => {});
+    }
+  }, 30_000);
 });


### PR DESCRIPTION
## What

`topgun_list_maps` (DEPTH_MCP **F4** / TODO-520, HIGH) fabricated hard-coded "common patterns" (`users`/`tasks`/`posts`/`products`), asserted "all maps accessible", and never asked the server or checked connection state — the tool the description told agents to "use first to discover what data is available" discovered nothing (it emitted the happy text even while DISCONNECTED).

It is now **server-authoritative**.

## How / decision

- **Only enumeration surface is the admin HTTP control plane** `GET /api/admin/maps`. There is **no** data-plane (WebSocket) list-maps message — confirmed by grepping the client-message schemas and the Rust WS handlers. So the tool derives the HTTP base from the client's WebSocket URL (`ws→http`, `wss→https`, host:port preserved, path → `/api/admin/maps`) and authenticates with the same bearer token the client uses. Returns real names + entry counts.
- **No fabrication.** The boilerplate is deleted. Every failure mode is a typed `isError`:
  - DISCONNECTED / not-online → "not connected … NOT an empty catalog" (no round-trip)
  - 401/403 → "requires an admin-scoped token; configure allowedMaps or use topgun_query with a known map"
  - 404 → "server does not expose a map-enumeration endpoint"
  - network error / unexpected shape / token-provider failure → distinct honest errors
- **`allowedMaps` still short-circuits** — an explicit allow-list IS the authoritative *access scope* for this MCP server (not a server-existence claim), returned directly without a round-trip. Tool description updated to state both modes honestly.
- **Auth-plane note (documented, not guessed):** the admin extractor requires the lowercase `admin` role, distinct from the data-plane uppercase `ADMIN`. The MCP token therefore needs an admin-scoped claim to enumerate; an ordinary app token gets an honest 403 rather than fiction. Broad non-admin enumeration would be a separate server-side feature if a product need arises.

## Client API added (single source of truth for the tool)

- `TopGunClient.getServerUrl(): string | undefined`
- `TopGunClient.getAuthToken(): Promise<string | null>` → `SyncEngine.getResolvedToken()` (propagates a throwing token provider rather than masking it as a 401)

## Tests

- **Real-server harness** (`tests/integration-rust/mcp-server.test.ts`): seeds two distinctly-named maps over the wire → `list_maps` returns exactly those with entry counts; negative control asserts the retired fabricated names never appear; second negative control proves DISCONNECTED is honest.
- **Unit** (`tools.test.ts`): allow-list short-circuit (no fetch), real catalog via mocked admin endpoint, DISCONNECTED honesty, 403-not-admin honesty — all assert no fabricated names.

## Verification

- mcp-server unit: **103/103** pass
- mcp real-server integration: **6/6** pass (incl. new F4 happy + DISCONNECTED negative)
- client unit: **652/652** pass
- All non-cluster integration suites pass; `cluster-routing` shows the known cold join-race flake (TODO-504, carved non-blocking, unrelated to this change)
- `pnpm lint` 0 errors · `pnpm format:check` clean
- Optional cross-vendor adversarial pass (glm-5.2) findings triaged: 2 HIGH fixed (description honesty, token-provider error propagation), MED/LOW assessed not-applicable to this codebase