### PR TITLE
G6 security hardening: admin scoping (F5), namespace glob (F6), iss/aud (F7), anon HLC re-stamp (F3)

### DIFF
--- a/packages/server-rust/benches/load_harness/main.rs
+++ b/packages/server-rust/benches/load_harness/main.rs
@@ -235,6 +235,7 @@ async fn main() {
                 store_factory: None,
                 server_config: None,
                 policy_store: None,
+                admin_subjects: Arc::new(std::collections::HashSet::new()),
                 auth_providers: Arc::new(vec![]),
                 refresh_grant_store: None,
                 auth_validator: None,

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -464,7 +464,33 @@ async fn main() -> anyhow::Result<()> {
         }
         StorageBackend::Null => Arc::new(InMemoryPolicyStore::new()),
     };
-    let policy_evaluator = Arc::new(PolicyEvaluator::new(Arc::clone(&policy_store)));
+    // Server-trusted admin-subject allow-list. Only subjects listed here receive
+    // the RBAC admin bypass; a `roles:["admin"]` JWT claim never does. This anchors
+    // privilege to operator configuration rather than to (possibly self-granted)
+    // token claims. Empty by default => no data-plane admin bypass.
+    let admin_subjects: Arc<std::collections::HashSet<String>> = Arc::new(
+        std::env::var("TOPGUN_ADMIN_SUBJECTS")
+            .ok()
+            .map(|v| {
+                v.split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default(),
+    );
+    if !admin_subjects.is_empty() {
+        tracing::info!(
+            count = admin_subjects.len(),
+            "RBAC admin bypass anchored to {} server-configured admin subject(s)",
+            admin_subjects.len()
+        );
+    }
+    let policy_evaluator = Arc::new(PolicyEvaluator::with_admin_subjects(
+        Arc::clone(&policy_store),
+        Arc::clone(&admin_subjects),
+    ));
 
     // Counts for the boot summary so operators can confirm RBAC survived restart.
     let policies_loaded: usize = policy_store
@@ -825,6 +851,15 @@ async fn main() -> anyhow::Result<()> {
         .map(|v| matches!(v.to_lowercase().as_str(), "true" | "1"))
         .unwrap_or(false);
 
+    // Optional request-path JWT issuer/audience enforcement (audit F7). Unset =>
+    // not checked (TopGun-minted tokens). Set these when jwt_secret is an IdP key.
+    let jwt_issuer = std::env::var("TOPGUN_JWT_ISSUER")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let jwt_audience = std::env::var("TOPGUN_JWT_AUDIENCE")
+        .ok()
+        .filter(|s| !s.is_empty());
+
     // Comma-separated list of allowed CORS origins. Empty (the default) rejects
     // all cross-origin browser requests, which is the safe default but means
     // browser SDKs hosted on a different origin than the server cannot connect
@@ -868,6 +903,8 @@ async fn main() -> anyhow::Result<()> {
         config: Arc::new(NetworkConfig {
             insecure_forward_auth_errors,
             cors_origins,
+            jwt_issuer,
+            jwt_audience,
             ..NetworkConfig::default()
         }),
         start_time: Instant::now(),
@@ -882,6 +919,7 @@ async fn main() -> anyhow::Result<()> {
             ..ServerConfig::default()
         }))),
         policy_store: Some(policy_store),
+        admin_subjects: Arc::clone(&admin_subjects),
         auth_providers: Arc::new(vec![]),
         refresh_grant_store: None,
         auth_validator: None,

--- a/packages/server-rust/src/network/config.rs
+++ b/packages/server-rust/src/network/config.rs
@@ -51,6 +51,18 @@ pub struct NetworkConfig {
     /// Defaults to `false` (production-safe: generic "Authentication failed" is returned).
     /// Set `INSECURE_FORWARD_AUTH_ERRORS=true` in the environment for development debugging.
     pub insecure_forward_auth_errors: bool,
+    /// Expected JWT `iss` (issuer) for request-path token validation. When `Some`,
+    /// the WS handshake and HTTP `/sync` extractor reject tokens whose `iss` does
+    /// not match. When `None` (default), issuer is not checked — correct for
+    /// TopGun-minted tokens. Set `TOPGUN_JWT_ISSUER` to enforce, which is required
+    /// when `jwt_secret` is pointed at a shared `IdP` key (otherwise that `IdP`'s
+    /// tokens for any audience are accepted — audit F7).
+    pub jwt_issuer: Option<String>,
+    /// Expected JWT `aud` (audience) for request-path token validation. When
+    /// `Some`, the WS handshake and HTTP `/sync` extractor reject tokens whose
+    /// `aud` does not match and require the claim to be present. When `None`
+    /// (default), audience is not checked. Set `TOPGUN_JWT_AUDIENCE` to enforce.
+    pub jwt_audience: Option<String>,
 }
 
 impl Default for NetworkConfig {
@@ -70,6 +82,8 @@ impl Default for NetworkConfig {
             rate_limit_burst: 50,
             auth_providers: vec![],
             insecure_forward_auth_errors: false,
+            jwt_issuer: None,
+            jwt_audience: None,
         }
     }
 }

--- a/packages/server-rust/src/network/handlers/auth.rs
+++ b/packages/server-rust/src/network/handlers/auth.rs
@@ -49,6 +49,36 @@ pub(crate) fn decode_jwt_key(secret: &str) -> Result<(Algorithm, DecodingKey), S
     }
 }
 
