### PR TITLE
fix(mcp): server-authoritative search bodies + honest pagination (DEPTH_MCP F6/F7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,9 @@ topgun.runtime.json
 # Vector index descriptor (generated at runtime; path configurable via TOPGUN_VECTOR_INDEX_PATH)
 vector_indexes.json
 
+# Scalar index descriptor (generated at runtime; path configurable via TOPGUN_INDEX_PATH)
+scalar_indexes.json
+
 # Embedded redb backend file (generated at runtime by `pnpm start:server`)
 topgun.redb
 

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -141,7 +141,12 @@ class MockTopGunClient {
   // to simulate offline / not-settled.
   async queryOncePaged(
     mapName: string,
-    filter: { where?: Record<string, unknown>; limit?: number; cursor?: string } = {},
+    filter: {
+      where?: Record<string, unknown>;
+      predicate?: { op: string; attribute: string; value: unknown };
+      limit?: number;
+      cursor?: string;
+    } = {},
   ): Promise<{
     items: Array<Record<string, unknown> & { _key: string }>;
     cursor?: string;
@@ -166,6 +171,14 @@ class MockTopGunClient {
     if (filter.where) {
       const where = filter.where as Record<string, unknown>;
       items = items.filter((item) => Object.entries(where).every(([k, v]) => item[k] === v));
+    }
+
+    // Mirror the server's `_key IN (...)` predicate so key-targeted hydration
+    // returns exactly the requested records (the real server injects `_key` as a
+    // filterable column on every row).
+    if (filter.predicate?.op === 'in' && filter.predicate.attribute === '_key') {
+      const allowed = new Set(filter.predicate.value as string[]);
+      items = items.filter((item) => allowed.has(item._key));
     }
 
     // Apply limit
@@ -424,6 +437,28 @@ describe('MCP Tools', () => {
       expect(result.content[0].text).toContain('1 result');
       expect(result.content[0].text).not.toContain('More rows match');
       expect(result.content[0].text).not.toContain('cursor:');
+    });
+
+    it('should NOT render cursor:"undefined" when hasMore is true but no token is available', async () => {
+      const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
+      for (let i = 0; i < 5; i++) {
+        mockClient.getMap('tasks').set(`task${i}`, { title: `Task ${i}`, index: i });
+      }
+      // Server signals more rows exist but returns NO usable cursor (the F7 gap).
+      mockClient.queryOncePagedHasMore = true;
+      mockClient.queryOncePagedCursor = undefined;
+
+      const result = await handleQuery({ map: 'tasks', limit: 5 }, ctx);
+
+      expect(result.isError).toBeUndefined();
+      // The truncation is still disclosed...
+      expect(result.content[0].text).toContain('More rows match than were returned');
+      // ...but the agent is NEVER told to page with the string "undefined".
+      expect(result.content[0].text).not.toContain('cursor: "undefined"');
+      expect(result.content[0].text).not.toContain('cursor:');
+      // Instead it is advised to narrow the query.
+      expect(result.content[0].text).toContain('narrow with');
     });
 
     it('should deny access to restricted maps', async () => {
@@ -820,11 +855,11 @@ describe('MCP Tools', () => {
       expect(result.content[0].text).not.toContain('Matched:');
     });
 
-    it('should emit the not-available-locally marker when the key is absent from the local replica', async () => {
+    it('should emit the not-available marker when the hit key is absent from the server read', async () => {
       const ctx = createTestContext();
       const mockClient = ctx.client as unknown as MockTopGunClient;
-      // Intentionally do NOT pre-populate the map — simulates an evicted or
-      // partially-replicated record where lwwMap.get() returns undefined.
+      // Intentionally do NOT pre-populate the map — the server-authoritative
+      // hydration read (queryOncePaged) returns no body for this key.
       mockClient.hybridSearchResults = [
         { key: 'missing-key', score: 0.9, methodScores: { fullText: 0.9 } },
       ];
@@ -833,7 +868,63 @@ describe('MCP Tools', () => {
       const result = await handleSearch({ map: 'tasks', query: 'term' }, ctx);
 
       expect(result.isError).toBeUndefined();
-      expect(result.content[0].text).toContain('Data: (record body not available locally)');
+      expect(result.content[0].text).toContain('Data: (record body not available on the server)');
+      // The old cold-cache marker must be gone — hydration is now server-authoritative.
+      expect(result.content[0].text).not.toContain('not available locally');
+    });
+
+    it('should hydrate bodies from the server read, not the local replica', async () => {
+      const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
+      // Body lives only in the store the server read (queryOncePaged) sees.
+      mockClient.getMap('tasks').set('task1', { title: 'Server Body', status: 'open' });
+      mockClient.hybridSearchResults = [
+        { key: 'task1', score: 0.5, methodScores: { fullText: 0.5 } },
+      ];
+
+      const result = await handleSearch({ map: 'tasks', query: 'server' }, ctx);
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Server Body');
+      expect(result.content[0].text).toContain('open');
+      expect(result.content[0].text).not.toContain('not available');
+    });
+
+    it('should hydrate a hit whose key sorts beyond the first page (key-targeted, not first-page scan)', async () => {
+      const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
+      // Populate well past the maxLimit page size; the single hit is the LAST key,
+      // so a first-page scan (limit=maxLimit) ordered by insertion would miss it.
+      for (let i = 0; i < 150; i++) {
+        mockClient.getMap('big').set(`task${i}`, { title: `Task ${i}`, n: i });
+      }
+      mockClient.hybridSearchResults = [
+        { key: 'task149', score: 0.99, methodScores: { fullText: 0.99 } },
+      ];
+
+      const result = await handleSearch({ map: 'big', query: 'task' }, ctx);
+
+      expect(result.isError).toBeUndefined();
+      // The body is hydrated by exact key, never marked "not available".
+      expect(result.content[0].text).toContain('Task 149');
+      expect(result.content[0].text).not.toContain('not available');
+    });
+
+    it('should still render ranked keys when the server hydration read does not settle', async () => {
+      const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
+      mockClient.hybridSearchResults = [
+        { key: 'task1', score: 0.7, methodScores: { fullText: 0.7 } },
+      ];
+      // hybridSearch succeeds (ranking), but the body hydration read is offline.
+      mockClient.queryOnceRejection = new QueryOnceUnsettledError('offline', 'tasks');
+
+      const result = await handleSearch({ map: 'tasks', query: 'term' }, ctx);
+
+      // The hit is still surfaced (key + score), with the body honestly marked unfetched.
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('task1');
+      expect(result.content[0].text).toContain('did not settle');
     });
 
     it('should return the empty-results message when search returns no hits', async () => {
@@ -892,22 +983,45 @@ describe('MCP Tools', () => {
       expect(result.content[0].text).toContain('fullText:');
     });
 
-    it('should surface an actionable retry message when the server cannot embed for the semantic leg', async () => {
+    it('should reject a semantic-only request honestly (vector search is dark on the server)', async () => {
       const ctx = createTestContext();
       const mockClient = ctx.client as unknown as MockTopGunClient;
-      mockClient.hybridSearchRejection = new Error(
-        'failed to embed query: no embedding model configured',
+      // If the gate failed and the request reached hybridSearch, lastHybridSearchOptions
+      // would be populated — assert it stays null to prove the leg never ran.
+      const result = await handleSearch(
+        { map: 'docs', query: 'login', methods: ['semantic'] },
+        ctx,
       );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Semantic (vector) search is not yet available');
+      // The message must tell the agent how to retry without the semantic leg.
+      expect(result.content[0].text).toContain('methods: ["fullText"]');
+      // The dead leg was never invoked — no silent Noop round-trip.
+      expect(mockClient.lastHybridSearchOptions).toBeNull();
+    });
+
+    it('should skip the semantic leg with a note when combined with a working method', async () => {
+      const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
+      mockClient.getMap('docs').set('doc1', { title: 'Login Guide' });
+      mockClient.hybridSearchResults = [
+        { key: 'doc1', score: 0.6, methodScores: { fullText: 0.6 } },
+      ];
 
       const result = await handleSearch(
         { map: 'docs', query: 'login', methods: ['fullText', 'semantic'] },
         ctx,
       );
 
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Semantic search requires server-side embedding');
-      // The message must tell the agent how to retry without the semantic leg.
-      expect(result.content[0].text).toContain('methods: ["fullText"]');
+      // The working leg still returns results...
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Login Guide');
+      // ...and the agent is told the semantic leg was skipped — never silently dropped.
+      expect(result.content[0].text).toContain('"semantic" method was skipped');
+      // Only the non-semantic methods were forwarded to the server.
+      const opts = mockClient.lastHybridSearchOptions as { methods: string[] };
+      expect(opts.methods).toEqual(['fullText']);
     });
 
     it('should point the agent at topgun_query when full-text search is not enabled for the map', async () => {
@@ -918,8 +1032,23 @@ describe('MCP Tools', () => {
       const result = await handleSearch({ map: 'docs', query: 'login' }, ctx);
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain("Full-text search is not enabled for map 'docs'");
+      expect(result.content[0].text).toContain("Full-text search is not available for map 'docs'");
       expect(result.content[0].text).toContain('topgun_query');
+    });
+
+    it('should map the raw "index registry not found" server error to a friendly message (no raw leak)', async () => {
+      const ctx = createTestContext();
+      const mockClient = ctx.client as unknown as MockTopGunClient;
+      // The exact low-level string the server emits for an unindexed auto-created map.
+      mockClient.hybridSearchRejection = new Error('index registry not found for map');
+
+      const result = await handleSearch({ map: 'fresh', query: 'anything' }, ctx);
+
+      expect(result.isError).toBe(true);
+      // Friendly, actionable text — not the raw internal error.
+      expect(result.content[0].text).toContain("Full-text search is not available for map 'fresh'");
+      expect(result.content[0].text).toContain('topgun_query');
+      expect(result.content[0].text).not.toContain('index registry not found');
     });
   });
 });

--- a/packages/mcp-server/src/schemas.ts
+++ b/packages/mcp-server/src/schemas.ts
@@ -76,10 +76,10 @@ export const SearchArgsSchema = z.object({
     .describe(
       'Search methods to combine via Reciprocal Rank Fusion. ' +
         '"exact" matches field values exactly; ' +
-        '"fullText" uses BM25 full-text search; ' +
-        '"semantic" uses vector similarity (requires server-side auto-embedding — ' +
-        'the tool sends a text query, not a vector). ' +
-        'Defaults to ["fullText"] to preserve existing behaviour when omitted.',
+        '"fullText" uses BM25 full-text search. ' +
+        '"semantic" (vector similarity) is NOT yet available on the server — ' +
+        'requesting it alone is rejected, and combined with other methods it is skipped with a note. ' +
+        'Defaults to ["fullText"] when omitted.',
     ),
 });
 
@@ -256,10 +256,10 @@ export const toolSchemas = {
         description:
           'Search methods to combine via Reciprocal Rank Fusion. ' +
           '"exact" matches field values exactly; ' +
-          '"fullText" uses BM25 full-text search; ' +
-          '"semantic" uses vector similarity (requires server-side auto-embedding — ' +
-          'the tool sends a text query, not a vector). ' +
-          'Defaults to ["fullText"] to preserve existing behaviour when omitted.',
+          '"fullText" uses BM25 full-text search. ' +
+          '"semantic" (vector similarity) is NOT yet available on the server — ' +
+          'requesting it alone is rejected, and combined with other methods it is skipped with a note. ' +
+          'Defaults to ["fullText"] when omitted.',
         default: ['fullText'],
       },
     },

--- a/packages/mcp-server/src/tools/query.ts
+++ b/packages/mcp-server/src/tools/query.ts
@@ -134,17 +134,25 @@ export async function handleQuery(rawArgs: unknown, ctx: ToolContext): Promise<M
       .join('\n\n');
 
     // When the server indicates more results are available, surface the opaque
-    // continuation cursor token so the agent can request the next page — without
-    // it the pagination surface is purely informational.
-    const continuationNote = hasMore
-      ? `\n\n---\nMore rows match than were returned; showing the first ${effectiveLimit}. ` +
-        `To fetch the next page, call this tool again with cursor: "${nextCursor}". ` +
-        `Alternatively, narrow with \`filter\`/\`sort\`` +
-        (effectiveLimit < ctx.config.maxLimit
-          ? ` or raise \`limit\` (up to ${ctx.config.maxLimit})`
-          : '') +
-        `.`
-      : '';
+    // continuation cursor token so the agent can request the next page. The server
+    // can report hasMore WITHOUT a usable cursor (a known getPaginationInfo gap); in
+    // that case we must NOT render the missing token verbatim (the "cursor:
+    // \"undefined\"" defect) — instead advise narrowing the query, so the agent is
+    // never told to page with a non-token.
+    const hasUsableCursor = typeof nextCursor === 'string' && nextCursor.length > 0;
+    const raiseLimitHint =
+      effectiveLimit < ctx.config.maxLimit
+        ? ` or raise \`limit\` (up to ${ctx.config.maxLimit})`
+        : '';
+    let continuationNote = '';
+    if (hasMore) {
+      continuationNote = hasUsableCursor
+        ? `\n\n---\nMore rows match than were returned; showing the first ${effectiveLimit}. ` +
+          `To fetch the next page, call this tool again with cursor: "${nextCursor}". ` +
+          `Alternatively, narrow with \`filter\`/\`sort\`${raiseLimitHint}.`
+        : `\n\n---\nMore rows match than were returned; showing the first ${effectiveLimit}. ` +
+          `No pagination cursor is available for this query, so narrow with \`filter\`/\`sort\`${raiseLimitHint} to see the rest.`;
+    }
 
     return {
       content: [

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -1,20 +1,32 @@
 /**
- * topgun_search — Tri-hybrid search (exact + full-text BM25 + semantic) via RRF fusion.
+ * topgun_search — Hybrid search (exact + full-text BM25) via RRF fusion.
  * Routes through the hybridSearch client method so the tool actually performs what it advertises.
+ *
+ * Result bodies are read server-authoritatively (the same settled server read
+ * topgun_query uses), NOT from the MCP process's local CRDT replica. That replica
+ * is only ever populated by topgun_mutate writes made in this process, so for any
+ * record the agent did not write itself it is cold — a body read from it renders
+ * "(not available)" even when the server holds the real record.
+ *
+ * The "semantic" (vector) leg is not yet functional on the server, so it is not
+ * advertised and a semantic-only request is rejected honestly rather than silently
+ * routed to a dead leg.
  */
 
 import type { MCPTool, MCPToolResult, ToolContext } from '../types';
 import { SearchArgsSchema, toolSchemas, type SearchArgs } from '../schemas';
+import { fetchServerRecordsByKeys, ServerReadUnsettledError } from './serverRead';
 
 export const searchTool: MCPTool = {
   name: 'topgun_search',
   description:
-    'Search a TopGun map combining exact, full-text (BM25), and semantic methods, ' +
+    'Search a TopGun map combining exact and full-text (BM25) methods, ' +
     'fused with Reciprocal Rank Fusion. ' +
     'Defaults to full-text only. ' +
-    'Pass methods: ["exact","fullText"] or ["fullText","semantic"] to enable additional legs. ' +
-    '"semantic" requires server-side auto-embedding (the tool sends a text query, not a vector). ' +
-    'Returns results ranked by a fused relevance score with per-method score breakdown.',
+    'Pass methods: ["exact","fullText"] to combine both legs. ' +
+    'Result bodies are read authoritatively from the server. ' +
+    'Returns results ranked by a fused relevance score with per-method score breakdown. ' +
+    '(Semantic / vector search is not yet available on the server.)',
   inputSchema: toolSchemas.search as MCPTool['inputSchema'],
 };
 
@@ -49,8 +61,28 @@ export async function handleSearch(rawArgs: unknown, ctx: ToolContext): Promise<
 
   // Map the existing `limit` arg to hybridSearch's `k` so agents keep using the same param name.
   const effectiveLimit = Math.min(limit ?? ctx.config.defaultLimit, ctx.config.maxLimit);
-  const effectiveMethods = methods ?? ['fullText'];
+  const requestedMethods = methods ?? ['fullText'];
   const effectiveMinScore = minScore ?? 0;
+
+  // The semantic (vector) leg is dark on the server: routing a request to it would
+  // silently contribute nothing or stall on a dead embedding path. Drop it and tell
+  // the agent honestly rather than pretending it ran. When the remaining methods are
+  // empty (a semantic-only request) there is nothing to run, so reject outright.
+  const semanticRequested = requestedMethods.includes('semantic');
+  const effectiveMethods = requestedMethods.filter((m) => m !== 'semantic');
+  if (effectiveMethods.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text:
+            `Semantic (vector) search is not yet available on this server. ` +
+            `Retry with methods: ["fullText"] or methods: ["exact", "fullText"].`,
+        },
+      ],
+      isError: true,
+    };
+  }
 
   try {
     const results = await ctx.client.hybridSearch(map, query, {
@@ -70,17 +102,42 @@ export async function handleSearch(rawArgs: unknown, ctx: ToolContext): Promise<
       };
     }
 
-    // Obtain a single map handle before the loop — same accessor topgun_mutate uses —
-    // so each hit's body is read from the local CRDT replica without a network round-trip.
-    const lwwMap = ctx.client.getMap<string, Record<string, unknown>>(map);
+    // hybridSearch ranks keys but does not return record bodies. Hydrate them from a
+    // settled, server-authoritative read keyed by exactly the hit keys (a single
+    // `_key IN (...)` query), instead of the cold local replica, so each hit renders
+    // the real server body. Keying by the hits keeps this O(hits) and — unlike a
+    // first-page scan — never marks a real record "not available" just because its
+    // key sorted beyond a page boundary.
+    //
+    // A hydration failure must NOT be reclassified as a search/FTS error (ranking
+    // already succeeded): handle it here and degrade the bodies, rather than letting
+    // it fall through to the outer catch's FTS/index matcher.
+    let serverBodies = new Map<string, Record<string, unknown>>();
+    let hydrationFailure: 'unsettled' | 'failed' | null = null;
+    try {
+      serverBodies = await fetchServerRecordsByKeys(
+        ctx,
+        map,
+        results.map((r) => r.key),
+      );
+    } catch (hydrationError) {
+      hydrationFailure =
+        hydrationError instanceof ServerReadUnsettledError ? 'unsettled' : 'failed';
+    }
 
     const formatted = results
       .map((result, idx) => {
-        const body = lwwMap.get(result.key);
-        const dataLine =
-          body !== undefined
-            ? `Data: ${JSON.stringify(body, null, 2).split('\n').join('\n   ')}`
-            : `Data: (record body not available locally)`;
+        const body = serverBodies.get(result.key);
+        let dataLine: string;
+        if (body !== undefined) {
+          dataLine = `Data: ${JSON.stringify(body, null, 2).split('\n').join('\n   ')}`;
+        } else if (hydrationFailure === 'unsettled') {
+          dataLine = `Data: (record body not fetched — server read did not settle; retry)`;
+        } else if (hydrationFailure === 'failed') {
+          dataLine = `Data: (record body not fetched — server read failed; retry)`;
+        } else {
+          dataLine = `Data: (record body not available on the server)`;
+        }
 
         // Render per-method score breakdown so the calling agent can see which leg contributed.
         const methodScoreEntries = Object.entries(result.methodScores)
@@ -98,46 +155,41 @@ export async function handleSearch(rawArgs: unknown, ctx: ToolContext): Promise<
       })
       .join('\n\n');
 
+    // When the agent asked for the semantic leg, tell it the leg was skipped so the
+    // ranking is never silently narrower than requested.
+    const semanticNote = semanticRequested
+      ? `\n\n(Note: the "semantic" method was skipped — vector search is not yet available on this server. ` +
+        `Results above use only ${effectiveMethods.map((m) => `"${m}"`).join(', ')}.)`
+      : '';
+
     return {
       content: [
         {
           type: 'text',
-          text: `Found ${results.length} result(s) in map '${map}' for query "${query}":\n\n${formatted}`,
+          text: `Found ${results.length} result(s) in map '${map}' for query "${query}":\n\n${formatted}${semanticNote}`,
         },
       ],
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
 
-    // When the server cannot embed the query for semantic search, surface an actionable message
-    // so the calling agent knows to retry without the semantic leg.
+    // Full-text search index is absent for this map. The server surfaces this as
+    // several low-level strings ("FTS not enabled", "index registry not found for
+    // map", "no index"); map them all to one actionable message instead of leaking
+    // the raw internal error to the agent.
     if (
-      message.toLowerCase().includes('embed') ||
-      (effectiveMethods.includes('semantic') &&
-        (message.includes('semantic') || message.includes('vector')))
+      message.includes('not enabled') ||
+      message.includes('FTS') ||
+      /index registry not found/i.test(message) ||
+      /no (search )?index/i.test(message)
     ) {
       return {
         content: [
           {
             type: 'text',
             text:
-              `Semantic search requires server-side embedding, which is not available for map '${map}'. ` +
-              `Retry with methods: ["fullText"] or methods: ["exact", "fullText"] to avoid the semantic leg.`,
-          },
-        ],
-        isError: true,
-      };
-    }
-
-    // Handle case where full-text search is not enabled for the map
-    if (message.includes('not enabled') || message.includes('FTS')) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text:
-              `Full-text search is not enabled for map '${map}'. ` +
-              `Use topgun_query instead for exact matching, or enable FTS on the server.`,
+              `Full-text search is not available for map '${map}' (no search index yet). ` +
+              `Use topgun_query instead for exact matching, or enable full-text search on the server.`,
           },
         ],
         isError: true,

--- a/packages/mcp-server/src/tools/serverRead.ts
+++ b/packages/mcp-server/src/tools/serverRead.ts
@@ -64,7 +64,11 @@ export class ServerReadUnsettledError extends Error {
 type ClientWithPaged = {
   queryOncePaged(
     map: string,
-    filter: { where?: Record<string, unknown>; limit?: number },
+    filter: {
+      where?: Record<string, unknown>;
+      predicate?: { op: string; attribute: string; value: unknown };
+      limit?: number;
+    },
   ): Promise<{
     items: Array<Record<string, unknown> & { _key: string }>;
     hasMore: boolean;
@@ -99,6 +103,52 @@ export async function fetchServerRecords(
       return { key: _key, value };
     });
     return { records, hasMore: paged.hasMore };
+  } catch (error) {
+    if (error instanceof QueryOnceUnsettledError) {
+      throw new ServerReadUnsettledError(error.reason, map);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Fetch settled, server-authoritative bodies for a specific set of record keys.
+ *
+ * Uses a single `_key IN (...)` predicate query so hydration is O(number of keys)
+ * — NOT a full-map scan — and never bounded by which rows happen to fall in the
+ * first page (the scan approach would fabricate "not available" for a real record
+ * whose key sorted beyond the first page). The server injects the real record key
+ * as the `_key` column on every row, so it is directly filterable.
+ *
+ * Returns a `key → body` map containing only the keys the server actually holds;
+ * absent keys are simply missing from the map (the caller decides how to render
+ * them). Offline/timeout surfaces as {@link ServerReadUnsettledError}, same as
+ * {@link fetchServerRecords}.
+ */
+export async function fetchServerRecordsByKeys(
+  ctx: ToolContext,
+  map: string,
+  keys: string[],
+): Promise<Map<string, Record<string, unknown>>> {
+  const bodies = new Map<string, Record<string, unknown>>();
+  if (keys.length === 0) {
+    return bodies;
+  }
+
+  // Deduplicate so the predicate list is minimal even if a key repeats.
+  const uniqueKeys = Array.from(new Set(keys));
+  const filter = {
+    predicate: { op: 'in', attribute: '_key', value: uniqueKeys },
+    limit: Math.min(uniqueKeys.length, ctx.config.maxLimit),
+  };
+
+  try {
+    const paged = await (ctx.client as unknown as ClientWithPaged).queryOncePaged(map, filter);
+    for (const item of paged.items) {
+      const { _key, ...value } = item;
+      bodies.set(_key, value);
+    }
+    return bodies;
   } catch (error) {
     if (error instanceof QueryOnceUnsettledError) {
       throw new ServerReadUnsettledError(error.reason, map);

--- a/tests/integration-rust/mcp-server.test.ts
+++ b/tests/integration-rust/mcp-server.test.ts
@@ -635,4 +635,188 @@ describe('Integration: MCP tools against a real Rust server (cold cache)', () =>
       await mcpClient.close().catch(() => {});
     }
   }, 30_000);
+
+  // F6 — topgun_search must hydrate hit bodies SERVER-AUTHORITATIVELY. hybridSearch
+  // ranks keys on the server but returns no bodies; the MCP process's local CRDT
+  // replica is cold for any record it did not write itself. The pre-fix tool read
+  // the body from that cold replica, so every hit rendered "(record body not
+  // available locally)" against real server data. We seed FTS-indexable docs from a
+  // SEPARATE client over the wire, then search from a COLD MCP client and assert the
+  // real server body text appears — the only configuration that exposes the bug.
+  //
+  // hybrid search additionally gates on the map having a registered index registry
+  // (the real "index registry not found" path); we register it via the admin
+  // index endpoint so the fullText (tantivy) leg actually returns ranked hits.
+  test('search hydrates hit bodies from the server, not the cold local replica (F6)', async () => {
+    const server = await spawnRustServer();
+    const seeder = await createRustTestClient(server.port, {
+      userId: 'mcp-seeder',
+      roles: ['ADMIN'],
+    });
+    const mcpClient = makeClient(server.port, 'mcp-searcher');
+    const mcp = new TopGunMCPServer({ client: mcpClient });
+
+    try {
+      await seeder.waitForMessage('AUTH_ACK', 10_000);
+      await mcpClient.start();
+      await waitForState(mcpClient, SyncState.CONNECTED);
+
+      // Seed articles with distinctive, FTS-indexable body text over the wire.
+      const mapName = `mcp_search_${Date.now()}`;
+      const articles: Array<{ key: string; title: string; body: string }> = [
+        {
+          key: 'art-1',
+          title: 'Introduction to Machine Learning',
+          body: 'Machine learning is a subset of artificial intelligence.',
+        },
+        {
+          key: 'art-2',
+          title: 'Deep Learning Fundamentals',
+          body: 'Deep learning uses neural networks with many layers.',
+        },
+        {
+          key: 'art-3',
+          title: 'Advanced Machine Learning Techniques',
+          body: 'Covers advanced machine learning algorithms and optimization.',
+        },
+      ];
+      for (const art of articles) {
+        seeder.messages.length = 0;
+        seeder.send({
+          type: 'CLIENT_OP',
+          payload: {
+            id: `seed-${art.key}`,
+            mapName,
+            opType: 'PUT',
+            key: art.key,
+            record: createLWWRecord({ id: art.key, title: art.title, body: art.body }),
+          },
+        });
+        await seeder.waitForMessage('OP_ACK', 10_000);
+      }
+
+      // Register the map's index registry so hybrid search clears its
+      // "index registry not found" gate and the tantivy fullText leg runs. Requires
+      // an admin-plane ('admin') JWT — distinct from the data-plane 'ADMIN' role.
+      const adminToken = createTestToken('mcp-index-admin', ['admin']);
+      const createIndexResp = await fetch(`http://localhost:${server.port}/api/admin/indexes`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${adminToken}`,
+        },
+        body: JSON.stringify({ mapName, attribute: 'title', indexType: 'inverted' }),
+      });
+      expect(createIndexResp.status).toBe(201);
+
+      // Poll the search until the full-text index has caught up (lazy/batched
+      // indexing). A genuine server-blind read is NOT a "no results" case, so this
+      // loop never masks the negative control: once hits arrive, their bodies must
+      // be the real server bodies.
+      let result: MCPToolResult | undefined;
+      const deadline = Date.now() + 20_000;
+      while (Date.now() < deadline) {
+        await waitForState(mcp.getClient(), SyncState.CONNECTED, 8_000).catch(() => {});
+        result = await mcp.callTool('topgun_search', {
+          map: mapName,
+          query: 'machine learning',
+        });
+        if (!result.isError && /Found \d+ result/.test(text(result))) break;
+        await waitMs(500);
+      }
+
+      expect(result!.isError).toBeFalsy();
+      const out = text(result!);
+      expect(out).toMatch(/Found \d+ result/);
+      // The hit bodies are the REAL server bodies, hydrated server-authoritatively.
+      expect(out).toContain('Machine Learning');
+      expect(out).toMatch(/subset of artificial intelligence|machine learning algorithms/);
+      // Negative control: the pre-fix cold-cache markers must never appear.
+      expect(out).not.toContain('not available locally');
+      expect(out).not.toContain('not available on the server');
+    } finally {
+      await mcp.stop().catch(() => {});
+      await mcpClient.close().catch(() => {});
+      seeder.close();
+      await server.cleanup().catch(() => {});
+    }
+  }, 60_000);
+
+  // F6 — a semantic-only request must be rejected honestly (vector search is dark
+  // on the server), never silently routed to a dead leg.
+  test('search rejects a semantic-only request honestly (F6 semantic dark)', async () => {
+    const server = await spawnRustServer();
+    const mcpClient = makeClient(server.port, 'mcp-semantic');
+    const mcp = new TopGunMCPServer({ client: mcpClient });
+
+    try {
+      await mcpClient.start();
+      await waitForState(mcpClient, SyncState.CONNECTED);
+
+      const result = await mcp.callTool('topgun_search', {
+        map: `mcp_semantic_${Date.now()}`,
+        query: 'anything',
+        methods: ['semantic'],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(text(result)).toMatch(/semantic.*not yet available/i);
+      expect(text(result)).toContain('methods: ["fullText"]');
+    } finally {
+      await mcpClient.close().catch(() => {});
+      await server.cleanup().catch(() => {});
+    }
+  }, 30_000);
+
+  // F7 — topgun_query must NEVER instruct the agent to page with the literal string
+  // "undefined". When the server reports hasMore without a usable cursor token (a
+  // known getPaginationInfo gap), the pre-fix tool rendered `cursor: "undefined"`.
+  // We seed more rows than the page limit and assert the truncation is disclosed but
+  // the "undefined" token never appears.
+  test('query never renders cursor:"undefined" when more rows exist (F7)', async () => {
+    const server = await spawnRustServer();
+    const seeder = await createRustTestClient(server.port, {
+      userId: 'mcp-seeder',
+      roles: ['ADMIN'],
+    });
+    const mcpClient = makeClient(server.port, 'mcp-pager');
+    const mcp = new TopGunMCPServer({ client: mcpClient });
+
+    try {
+      await seeder.waitForMessage('AUTH_ACK', 10_000);
+      await mcpClient.start();
+      await waitForState(mcpClient, SyncState.CONNECTED);
+
+      const mapName = `mcp_page_${Date.now()}`;
+      for (let i = 0; i < RECORD_COUNT; i++) {
+        seeder.messages.length = 0;
+        seeder.send({
+          type: 'CLIENT_OP',
+          payload: {
+            id: `seed-${i}`,
+            mapName,
+            opType: 'PUT',
+            key: `k${i}`,
+            record: createLWWRecord({ id: `k${i}`, title: `doc ${i}`, n: i }),
+          },
+        });
+        await seeder.waitForMessage('OP_ACK', 10_000);
+      }
+
+      // limit:5 over 25 rows → the server reports more rows exist.
+      const result = await callStable(mcp, 'topgun_query', { map: mapName, limit: 5 });
+      expect(result.isError).toBeFalsy();
+      const out = text(result);
+      expect(out).toContain('Found 5 result(s)');
+      // Truncation must be disclosed...
+      expect(out).toContain('More rows match than were returned');
+      // ...but the agent is NEVER handed the string "undefined" as a cursor.
+      expect(out).not.toContain('cursor: "undefined"');
+      expect(out).not.toContain('"undefined"');
+    } finally {
+      await mcpClient.close().catch(() => {});
+      seeder.close();
+      await server.cleanup().catch(() => {});
+    }
+  }, 60_000);
 });


### PR DESCRIPTION
Closes DEPTH_MCP **F6 (TODO-522)** and **F7 (TODO-523)**, verified under the real-server MCP harness (blocking `integration-rust` gate).

## F6 — `topgun_search` (TODO-522)
- **Server-authoritative bodies.** `hybridSearch` ranks keys but returns no bodies; the tool used to hydrate each hit from the MCP process's **cold local CRDT replica** (`lwwMap.get`), so any record the agent didn't write itself rendered `(record body not available locally)`. Bodies are now hydrated via a **key-targeted server read** — a single `_key IN (...)` query over exactly the ranked hit keys. This is O(hits) and, unlike a first-page scan, never marks a real record "not available" just because its key sorts beyond a page boundary.
- **No raw error leak.** The friendly-error mapping now also matches the real server string `index registry not found for map` (and `no index`), so the low-level error no longer reaches the agent.
- **Hydration failures don't get misdiagnosed.** A failed body read degrades the body line (`server read did not settle / failed; retry`) instead of falling through to the FTS/index error matcher.
- **Honest semantic leg.** Vector/semantic search is dark on the server, so a `semantic`-only request is rejected with guidance; combined with a working method it is **skipped with a note** rather than silently routed to a dead leg. Tool + schema descriptions no longer advertise semantic as functional.

## F7 — `topgun_query` (TODO-523)
- The continuation note rendered `cursor: "undefined"` when the server reported `hasMore` without a usable token. It now emits a cursor **only** when `nextCursor` is a non-empty string; otherwise it advises narrowing the query. (Underlying `getPaginationInfo` gap stays tracked under SPEC-306b.)

## Tests
- **Real-server harness** (`tests/integration-rust/mcp-server.test.ts`): F6 (cold-cache search returns real server bodies; semantic-only rejected honestly) and F7 (no `cursor:"undefined"` when more rows exist). The F6 body test registers the map's index registry via the admin index endpoint so the tantivy fullText leg actually ranks.
- **Unit** (`tools.test.ts`): key-targeted hydration incl. a hit beyond the first page, the semantic gate + skip-note, the index-registry error mapping, the hydration-failure degrade path, and the cursor guard. Mock `queryOncePaged` now mirrors the server's `_key IN` predicate.

## Review
Cross-vendor adversarial pass (glm-5.2) flagged the original full-map first-page hydration as fabricating "not available" for records beyond page 1 — fixed here by switching to the key-targeted `_key IN` query (empirically verified against the real server).

## Gate
- `pnpm --filter @topgunbuild/mcp-server test` → 109 passing
- `RUST_SERVER_BINARY=… pnpm test:integration-rust mcp-server` → 9/9 passing
- lint: 0 errors · format:check: clean