### PR TITLE
feat(server): enable env-configured vector/hybrid search end-to-end (TODO-457)

### DIFF
--- a/apps/docs-astro/src/content/docs/guides/vector-and-hybrid-search.mdx
+++ b/apps/docs-astro/src/content/docs/guides/vector-and-hybrid-search.mdx
@@ -189,16 +189,31 @@ Records are auto-vectorized on write — no separate indexing pipeline is needed
 
 ### Server configuration
 
-`VectorConfig` is a **Rust server-side struct** (`provider` + per-map dimension config). Configure it via server environment variables; it is not a TypeScript client import.
+The embedding provider and which maps are auto-vectorized are configured entirely through **server environment variables** — there is no TypeScript client import. Set the provider, its dimension, and the maps/fields to embed, then start the server:
 
 ```bash
-# Path where the HNSW index is persisted
+# --- Local Ollama (zero egress) ---
+TOPGUN_EMBEDDING_PROVIDER=ollama
+TOPGUN_EMBEDDING_MODEL=nomic-embed-text
+TOPGUN_EMBEDDING_DIMENSION=768
+
+# --- OR any OpenAI-compatible endpoint ---
+# TOPGUN_EMBEDDING_PROVIDER=openai
+# TOPGUN_EMBEDDING_BASE_URL=https://api.openai.com
+# TOPGUN_EMBEDDING_API_KEY=sk-...
+# TOPGUN_EMBEDDING_MODEL=text-embedding-3-small
+# TOPGUN_EMBEDDING_DIMENSION=1536
+
+# Which maps/fields to auto-embed on write (dimension must match the provider)
+TOPGUN_VECTOR_MAPS='{"products":{"fields":["title","description"],"dimension":768}}'
+
+# Optional: directory where the HNSW index is persisted across restarts
 TOPGUN_VECTOR_INDEX_PATH=./data/vectors
 ```
 
-For the full `VectorConfig` struct (provider type, model, endpoint, dimensions per map) see the [Server reference](/docs/reference/server).
+On startup the server logs a single line showing the active provider, dimension, and the maps it will auto-embed, so you can confirm the configuration from the logs. For the full variable reference see the [Server reference](/docs/reference/server).
 
-<AlertBox variant="info" title="Semantic search requires server-side config" text="The 'exact' and 'fullText' methods work fully offline against local data. The 'semantic' method requires a running server with VectorConfig set (provider + TOPGUN_VECTOR_INDEX_PATH). Calls that include 'semantic' while offline gracefully fall back to the remaining methods." />
+<AlertBox variant="info" title="Semantic search requires an embedding provider" text="The 'exact' and 'fullText' methods work fully offline against local data. The 'semantic' method requires a running server with TOPGUN_EMBEDDING_PROVIDER configured. Without a provider, 'semantic' returns an explicit error rather than empty or meaningless results — it never silently fakes a ranking. Offline clients that include 'semantic' gracefully fall back to the remaining methods." />
 
 ---
 

--- a/apps/docs-astro/src/content/docs/reference/server.mdx
+++ b/apps/docs-astro/src/content/docs/reference/server.mdx
@@ -86,6 +86,28 @@ All variables below correspond to direct `std::env::var(...)` reads or `tracing-
 | `TOPGUN_INDEX_PATH` | path | none | `bin/topgun_server.rs:516`, `network/module.rs:316`, `network/handlers/admin.rs:1078` | Directory holding the BM25 full-text-search index. |
 | `TOPGUN_VECTOR_INDEX_PATH` | path | none | `network/module.rs:286`, `network/handlers/admin.rs:1139` | Directory holding the HNSW vector index. |
 
+### Embeddings and semantic search
+
+Semantic / vector / hybrid search requires a configured embedding provider. When
+`TOPGUN_EMBEDDING_PROVIDER` is unset, the `'semantic'` method is **disabled** and
+returns an explicit error instead of empty or meaningless results — `'exact'` and
+`'fullText'` are unaffected. The server logs the active provider, dimension, and
+auto-embedded maps in a single config line at startup.
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `TOPGUN_EMBEDDING_PROVIDER` | string | unset (disabled) | One of `ollama`, `openai` (alias `http`), `deterministic`, `noop`. Unset / `none` disables semantic search. |
+| `TOPGUN_EMBEDDING_MODEL` | string | provider default | Embedding model name. Ollama default: `nomic-embed-text`. Required for `openai`/`http`. |
+| `TOPGUN_EMBEDDING_BASE_URL` | string | provider default | Endpoint base URL. Ollama default: `http://localhost:11434`. Required for `openai`/`http`. |
+| `TOPGUN_EMBEDDING_API_KEY` | string | none | Bearer token for `openai`/`http` providers. |
+| `TOPGUN_EMBEDDING_DIMENSION` | u16 | provider default | Output vector dimension; must match the model. Defaults: `ollama` 768, `deterministic` 256, `noop` 4. Required for `openai`/`http`. |
+| `TOPGUN_VECTOR_MAPS` | JSON | none | Maps auto-vectorized on write: `{"docs":{"fields":["title","body"],"dimension":768}}`. Each map's `dimension` must equal the provider dimension. |
+
+`deterministic` produces stable hashed bag-of-words vectors with no external
+dependency — intended for tests and local experiments, not production semantics.
+`noop` returns all-zero vectors and logs a loud warning; it is a development-only
+mode and never the default. Use `ollama` or `openai` for real semantic search.
+
 ### Observability
 
 | Variable | Type | Default | Consumer | Notes |

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -55,8 +55,11 @@ use topgun_server::service::domain::coordination::CoordinationService;
 use topgun_server::service::domain::counter::CounterRegistry;
 use topgun_server::service::domain::crdt::CrdtService;
 use topgun_server::service::domain::embedding::{
-    noop::NoopEmbeddingProvider, EmbeddingConfig, EmbeddingObserverFactory, EmbeddingProvider,
-    EmbeddingProviderConfig, NoopConfig, VectorConfig as EmbeddingVectorConfig,
+    deterministic::DeterministicEmbeddingProvider, http::HttpEmbeddingProvider,
+    noop::NoopEmbeddingProvider, ollama::OllamaEmbeddingProvider, DeterministicConfig,
+    EmbeddingConfig, EmbeddingObserverFactory, EmbeddingProvider, EmbeddingProviderConfig,
+    HttpProviderConfig, MapVectorConfig, NoopConfig, OllamaConfig,
+    VectorConfig as EmbeddingVectorConfig,
 };
 use topgun_server::service::domain::index::IndexObserverFactory;
 use topgun_server::service::domain::journal::JournalStore;