+/// Applies optional issuer/audience validation to a JWT `Validation`.
+///
+/// When `issuer`/`audience` are configured (operator sets `TOPGUN_JWT_ISSUER` /
+/// `TOPGUN_JWT_AUDIENCE`), the request path enforces them — closing the gap where
+/// a token minted by a different issuer or for a different audience was accepted
+/// whenever `jwt_secret` was pointed at a shared `IdP` key. When unset, the prior
+/// behavior (no `iss`/`aud` check) is preserved so TopGun-minted tokens keep
+/// working. `exp` enforcement (the default required claim) is untouched.
+pub(crate) fn apply_iss_aud_validation(
+    validation: &mut Validation,
+    issuer: Option<&str>,
+    audience: Option<&str>,
+) {
+    if let Some(aud) = audience {
+        validation.set_audience(&[aud]);
+        validation.validate_aud = true;
+        // Require the `aud` claim to be present: jsonwebtoken does not list `aud`
+        // in its default required-spec-claims, so a token with no audience would
+        // otherwise slip past an enforced-audience check. Keep `exp` required too.
+        validation.set_required_spec_claims(&["exp", "aud"]);
+    } else {
+        // No configured audience: keep audience validation off (TopGun tokens
+        // carry no `aud`). jsonwebtoken would otherwise reject a missing `aud`.
+        validation.validate_aud = false;
+    }
+    if let Some(iss) = issuer {
+        validation.set_issuer(&[iss]);
+    }
+}
+
 /// Errors that can occur during authentication.
 #[derive(Debug, thiserror::Error)]
 pub enum AuthError {
@@ -90,16 +120,37 @@ pub struct AuthHandler {
     /// Optional custom post-JWT-verification validator.
     /// `None` means accept all valid JWTs (default behavior).
     auth_validator: Option<Arc<dyn AuthValidator>>,
+    /// Expected JWT issuer; `None` disables issuer checking (default).
+    issuer: Option<String>,
+    /// Expected JWT audience; `None` disables audience checking (default).
+    audience: Option<String>,
 }
 
 impl AuthHandler {
     /// Create a new `AuthHandler` with the given JWT secret and optional validator.
+    /// Issuer/audience validation are disabled until set via
+    /// [`AuthHandler::with_issuer_audience`].
     #[must_use]
     pub fn new(jwt_secret: String, auth_validator: Option<Arc<dyn AuthValidator>>) -> Self {
         Self {
             jwt_secret,
             auth_validator,
+            issuer: None,
+            audience: None,
         }
+    }
+
+    /// Enables request-path issuer/audience validation (audit F7). Each is
+    /// independently optional; `None` leaves that check disabled.
+    #[must_use]
+    pub fn with_issuer_audience(
+        mut self,
+        issuer: Option<String>,
+        audience: Option<String>,
+    ) -> Self {
+        self.issuer = issuer;
+        self.audience = audience;
+        self
     }
 
     /// Send `AUTH_REQUIRED` message to the client.
@@ -154,10 +205,14 @@ impl AuthHandler {
         let (algorithm, key) = decode_jwt_key(&self.jwt_secret)
             .map_err(|reason| AuthError::InvalidToken { reason })?;
         let mut validation = Validation::new(algorithm);
-        // Disable audience/issuer checks since TopGun tokens do not use them.
-        // Do NOT clear required_spec_claims: the jsonwebtoken crate defaults to
-        // requiring `exp`, which enforces token expiry validation.
-        validation.validate_aud = false;
+        // Apply optional issuer/audience checks (off unless configured). Do NOT
+        // clear required_spec_claims: the jsonwebtoken crate defaults to requiring
+        // `exp`, which enforces token expiry validation.
+        apply_iss_aud_validation(
+            &mut validation,
+            self.issuer.as_deref(),
+            self.audience.as_deref(),
+        );
         validation.leeway = leeway;
 
         match jsonwebtoken::decode::<serde_json::Value>(&auth_msg.token, &key, &validation) {
@@ -622,6 +677,107 @@ RQIDAQAB
         } else {
             panic!("expected AuthFail message");
         }
+    }
+
+    // ── F7: request-path issuer/audience validation ──────────────────────────
+
+    /// Claims carrying optional `aud`/`iss` for iss/aud validation tests.
+    #[derive(Serialize)]
+    struct ClaimsAudIss {
+        sub: String,
+        exp: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        aud: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        iss: Option<String>,
+    }
+
+    fn make_token_aud_iss(sub: &str, aud: Option<&str>, iss: Option<&str>) -> String {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let claims = ClaimsAudIss {
+            sub: sub.to_owned(),
+            exp: now + 3600,
+            aud: aud.map(str::to_owned),
+            iss: iss.map(str::to_owned),
+        };
+        jsonwebtoken::encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(TEST_SECRET.as_bytes()),
+        )
+        .unwrap()
+    }
+
+    async fn run_auth(handler: &AuthHandler, token: String) -> Result<Principal, AuthError> {
+        let (tx, _rx) = mpsc::channel(8);
+        let auth_msg = AuthMessage {
+            token,
+            protocol_version: None,
+        };
+        handler.handle_auth(&auth_msg, &tx, 60, false).await
+    }
+
+    // Configured audience accepts a matching `aud`.
+    #[tokio::test]
+    async fn aud_configured_accepts_matching() {
+        let handler = AuthHandler::new(TEST_SECRET.to_owned(), None)
+            .with_issuer_audience(None, Some("topgun".to_string()));
+        let token = make_token_aud_iss("u1", Some("topgun"), None);
+        assert!(run_auth(&handler, token).await.is_ok());
+    }
+
+    // F7 core: configured audience rejects a token minted for a different audience.
+    #[tokio::test]
+    async fn aud_configured_rejects_wrong_audience() {
+        let handler = AuthHandler::new(TEST_SECRET.to_owned(), None)
+            .with_issuer_audience(None, Some("topgun".to_string()));
+        let token = make_token_aud_iss("u1", Some("some-other-app"), None);
+        assert!(
+            run_auth(&handler, token).await.is_err(),
+            "token for a different audience must be rejected when aud is enforced"
+        );
+    }
+
+    // F7: configured audience rejects a token with no `aud` claim at all.
+    #[tokio::test]
+    async fn aud_configured_rejects_missing_audience() {
+        let handler = AuthHandler::new(TEST_SECRET.to_owned(), None)
+            .with_issuer_audience(None, Some("topgun".to_string()));
+        let token = make_token_aud_iss("u1", None, None);
+        assert!(run_auth(&handler, token).await.is_err());
+    }
+
+    // F7: configured issuer rejects a token from a different issuer.
+    #[tokio::test]
+    async fn iss_configured_rejects_wrong_issuer() {
+        let handler = AuthHandler::new(TEST_SECRET.to_owned(), None)
+            .with_issuer_audience(Some("https://idp.example".to_string()), None);
+        let token = make_token_aud_iss("u1", None, Some("https://evil.example"));
+        assert!(
+            run_auth(&handler, token).await.is_err(),
+            "token from a different issuer must be rejected when iss is enforced"
+        );
+    }
+
+    #[tokio::test]
+    async fn iss_configured_accepts_matching_issuer() {
+        let handler = AuthHandler::new(TEST_SECRET.to_owned(), None)
+            .with_issuer_audience(Some("https://idp.example".to_string()), None);
+        let token = make_token_aud_iss("u1", None, Some("https://idp.example"));
+        assert!(run_auth(&handler, token).await.is_ok());
+    }
+
+    // F7 negative control / backward-compat: when neither iss nor aud is
+    // configured, a token carrying ANY audience is still accepted (TopGun-minted
+    // token model unchanged).
+    #[tokio::test]
+    async fn unconfigured_accepts_any_audience() {
+        let handler = AuthHandler::new(TEST_SECRET.to_owned(), None);
+        let token = make_token_aud_iss("u1", Some("whatever"), Some("whoever"));
+        assert!(run_auth(&handler, token).await.is_ok());
     }
 
     // normalize_pem replaces escaped backslash-n with real newlines.

--- a/packages/server-rust/src/network/handlers/auth.rs
+++ b/packages/server-rust/src/network/handlers/auth.rs
@@ -62,13 +62,16 @@ pub(crate) fn apply_iss_aud_validation(
     issuer: Option<&str>,
     audience: Option<&str>,
 ) {
+    // Build the required-spec-claims set so any enforced claim must be PRESENT,
+    // not merely consistent-if-present. jsonwebtoken lists only `exp` by default,
+    // so without this a token omitting `aud`/`iss` would slip past an enforced
+    // check. `exp` is always kept (token-expiry enforcement).
+    let mut required: Vec<&str> = vec!["exp"];
+
     if let Some(aud) = audience {
         validation.set_audience(&[aud]);
         validation.validate_aud = true;
-        // Require the `aud` claim to be present: jsonwebtoken does not list `aud`
-        // in its default required-spec-claims, so a token with no audience would
-        // otherwise slip past an enforced-audience check. Keep `exp` required too.
-        validation.set_required_spec_claims(&["exp", "aud"]);
+        required.push("aud");
     } else {
         // No configured audience: keep audience validation off (TopGun tokens
         // carry no `aud`). jsonwebtoken would otherwise reject a missing `aud`.
@@ -76,6 +79,11 @@ pub(crate) fn apply_iss_aud_validation(
     }
     if let Some(iss) = issuer {
         validation.set_issuer(&[iss]);
+        required.push("iss");
+    }
+
+    if required.len() > 1 {
+        validation.set_required_spec_claims(&required);
     }
 }
 
@@ -768,6 +776,16 @@ RQIDAQAB
             .with_issuer_audience(Some("https://idp.example".to_string()), None);
         let token = make_token_aud_iss("u1", None, Some("https://idp.example"));
         assert!(run_auth(&handler, token).await.is_ok());
+    }
+
+    // F7: configured issuer rejects a token with no `iss` claim (claim must be
+    // present when enforced — symmetric with the audience requirement).
+    #[tokio::test]
+    async fn iss_configured_rejects_missing_issuer() {
+        let handler = AuthHandler::new(TEST_SECRET.to_owned(), None)
+            .with_issuer_audience(Some("https://idp.example".to_string()), None);
+        let token = make_token_aud_iss("u1", None, None);
+        assert!(run_auth(&handler, token).await.is_err());
     }
 
     // F7 negative control / backward-compat: when neither iss nor aud is

--- a/packages/server-rust/src/network/handlers/http_sync.rs
+++ b/packages/server-rust/src/network/handlers/http_sync.rs
@@ -152,7 +152,13 @@ impl OptionalFromRequestParts<AppState> for ClientClaims {
             return Ok(None);
         };
         let mut validation = Validation::new(algorithm);
-        validation.validate_aud = false;
+        // Apply optional issuer/audience checks (off unless configured) so the
+        // HTTP request path enforces the same iss/aud as the WS handshake.
+        super::auth::apply_iss_aud_validation(
+            &mut validation,
+            state.config.jwt_issuer.as_deref(),
+            state.config.jwt_audience.as_deref(),
+        );
         validation.leeway = state.config.jwt_clock_skew_secs;
 
         // Decode into serde_json::Value to obtain raw_claims for AuthValidationContext.
@@ -367,15 +373,18 @@ async fn dispatch_queries(
     store_factory: &RecordStoreFactory,
     principal: Option<&topgun_core::Principal>,
     policy_store: Option<&Arc<dyn PolicyStore>>,
+    admin_subjects: &Arc<std::collections::HashSet<String>>,
     response: &mut HttpSyncResponse,
 ) {
     for q in queries {
         let map_name = q.map_name.clone();
 
-        // RBAC map-level read access check. Constructing PolicyEvaluator inline
-        // keeps all changes within this file (no AppState field changes needed).
+        // RBAC map-level read access check. The admin bypass is anchored to the
+        // server-trusted admin-subject allow-list (never to a roles claim), so the
+        // evaluator is built with the same allow-list the middleware uses.
         if let Some(store) = policy_store {
-            let evaluator = PolicyEvaluator::new(Arc::clone(store));
+            let evaluator =
+                PolicyEvaluator::with_admin_subjects(Arc::clone(store), Arc::clone(admin_subjects));
             // Single fail-closed gate shared with the authorization middleware.
             // AllowAll = never-configured store (allow the read for backward
             // compat); Evaluate = configured store, enforce policy (default-deny
@@ -679,6 +688,7 @@ pub async fn http_sync_handler(
                 store_factory,
                 principal.as_ref(),
                 state.policy_store.as_ref(),
+                &state.admin_subjects,
                 &mut http_response,
             )
             .await;
@@ -1117,6 +1127,7 @@ mod tests {
                 sf,
                 None,
                 state.policy_store.as_ref(),
+                &state.admin_subjects,
                 &mut response,
             )
             .await;

--- a/packages/server-rust/src/network/handlers/mod.rs
+++ b/packages/server-rust/src/network/handlers/mod.rs
@@ -104,6 +104,11 @@ pub struct AppState {
     /// Policy store for permission policy CRUD and evaluation.
     /// `None` when policy engine is not configured.
     pub policy_store: Option<Arc<dyn PolicyStore>>,
+    /// Subjects (`Principal.id`) granted the RBAC admin bypass, sourced only from
+    /// server-trusted configuration (`TOPGUN_ADMIN_SUBJECTS`). Used to build the
+    /// HTTP read-path `PolicyEvaluator` so a `roles:["admin"]` claim cannot grant
+    /// the bypass — privilege is anchored to this allow-list. Empty by default.
+    pub admin_subjects: Arc<std::collections::HashSet<String>>,
     /// External auth providers for token exchange at POST /api/auth/token.
     /// Empty when token exchange is not configured (endpoint returns 404).
     pub auth_providers: Arc<Vec<Arc<dyn AuthProvider>>>,
@@ -190,6 +195,7 @@ impl AppState {
             store_factory: None,
             server_config: None,
             policy_store: None,
+            admin_subjects: Arc::new(std::collections::HashSet::new()),
             // Empty slice because tests that need auth providers supply them
             // explicitly via struct-update syntax.
             auth_providers: Arc::new(vec![]),

--- a/packages/server-rust/src/network/handlers/token_exchange.rs
+++ b/packages/server-rust/src/network/handlers/token_exchange.rs
@@ -141,9 +141,32 @@ pub async fn token_exchange_handler(
                     .as_secs();
                 let exp = now + 3600;
 
+                // Strip server-reserved privileged roles from the external claims
+                // before minting. An external provider's roles are attacker-
+                // influenced (a deployment may map a user-settable IdP profile
+                // field to its roles claim), so copying a reserved role like
+                // "admin" verbatim would let a user self-grant a privileged role
+                // that could satisfy a policy condition referencing $auth.roles.
+                // The RBAC admin bypass itself is already server-anchored to an
+                // allow-list of subjects, never roles; stripping here is
+                // defense-in-depth at the untrusted mint boundary.
+                let mut roles = external_claims.roles;
+                let before = roles.len();
+                roles.retain(|r| {
+                    !crate::service::policy::RESERVED_PRIVILEGED_ROLES.contains(&r.as_str())
+                });
+                if roles.len() != before {
+                    tracing::warn!(
+                        sub = %external_claims.sub,
+                        provider = provider.name(),
+                        "stripped reserved privileged role(s) from exchanged external token; \
+                         reserved roles cannot be self-granted via token exchange"
+                    );
+                }
+
                 let claims = ExchangeJwtClaims {
                     sub: external_claims.sub,
-                    roles: external_claims.roles,
+                    roles,
                     exp,
                     iat: now,
                 };
@@ -358,6 +381,50 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert!(body["token"].as_str().is_some());
         assert!(body["expiresAt"].as_u64().is_some());
+    }
+
+    /// F5 negative control: a reserved privileged role ("admin") present in the
+    /// external provider's claims must be stripped from the minted `TopGun` token,
+    /// so a user cannot self-grant admin via token exchange. A non-reserved role
+    /// is preserved.
+    #[tokio::test]
+    async fn reserved_admin_role_is_stripped_from_minted_token() {
+        use jsonwebtoken::{DecodingKey, Validation};
+
+        const SECRET: &str = "exchange-secret";
+        let provider: Arc<dyn AuthProvider> = Arc::new(AlwaysSucceed {
+            name: "idp".to_string(),
+            sub: "attacker".to_string(),
+            roles: vec!["admin".to_string(), "editor".to_string()],
+        });
+        let app = make_app(make_state(vec![provider], Some(SECRET)));
+        let (status, body) = post_exchange(app, json!({ "token": "any" })).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let minted = body["token"].as_str().expect("minted token present");
+        let mut validation = Validation::default(); // HS256
+        validation.validate_aud = false;
+        let decoded = jsonwebtoken::decode::<Value>(
+            minted,
+            &DecodingKey::from_secret(SECRET.as_bytes()),
+            &validation,
+        )
+        .expect("minted token must verify with the signing secret");
+
+        let roles: Vec<String> = decoded.claims["roles"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            !roles.contains(&"admin".to_string()),
+            "reserved admin role must be stripped, got {roles:?}"
+        );
+        assert!(
+            roles.contains(&"editor".to_string()),
+            "non-reserved roles must be preserved, got {roles:?}"
+        );
     }
 
     #[tokio::test]

--- a/packages/server-rust/src/network/handlers/token_exchange.rs
+++ b/packages/server-rust/src/network/handlers/token_exchange.rs
@@ -152,8 +152,13 @@ pub async fn token_exchange_handler(
                 // defense-in-depth at the untrusted mint boundary.
                 let mut roles = external_claims.roles;
                 let before = roles.len();
+                // Case-insensitive: an IdP returning "Admin"/"ADMIN" must be
+                // stripped too, so a self-granted role cannot satisfy a policy
+                // condition that compares roles case-insensitively.
                 roles.retain(|r| {
-                    !crate::service::policy::RESERVED_PRIVILEGED_ROLES.contains(&r.as_str())
+                    !crate::service::policy::RESERVED_PRIVILEGED_ROLES
+                        .iter()
+                        .any(|reserved| r.eq_ignore_ascii_case(reserved))
                 });
                 if roles.len() != before {
                     tracing::warn!(
@@ -425,6 +430,48 @@ mod tests {
             roles.contains(&"editor".to_string()),
             "non-reserved roles must be preserved, got {roles:?}"
         );
+    }
+
+    /// F5 hardening: reserved-role stripping is case-insensitive, so a
+    /// mixed-case "Admin" claim is also removed.
+    #[tokio::test]
+    async fn reserved_admin_role_strip_is_case_insensitive() {
+        use jsonwebtoken::{DecodingKey, Validation};
+
+        const SECRET: &str = "exchange-secret";
+        let provider: Arc<dyn AuthProvider> = Arc::new(AlwaysSucceed {
+            name: "idp".to_string(),
+            sub: "attacker".to_string(),
+            roles: vec![
+                "Admin".to_string(),
+                "ADMIN".to_string(),
+                "viewer".to_string(),
+            ],
+        });
+        let app = make_app(make_state(vec![provider], Some(SECRET)));
+        let (status, body) = post_exchange(app, json!({ "token": "any" })).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let minted = body["token"].as_str().unwrap();
+        let mut validation = Validation::default();
+        validation.validate_aud = false;
+        let decoded = jsonwebtoken::decode::<Value>(
+            minted,
+            &DecodingKey::from_secret(SECRET.as_bytes()),
+            &validation,
+        )
+        .unwrap();
+        let roles: Vec<String> = decoded.claims["roles"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_lowercase())
+            .collect();
+        assert!(
+            !roles.iter().any(|r| r == "admin"),
+            "any case of admin must be stripped, got {roles:?}"
+        );
+        assert!(roles.contains(&"viewer".to_string()));
     }
 
     #[tokio::test]

--- a/packages/server-rust/src/network/handlers/websocket.rs
+++ b/packages/server-rust/src/network/handlers/websocket.rs
@@ -170,7 +170,11 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                     if let TopGunMessage::Auth(ref auth_msg) = tg_msg {
                         if let Some(ref secret) = state.jwt_secret {
                             let auth_handler =
-                                AuthHandler::new(secret.clone(), state.auth_validator.clone());
+                                AuthHandler::new(secret.clone(), state.auth_validator.clone())
+                                    .with_issuer_audience(
+                                        state.config.jwt_issuer.clone(),
+                                        state.config.jwt_audience.clone(),
+                                    );
                             match auth_handler
                                 .handle_auth(
                                     auth_msg,

--- a/packages/server-rust/src/network/module.rs
+++ b/packages/server-rust/src/network/module.rs
@@ -755,6 +755,21 @@ fn build_app(
     // without requiring secret injection through application code paths.
     let jwt_secret = std::env::var("JWT_SECRET").ok().filter(|s| !s.is_empty());
 
+    // Server-trusted admin-subject allow-list for the RBAC admin bypass (see
+    // PolicyEvaluator). Anchors privilege to operator config, never to JWT roles.
+    let admin_subjects: Arc<std::collections::HashSet<String>> = Arc::new(
+        std::env::var("TOPGUN_ADMIN_SUBJECTS")
+            .ok()
+            .map(|v| {
+                v.split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default(),
+    );
+
     // Refuse to start when auth is required but no secret is configured.
     // Only enforced when server_config is Some (production paths). Unit tests
     // and the load harness construct AppState directly with server_config: None
@@ -846,6 +861,7 @@ fn build_app(
         store_factory,
         server_config,
         policy_store,
+        admin_subjects,
         auth_providers: Arc::new(auth_providers),
         refresh_grant_store: None,
         auth_validator: None,

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -198,7 +198,21 @@ impl CrdtService {
                 .admit_write(ctx, &metadata_snapshot, &op.map_name, value_size)?;
             self.validate_schema_for_op(op)?;
             Some(self.write_validator.sanitize_hlc())
+        } else if ctx.caller_origin == CallerOrigin::Anonymous {
+            // Anonymous HTTP /sync write (no connection_id, no JWT identity).
+            // Auth admission for this path is enforced at the HTTP handler
+            // (require_auth / enforce_auth) BEFORE dispatch, so admit_write is not
+            // re-run here — it would unconditionally reject Anonymous and break the
+            // no-auth dev/demo tier. The HLC, however, is still client-supplied and
+            // MUST be re-stamped: otherwise a forged millis:u64::MAX wins
+            // Last-Write-Wins forever and survives a later auth upgrade. HLC
+            // re-stamp is an integrity control gated on transport (client/http),
+            // not on auth state.
+            self.validate_schema_for_op(op)?;
+            Some(self.write_validator.sanitize_hlc())
         } else {
+            // Genuine internal/system/forwarded call (trusted origin) — preserve
+            // the caller's HLC so cross-node convergence is not perturbed.
             None
         };
 
@@ -329,8 +343,38 @@ impl CrdtService {
                     last_id = id.clone();
                 }
             }
+        } else if ctx.caller_origin == CallerOrigin::Anonymous {
+            // Anonymous HTTP /sync batch (no connection_id, no JWT identity). Auth
+            // admission is enforced at the HTTP handler before dispatch, so
+            // admit_write is not re-run here (it would reject Anonymous and break
+            // the no-auth tier). Every op's client-supplied HLC is still re-stamped
+            // so a forged timestamp cannot win Last-Write-Wins — integrity gated on
+            // transport, not auth.
+            for op in ops {
+                self.validate_schema_for_op(op)?;
+            }
+            for op in ops {
+                let sanitized_ts = self.write_validator.sanitize_hlc();
+                let partition_id = hash_to_partition(&op.key);
+                let old_rmpv_value = self
+                    .read_old_value_for_queries(&op.map_name, &op.key, partition_id)
+                    .await;
+                let event_payload = self
+                    .apply_single_op(op, partition_id, Some(&sanitized_ts))
+                    .await?;
+                self.broadcast_event(&event_payload, ctx.connection_id)?;
+                self.broadcast_query_updates(
+                    &event_payload,
+                    old_rmpv_value.as_ref(),
+                    ctx.connection_id,
+                );
+                if let Some(id) = &op.id {
+                    last_id = id.clone();
+                }
+            }
         } else {
-            // Internal/system call (no connection_id) — skip validation.
+            // Genuine internal/system/forwarded call (trusted origin) — preserve
+            // the caller's HLC so cross-node convergence is not perturbed.
             for op in ops {
                 let partition_id = hash_to_partition(&op.key);
                 // Read old value before mutation for query broadcast filtering.
@@ -3316,5 +3360,213 @@ mod tests {
             vec!["drop-b"],
             "the removed tag must be tombstoned verbatim (no sanitization)"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Anonymous HTTP /sync HLC re-stamp (audit F3 / TODO-485).
+    //
+    // Under the default no-auth posture, an anonymous HTTP write reaches the
+    // CRDT service with caller_origin = Anonymous, connection_id = None, and no
+    // principal. Before the fix this landed in the trusted "internal/system"
+    // branch and the client HLC was stored verbatim — a forged millis:u64::MAX
+    // would win Last-Write-Wins forever. The anonymous arm must re-stamp the HLC
+    // exactly like the authenticated HttpClient arm, while genuine internal
+    // (System/Forwarded) origins must still preserve their timestamp.
+    // -----------------------------------------------------------------------
+
+    /// Builds an anonymous-HTTP-origin context (caller_origin = Anonymous,
+    /// connection_id = None, no principal) routed to the key's hash partition.
+    fn make_anon_http_ctx_for_key(key: &str) -> OperationContext {
+        let mut ctx = OperationContext::new(1, service_names::CRDT, make_timestamp(), 5000);
+        ctx.caller_origin = CallerOrigin::Anonymous;
+        ctx.connection_id = None;
+        ctx.principal = None;
+        ctx.partition_id = Some(hash_to_partition(key));
+        ctx
+    }
+
+    // F3: anonymous HTTP LWW PUT with a forged timestamp is re-stamped in both the
+    // stored record and the broadcast event — closing the no-auth LWW-poison hole.
+    #[tokio::test]
+    async fn anon_http_lww_put_restamps_forged_timestamp() {
+        let factory = make_factory();
+        let conn_registry = Arc::new(ConnectionRegistry::new());
+        let query_registry = Arc::new(QueryRegistry::new());
+        let svc = Arc::new(CrdtService::new(
+            Arc::clone(&factory),
+            Arc::clone(&conn_registry),
+            make_validator(),
+            Arc::clone(&query_registry),
+            Arc::new(SchemaService::new()),
+        ));
+
+        let key = "anon-1";
+        let mut listener = subscribe_listener(&conn_registry, &query_registry, "users");
+
+        let record = topgun_core::LWWRecord {
+            value: Some(rmpv::Value::String("Mallory".into())),
+            timestamp: forged_timestamp(),
+            ttl_ms: None,
+        };
+        let op = Operation::ClientOp {
+            ctx: make_anon_http_ctx_for_key(key),
+            payload: topgun_core::messages::ClientOpMessage {
+                payload: topgun_core::messages::base::ClientOp {
+                    id: Some("anon-put".to_string()),
+                    map_name: "users".to_string(),
+                    key: key.to_string(),
+                    op_type: None,
+                    record: Some(Some(record)),
+                    or_record: None,
+                    or_tag: None,
+                    write_concern: None,
+                    timeout: None,
+                },
+            },
+        };
+
+        svc.clone().oneshot(op).await.unwrap();
+
+        let stored = read_lww_timestamp(&factory, "users", key)
+            .await
+            .expect("LWW record must be stored");
+        assert_eq!(
+            stored.node_id, SERVER_NODE_ID,
+            "stored timestamp must carry the server node_id, not the forged one"
+        );
+        assert_ne!(
+            stored.millis, FORGED_MILLIS,
+            "anonymous HTTP write must NOT keep the forged u64::MAX millis"
+        );
+
+        let events = drain_server_events(&mut listener);
+        let put_event = events
+            .iter()
+            .find(|e| e.event_type == ServerEventType::PUT)
+            .expect("a PUT ServerEvent must be broadcast");
+        let broadcast_ts = &put_event
+            .record
+            .as_ref()
+            .expect("PUT event must carry the record")
+            .timestamp;
+        assert_ne!(
+            broadcast_ts.millis, FORGED_MILLIS,
+            "broadcast timestamp must NOT keep the forged millis"
+        );
+    }
+
+    // F3: same protection on the batch path (anonymous OpBatch re-stamps each op).
+    #[tokio::test]
+    async fn anon_http_op_batch_restamps_forged_timestamp() {
+        let factory = make_factory();
+        let conn_registry = Arc::new(ConnectionRegistry::new());
+        let query_registry = Arc::new(QueryRegistry::new());
+        let svc = Arc::new(CrdtService::new(
+            Arc::clone(&factory),
+            Arc::clone(&conn_registry),
+            make_validator(),
+            Arc::clone(&query_registry),
+            Arc::new(SchemaService::new()),
+        ));
+
+        let key = "anon-batch-1";
+        let record = topgun_core::LWWRecord {
+            value: Some(rmpv::Value::String("Trudy".into())),
+            timestamp: forged_timestamp(),
+            ttl_ms: None,
+        };
+        let mut ctx = make_anon_http_ctx_for_key(key);
+        // OpBatch ctx carries no single partition_id (keys span partitions).
+        ctx.partition_id = None;
+        let op = Operation::OpBatch {
+            ctx,
+            payload: topgun_core::messages::sync::OpBatchMessage {
+                payload: topgun_core::messages::sync::OpBatchPayload {
+                    ops: vec![topgun_core::messages::base::ClientOp {
+                        id: Some("anon-batch-put".to_string()),
+                        map_name: "users".to_string(),
+                        key: key.to_string(),
+                        op_type: None,
+                        record: Some(Some(record)),
+                        or_record: None,
+                        or_tag: None,
+                        write_concern: None,
+                        timeout: None,
+                    }],
+                    write_concern: None,
+                    timeout: None,
+                },
+            },
+        };
+
+        svc.clone().oneshot(op).await.unwrap();
+
+        let stored = read_lww_timestamp(&factory, "users", key)
+            .await
+            .expect("LWW record must be stored");
+        assert_ne!(
+            stored.millis, FORGED_MILLIS,
+            "anonymous batch write must NOT keep the forged u64::MAX millis"
+        );
+        assert_eq!(stored.node_id, SERVER_NODE_ID);
+    }
+
+    // F3 negative control: a GENUINE internal/system origin (System) still has its
+    // client-supplied timestamp preserved verbatim — the re-stamp is gated on the
+    // untrusted client/http transports, not on every connection-less call. This
+    // guards the cross-node convergence path that broke in earlier re-stamp work.
+    #[tokio::test]
+    async fn internal_system_origin_preserves_timestamp() {
+        let factory = make_factory();
+        let conn_registry = Arc::new(ConnectionRegistry::new());
+        let query_registry = Arc::new(QueryRegistry::new());
+        let svc = Arc::new(CrdtService::new(
+            Arc::clone(&factory),
+            Arc::clone(&conn_registry),
+            make_validator(),
+            Arc::clone(&query_registry),
+            Arc::new(SchemaService::new()),
+        ));
+
+        let key = "system-1";
+        let mut ctx = OperationContext::new(1, service_names::CRDT, make_timestamp(), 5000);
+        ctx.caller_origin = CallerOrigin::System;
+        ctx.connection_id = None;
+        ctx.principal = None;
+        ctx.partition_id = Some(hash_to_partition(key));
+
+        let record = topgun_core::LWWRecord {
+            value: Some(rmpv::Value::String("from-peer".into())),
+            timestamp: forged_timestamp(),
+            ttl_ms: None,
+        };
+        let op = Operation::ClientOp {
+            ctx,
+            payload: topgun_core::messages::ClientOpMessage {
+                payload: topgun_core::messages::base::ClientOp {
+                    id: Some("system-put".to_string()),
+                    map_name: "users".to_string(),
+                    key: key.to_string(),
+                    op_type: None,
+                    record: Some(Some(record)),
+                    or_record: None,
+                    or_tag: None,
+                    write_concern: None,
+                    timeout: None,
+                },
+            },
+        };
+
+        svc.clone().oneshot(op).await.unwrap();
+
+        let stored = read_lww_timestamp(&factory, "users", key)
+            .await
+            .expect("LWW record must be stored");
+        assert_eq!(
+            stored.millis, FORGED_MILLIS,
+            "genuine internal/system origin must preserve the caller-supplied HLC \
+             (convergence path), not re-stamp it"
+        );
+        assert_eq!(stored.node_id, FORGED_NODE_ID);
     }
 }

--- a/packages/server-rust/src/service/policy/mod.rs
+++ b/packages/server-rust/src/service/policy/mod.rs
@@ -4,6 +4,7 @@
 //! read/write/remove access per map, with optional predicate conditions
 //! evaluated against auth context and record data.
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -19,6 +20,20 @@ pub mod durable;
 pub mod expr_parser;
 
 pub use durable::DurablePolicyStore;
+
+/// Role name with a hardcoded privileged meaning in the policy engine.
+///
+/// A principal is only granted the RBAC admin bypass when its subject is on the
+/// server-configured admin allow-list (see [`PolicyEvaluator`]) — never by
+/// carrying this role in a JWT claim. The string is still reserved so that
+/// untrusted mint paths (token exchange) strip it before signing, preventing a
+/// self-granted `admin` role from satisfying a policy condition that references
+/// `$auth.roles`.
+pub const RESERVED_ADMIN_ROLE: &str = "admin";
+
+/// Roles that an external/untrusted token must never be able to inject. Stripped
+/// at every mint boundary that copies attacker-influenced claims (token exchange).
+pub const RESERVED_PRIVILEGED_ROLES: &[&str] = &[RESERVED_ADMIN_ROLE];
 
 // ---------------------------------------------------------------------------
 // Permission types
@@ -137,11 +152,19 @@ pub trait PolicyStore: Send + Sync {
 
 /// Matches a glob pattern against an input string using dot-separated segments.
 ///
-/// A lone `"*"` pattern matches any input. Otherwise each dot-separated
-/// segment must match exactly or be `"*"` (matching exactly one segment).
-/// Segment count must be equal for non-lone-star patterns.
+/// Segment semantics:
+/// - A lone `"*"` matches any input (historical "match everything" behavior).
+/// - `"*"` as a segment matches exactly one segment (`users.*` ⇒ `users.profiles`
+///   but not `users` or `users.a.b`).
+/// - `"**"` matches zero or more segments (recursive namespace lock). A trailing
+///   `"**"` therefore locks an entire namespace: `users.**` matches `users`,
+///   `users.profiles`, and `users.a.b.c`. This is the namespace-isolation form an
+///   operator reaches for; single-segment `*` does NOT lock nested keys, so a deny
+///   on `users.*` alone could be dodged by choosing a shallower/deeper map name.
+/// - Any other segment matches literally.
 fn glob_matches(pattern: &str, input: &str) -> bool {
-    // A lone "*" matches everything.
+    // A lone "*" matches everything (equivalent to "**"), kept as a fast path and
+    // for backward compatibility with existing allow/deny-all policies.
     if pattern == "*" {
         return true;
     }
@@ -149,14 +172,32 @@ fn glob_matches(pattern: &str, input: &str) -> bool {
     let pat_segs: Vec<&str> = pattern.split('.').collect();
     let inp_segs: Vec<&str> = input.split('.').collect();
 
-    if pat_segs.len() != inp_segs.len() {
-        return false;
-    }
+    glob_match_segments(&pat_segs, &inp_segs)
+}
 
-    pat_segs
-        .iter()
-        .zip(inp_segs.iter())
-        .all(|(p, i)| *p == "*" || p == i)
+/// Recursive segment matcher backing [`glob_matches`].
+///
+/// `**` matches zero or more input segments; `*` matches exactly one; every other
+/// pattern segment must equal the corresponding input segment.
+fn glob_match_segments(pat: &[&str], inp: &[&str]) -> bool {
+    match pat.first() {
+        // Pattern exhausted: match iff input is also exhausted.
+        None => inp.is_empty(),
+        Some(&"**") => {
+            // Try consuming 0, 1, 2, ... input segments against the remaining
+            // pattern. Zero-consumption first so `users.**` matches `users`.
+            for skip in 0..=inp.len() {
+                if glob_match_segments(&pat[1..], &inp[skip..]) {
+                    return true;
+                }
+            }
+            false
+        }
+        // `*` consumes exactly one input segment.
+        Some(&"*") => !inp.is_empty() && glob_match_segments(&pat[1..], &inp[1..]),
+        // Literal segment must match exactly.
+        Some(seg) => !inp.is_empty() && *seg == inp[0] && glob_match_segments(&pat[1..], &inp[1..]),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -236,17 +277,47 @@ impl PolicyStore for InMemoryPolicyStore {
 /// Evaluates permission policies for a given principal, action, and map.
 ///
 /// Uses deny-wins semantics: if any matching policy denies, the result is
-/// `Deny` regardless of allow policies. Principals with role "admin" bypass
-/// all policy checks.
+/// `Deny` regardless of allow policies.
+///
+/// The admin RBAC bypass is **server-anchored**: a principal bypasses policy
+/// checks only when its subject (`Principal.id`) is on the `admin_subjects`
+/// allow-list, which is sourced exclusively from server-trusted configuration
+/// (e.g. `TOPGUN_ADMIN_SUBJECTS`). A `roles: ["admin"]` claim in a JWT — whether
+/// minted by an app, copied from an external `IdP` via token exchange, or issued by
+/// the operator console — does **not** grant the bypass. This closes the
+/// transitive-trust / self-grant footgun where a user-controllable `IdP` field
+/// mapped to a roles claim could escalate to full RBAC bypass.
 pub struct PolicyEvaluator {
     store: Arc<dyn PolicyStore>,
+    /// Subjects (`Principal.id`) granted the unconditional RBAC bypass. Sourced
+    /// only from server-trusted config; empty by default (no data-plane admin).
+    admin_subjects: Arc<HashSet<String>>,
 }
 
 impl PolicyEvaluator {
-    /// Creates a new evaluator backed by the given policy store.
+    /// Creates a new evaluator backed by the given policy store with no admin
+    /// subjects configured (no principal receives the RBAC bypass).
     #[must_use]
     pub fn new(store: Arc<dyn PolicyStore>) -> Self {
-        Self { store }
+        Self {
+            store,
+            admin_subjects: Arc::new(HashSet::new()),
+        }
+    }
+
+    /// Creates an evaluator with a server-trusted admin-subject allow-list.
+    ///
+    /// Only subjects in `admin_subjects` receive the RBAC admin bypass; the set
+    /// must come from server configuration, never from token claims.
+    #[must_use]
+    pub fn with_admin_subjects(
+        store: Arc<dyn PolicyStore>,
+        admin_subjects: Arc<HashSet<String>>,
+    ) -> Self {
+        Self {
+            store,
+            admin_subjects,
+        }
     }
 
     /// Returns true if the store contains at least one policy.
@@ -300,9 +371,12 @@ impl PolicyEvaluator {
     ) -> PolicyDecision {
         use crate::service::domain::predicate::{evaluate_predicate, EvalContext};
 
-        // Admin principals bypass all policy checks.
+        // Admin bypass is server-anchored: only subjects on the configured
+        // allow-list bypass policy checks. A `roles: ["admin"]` JWT claim is
+        // deliberately NOT sufficient — privilege must originate from server
+        // configuration, not from a (possibly self-granted) token claim.
         if let Some(p) = principal {
-            if p.roles.iter().any(|r| r == "admin") {
+            if self.admin_subjects.contains(&p.id) {
                 return PolicyDecision::Allow;
             }
         }
@@ -402,6 +476,45 @@ mod tests {
         assert!(!glob_matches("users.*.settings", "users.settings"));
     }
 
+    // F6: recursive `**` locks an entire namespace — covers the base segment and
+    // any depth beneath it. This is the namespace-isolation form single-segment
+    // `*` could not express.
+    #[test]
+    fn glob_double_star_locks_namespace() {
+        assert!(glob_matches("users.**", "users")); // base segment
+        assert!(glob_matches("users.**", "users.profiles")); // one deeper
+        assert!(glob_matches("users.**", "users.a.b.c")); // arbitrarily deep
+                                                          // Does not leak into a sibling namespace.
+        assert!(!glob_matches("users.**", "posts"));
+        assert!(!glob_matches("users.**", "usersX.a"));
+    }
+
+    // F6 negative control (crafted-key bypass): with the OLD single-segment glob,
+    // a deny on `users.*` could be dodged by choosing a map name at a different
+    // depth (`users`, `users.a.b`). A `users.**` deny must catch every such
+    // crafted name so the namespace lock cannot be escaped.
+    #[test]
+    fn glob_double_star_blocks_crafted_key_bypass() {
+        for crafted in [
+            "users",
+            "users.public",
+            "users.private.secret",
+            "users.a.b.c.d",
+        ] {
+            assert!(
+                glob_matches("users.**", crafted),
+                "namespace lock users.** must match crafted name {crafted}"
+            );
+        }
+    }
+
+    // F6: `**` alone matches everything (recursive equivalent of lone `*`).
+    #[test]
+    fn glob_double_star_alone_matches_all() {
+        assert!(glob_matches("**", "users"));
+        assert!(glob_matches("**", "a.b.c.d"));
+    }
+
     // -- InMemoryPolicyStore --
 
     #[tokio::test]
@@ -498,12 +611,18 @@ mod tests {
         }
     }
 
+    fn admin_subjects(subs: &[&str]) -> Arc<HashSet<String>> {
+        Arc::new(subs.iter().map(|s| (*s).to_string()).collect())
+    }
+
+    // A subject on the server-trusted allow-list bypasses all policy checks,
+    // even with no matching policies (which would otherwise default-deny).
     #[tokio::test]
-    async fn admin_always_allowed() {
+    async fn allow_listed_subject_bypasses_policies() {
         let store = make_store_with(vec![]);
-        let eval = PolicyEvaluator::new(store);
+        let eval = PolicyEvaluator::with_admin_subjects(store, admin_subjects(&["admin1"]));
         let data = rmpv::Value::Nil;
-        let principal = admin_principal();
+        let principal = admin_principal(); // id == "admin1"
         let decision = eval
             .evaluate(
                 Some(&principal),
@@ -513,6 +632,49 @@ mod tests {
             )
             .await;
         assert_eq!(decision, PolicyDecision::Allow);
+    }
+
+    // F5 negative control / regression: a principal carrying `roles: ["admin"]`
+    // whose subject is NOT on the server allow-list must NOT receive the bypass.
+    // This is the self-grant vector (token-exchange / app-minted claims) — it
+    // must default-deny, not escalate.
+    #[tokio::test]
+    async fn admin_role_claim_alone_does_not_bypass() {
+        // Empty allow-list: even via `new` (no admin subjects), an admin-role
+        // claim cannot escalate.
+        let store = make_store_with(vec![]);
+        let eval = PolicyEvaluator::new(store);
+        let data = rmpv::Value::Nil;
+        let principal = admin_principal(); // roles: ["admin"], id "admin1"
+        let decision = eval
+            .evaluate(
+                Some(&principal),
+                PermissionAction::Write,
+                "users.profiles",
+                &data,
+            )
+            .await;
+        assert_eq!(
+            decision,
+            PolicyDecision::Deny,
+            "a roles:[\"admin\"] claim must not grant the RBAC bypass; only server-configured \
+             admin subjects do"
+        );
+    }
+
+    // F5: the allow-list is keyed on subject, not role. A different subject that
+    // also happens to claim the admin role is still denied.
+    #[tokio::test]
+    async fn admin_subject_match_is_by_id_not_role() {
+        let store = make_store_with(vec![]);
+        let eval = PolicyEvaluator::with_admin_subjects(store, admin_subjects(&["ops-root"]));
+        let data = rmpv::Value::Nil;
+        // user1 with roles:["user"] is not "ops-root" -> denied.
+        let principal = user_principal();
+        let decision = eval
+            .evaluate(Some(&principal), PermissionAction::Read, "users.x", &data)
+            .await;
+        assert_eq!(decision, PolicyDecision::Deny);
     }
 
     #[tokio::test]

--- a/tests/integration-rust/rbac.test.ts
+++ b/tests/integration-rust/rbac.test.ts
@@ -167,7 +167,13 @@ describe('Integration: RBAC Policy Enforcement (Rust Server)', () => {
   let server: SpawnedServer;
 
   beforeAll(async () => {
-    server = await spawnRustServer();
+    // The data-plane RBAC admin bypass is server-anchored: only subjects listed
+    // in TOPGUN_ADMIN_SUBJECTS receive it, never a roles:["admin"] JWT claim. The
+    // legitimate admin subjects exercised by Test 3 / Test 8 are configured here;
+    // a roles:["admin"] token whose subject is NOT listed is denied (Test 3b).
+    server = await spawnRustServer({
+      env: { TOPGUN_ADMIN_SUBJECTS: 'admin-1,admin-owner-test' },
+    });
     const { port } = server;
 
     // Seed policies used across test cases.
@@ -257,12 +263,13 @@ describe('Integration: RBAC Policy Enforcement (Rust Server)', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Test 3: Principal with "admin" role bypasses all policy checks
+  // Test 3: A server-configured admin SUBJECT bypasses all policy checks
   // -------------------------------------------------------------------------
-  test('Test 3: "admin" role bypasses all policies regardless of map', async () => {
+  test('Test 3: server-configured admin subject bypasses all policies regardless of map', async () => {
     const adminClient = await createRustTestClient(server.port, {
+      // 'admin-1' is in TOPGUN_ADMIN_SUBJECTS (server-trusted). The bypass is
+      // anchored to the subject, not the role claim.
       userId: 'admin-1',
-      // "admin" (lowercase) matches the PolicyEvaluator admin bypass check.
       roles: ['admin'],
     });
 
@@ -275,6 +282,30 @@ describe('Integration: RBAC Policy Enforcement (Rust Server)', () => {
       expect(resp.type).toBe('OP_ACK');
     } finally {
       adminClient.close();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3b (F5 negative control): a roles:["admin"] JWT whose subject is NOT
+  // on the server allow-list must NOT receive the bypass — this is the
+  // self-grant vector (an attacker minting/exchanging a token with an admin
+  // role claim). It must be denied on an uncovered map.
+  // -------------------------------------------------------------------------
+  test('Test 3b: roles:["admin"] claim alone does NOT bypass (self-grant blocked)', async () => {
+    const fakeAdmin = await createRustTestClient(server.port, {
+      userId: 'not-allow-listed-admin',
+      roles: ['admin'],
+    });
+
+    try {
+      await fakeAdmin.waitForMessage('AUTH_ACK', 8000);
+
+      // Same uncovered map as Test 3 — but this subject is not server-trusted,
+      // so default-deny applies despite the admin role claim.
+      const resp = await writeAndWaitForResponse(fakeAdmin, 'no-policy-map', 'forged-admin-key');
+      expect(resp.type).toBe('ERROR');
+    } finally {
+      fakeAdmin.close();
     }
   });
 
@@ -394,10 +425,11 @@ describe('Integration: RBAC Policy Enforcement (Rust Server)', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Test 8: Admin bypasses record-level conditions
+  // Test 8: A server-configured admin subject bypasses record-level conditions
   // -------------------------------------------------------------------------
-  test('Test 8: admin bypasses record-level conditions', async () => {
-    // Reuses the "owned-docs" policy from Test 6.
+  test('Test 8: admin subject bypasses record-level conditions', async () => {
+    // Reuses the "owned-docs" policy from Test 6. 'admin-owner-test' is in
+    // TOPGUN_ADMIN_SUBJECTS, so the bypass applies regardless of the condition.
     const adminClient = await createRustTestClient(server.port, {
       userId: 'admin-owner-test',
       roles: ['admin'],


### PR DESCRIPTION
Closes G6 hardening batch from `DEPTH_SECURITY_AUTHZ.md` — **TODO-487** (F5/F6/F7) + **TODO-485** (F3). Server-rust only; each finding has a behavioral test **and** a negative control.

## F5 — admin role scoping (re-evaluated MEDIUM → **HIGH**, privilege-escalation)
The `"admin"` RBAC bypass was a free-text JWT claim trusted transitively. Token-exchange copied an external IdP's `roles` **verbatim**, so a deployment mapping a user-controllable IdP profile field to its `roles_claim` made `admin` **trivially self-grantable** — full RBAC bypass. That's privilege-escalation, not a medium footgun.

- The bypass is now **server-anchored** to an admin-subject allow-list (`TOPGUN_ADMIN_SUBJECTS`). `Principal.id ∈ allow-list` grants it; a `roles:["admin"]` claim never does. Empty by default → no data-plane admin.
- Token-exchange **strips reserved privileged roles** (case-insensitive) from external claims — defense-in-depth so a self-granted role can't satisfy a `$auth.roles` policy condition.
- Threaded through binary + `module.rs` + the HTTP read path; the Tower `AuthorizationLayer` uses the same allow-list-aware evaluator.
- Tests: allow-listed subject bypasses; `roles:["admin"]` alone denied (unit + **e2e Test 3b**); subject-keyed not role-keyed; token-exchange strip (incl. mixed-case).

## F6 — glob namespace lock
`glob_matches` was single-segment, so `users.*` didn't lock nested keys and a crafted map name at another depth dodged a deny. Added recursive `**` (zero-or-more segments): `users.**` covers `users`, `users.a`, `users.a.b.c`. Lone `*` unchanged. Crafted-key bypass negative control added.

## F7 — request-path iss/aud
WS handshake + HTTP `/sync` now validate `iss`/`aud` when `TOPGUN_JWT_ISSUER`/`TOPGUN_JWT_AUDIENCE` are set; an enforced claim must be **present**. Unset = prior behavior (TopGun-minted tokens). Shared `apply_iss_aud_validation` helper. Tests: wrong/missing/ matching for both; unconfigured accepts any (backward compat).

## F3 (TODO-485) — anonymous HTTP HLC re-stamp (sim-gated)
Anonymous HTTP `/sync` writes/batches landed in the trusted internal branch and stored the client HLC verbatim → forged `millis:u64::MAX` poisoned LWW permanently under default no-auth. Now re-stamped via `sanitize_hlc`, **gated on transport, not auth** (`admit_write` not re-run — would reject Anonymous and break the no-auth tier; auth admission stays at the HTTP handler). Genuine `System`/`Forwarded` origins still preserve their timestamp. Tests: anon single + batch restamp; **System-origin preserves ts** negative control.

## Gate
- `cargo test --release -p topgun-server` — all 13 targets green (1403 lib tests).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Sim: 3 convergence proptests green (the F3 stop-condition) + 2 randomized convergence proptests.
- `integration-rust`: 13/14 suites green incl. updated `rbac.test.ts`. `cluster-routing` flakes run-to-run (cold join-race, TODO-504, non-blocking) — confirmed independent of this security-only diff.
- Optional cross-vendor (glm-5.2) adversarial review applied: case-insensitive role strip + iss-required. Two HIGH/MED review findings verified as **false positives** against full source (the unchanged `HttpClient` re-stamp arm; the shared allow-list-aware evaluator).

## Operator-facing config (all optional, backward-compatible defaults)
- `TOPGUN_ADMIN_SUBJECTS` — comma-separated subjects granted the RBAC admin bypass.
- `TOPGUN_JWT_ISSUER` / `TOPGUN_JWT_AUDIENCE` — enforce request-path iss/aud.