@@ -1178,6 +1181,205 @@ type ClusterParams = (
 /// Domain services are `Arc`-wrapped and shared across all worker pipelines.
 /// Each worker gets its own `OperationRouter` + `OperationPipeline` via a
 /// factory closure passed to `PartitionDispatcher::new()`.
+/// Resolved server-side embedding / vector-search configuration, built from
+/// environment variables. See [`build_embedding_setup`].
+struct EmbeddingSetup {
+    /// Provider config + per-map field config consumed by the write-path
+    /// `EmbeddingObserverFactory`. `maps` is empty when semantic search is disabled.
+    vector_config: Arc<EmbeddingVectorConfig>,
+    /// Provider instance used by the write-path auto-embed observer. A harmless
+    /// Noop placeholder when disabled (no maps means it is never invoked).
+    write_provider: Arc<dyn EmbeddingProvider>,
+    /// Provider wired into the query-path `HybridSearchEngine`. `None` when no
+    /// provider is configured, so `semantic` queries return an explicit
+    /// "no embedding provider configured" error instead of silent empty results.
+    query_provider: Option<Arc<dyn EmbeddingProvider>>,
+    /// `(map_name, dimension)` pairs to register an `_embedding` HNSW vector
+    /// index for, so auto-embedded vectors are indexed and queryable.
+    vector_indexes: Vec<(String, u16)>,
+    /// Human-readable provider label for the startup config line ("none" when disabled).
+    provider_label: String,
+    /// Effective embedding dimension, when a provider is configured.
+    dimension: Option<u16>,
+}
+
+/// Reads the embedding provider + vector-map configuration from the environment.
+///
+/// Recognized variables:
+/// - `TOPGUN_EMBEDDING_PROVIDER`: `ollama` | `openai` (alias `http`) | `deterministic`
+///   | `noop`. Unset / empty / `none` disables semantic search.
+/// - `TOPGUN_EMBEDDING_MODEL`, `TOPGUN_EMBEDDING_BASE_URL`, `TOPGUN_EMBEDDING_API_KEY`,
+///   `TOPGUN_EMBEDDING_DIMENSION`: provider connection + output dimension.
+/// - `TOPGUN_VECTOR_MAPS`: JSON object mapping map name to `{ "fields": [...],
+///   "dimension": N }`, declaring which maps/fields are auto-vectorized on write.
+///
+/// Honesty contract: when no provider is configured, the query path provider is
+/// `None` (semantic → explicit error) and no maps are auto-embedded. `noop` is an
+/// explicit, loudly-warned development mode — never a silent default.
+///
+/// On a malformed configuration (bad dimension, invalid JSON, dimension mismatch)
+/// the process aborts with a descriptive message rather than serving a silently
+/// broken semantic surface.
+#[allow(clippy::too_many_lines)]
+fn build_embedding_setup() -> EmbeddingSetup {
+    let disabled = || EmbeddingSetup {
+        vector_config: Arc::new(EmbeddingVectorConfig {
+            provider: EmbeddingProviderConfig::Noop(NoopConfig { dimension: 1 }),
+            maps: std::collections::HashMap::new(),
+        }),
+        write_provider: Arc::new(NoopEmbeddingProvider::new(&NoopConfig { dimension: 1 })),
+        query_provider: None,
+        vector_indexes: Vec::new(),
+        provider_label: "none".to_string(),
+        dimension: None,
+    };
+
+    let kind = std::env::var("TOPGUN_EMBEDDING_PROVIDER")
+        .unwrap_or_default()
+        .trim()
+        .to_lowercase();
+
+    if kind.is_empty() || kind == "none" {
+        if std::env::var("TOPGUN_VECTOR_MAPS").is_ok() {
+            tracing::warn!(
+                "TOPGUN_VECTOR_MAPS is set but TOPGUN_EMBEDDING_PROVIDER is unset — \
+                 no fields will be auto-embedded and semantic search stays disabled. \
+                 Set TOPGUN_EMBEDDING_PROVIDER to enable vector/hybrid search."
+            );
+        }
+        return disabled();
+    }
+
+    // Per-provider default dimension; overridable via TOPGUN_EMBEDDING_DIMENSION.
+    let default_dim: Option<u16> = match kind.as_str() {
+        "ollama" => Some(768),
+        "deterministic" => Some(256),
+        "noop" => Some(4),
+        _ => None, // openai/http: model-specific, must be explicit
+    };
+    let dimension: u16 = match std::env::var("TOPGUN_EMBEDDING_DIMENSION") {
+        Ok(raw) => raw.trim().parse().unwrap_or_else(|_| {
+            eprintln!("FATAL: TOPGUN_EMBEDDING_DIMENSION='{raw}' is not a valid u16");
+            std::process::exit(1);
+        }),
+        Err(_) => default_dim.unwrap_or_else(|| {
+            eprintln!(
+                "FATAL: TOPGUN_EMBEDDING_PROVIDER='{kind}' requires TOPGUN_EMBEDDING_DIMENSION \
+                 (the embedding model's output size, e.g. 1536 for text-embedding-3-small)"
+            );
+            std::process::exit(1);
+        }),
+    };
+
+    let model = std::env::var("TOPGUN_EMBEDDING_MODEL").ok();
+    let base_url = std::env::var("TOPGUN_EMBEDDING_BASE_URL").ok();
+    let api_key = std::env::var("TOPGUN_EMBEDDING_API_KEY").ok();
+
+    let (provider_config, provider): (EmbeddingProviderConfig, Arc<dyn EmbeddingProvider>) =
+        match kind.as_str() {
+            "ollama" => {
+                let cfg = OllamaConfig {
+                    base_url: base_url.unwrap_or_else(|| "http://localhost:11434".to_string()),
+                    model: model.unwrap_or_else(|| "nomic-embed-text".to_string()),
+                    dimension,
+                };
+                (
+                    EmbeddingProviderConfig::Ollama(cfg.clone()),
+                    Arc::new(OllamaEmbeddingProvider::new(cfg)),
+                )
+            }
+            "openai" | "http" => {
+                let base_url = base_url.unwrap_or_else(|| {
+                    eprintln!(
+                        "FATAL: TOPGUN_EMBEDDING_PROVIDER='{kind}' requires TOPGUN_EMBEDDING_BASE_URL \
+                         (e.g. https://api.openai.com)"
+                    );
+                    std::process::exit(1);
+                });
+                let model = model.unwrap_or_else(|| {
+                    eprintln!(
+                        "FATAL: TOPGUN_EMBEDDING_PROVIDER='{kind}' requires TOPGUN_EMBEDDING_MODEL \
+                         (e.g. text-embedding-3-small)"
+                    );
+                    std::process::exit(1);
+                });
+                let cfg = HttpProviderConfig {
+                    base_url,
+                    api_key,
+                    model,
+                    dimension,
+                };
+                (
+                    EmbeddingProviderConfig::Http(cfg.clone()),
+                    Arc::new(HttpEmbeddingProvider::new(cfg)),
+                )
+            }
+            "deterministic" => (
+                EmbeddingProviderConfig::Deterministic(DeterministicConfig { dimension }),
+                Arc::new(DeterministicEmbeddingProvider::new(dimension)),
+            ),
+            "noop" => {
+                tracing::warn!(
+                    "TOPGUN_EMBEDDING_PROVIDER=noop — embeddings are ALL-ZERO vectors with no \
+                     semantic meaning. Vector/hybrid 'semantic' results are NOT meaningful. \
+                     This is a development-only mode; use 'ollama' or 'openai' in production."
+                );
+                (
+                    EmbeddingProviderConfig::Noop(NoopConfig { dimension }),
+                    Arc::new(NoopEmbeddingProvider::new(&NoopConfig { dimension })),
+                )
+            }
+            other => {
+                eprintln!(
+                    "FATAL: unknown TOPGUN_EMBEDDING_PROVIDER='{other}' \
+                     (expected: ollama | openai | deterministic | noop)"
+                );
+                std::process::exit(1);
+            }
+        };
+
+    // Parse per-map auto-embed config. Absent => provider is configured but no
+    // maps are vectorized (semantic queries embed but find an empty index).
+    let maps: std::collections::HashMap<String, MapVectorConfig> =
+        if let Ok(raw) = std::env::var("TOPGUN_VECTOR_MAPS") {
+            serde_json::from_str(&raw).unwrap_or_else(|e| {
+                eprintln!("FATAL: TOPGUN_VECTOR_MAPS is not valid JSON: {e}");
+                std::process::exit(1);
+            })
+        } else {
+            tracing::warn!(
+                "TOPGUN_EMBEDDING_PROVIDER='{kind}' is set but TOPGUN_VECTOR_MAPS is empty — \
+                 no maps will be auto-embedded. Set TOPGUN_VECTOR_MAPS to a JSON object like \
+                 '{{\"docs\":{{\"fields\":[\"title\",\"body\"],\"dimension\":{dimension}}}}}'."
+            );
+            std::collections::HashMap::new()
+        };
+
+    let vector_config = EmbeddingVectorConfig {
+        provider: provider_config,
+        maps,
+    };
+    if let Err(e) = vector_config.validate() {
+        eprintln!("FATAL: invalid TOPGUN_VECTOR_MAPS configuration: {e}");
+        std::process::exit(1);
+    }
+
+    let vector_indexes: Vec<(String, u16)> = vector_config
+        .maps
+        .iter()
+        .map(|(map_name, cfg)| (map_name.clone(), cfg.dimension))
+        .collect();
+
+    EmbeddingSetup {
+        vector_config: Arc::new(vector_config),
+        write_provider: Arc::clone(&provider),
+        query_provider: Some(provider),
+        vector_indexes,
+        provider_label: kind,
+        dimension: Some(dimension),
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 fn build_services(
     node_id: String,
@@ -1239,22 +1441,45 @@ fn build_services(
         Arc::new(MerkleObserverFactory::new(Arc::clone(&merkle_manager)));
 
     // Phase 1: construct the embedding observer factory before RecordStoreFactory exists.
-    // Uses a noop provider for the test server (no real embedding service dependency).
-    // The maps config is empty so no observer is registered for any map by default;
-    // integration tests that need embedding can wire a custom VectorConfig.
-    let embedding_vector_config = Arc::new(EmbeddingVectorConfig {
-        provider: EmbeddingProviderConfig::Noop(NoopConfig { dimension: 4 }),
-        maps: std::collections::HashMap::new(),
-    });
-    let embedding_provider: Arc<dyn EmbeddingProvider> =
-        Arc::new(NoopEmbeddingProvider::new(&NoopConfig { dimension: 4 }));
+    // Provider + per-map field config are resolved from the environment
+    // (TOPGUN_EMBEDDING_PROVIDER / TOPGUN_VECTOR_MAPS). When no provider is
+    // configured the maps config is empty, so no auto-embed observer is registered
+    // and the query path stays honest (semantic → explicit "not configured" error).
+    let embedding_setup = build_embedding_setup();
     let embedding_factory = Arc::new(EmbeddingObserverFactory::new(
         EmbeddingConfig::default(),
-        embedding_vector_config,
-        embedding_provider,
+        Arc::clone(&embedding_setup.vector_config),
+        Arc::clone(&embedding_setup.write_provider),
     ));
 
     let index_observer_factory = Arc::new(IndexObserverFactory::new());
+
+    // Register an `_embedding` HNSW vector index for every auto-embedded map so the
+    // vectors written back by the embedding hook are indexed and queryable. Both
+    // the write path (IndexMutationObserver) and the query path (HybridSearchEngine)
+    // read this same per-map IndexRegistry, so registering here wires both ends.
+    for (map_name, dim) in &embedding_setup.vector_indexes {
+        let registry = index_observer_factory.register_map(map_name.clone());
+        registry.add_vector_index(
+            "_embedding",
+            *dim,
+            topgun_core::vector::DistanceMetric::Cosine,
+        );
+    }
+
+    // Single operator-facing line so the active embedding provider, dimension, and
+    // auto-embedded maps can be confirmed from logs (mirrors the eviction/WAL line).
+    tracing::info!(
+        embedding_provider = %embedding_setup.provider_label,
+        embedding_dimension = ?embedding_setup.dimension,
+        semantic_search_enabled = embedding_setup.query_provider.is_some(),
+        vectorized_maps = ?embedding_setup
+            .vector_indexes
+            .iter()
+            .map(|(m, _)| m.as_str())
+            .collect::<Vec<_>>(),
+        "embedding / vector-search configuration initialized"
+    );
 
     #[allow(unused_mut)]
     let mut observer_factories: Vec<Arc<dyn ObserverFactory>> = vec![
@@ -1370,10 +1595,13 @@ fn build_services(
     // tasks can be spawned when observers are created for each map.
     search_observer_factory.init_search_service(Arc::clone(&search_svc));
     // Two-phase OnceLock wiring: construct engine after search_svc, then set it.
+    // The query-path embedding provider (if configured) lets `semantic` queries
+    // auto-embed their query text; `None` makes them return an explicit
+    // "no embedding provider configured" error rather than silent empty results.
     let hybrid_engine = topgun_server::service::domain::search::HybridSearchEngine::new(
         Arc::clone(&search_svc),
         Arc::clone(&record_store_factory),
-        None,
+        embedding_setup.query_provider.clone(),
     );
     search_svc.set_hybrid_engine(Arc::new(hybrid_engine));
     let persistence_svc = Arc::new(PersistenceService::new(

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -1270,6 +1270,11 @@ fn build_embedding_setup() -> EmbeddingSetup {
             std::process::exit(1);
         }),
     };
+    if dimension == 0 {
+        // A zero dimension would panic the bucketing math and produce empty vectors.
+        eprintln!("FATAL: TOPGUN_EMBEDDING_DIMENSION must be greater than 0");
+        std::process::exit(1);
+    }
 
     let model = std::env::var("TOPGUN_EMBEDDING_MODEL").ok();
     let base_url = std::env::var("TOPGUN_EMBEDDING_BASE_URL").ok();

--- a/packages/server-rust/src/service/domain/embedding/deterministic.rs
+++ b/packages/server-rust/src/service/domain/embedding/deterministic.rs
@@ -1,0 +1,147 @@
+//! Deterministic embedding provider — hashes text into a stable vector.
+//!
+//! Unlike [`NoopEmbeddingProvider`](super::noop::NoopEmbeddingProvider), which
+//! returns all-zero vectors that carry no semantic signal, this provider produces
+//! a reproducible bag-of-words vector: tokens are hashed into dimension buckets,
+//! term frequencies are accumulated, and the result is L2-normalized.
+//!
+//! Properties that make it suitable for CI integration tests of the semantic
+//! search path, without requiring an external embedding service:
+//! - **Deterministic**: the same text always maps to the same vector, on every
+//!   run and platform (FNV-1a hashing, no RNG, no global hasher state).
+//! - **Semantically ordered**: texts that share tokens have higher cosine
+//!   similarity than texts that share none, so nearest-neighbour ranking is
+//!   meaningful enough to assert on.
+//!
+//! This is NOT a real embedding model — it has no understanding of synonyms or
+//! word order. It exists so the vector/hybrid pipeline can be exercised
+//! end-to-end deterministically. Production deployments use the Ollama or HTTP
+//! providers.
+
+use async_trait::async_trait;
+
+use super::{EmbeddingError, EmbeddingProvider};
+
+/// Embedding provider that derives a stable hashed bag-of-words vector from text.
+pub struct DeterministicEmbeddingProvider {
+    dimension: u16,
+}
+
+impl DeterministicEmbeddingProvider {
+    #[must_use]
+    pub fn new(dimension: u16) -> Self {
+        Self { dimension }
+    }
+
+    /// Splits text into lowercase alphanumeric tokens.
+    fn tokenize(text: &str) -> impl Iterator<Item = String> + '_ {
+        text.split(|c: char| !c.is_alphanumeric())
+            .filter(|t| !t.is_empty())
+            .map(str::to_lowercase)
+    }
+
+    /// FNV-1a 64-bit hash — deterministic across runs and platforms, no seed state.
+    fn fnv1a(token: &str) -> u64 {
+        let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+        for byte in token.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        hash
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for DeterministicEmbeddingProvider {
+    fn name(&self) -> &'static str {
+        "deterministic"
+    }
+
+    fn dimension(&self) -> u16 {
+        self.dimension
+    }
+
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        let dim = self.dimension as usize;
+        let mut vec = vec![0.0f32; dim];
+
+        for token in Self::tokenize(text) {
+            let h = Self::fnv1a(&token);
+            // Bucket the term, and use a second hash bit to assign a sign so that
+            // distinct tokens colliding into the same bucket do not always add
+            // constructively — this spreads the signal across the space.
+            // `h % dim` is always < dim (<= u16::MAX), so it fits usize on every target.
+            let bucket = usize::try_from(h % dim as u64).unwrap_or(0);
+            let sign = if (h >> 63) & 1 == 0 { 1.0 } else { -1.0 };
+            vec[bucket] += sign;
+        }
+
+        // L2-normalize so cosine similarity is well-defined. Empty / token-less
+        // text yields a zero vector (the write-path hook skips empty text, and a
+        // zero query vector simply matches nothing rather than erroring).
+        let norm: f32 = vec.iter().map(|v| v * v).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for v in &mut vec {
+                *v /= norm;
+            }
+        }
+
+        Ok(vec)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cosine(a: &[f32], b: &[f32]) -> f32 {
+        a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+    }
+
+    #[tokio::test]
+    async fn same_text_same_vector() {
+        let p = DeterministicEmbeddingProvider::new(64);
+        let a = p.embed("wireless bluetooth headphones").await.unwrap();
+        let b = p.embed("wireless bluetooth headphones").await.unwrap();
+        assert_eq!(a, b, "deterministic provider must be reproducible");
+        assert_eq!(a.len(), 64);
+    }
+
+    #[tokio::test]
+    async fn normalized_unit_length() {
+        let p = DeterministicEmbeddingProvider::new(128);
+        let v = p.embed("some non empty text here").await.unwrap();
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-4, "expected unit norm, got {norm}");
+    }
+
+    #[tokio::test]
+    async fn shared_tokens_rank_above_disjoint() {
+        // A query is more similar to a doc sharing tokens than to one sharing none.
+        let p = DeterministicEmbeddingProvider::new(256);
+        let query = p.embed("wireless bluetooth headphones").await.unwrap();
+        let related = p
+            .embed("noise cancelling wireless headphones over ear")
+            .await
+            .unwrap();
+        let unrelated = p.embed("fresh organic banana fruit basket").await.unwrap();
+
+        let sim_related = cosine(&query, &related);
+        let sim_unrelated = cosine(&query, &unrelated);
+        assert!(
+            sim_related > sim_unrelated,
+            "shared-token doc ({sim_related}) should outrank disjoint doc ({sim_unrelated})"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_text_is_zero_vector() {
+        let p = DeterministicEmbeddingProvider::new(16);
+        let v = p.embed("").await.unwrap();
+        assert!(v.iter().all(|&x| x == 0.0));
+    }
+}

--- a/packages/server-rust/src/service/domain/embedding/deterministic.rs
+++ b/packages/server-rust/src/service/domain/embedding/deterministic.rs
@@ -65,7 +65,9 @@ impl EmbeddingProvider for DeterministicEmbeddingProvider {
         let dim = self.dimension as usize;
         let mut vec = vec![0.0f32; dim];
 
+        let mut token_count = 0usize;
         for token in Self::tokenize(text) {
+            token_count += 1;
             let h = Self::fnv1a(&token);
             // Bucket the term, and use a second hash bit to assign a sign so that
             // distinct tokens colliding into the same bucket do not always add
@@ -76,9 +78,19 @@ impl EmbeddingProvider for DeterministicEmbeddingProvider {
             vec[bucket] += sign;
         }
 
-        // L2-normalize so cosine similarity is well-defined. Empty / token-less
-        // text yields a zero vector (the write-path hook skips empty text, and a
-        // zero query vector simply matches nothing rather than erroring).
+        // Non-empty text that tokenizes to nothing (e.g. only punctuation) would
+        // otherwise produce a zero vector, which yields NaN cosine distances once
+        // indexed in HNSW. Fall back to hashing the raw text so the vector is
+        // always non-zero for non-empty input.
+        if token_count == 0 && !text.trim().is_empty() {
+            let h = Self::fnv1a(text.trim());
+            let bucket = usize::try_from(h % dim as u64).unwrap_or(0);
+            vec[bucket] = 1.0;
+        }
+
+        // L2-normalize so cosine similarity is well-defined. Genuinely empty text
+        // yields a zero vector (the write-path hook skips empty text, and a zero
+        // query vector simply matches nothing rather than erroring).
         let norm: f32 = vec.iter().map(|v| v * v).sum::<f32>().sqrt();
         if norm > 0.0 {
             for v in &mut vec {
@@ -143,5 +155,15 @@ mod tests {
         let p = DeterministicEmbeddingProvider::new(16);
         let v = p.embed("").await.unwrap();
         assert!(v.iter().all(|&x| x == 0.0));
+    }
+
+    #[tokio::test]
+    async fn punctuation_only_text_is_nonzero_unit_vector() {
+        // Non-empty but token-less text must not produce a zero vector (which would
+        // yield NaN cosine distances in the HNSW index).
+        let p = DeterministicEmbeddingProvider::new(16);
+        let v = p.embed("!!! ??? ...").await.unwrap();
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-4, "expected unit norm, got {norm}");
     }
 }

--- a/packages/server-rust/src/service/domain/embedding/hook.rs
+++ b/packages/server-rust/src/service/domain/embedding/hook.rs
@@ -346,8 +346,13 @@ async fn flush_batch(
             }
         };
 
-        // Serialize the embedding as a MsgPack binary blob (Vec<f32> via rmp_serde).
-        let embedding_bytes = match rmp_serde::to_vec_named(&embedding) {
+        // Serialize the embedding in the canonical `Vector` wire form
+        // (`{"type":"f32","data":<LE bytes>}`) so the vector index's
+        // `decode_vector_from_record` can read it back. A bare `Vec<f32>` would
+        // serialize as a plain MsgPack array and silently fail to decode as a
+        // `Vector`, leaving the HNSW index empty.
+        let embedding_vector = topgun_core::vector::Vector::F32(embedding);
+        let embedding_bytes = match rmp_serde::to_vec_named(&embedding_vector) {
             Ok(b) => b,
             Err(err) => {
                 tracing::warn!(
@@ -781,16 +786,20 @@ mod tests {
                 "record should have _embedding field after write-back; got keys: {:?}",
                 m.keys().collect::<Vec<_>>()
             );
-            // Verify the embedding field contains a binary blob (MsgPack-encoded Vec<f32>).
+            // Verify the embedding field contains the canonical `Vector` wire
+            // form so the vector index can decode it (not a bare Vec<f32>).
             if let Some(Value::Bytes(ref bytes)) = m.get("_embedding") {
-                let decoded: Vec<f32> = rmp_serde::from_slice(bytes).unwrap();
+                let decoded: topgun_core::vector::Vector = rmp_serde::from_slice(bytes).unwrap();
                 assert_eq!(
-                    decoded.len(),
+                    decoded.dimension(),
                     4,
                     "embedding should have 4 dimensions (noop provider)"
                 );
+                let topgun_core::vector::Vector::F32(ref floats) = decoded else {
+                    panic!("noop provider should produce an F32 vector");
+                };
                 assert!(
-                    decoded.iter().all(|&v| v == 0.0f32),
+                    floats.iter().all(|&v| v == 0.0f32),
                     "noop provider should return zero vectors"
                 );
             } else {

--- a/packages/server-rust/src/service/domain/embedding/mod.rs
+++ b/packages/server-rust/src/service/domain/embedding/mod.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use std::collections::HashMap;
 
+pub mod deterministic;
 pub mod hook;
 pub mod http;
 pub mod noop;
@@ -81,6 +82,7 @@ impl VectorConfig {
             EmbeddingProviderConfig::Ollama(c) => c.dimension,
             EmbeddingProviderConfig::Http(c) => c.dimension,
             EmbeddingProviderConfig::Noop(c) => c.dimension,
+            EmbeddingProviderConfig::Deterministic(c) => c.dimension,
         };
         for (map_name, map_cfg) in &self.maps {
             if map_cfg.dimension != provider_dim {
@@ -100,6 +102,9 @@ pub enum EmbeddingProviderConfig {
     Ollama(OllamaConfig),
     Http(HttpProviderConfig),
     Noop(NoopConfig),
+    /// Stable hashed bag-of-words embeddings for deterministic CI tests.
+    /// Not a real model — see [`deterministic::DeterministicEmbeddingProvider`].
+    Deterministic(DeterministicConfig),
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -125,6 +130,12 @@ pub struct HttpProviderConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NoopConfig {
+    pub dimension: u16,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeterministicConfig {
     pub dimension: u16,
 }
 

--- a/packages/server-rust/src/service/domain/embedding/mod.rs
+++ b/packages/server-rust/src/service/domain/embedding/mod.rs
@@ -117,7 +117,7 @@ pub struct OllamaConfig {
     pub dimension: u16,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HttpProviderConfig {
     pub base_url: String,
@@ -125,6 +125,19 @@ pub struct HttpProviderConfig {
     pub api_key: Option<String>,
     pub model: String,
     pub dimension: u16,
+}
+
+// Manual Debug that redacts `api_key` so a bearer token never reaches logs via
+// `{:?}` on the (Arc-shared) provider config.
+impl std::fmt::Debug for HttpProviderConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpProviderConfig")
+            .field("base_url", &self.base_url)
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .field("model", &self.model)
+            .field("dimension", &self.dimension)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/tests/integration-rust/vector-hybrid.test.ts
+++ b/tests/integration-rust/vector-hybrid.test.ts
@@ -1,0 +1,245 @@
+import {
+  createRustTestClient,
+  spawnRustServer,
+  createLWWRecord,
+  waitForSync,
+  waitUntil,
+} from './helpers';
+
+/**
+ * End-to-end vector + hybrid search against a real Rust server.
+ *
+ * This is the integration coverage that was missing while vector/hybrid were a
+ * dark feature (CAPABILITY_MATRIX F2 / TODO-464): vector=0, hybrid=0 tests.
+ *
+ * The server is spawned with a DETERMINISTIC embedding provider
+ * (TOPGUN_EMBEDDING_PROVIDER=deterministic) so the semantic path runs without
+ * an external embedding service while still producing meaningful, reproducible
+ * rankings — shared tokens yield higher cosine similarity. The `products` map is
+ * declared in TOPGUN_VECTOR_MAPS so writes are auto-embedded on the server.
+ */
+const EMBED_DIM = 64;
+const VECTOR_MAPS = JSON.stringify({
+  products: { fields: ['title', 'description'], dimension: EMBED_DIM },
+});
+
+const PRODUCTS = [
+  {
+    key: 'p1',
+    value: {
+      title: 'Wireless Bluetooth Headphones',
+      description: 'Over ear noise cancelling wireless bluetooth headphones for music',
+    },
+  },
+  {
+    key: 'p2',
+    value: {
+      title: 'Organic Banana Bunch',
+      description: 'Fresh organic bananas tropical fruit snack',
+    },
+  },
+  {
+    key: 'p3',
+    value: {
+      title: 'Wireless Gaming Mouse',
+      description: 'Ergonomic wireless mouse for gaming and office',
+    },
+  },
+];
+
+describe('Integration: Vector & Hybrid search (Rust Server)', () => {
+  describe('with a configured embedding provider', () => {
+    let cleanup: () => Promise<void>;
+    let port: number;
+
+    beforeAll(async () => {
+      const server = await spawnRustServer({
+        env: {
+          TOPGUN_EMBEDDING_PROVIDER: 'deterministic',
+          TOPGUN_EMBEDDING_DIMENSION: String(EMBED_DIM),
+          TOPGUN_VECTOR_MAPS: VECTOR_MAPS,
+        },
+      });
+      port = server.port;
+      cleanup = server.cleanup;
+    });
+
+    afterAll(async () => {
+      await cleanup();
+    });
+
+    /** Writes the product catalog and waits for server-side auto-embedding to index it. */
+    async function seedProducts(client: any): Promise<void> {
+      for (const p of PRODUCTS) {
+        client.messages.length = 0;
+        client.send({
+          type: 'CLIENT_OP',
+          payload: {
+            id: `vec-put-${p.key}`,
+            mapName: 'products',
+            opType: 'PUT',
+            key: p.key,
+            record: createLWWRecord(p.value),
+          },
+        });
+        await client.waitForMessage('OP_ACK');
+      }
+      // Auto-embed batch window (100ms) + write-back + index insert.
+      await waitForSync(600);
+    }
+
+    function hybridSearch(
+      client: any,
+      requestId: string,
+      methods: string[],
+      queryText: string,
+      extra: Record<string, unknown> = {},
+    ): void {
+      client.messages.length = 0;
+      client.send({
+        type: 'HYBRID_SEARCH',
+        payload: { requestId, mapName: 'products', queryText, methods, k: 10, ...extra },
+      });
+    }
+
+    test('semantic search returns auto-embedded results ranked by similarity', async () => {
+      const client = await createRustTestClient(port, {
+        nodeId: 'vec-sem-1',
+        userId: 'vec-sem-user',
+        roles: ['ADMIN'],
+      });
+      await client.waitForMessage('AUTH_ACK');
+      await seedProducts(client);
+
+      // Retry the query a few times: auto-embed is async, so the vector may not be
+      // indexed on the first attempt right after seeding.
+      let results: any[] = [];
+      await waitUntil(async () => {
+        hybridSearch(client, 'sem-req', ['semantic'], 'wireless headphones for listening to music');
+        const resp = await client.waitForMessage('HYBRID_SEARCH_RESP');
+        expect(resp.payload.error).toBeUndefined();
+        results = resp.payload.results;
+        return results.length > 0;
+      }, 8000);
+
+      const keys = results.map((r) => r.key);
+      expect(keys).toContain('p1'); // headphones — shares the most query tokens
+
+      // Every result must expose a semantic method score (proves the vector leg ran,
+      // not a silent fallback to another method).
+      for (const r of results) {
+        expect(typeof r.score).toBe('number');
+        expect(r.methodScores).toBeDefined();
+        expect(typeof r.methodScores.semantic).toBe('number');
+      }
+
+      // The headphones product must outrank the unrelated banana product.
+      const rank = (k: string) => keys.indexOf(k);
+      if (rank('p2') !== -1) {
+        expect(rank('p1')).toBeLessThan(rank('p2'));
+      }
+
+      client.close();
+    });
+
+    test('hybrid fullText + semantic fuses both method scores via RRF', async () => {
+      const client = await createRustTestClient(port, {
+        nodeId: 'vec-hyb-1',
+        userId: 'vec-hyb-user',
+        roles: ['ADMIN'],
+      });
+      await client.waitForMessage('AUTH_ACK');
+      await seedProducts(client);
+
+      let results: any[] = [];
+      await waitUntil(async () => {
+        hybridSearch(client, 'hyb-req', ['fullText', 'semantic'], 'wireless');
+        const resp = await client.waitForMessage('HYBRID_SEARCH_RESP');
+        expect(resp.payload.error).toBeUndefined();
+        results = resp.payload.results;
+        // Wait until at least one result has been scored by BOTH methods.
+        return results.some(
+          (r) =>
+            typeof r.methodScores?.fullText === 'number' &&
+            typeof r.methodScores?.semantic === 'number',
+        );
+      }, 8000);
+
+      const keys = results.map((r) => r.key);
+      // The two "wireless" products should surface.
+      expect(keys).toContain('p1');
+      expect(keys).toContain('p3');
+
+      const fused = results.find(
+        (r) =>
+          typeof r.methodScores?.fullText === 'number' &&
+          typeof r.methodScores?.semantic === 'number',
+      );
+      expect(fused).toBeDefined();
+      expect(fused.score).toBeGreaterThan(0);
+
+      client.close();
+    });
+  });
+
+  describe('honesty: without a configured embedding provider', () => {
+    let cleanup: () => Promise<void>;
+    let port: number;
+
+    beforeAll(async () => {
+      // No TOPGUN_EMBEDDING_PROVIDER -> semantic search is disabled. It must return
+      // an explicit error rather than silent empty/garbage results.
+      const server = await spawnRustServer();
+      port = server.port;
+      cleanup = server.cleanup;
+    });
+
+    afterAll(async () => {
+      await cleanup();
+    });
+
+    test('semantic search returns an explicit error, never silent fake results', async () => {
+      const client = await createRustTestClient(port, {
+        nodeId: 'vec-honesty-1',
+        userId: 'vec-honesty-user',
+        roles: ['ADMIN'],
+      });
+      await client.waitForMessage('AUTH_ACK');
+
+      client.messages.length = 0;
+      client.send({
+        type: 'CLIENT_OP',
+        payload: {
+          id: 'honesty-put',
+          mapName: 'unconfigured',
+          opType: 'PUT',
+          key: 'x1',
+          record: createLWWRecord({ title: 'Wireless Headphones' }),
+        },
+      });
+      await client.waitForMessage('OP_ACK');
+      await waitForSync(200);
+
+      client.messages.length = 0;
+      client.send({
+        type: 'HYBRID_SEARCH',
+        payload: {
+          requestId: 'honesty-req',
+          mapName: 'unconfigured',
+          queryText: 'wireless headphones',
+          methods: ['semantic'],
+          k: 5,
+        },
+      });
+
+      const resp = await client.waitForMessage('HYBRID_SEARCH_RESP');
+      expect(resp.payload.requestId).toBe('honesty-req');
+      // The contract: no silent fake results. An explicit error is surfaced and
+      // the result set is empty (not fabricated).
+      expect(resp.payload.error).toBeDefined();
+      expect(resp.payload.results).toHaveLength(0);
+
+      client.close();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Enables **vector / hybrid (semantic) search end-to-end** on the published server. It was a dark feature: the binary hardcoded a `Noop(dim 4)` embedding provider with an empty maps config and had no env switch, so `semantic` queries returned empty/garbage with no honest error (CAPABILITY_MATRIX **F2** / TODO-457).

While implementing, I verified the chain was broken in **two further places the ticket did not mention** — both would have kept the feature dark even after an env switch:

1. **No production path registered an `_embedding` HNSW vector index per map** → `first_vector_index_attribute()` was always `None` → semantic always empty.
2. **The auto-embed hook serialized a bare `Vec<f32>`**, but the vector-index extractor decodes `topgun_core::vector::Vector` (`{type,data}` form) → every auto-embedded vector was silently dropped.

Both are fixed here alongside the env wiring, so vector/hybrid genuinely works.

## Changes

- **Env-driven provider** in the binary: `TOPGUN_EMBEDDING_PROVIDER` (`ollama` | `openai`/`http` | `deterministic` | `noop`) + `_MODEL` / `_BASE_URL` / `_API_KEY` / `_DIMENSION`, and per-map `TOPGUN_VECTOR_MAPS`. Provider is wired into **both** the write-path embedding factory **and** the query-path `HybridSearchEngine` (was hardcoded `None`).
- **Register** an `_embedding` Cosine vector index for every configured map in the shared `IndexObserverFactory` registry (read by both write and query paths).
- **Hook format fix**: write `Vector::F32(embedding)` so the index can decode it.
- **Honesty**: no provider configured → query path `None` → `semantic` returns an explicit error, never silent empty/garbage. `noop` is an explicit WARN-logged dev mode, never a default. Malformed config aborts at startup with a descriptive message.
- **Startup `tracing::info!`** line reporting provider, dimension, and vectorized maps (mirrors the eviction/WAL config line).
- **`DeterministicEmbeddingProvider`** (stable hashed bag-of-words) for CI-stable semantic e2e without an external embedding service.
- **Integration tests** (`tests/integration-rust/vector-hybrid.test.ts`): semantic ranking, fullText+semantic RRF fusion, and the no-provider honesty error — all against a real Rust server. (Closes the vector/hybrid e2e gap; was 0 tests — TODO-464.)
- **Docs**: real env-var configuration in `vector-and-hybrid-search.mdx` + server reference; honesty caveat replaces the prior vague framing.
- **Cross-vendor review hardening** (second commit): reject `DIMENSION=0`; redact `api_key` in `HttpProviderConfig`'s `Debug`; deterministic provider never emits a zero vector for non-empty input (avoids NaN cosine in HNSW).

A pre-existing gap surfaced by the review — provider outage silently skips write-back (degraded semantic coverage without an operator signal) — is tracked as a follow-up, not folded into this enablement change.

## Verification

- `cargo test --release -p topgun-server --lib` — **1385 passed**
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `pnpm test:integration-rust` (excl. flaky cluster-routing) — **13 suites / 88 tests passed**, incl. the new vector-hybrid suite
- Load harness (50 conn / 10s) — **PASS** (9306 ops/sec, p99 8.9ms). Auto-embed only activates for configured maps, so default hot-path overhead is zero.
- `apps-docs-astro` build — clean (61 pages)

## Impact on other surfaces

MCP `topgun_search` semantic leg (DEPTH_MCP F6) and react `useVectorSearch`/`useHybridSearch` are no longer dark when an embedding provider is configured.
