### PR TITLE
feat(docs): G2 doc-test harness — executable documentation gate

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -1,0 +1,129 @@
+name: Doc tests (executable documentation — G2 gate)
+
+# Extracts every code snippet from the published docs (README + apps/docs-astro)
+# and exercises it against reality: TS executed against a live Rust server or
+# type-checked against the real package types, bash run if hermetic-safe, and
+# everything else explicitly skipped with a visible reason. New snippets are
+# picked up automatically (no allowlist). This is the stabilization program's
+# G2 gate — it stops the docs from drifting out of sync with the code.
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'README.md'
+      - 'apps/docs-astro/**'
+      - 'packages/core/**'
+      - 'packages/client/**'
+      - 'packages/react/**'
+      - 'packages/adapters/**'
+      - 'packages/server-rust/**'
+      - 'packages/core-rust/**'
+      - 'tests/doc-tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/doc-tests.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'README.md'
+      - 'apps/docs-astro/**'
+      - 'packages/core/**'
+      - 'packages/client/**'
+      - 'packages/react/**'
+      - 'packages/adapters/**'
+      - 'packages/server-rust/**'
+      - 'packages/core-rust/**'
+      - 'tests/doc-tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/doc-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-server:
+    name: Build server binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-doctests-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-doctests-
+            ${{ runner.os }}-cargo-integration-
+            ${{ runner.os }}-cargo-
+
+      - name: Build topgun-server (release)
+        run: cargo build --release --bin topgun-server
+
+      - name: Upload server binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: topgun-server-doctests
+          path: target/release/topgun-server
+          retention-days: 1
+          if-no-files-found: error
+
+  # BLOCKING gate. Runs the full doc-test suite (typecheck + run-against-server +
+  # bash + negative control) against the prebuilt binary.
+  doc-tests:
+    name: Doc tests (blocking)
+    needs: [build-server]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download server binary
+        uses: actions/download-artifact@v4
+        with:
+          name: topgun-server-doctests
+          path: target/release
+
+      - name: Make server binary executable
+        run: chmod +x target/release/topgun-server
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm via corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.13.1 --activate
+
+      - name: Install dependencies (frozen lockfile)
+        run: pnpm install --frozen-lockfile
+
+      - name: Run doc tests (snippets against the real server)
+        # ts-jest compiles @topgunbuild/{core,client,react,adapters} from source
+        # via moduleNameMapper, so no package build is needed. RUST_SERVER_BINARY
+        # points the run tier at the prebuilt binary (skips cargo). --runInBand
+        # keeps the spawned server's fixed-port lifecycle deterministic.
+        env:
+          RUST_SERVER_BINARY: ${{ github.workspace }}/target/release/topgun-server
+        run: pnpm test:docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ Working around a failure by narrowing scope (`pnpm --filter "./packages/*"` inst
 
 - Rust server tests: `SDKROOT=$(/usr/bin/xcrun --sdk macosx --show-sdk-path) cargo test --release -p topgun-server`
 - Integration tests (TS client to Rust server): `pnpm test:integration-rust`
+- Doc tests (G2 gate — every doc snippet run against the real server / type-checked against real types / explicitly skipped with a reason): `pnpm test:docs` (set `RUST_SERVER_BINARY` to a prebuilt binary to skip cargo). Authoring contract: `tests/doc-tests/README.md`. New snippets are picked up automatically — no allowlist; to exclude a block add an explicit `doctest skip reason="…"` directive.
 - Run TS tests sequentially in CI to avoid port conflicts: `pnpm test -- --runInBand`
 
 ## Production Defaults (Memory + Persistence)

--- a/README.md
+++ b/README.md
@@ -110,13 +110,14 @@ Prometheus metrics endpoint and structured-log hooks are planned.
 
 **Client wiring (both paths):**
 
+<!-- doctest run reason="flagship wiring — executed against the live server in CI" -->
 ```typescript
 import { TopGunClient } from '@topgunbuild/client';
 import { IDBAdapter } from '@topgunbuild/adapters';
 
 const client = new TopGunClient({
   serverUrl: 'ws://localhost:8080',  // optional — omit for local-only
-  storage: new IDBAdapter('my-app'),
+  storage: new IDBAdapter(),
 });
 client.start();
 

--- a/apps/docs-astro/public/llms-full.txt
+++ b/apps/docs-astro/public/llms-full.txt
@@ -2142,8 +2142,11 @@ public onBackpressure(
 Subscribe to backpressure transitions.
 
 ```typescript
-client.onBackpressure('backpressure:high', ({ pending, max }) => {
-  console.warn(`Warning: ${pending}/${max} pending ops`);
+client.onBackpressure('backpressure:high', (e) => {
+  // Threshold events carry `pending` / `max` counts.
+  if (e && 'pending' in e) {
+    console.warn(`Warning: ${e.pending}/${e.max} pending ops`);
+  }
 });
 client.onBackpressure('backpressure:paused', () => showLoadingSpinner());
 client.onBackpressure('backpressure:resumed', () => hideLoadingSpinner());
@@ -2603,7 +2606,7 @@ Combine FTS predicates with traditional filter predicates (`where`/`sort`/`limit
 
 ```tsx
 
-const { data } = useHybridQuery<Article>('articles', {
+const { results } = useHybridQuery<Article>('articles', {
   predicate: Predicates.and(
     Predicates.match('body', 'machine learning'),
     Predicates.equal('category', 'tech')

--- a/apps/docs-astro/src/content/blog/distributed-live-subscriptions.mdx
+++ b/apps/docs-astro/src/content/blog/distributed-live-subscriptions.mdx
@@ -230,7 +230,6 @@ Distributed live subscriptions unlock patterns that weren't practical before:
 // Monitor orders across all regions
 const handle = client.searchSubscribe('orders', 'status:pending', {
   limit: 100,
-  sort: { createdAt: 'desc' }
 });
 
 handle.subscribe((orders) => {

--- a/apps/docs-astro/src/content/blog/hybrid-logical-clocks.mdx
+++ b/apps/docs-astro/src/content/blog/hybrid-logical-clocks.mdx
@@ -244,10 +244,12 @@ const remote: Timestamp = {
 };
 ```
 
-TopGun detects this with a drift threshold:
+TopGun detects this with a configurable drift ceiling — the `maxDriftMs` option
+on the HLC (default `60_000` ms):
 
 ```typescript
-if (remote.millis > systemTime + HLC.MAX_DRIFT) {
+const maxDriftMs = 60_000; // HLC option, default 60s
+if (remote.millis > systemTime + maxDriftMs) {
   console.warn(`Clock drift detected: Remote ${remote.millis} ahead of local ${systemTime}`);
 }
 ```

--- a/apps/docs-astro/src/content/docs/guides/migrating-from-firebase.mdx
+++ b/apps/docs-astro/src/content/docs/guides/migrating-from-firebase.mdx
@@ -71,8 +71,8 @@ This guide is for Firestore users, Firebase Realtime Database users, and anyone 
       </tr>
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground">Realtime Database <code>ref.on('value')</code></td>
-        <td className="py-3 px-4 text-foreground"><code>client.getMap(name).onChange(callback)</code></td>
-        <td className="py-3 px-4 text-neutral-500">Local LWWMap change notification — fires on any write to the map (local or synced); callback receives no arguments, caller reads <code>getMap().get(key)</code> for current value</td>
+        <td className="py-3 px-4 text-foreground"><code>client.getMap(name).subscribe(callback)</code></td>
+        <td className="py-3 px-4 text-neutral-500">Local LWWMap change notification — fires on any write to the map (local or synced); callback receives the current <code>[key, value]</code> snapshot, caller reads <code>getMap().get(key)</code> for a single value</td>
       </tr>
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground">Presence (<code>onDisconnect</code>)</td>
@@ -223,16 +223,17 @@ const unsub = query.subscribe((results) => {
 // const results = useQuery('users', { where: ... });
 
 // Raw local-change notifications (no filter):
-const unsubLocal = client.getMap('users').onChange(() => {
-  const record = client.getMap('users').get(userId);
-  console.log(record);
+const unsubLocal = client.getMap('users').subscribe((entries) => {
+  // Fires on any write to the local LWWMap; `entries` is the current
+  // [key, value] snapshot. Look up a single record with `.get(userId)`.
+  console.log(entries.length, client.getMap('users').get(userId));
 });
 ```
 
   </div>
 </div>
 
-TopGun reads and writes are **synchronous** because data lives in local memory first. The `SyncEngine` syncs changes to the server in the background. The `client.query().subscribe()` path delivers server-pushed, filter-aware deltas — the closest equivalent to Firestore's `onSnapshot` query listener. `client.getMap().onChange()` is a lower-level notification that fires on any write to the local LWWMap (local or synced), with no filter; the callback receives no arguments and the caller reads the current value by calling `get()`.
+TopGun reads and writes are **synchronous** because data lives in local memory first. The `SyncEngine` syncs changes to the server in the background. The `client.query().subscribe()` path delivers server-pushed, filter-aware deltas — the closest equivalent to Firestore's `onSnapshot` query listener. `client.getMap().subscribe()` is a lower-level notification that fires on any write to the local LWWMap (local or synced), with no filter; the callback receives the current `[key, value]` snapshot, and a single record can be read with `get()`.
 
 #### If you're using React
 

--- a/apps/docs-astro/src/content/docs/guides/migrating-from-supabase-realtime.mdx
+++ b/apps/docs-astro/src/content/docs/guides/migrating-from-supabase-realtime.mdx
@@ -202,8 +202,9 @@ topic.publish({ text: 'hello' });
 
 // CRDT-backed query subscription
 // Server-pushed deltas via WebSocket; emitted from
-// CRDT merge, not from Postgres WAL.
-const query = client.query('todos');
+// CRDT merge, not from Postgres WAL. Pass `{}` to watch
+// the whole map (or a filter to scope it server-side).
+const query = client.query('todos', {});
 
 const unsubQuery = query.subscribe((results) => {
   console.log('todos', results);
@@ -259,7 +260,7 @@ client.getMap('users').set('alice', {
 
 // Listen via the same query subscription; merges
 // from this client and others both arrive here.
-const query = client.query('users');
+const query = client.query('users', {});
 const unsub = query.subscribe((results) => {
   console.log('users', results);
 });

--- a/apps/docs-astro/src/content/docs/guides/migrating-from-yjs.mdx
+++ b/apps/docs-astro/src/content/docs/guides/migrating-from-yjs.mdx
@@ -60,8 +60,8 @@ This guide is for Y.js users who want a server-backed, offline-first data layer 
       </tr>
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground"><code>doc.observe()</code> / <code>map.observe()</code></td>
-        <td className="py-3 px-4 text-foreground"><code>client.getMap(name).onChange(callback)</code> or <code>client.query(name, filter).subscribe(callback)</code></td>
-        <td className="py-3 px-4 text-neutral-500">Use <code>onChange</code> for raw local notifications; use <code>query().subscribe()</code> for filter-aware server-pushed deltas</td>
+        <td className="py-3 px-4 text-foreground"><code>client.getMap(name).subscribe(callback)</code> or <code>client.query(name, filter).subscribe(callback)</code></td>
+        <td className="py-3 px-4 text-neutral-500">Use <code>subscribe</code> for raw local notifications; use <code>query().subscribe()</code> for filter-aware server-pushed deltas</td>
       </tr>
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground"><code>Y.transact(() =&gt; {"{...}"})</code></td>
@@ -204,9 +204,10 @@ client.getMap('todos').set('todo-1', {
 });
 
 // Raw local-change notifications (no filter):
-const unsubLocal = client.getMap('todos').onChange(() => {
+const unsubLocal = client.getMap('todos').subscribe((entries) => {
+  // `entries` is the current [key, value] snapshot on any local write.
   const todo = client.getMap('todos').get('todo-1');
-  console.log(todo);
+  console.log(entries.length, todo);
 });
 
 // Filter-aware server-pushed deltas:
@@ -221,7 +222,7 @@ const unsub = query.subscribe((results) => {
   </div>
 </div>
 
-`yMap.observe` and `client.getMap().onChange()` are the closest match — both fire on any write to the local map. For filter-aware deltas (e.g. "only show open todos"), use `client.query().subscribe()`, which Y.js does not provide because all filtering in Y.js is client-side over the full document.
+`yMap.observe` and `client.getMap().subscribe()` are the closest match — both fire on any write to the local map. For filter-aware deltas (e.g. "only show open todos"), use `client.query().subscribe()`, which Y.js does not provide because all filtering in Y.js is client-side over the full document.
 
 #### If you're using React
 
@@ -291,7 +292,7 @@ For a first migration, start on single-node. The partition-routed cluster mode w
 2. Cross-reference each against the Concept Mapping table above; mark mappings vs. gaps.
 3. Flag any feature that maps to a "Not supported" or "Roadmap" cell — those need an explicit decision (drop, work around, or wait for the roadmap item).
 4. Port the provider layer: replace `Y.Doc + WebsocketProvider + IndexeddbPersistence` with `new TopGunClient({ serverUrl, storage: new IDBAdapter() })` and `client.setAuthToken(jwt)`.
-5. Port reads/writes/observes one map at a time: replace `yMap.set` / `yMap.get` / `yMap.observe` with `client.getMap().set` / `.get` / `.onChange` (and `client.query().subscribe` for filter-aware server-pushed deltas).
+5. Port reads/writes/observes one map at a time: replace `yMap.set` / `yMap.get` / `yMap.observe` with `client.getMap().set` / `.get` / `.subscribe` (and `client.query().subscribe` for filter-aware server-pushed deltas).
 6. Backfill data: write a one-time migration script that reads from your Y.js persistence (e.g. y-leveldb / y-redis / y-mongodb) and writes to TopGun via the client SDK or directly to Postgres.
 
 <div className="flex justify-between pt-10 mt-10 border-t border-card-border not-prose">

--- a/apps/docs-astro/src/content/docs/reference/adapters.mdx
+++ b/apps/docs-astro/src/content/docs/reference/adapters.mdx
@@ -121,15 +121,34 @@ An at-rest-encryption wrapper around any `IStorageAdapter`. Exported from `@topg
 import { TopGunClient, EncryptedStorageAdapter } from '@topgunbuild/client';
 import { IDBAdapter } from '@topgunbuild/adapters';
 
-const encrypted = new EncryptedStorageAdapter(
-  new IDBAdapter(),
-  { passphrase: 'user-provided-secret' }
+// EncryptedStorageAdapter takes a pre-derived AES-GCM CryptoKey. Derive one
+// from a user passphrase with PBKDF2 (Web Crypto). Persist `salt` with your app
+// config — the same salt must be reused to unseal on the next session.
+const salt = crypto.getRandomValues(new Uint8Array(16));
+const baseKey = await crypto.subtle.importKey(
+  'raw',
+  new TextEncoder().encode('user-provided-secret'),
+  'PBKDF2',
+  false,
+  ['deriveKey'],
 );
+const key = await crypto.subtle.deriveKey(
+  { name: 'PBKDF2', salt, iterations: 600_000, hash: 'SHA-256' },
+  baseKey,
+  { name: 'AES-GCM', length: 256 },
+  false,
+  ['encrypt', 'decrypt'],
+);
+
+const encrypted = new EncryptedStorageAdapter(new IDBAdapter(), key);
 
 const client = new TopGunClient({
   storage: encrypted,
 });
 ```
+
+> A `fromPassphrase()` convenience that performs this derivation for you is on
+> the roadmap — see TODO-527.
 
 Values are AES-GCM-encrypted before they hit the underlying adapter. Keys and metadata stay plaintext so the sync engine and Merkle tree can still iterate without unsealing every record.
 

--- a/apps/docs-astro/src/content/docs/reference/client.mdx
+++ b/apps/docs-astro/src/content/docs/reference/client.mdx
@@ -645,8 +645,11 @@ public onBackpressure(
 Subscribe to backpressure transitions.
 
 ```typescript
-client.onBackpressure('backpressure:high', ({ pending, max }) => {
-  console.warn(`Warning: ${pending}/${max} pending ops`);
+client.onBackpressure('backpressure:high', (e) => {
+  // Threshold events carry `pending` / `max` counts.
+  if (e && 'pending' in e) {
+    console.warn(`Warning: ${e.pending}/${e.max} pending ops`);
+  }
 });
 client.onBackpressure('backpressure:paused', () => showLoadingSpinner());
 client.onBackpressure('backpressure:resumed', () => hideLoadingSpinner());

--- a/apps/docs-astro/src/content/docs/reference/react.mdx
+++ b/apps/docs-astro/src/content/docs/reference/react.mdx
@@ -319,7 +319,7 @@ Combine FTS predicates with traditional filter predicates (`where`/`sort`/`limit
 import { useHybridQuery } from '@topgunbuild/react';
 import { Predicates } from '@topgunbuild/core';
 
-const { data } = useHybridQuery<Article>('articles', {
+const { results } = useHybridQuery<Article>('articles', {
   predicate: Predicates.and(
     Predicates.match('body', 'machine learning'),
     Predicates.equal('category', 'tech')

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:sim": "cargo test --profile ci-sim --features simulation -p topgun-server -- sim",
     "test:cli": "pnpm --filter @topgunbuild/cli test",
     "test:integration-rust": "jest --config tests/integration-rust/jest.config.js",
+    "test:docs": "jest --config tests/doc-tests/jest.config.js --runInBand",
     "test:coverage": "pnpm -r test:coverage",
     "test:coverage:core": "pnpm --filter @topgunbuild/core test:coverage",
     "test:coverage:client": "pnpm --filter @topgunbuild/client test:coverage",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,6 +9,9 @@ export * from './hooks/useTopic';
 
 // Per-record sync-state type re-export from @topgunbuild/client
 export type { RecordSyncState } from '@topgunbuild/client';
+// Query result item type — the element type of `useQuery().data` (`T & { _key }`).
+// Re-exported so apps can annotate component props with the hook's own item type.
+export type { QueryResultItem } from '@topgunbuild/client';
 export * from './hooks/usePNCounter';
 export * from './hooks/useEventJournal';
 

--- a/tests/doc-tests/README.md
+++ b/tests/doc-tests/README.md
@@ -1,0 +1,100 @@
+# Doc-test harness (G2 gate)
+
+Every code snippet in the published documentation is extracted and **exercised
+against reality** — either executed against a live Rust server, type-checked
+against the real published package types, or explicitly skipped with a visible
+reason. This is the G2 "executable documentation" gate from the stabilization
+program: the mechanism that stops the docs from drifting out of sync with the
+code.
+
+```bash
+pnpm test:docs           # cargo-builds the server on first run
+RUST_SERVER_BINARY=$PWD/target/release/topgun-server pnpm test:docs   # CI: prebuilt
+```
+
+## What it covers
+
+Sources walked (sorted, deterministic):
+
+- `README.md`
+- every `*.md` / `*.mdx` under `apps/docs-astro/src/content/`
+
+`apps/docs-astro/public/llms-full.txt` is **not** walked separately — it is a
+generated artifact (`scripts/build-llms-full.mjs`) whose snippets are a strict
+subset of the MDX it is built from. Testing the MDX sources subsumes it.
+
+## The three tiers
+
+Every snippet gets exactly one verdict. There is no fourth "silently untested"
+state, and there is **no allowlist** — a newly-added snippet is picked up
+automatically.
+
+| Tier | What happens | When |
+|------|--------------|------|
+| **run** | Executed for real: TS against a live Rust server (`spawnRustServer`, no-auth + deterministic embeddings), bash in a throwaway temp dir. | A self-contained, non-networking program (auto), or any block the author marks `doctest run` / `doctest setup`. Bash that is hermetic-safe. |
+| **typecheck** | Compiled against the real `@topgunbuild/*` types. A renamed export/method, a wrong argument, a bad import — i.e. docs-overpromise — fails here. | Default for every TS/TSX fragment. |
+| **skip** | Not exercised — but always with a **reason**, surfaced in the manifest. | Explicit `doctest skip`, non-executable languages (json/rust/text/…), non-standalone-parseable notation, and side-effecting shell commands. |
+
+The run tier substitutes the documented `localhost:8080` authority for the live
+ephemeral port (the snippet's path is preserved, so a wrong documented WS path
+is still caught), maps `@topgunbuild/adapters` → an in-memory adapter (no
+IndexedDB in Node), and stubs UI-placeholder calls (`render`, `display`, …) so
+wiring examples run headless. A wired-up client must reach `CONNECTED` — that is
+what makes "runs against a real server" real and not just "constructs an
+object".
+
+## Authoring directives
+
+By default you write nothing — TS is type-checked, runnable TS/bash runs. Opt
+out or escalate with a directive, carried either as a render-invisible comment
+immediately above the fence, or as tokens on the fence info string:
+
+```mdx
+{/* doctest skip reason="illustrative pseudocode" */}
+```ts
+// ... not executed, but visible in the manifest with the reason ...
+```
+```
+
+```md
+<!-- doctest run reason="flagship example — executed against the live server" -->
+```typescript
+// ... executed end-to-end ...
+```
+```
+
+Recognised tokens after `doctest`:
+
+- `skip` — illustrative; **requires** `reason="…"`. The manifest integrity test
+  fails on a reasonless skip.
+- `run` — force-execute this block (a complete runnable example).
+- `setup` — like `run`, and also contribute this block as a shared preamble for
+  the other run blocks on the same page (mdBook-style narrative).
+- `vector` — needs the embedding-enabled server profile.
+
+`doctest-skip` / `doctest-run` (dash form) work too.
+
+## Negative control
+
+`negative-control.test.ts` proves the gate fails when docs break — it feeds
+deliberately-broken snippets (renamed method, bad import, wrong arity, runtime
+throw, reasonless skip) through the real pipeline and asserts each is caught. To
+verify by hand, introduce a typo in any doc snippet (`client.getMap` →
+`client.getMapp`) and watch the typecheck suite redden.
+
+## Files
+
+| File | Role |
+|------|------|
+| `helpers/extract.ts` | Walk docs, parse fenced blocks + directives |
+| `helpers/classify.ts` | Assign the run/typecheck/skip verdict |
+| `helpers/tsc.ts` | Typecheck against real types; drift-vs-fragment-noise filter; self-containment |
+| `helpers/doc-scope.d.ts` | Typed glossary of ambient doc identifiers (`client`, `Predicates`, …) |
+| `helpers/assemble.ts` | Build + execute a run-tier module (import→require, URL inject, vm) |
+| `helpers/server.ts` | Boot the Rust server with the doc profile |
+| `helpers/client-shim.ts` | Track clients → assert handshake + tear down |
+| `helpers/memory-adapter.ts` / `adapters-shim.ts` | In-memory storage for headless Node |
+| `doc-typecheck.test.ts` | Manifest integrity + typecheck tier |
+| `doc-exec.test.ts` | Run tier against the live server |
+| `doc-bash.test.ts` | Bash tier |
+| `negative-control.test.ts` | Prove the gate fails on broken docs |

--- a/tests/doc-tests/doc-bash.test.ts
+++ b/tests/doc-tests/doc-bash.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Bash tier.
+ *
+ * TopGun's documented shell commands are almost entirely side-effecting infra
+ * (install, scaffold, `cargo run`, `docker pull/run`, env exports, curl against
+ * placeholder hosts). A doc-test sandbox must not execute those — they are
+ * validated by the CI jobs named in each snippet's skip reason (node,
+ * create-topgun-app, post-publish-smoke, docker, rust). So the classifier marks
+ * them EXPLICIT skips with a categorized reason (visible in the manifest), and
+ * only runs a snippet whose every command is hermetic-safe.
+ *
+ * This suite (a) executes any run-tier bash in a throwaway temp dir, and
+ * (b) asserts every bash snippet is classified — run, or skip WITH a reason.
+ * New bash snippets are picked up automatically; an unclassifiable one fails.
+ */
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { extractAll, BASH_LANGS } from './helpers/extract';
+import { classifyAll } from './helpers/classify';
+
+const classified = classifyAll(extractAll());
+const bash = classified.filter((c) => BASH_LANGS.has(c.snippet.lang));
+const runBash = bash.filter((c) => c.verdict === 'run');
+
+describe('bash tier', () => {
+  it('classifies every bash snippet (run, or skip with a reason)', () => {
+    const bad = bash.filter((c) => c.verdict !== 'run' && (!c.reason || c.reason.trim() === ''));
+    if (bad.length) {
+      throw new Error(
+        `bash snippets skipped without a reason:\n${bad.map((c) => '  ' + c.snippet.id).join('\n')}`,
+      );
+    }
+    expect(bash.length).toBeGreaterThan(0);
+  });
+
+  if (runBash.length === 0) {
+    it('has no hermetic-safe bash to execute (all are infra — skipped with reasons)', () => {
+      // Documented expectation, not a silent gap: the manifest lists each skip.
+      expect(runBash).toHaveLength(0);
+    });
+  }
+
+  for (const c of runBash) {
+    it(`runs — ${c.snippet.id}`, () => {
+      const dir = mkdtempSync(join(tmpdir(), 'topgun-doc-bash-'));
+      try {
+        execSync(c.snippet.code, { cwd: dir, timeout: 15_000, stdio: 'pipe' });
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/tests/doc-tests/doc-exec.test.ts
+++ b/tests/doc-tests/doc-exec.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Run tier — executes documentation snippets against a real Rust server.
+ *
+ * This is the heart of the G2 gate: a snippet the docs present as runnable is
+ * actually run. The server is the same binary the integration-rust suite uses
+ * (prebuilt via RUST_SERVER_BINARY in CI, cargo locally), booted once with the
+ * doc profile (no-auth + deterministic embeddings). Per page, `doctest setup`
+ * blocks accumulate into a preamble so a "create the client" block can feed a
+ * later "write" block; each run block executes as (page-setup ++ block).
+ *
+ * Verbatim except for one rewrite: the documented `localhost:8080` authority is
+ * swapped for the live ephemeral port (the path the doc wrote is preserved, so
+ * a wrong documented WS path is still caught).
+ */
+import { extractAll } from './helpers/extract';
+import { classifyAll } from './helpers/classify';
+import { assembleRunModule, executeModule } from './helpers/assemble';
+import { startDocServer, DocServer } from './helpers/server';
+import { __doctestAwaitConnected, __doctestResetClients } from './helpers/client-shim';
+
+const PER_SNIPPET_TIMEOUT_MS = 15_000;
+const CONNECT_TIMEOUT_MS = 10_000;
+
+const classified = classifyAll(extractAll());
+const runnable = classified.filter((c) => c.verdict === 'run' && c.snippet.kind === 'ts');
+
+/** Per page, the forced-setup blocks that form the shared preamble. */
+function setupBlocksFor(file: string): string[] {
+  return classified
+    .filter(
+      (c) =>
+        c.snippet.file === file &&
+        c.snippet.kind === 'ts' &&
+        c.snippet.directive.setup &&
+        c.verdict === 'run',
+    )
+    .map((c) => c.snippet.code);
+}
+
+describe('run tier — docs execute against a live Rust server', () => {
+  let server: DocServer;
+
+  beforeAll(async () => {
+    server = await startDocServer();
+  }, 120_000);
+
+  afterAll(async () => {
+    if (server) await server.cleanup();
+  });
+
+  if (runnable.length === 0) {
+    it('has runnable snippets', () => {
+      throw new Error('no run-tier snippets found — classification regressed');
+    });
+  }
+
+  for (const c of runnable) {
+    const label = c.snippet.directive.setup ? `${c.snippet.id} (setup)` : c.snippet.id;
+    it(
+      `runs — ${label}`,
+      async () => {
+        // A setup block on its own page is executed in-line with each run block,
+        // so running it standalone here would double-execute; skip the redundant
+        // standalone run when it is purely a preamble for siblings.
+        const setupBlocks = setupBlocksFor(c.snippet.file).filter(
+          (code) => code !== c.snippet.code,
+        );
+        const assembled = assembleRunModule(setupBlocks, c.snippet.code, {
+          authority: server.authority,
+        });
+        try {
+          await executeModule(assembled, require, PER_SNIPPET_TIMEOUT_MS);
+          // If the snippet wired up a client, prove it actually handshook with the
+          // live server — this is what makes "runs against a real server" real
+          // rather than just "constructs an object". No-ops for local-only / pure
+          // snippets that never opened a connection.
+          await __doctestAwaitConnected(CONNECT_TIMEOUT_MS);
+        } catch (err) {
+          throw new Error(
+            `run-tier snippet failed: ${c.snippet.id} (${c.snippet.file})\n` +
+              `${(err as Error).message}\n\nSnippet:\n${c.snippet.code}`,
+          );
+        } finally {
+          // Tear every client down so reconnect timers don't keep Jest alive and
+          // snippets stay isolated.
+          await __doctestResetClients();
+        }
+      },
+      PER_SNIPPET_TIMEOUT_MS + 5_000,
+    );
+  }
+});

--- a/tests/doc-tests/doc-typecheck.test.ts
+++ b/tests/doc-tests/doc-typecheck.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Typecheck tier + manifest integrity.
+ *
+ * - Every documentation snippet is classified into exactly one tier
+ *   (run / typecheck / skip). There is no fourth "silently untested" state.
+ * - Every `skip` carries a non-empty reason, so the manifest can be audited:
+ *   nothing leaves the gate unexercised without an explicit, visible reason.
+ * - Every `typecheck`/`run` snippet compiles against the REAL published package
+ *   types with zero API-drift diagnostics. A renamed/removed export or method,
+ *   a wrong argument — the docs-overpromise class the G2 gate exists to catch —
+ *   fails here.
+ *
+ * This suite needs no server; it is pure static analysis and runs fast.
+ */
+import { extractAll } from './helpers/extract';
+import { classifyAll, Classified } from './helpers/classify';
+
+const snippets = extractAll();
+const classified: Classified[] = classifyAll(snippets);
+
+const byVerdict = (v: string) => classified.filter((c) => c.verdict === v);
+
+describe('doc-test manifest integrity', () => {
+  it('classifies every snippet into exactly one tier', () => {
+    for (const c of classified) {
+      expect(['run', 'typecheck', 'skip']).toContain(c.verdict);
+    }
+    // Sanity: the corpus is non-trivial, so a regression that silently drops
+    // extraction (0 snippets) cannot masquerade as "all green".
+    expect(classified.length).toBeGreaterThan(100);
+  });
+
+  it('never skips silently — every skip has a non-empty reason', () => {
+    const offenders = byVerdict('skip').filter(
+      (c) => !c.reason || c.reason.trim() === '' || c.reason === '(no reason given)',
+    );
+    if (offenders.length) {
+      const list = offenders.map((c) => `  ${c.snippet.id} (${c.snippet.lang})`).join('\n');
+      throw new Error(`Snippets skipped without a reason:\n${list}`);
+    }
+    expect(offenders).toHaveLength(0);
+  });
+
+  it('prints the doc-test manifest summary', () => {
+    const run = byVerdict('run').length;
+    const tc = byVerdict('typecheck').length;
+    const skip = byVerdict('skip').length;
+    // eslint-disable-next-line no-console
+    console.log(
+      `\nDoc-test manifest: ${classified.length} snippets — ` +
+        `${run} run · ${tc} typecheck · ${skip} skip\n`,
+    );
+    expect(run + tc + skip).toBe(classified.length);
+  });
+});
+
+describe('typecheck tier — docs compile against real package types', () => {
+  const checkable = classified.filter(
+    (c) => (c.verdict === 'typecheck' || c.verdict === 'run') && c.diagnostics,
+  );
+
+  if (checkable.length === 0) {
+    it('has checkable snippets', () => {
+      throw new Error('no typecheck-tier snippets found — extraction or classification broke');
+    });
+  }
+
+  for (const c of checkable) {
+    it(`no API drift — ${c.snippet.id}`, () => {
+      const drift = c.diagnostics!.drift;
+      if (drift.length) {
+        throw new Error(
+          `API drift in ${c.snippet.id} (${c.snippet.file}):\n` +
+            drift.map((d) => `  ${d}`).join('\n') +
+            `\n\nSnippet:\n${c.snippet.code}`,
+        );
+      }
+      expect(drift).toHaveLength(0);
+    });
+  }
+});

--- a/tests/doc-tests/helpers/adapters-shim.ts
+++ b/tests/doc-tests/helpers/adapters-shim.ts
@@ -1,0 +1,11 @@
+/**
+ * Execution-time stand-in for `@topgunbuild/adapters`.
+ *
+ * The run tier executes documentation snippets in Node, where IndexedDB does
+ * not exist. The doc-tests jest config maps `@topgunbuild/adapters` to this
+ * module so a snippet's verbatim `import { IDBAdapter } from
+ * '@topgunbuild/adapters'` resolves to an in-memory adapter at runtime. The
+ * TYPECHECK tier is unaffected — it resolves the real package types (so e.g.
+ * `new IDBAdapter('name')` is still flagged against the real 0-arg constructor).
+ */
+export { MemoryStorageAdapter as IDBAdapter } from './memory-adapter';

--- a/tests/doc-tests/helpers/assemble.ts
+++ b/tests/doc-tests/helpers/assemble.ts
@@ -1,0 +1,210 @@
+/**
+ * Run-tier assembly + execution.
+ *
+ * A documentation example is rarely a single self-contained block: a "setup"
+ * block creates the client, later blocks write/read against it. The harness
+ * mirrors the mdBook / rustdoc model — per page, `doctest setup` blocks
+ * accumulate into a shared preamble, and each `run` block is executed as
+ * (page-setup ++ that block) so it sees the established scope without colliding
+ * with sibling run blocks.
+ *
+ * Execution is real: the assembled module is transpiled to CommonJS and run in
+ * a Node vm context whose `require` is the Jest module registry — so
+ * `@topgunbuild/client` resolves to workspace source and `@topgunbuild/adapters`
+ * resolves to the in-memory shim (jest moduleNameMapper). The only source
+ * rewrite is substituting the documented `ws://localhost:8080` for the live
+ * ephemeral test URL; everything else runs verbatim.
+ */
+
+import * as vm from 'vm';
+import * as ts from 'typescript';
+
+/**
+ * The documented authority the docs hard-code. We rewrite ONLY the host:port,
+ * never the path — so a snippet's `ws://localhost:8080` vs `ws://localhost:8080/ws`
+ * still connects to whatever path it actually wrote (the server dual-mounts WS
+ * at `/` and `/ws`). Rewriting the whole URL would let the harness mask a wrong
+ * documented path instead of catching it.
+ */
+const AUTHORITY_PATTERNS = [/localhost:8080/g, /127\.0\.0\.1:8080/g];
+
+export interface AssembledModule {
+  /** CommonJS source ready for vm execution. */
+  source: string;
+}
+
+interface ImportSplit {
+  requires: string[];
+  body: string;
+}
+
+/**
+ * Converts the leading `import` statements of a snippet into `require` calls and
+ * returns the remaining body. Type-only imports are dropped. Handles the import
+ * forms that appear in the docs: named, default, namespace, and side-effect.
+ */
+function splitImports(code: string): ImportSplit {
+  const requires: string[] = [];
+  const bodyLines: string[] = [];
+  const lines = code.split('\n');
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Drop type-only imports — they have no runtime form.
+    if (/^import\s+type\b/.test(trimmed)) continue;
+
+    // import { A, B as C } from 'x'
+    let m = trimmed.match(/^import\s+\{([^}]*)\}\s+from\s+['"]([^'"]+)['"]\s*;?$/);
+    if (m) {
+      const named = m[1]
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map((s) => s.replace(/\s+as\s+/, ': '))
+        // Drop inline `type` modifiers in named imports.
+        .map((s) => s.replace(/^type\s+/, ''))
+        .join(', ');
+      requires.push(`const { ${named} } = require(${JSON.stringify(m[2])});`);
+      continue;
+    }
+
+    // import * as X from 'x'
+    m = trimmed.match(/^import\s+\*\s+as\s+(\w+)\s+from\s+['"]([^'"]+)['"]\s*;?$/);
+    if (m) {
+      requires.push(`const ${m[1]} = require(${JSON.stringify(m[2])});`);
+      continue;
+    }
+
+    // import X from 'x'  (default)
+    m = trimmed.match(/^import\s+(\w+)\s+from\s+['"]([^'"]+)['"]\s*;?$/);
+    if (m) {
+      requires.push(
+        `const ${m[1]} = require(${JSON.stringify(m[2])}).default ?? require(${JSON.stringify(m[2])});`,
+      );
+      continue;
+    }
+
+    // import X, { A } from 'x'  (default + named)
+    m = trimmed.match(/^import\s+(\w+)\s*,\s*\{([^}]*)\}\s+from\s+['"]([^'"]+)['"]\s*;?$/);
+    if (m) {
+      const mod = JSON.stringify(m[3]);
+      const named = m[2]
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .join(', ');
+      requires.push(`const ${m[1]} = require(${mod}).default ?? require(${mod});`);
+      requires.push(`const { ${named} } = require(${mod});`);
+      continue;
+    }
+
+    // import 'x'  (side effect)
+    m = trimmed.match(/^import\s+['"]([^'"]+)['"]\s*;?$/);
+    if (m) {
+      requires.push(`require(${JSON.stringify(m[1])});`);
+      continue;
+    }
+
+    bodyLines.push(line);
+  }
+
+  return { requires, body: bodyLines.join('\n') };
+}
+
+function injectUrl(code: string, authority: string): string {
+  let out = code;
+  for (const p of AUTHORITY_PATTERNS) out = out.replace(p, authority);
+  return out;
+}
+
+/**
+ * Assembles a CommonJS module for one run block, prepended with the page's
+ * accumulated setup blocks. The body runs inside an async IIFE so top-level
+ * await in the docs works and the promise can be awaited by the caller.
+ */
+export function assembleRunModule(
+  setupBlocks: string[],
+  block: string,
+  opts: { authority: string },
+): AssembledModule {
+  const all = [...setupBlocks, block].map((c) => injectUrl(c, opts.authority));
+  const splits = all.map(splitImports);
+
+  const requires = splits.flatMap((s) => s.requires).join('\n');
+  const body = splits.map((s) => s.body).join('\n');
+
+  const tsSource = `${requires}
+exports.__run = (async () => {
+${body}
+})();
+`;
+
+  const js = ts.transpileModule(tsSource, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  }).outputText;
+
+  return { source: js };
+}
+
+/**
+ * Executes an assembled module in a fresh vm context that delegates module
+ * resolution to the provided `require` (the Jest registry). Resolves when the
+ * snippet's async body settles; rejects if it throws or times out.
+ */
+export async function executeModule(
+  assembled: AssembledModule,
+  requireFn: NodeJS.Require,
+  timeoutMs: number,
+): Promise<void> {
+  const moduleObj: { exports: Record<string, unknown> } = { exports: {} };
+  // UI-placeholder no-ops: wiring examples in the docs call render/display-style
+  // functions they never define (the reader supplies the UI). Stubbing them lets
+  // the surrounding real API calls execute headless. Documented in the harness
+  // README so authors know these names are provided, not asserted.
+  const uiStub = () => undefined;
+  const sandbox: Record<string, unknown> = {
+    require: requireFn,
+    module: moduleObj,
+    exports: moduleObj.exports,
+    console,
+    process,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    Buffer,
+    URL,
+    TextEncoder,
+    TextDecoder,
+    crypto: (globalThis as { crypto?: unknown }).crypto,
+    fetch: (globalThis as { fetch?: unknown }).fetch,
+    render: uiStub,
+    renderTodos: uiStub,
+    display: uiStub,
+    updateUI: uiStub,
+    showLoadingSpinner: uiStub,
+    hideLoadingSpinner: uiStub,
+  };
+  sandbox.global = sandbox;
+  sandbox.globalThis = sandbox;
+
+  vm.runInNewContext(assembled.source, sandbox, { timeout: timeoutMs });
+
+  const run = moduleObj.exports.__run as Promise<unknown> | undefined;
+  if (!run) return;
+
+  await Promise.race([
+    run,
+    new Promise((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`run-tier snippet timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      ),
+    ),
+  ]);
+}

--- a/tests/doc-tests/helpers/classify.ts
+++ b/tests/doc-tests/helpers/classify.ts
@@ -1,0 +1,242 @@
+/**
+ * Verdict resolution — assigns every documentation snippet exactly one tier.
+ *
+ * Tiers (strongest first):
+ *   run        — execute against a live Rust server (proves end-to-end behavior)
+ *   typecheck  — compile against the real package types (catches API drift)
+ *   skip       — explicitly NOT exercised; always carries a reason
+ *
+ * The contract that satisfies the G2 gate:
+ *   - DEFAULT is never "skip". A new ts/tsx/js block is type-checked
+ *     automatically (no allowlist); a new bash block runs automatically. The
+ *     only way to land an un-exercised snippet is an EXPLICIT skip directive
+ *     with a reason — so skips are always visible in the manifest.
+ *   - `run` is the author opting INTO execution for a complete, runnable
+ *     example (or a self-contained snippet the typechecker proves is a whole
+ *     program). It is a STRONGER assertion layered on top of the automatic
+ *     typecheck, never a way to test less.
+ *   - Non-executable languages (json, rust, text, …) are skipped with an
+ *     auto-filled reason, still surfaced in the manifest.
+ *   - A ts/tsx block that is not parseable as a standalone module (a bare
+ *     object-literal or signature fragment) is auto-skipped with a reason,
+ *     unless the author forced a tier. This keeps illustrative notation from
+ *     failing the gate while remaining explicit in the manifest.
+ */
+
+import { Snippet, TS_LANGS, BASH_LANGS } from './extract';
+import { checkSnippets, SnippetDiagnostics } from './tsc';
+
+export type Verdict = 'run' | 'typecheck' | 'skip';
+
+export interface Classified {
+  snippet: Snippet;
+  verdict: Verdict;
+  /** Required when verdict === 'skip'. */
+  reason: string | null;
+  /** Typecheck diagnostics, when the tier is typecheck or run. */
+  diagnostics?: SnippetDiagnostics;
+  /** True when the author forced the tier via a directive (vs auto-derived). */
+  forced: boolean;
+}
+
+/**
+ * Classifies every snippet. Type-checks the whole ts/tsx batch in one program
+ * for speed, then resolves each verdict.
+ */
+export function classifyAll(snippets: Snippet[]): Classified[] {
+  // Type-check every non-explicitly-skipped ts/tsx/js snippet up front, twice:
+  //  - WITH the doc-scope ambient → drift + syntax (member access on ambient
+  //    `client` is checked against the real API).
+  //  - WITHOUT it → self-containment (a snippet is standalone-runnable only if
+  //    it compiles clean with no ambient crutch; the run tier has no ambient).
+  const tsToCheck = snippets.filter((s) => TS_LANGS.has(s.lang) && !s.directive.skip);
+  const inputs = tsToCheck.map((s) => ({ id: s.id, code: s.code }));
+  const ambient = checkSnippets(inputs, { ambient: true });
+  const standalone = checkSnippets(inputs, { ambient: false });
+
+  const merged = new Map<string, SnippetDiagnostics>();
+  for (const s of tsToCheck) {
+    const a = ambient.get(s.id)!;
+    const st = standalone.get(s.id)!;
+    merged.set(s.id, {
+      ...a,
+      // Self-containment is judged WITHOUT the ambient crutch.
+      selfContained: st.selfContained,
+    });
+  }
+
+  return snippets.map((s) => classifyOne(s, merged.get(s.id)));
+}
+
+function classifyOne(s: Snippet, diag?: SnippetDiagnostics): Classified {
+  const d = s.directive;
+
+  // 1. Explicit skip always wins. Reason is mandatory (enforced by manifest test).
+  if (d.skip) {
+    return {
+      snippet: s,
+      verdict: 'skip',
+      reason: d.reason ?? '(no reason given)',
+      forced: true,
+    };
+  }
+
+  // 2. Non-executable languages: auto-skip with a language reason.
+  if (s.kind === 'other') {
+    return {
+      snippet: s,
+      verdict: 'skip',
+      reason: `non-executable language: ${s.lang || 'none'}`,
+      forced: false,
+    };
+  }
+
+  // 3. Bash: classified by side-effect safety. A command runs only if it is
+  //    hermetic (no install / daemon / docker / network / global mutation);
+  //    everything else is an EXPLICIT skip whose reason names the category and
+  //    the CI that actually validates it. New bash snippets are auto-evaluated
+  //    (no allowlist); the skip is visible in the manifest, never silent.
+  if (BASH_LANGS.has(s.lang)) {
+    return classifyBash(s);
+  }
+
+  // 4. ts / tsx / js.
+  // Author forced execution (`doctest run` executes this block; `doctest setup`
+  // also contributes it as a shared preamble for sibling run blocks).
+  if (d.run || d.setup) {
+    return { snippet: s, verdict: 'run', reason: null, diagnostics: diag, forced: true };
+  }
+
+  // Not parseable as a standalone module → illustrative fragment notation.
+  if (diag && diag.syntax.length > 0) {
+    return {
+      snippet: s,
+      verdict: 'skip',
+      reason: 'not parseable as standalone TypeScript (illustrative notation)',
+      diagnostics: diag,
+      forced: false,
+    };
+  }
+
+  // Self-contained whole program that imports the SDK → auto-promote to run.
+  // BUT only when it does not open a network connection: a snippet that wires up
+  // a client against a documented/placeholder URL (`wss://topgun.example.com`)
+  // would fire a real connect + reconnect storm. Networked examples must opt in
+  // explicitly via `doctest setup`/`run`, where the harness substitutes the live
+  // URL and tears the client down. Pure-core snippets (CRDT/HLC math) auto-run.
+  if (
+    diag &&
+    diag.selfContained &&
+    diag.importsTopgun &&
+    hasExecutableStatement(s.code) &&
+    !opensConnection(s.code)
+  ) {
+    return { snippet: s, verdict: 'run', reason: null, diagnostics: diag, forced: false };
+  }
+
+  // Default: typecheck the fragment against real types.
+  return { snippet: s, verdict: 'typecheck', reason: null, diagnostics: diag, forced: false };
+}
+
+/**
+ * Side-effect categories for bash snippets, each with the CI that genuinely
+ * exercises that command class. Matched against the first meaningful token of
+ * each command line. A snippet that contains ANY side-effecting command is
+ * skipped (with the most specific reason), because a doc-test sandbox must not
+ * install packages, pull images, start daemons, or hit the network.
+ */
+const BASH_SIDE_EFFECTS: Array<{ test: RegExp; reason: string }> = [
+  {
+    test: /\b(docker|docker-compose)\b/,
+    reason: 'docker command — validated by docker.yml, not doc-tests',
+  },
+  { test: /\bcargo\b/, reason: 'cargo build/run — validated by rust.yml, not doc-tests' },
+  {
+    test: /\b(pnpm|npm|npx|yarn|corepack)\b/,
+    reason:
+      'package-manager command (install/scaffold/dev/build) — validated by node.yml + create-topgun-app + post-publish-smoke, not doc-tests',
+  },
+  {
+    test: /\b(curl|wget|http)\b/,
+    reason: 'HTTP example (placeholder/admin endpoint) — illustrative, not executed',
+  },
+  {
+    test: /\b(sudo|rm|kill|lsof|chmod|chown|mv|cp|mkdir|systemctl|service)\b/,
+    reason: 'system/filesystem command — not safe in a doc-test sandbox',
+  },
+  {
+    test: /\btopgun\b/,
+    reason: 'topgun CLI invocation — illustrative (needs a scaffolded app / running server)',
+  },
+];
+
+/** Hermetic verbs that are safe to actually run if a bash snippet is ONLY these. */
+const BASH_SAFE_VERBS = /^(echo|true|:|printf)\b/;
+
+/**
+ * Classifies a bash snippet. Returns `run` only for hermetic snippets whose
+ * every command is a known-safe verb; otherwise an explicit, categorized skip.
+ */
+function classifyBash(s: Snippet): Classified {
+  const lines = s.code
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#'));
+
+  // Env-only snippets (just `export FOO=bar` / `FOO=bar`) are illustrative.
+  const allEnv = lines.length > 0 && lines.every((l) => /^(export\s+)?[A-Z_][A-Z0-9_]*=/.test(l));
+  if (allEnv) {
+    return {
+      snippet: s,
+      verdict: 'skip',
+      reason: 'environment-variable example — no command to execute',
+      forced: false,
+    };
+  }
+
+  for (const { test, reason } of BASH_SIDE_EFFECTS) {
+    if (lines.some((l) => test.test(l))) {
+      return { snippet: s, verdict: 'skip', reason, forced: false };
+    }
+  }
+
+  // Only reach here if nothing side-effecting matched. Run only if every line is
+  // a hermetic safe verb; otherwise skip conservatively (unknown command).
+  const allSafe =
+    lines.length > 0 && lines.every((l) => BASH_SAFE_VERBS.test(l.replace(/^\$\s*/, '')));
+  if (allSafe) {
+    return { snippet: s, verdict: 'run', reason: null, forced: s.directive.setup };
+  }
+  return {
+    snippet: s,
+    verdict: 'skip',
+    reason: 'shell command — not a server API call; illustrative',
+    forced: false,
+  };
+}
+
+/**
+ * Heuristic: does the snippet actually DO something at runtime (a call / await /
+ * new), as opposed to being pure type or interface declarations? Pure-type
+ * snippets stay in the typecheck tier rather than being executed.
+ */
+function hasExecutableStatement(code: string): boolean {
+  // Strip line comments to avoid matching prose-in-comments.
+  const stripped = code.replace(/\/\/.*$/gm, '');
+  return (
+    /\b(await|new|\w+\s*\()/.test(stripped) &&
+    !/^\s*(export\s+)?(type|interface)\b/.test(stripped.trim())
+  );
+}
+
+/**
+ * True when a snippet would open a network connection if run as-is. Such
+ * snippets must opt into the run tier explicitly so the harness can substitute
+ * the live test URL and guarantee teardown; otherwise they stay typecheck-only.
+ */
+function opensConnection(code: string): boolean {
+  const stripped = code.replace(/\/\/.*$/gm, '');
+  return /new\s+TopGunClient|\bserverUrl\b|\.start\s*\(|\bcluster\s*:|new\s+\w*SyncProvider|new\s+SyncEngine|pollInterval/.test(
+    stripped,
+  );
+}

--- a/tests/doc-tests/helpers/client-shim.ts
+++ b/tests/doc-tests/helpers/client-shim.ts
@@ -1,0 +1,76 @@
+/**
+ * Execution-time stand-in for `@topgunbuild/client` (run tier only).
+ *
+ * Re-exports the real client surface verbatim, but wraps `TopGunClient` so the
+ * harness can (a) prove a documented wiring snippet actually completed the WS
+ * handshake against the live server, and (b) tear every client down after each
+ * snippet — `close()` clears the reconnect timers that would otherwise keep the
+ * Jest event loop alive (see TopGunClient.close()).
+ *
+ * The TYPECHECK tier is unaffected — it resolves the real package types via the
+ * TS compiler (helpers/tsc.ts), not this runtime shim.
+ */
+// Import the REAL client via a relative path, NOT the '@topgunbuild/client'
+// specifier — the jest moduleNameMapper points that specifier at THIS file, so
+// importing it here would recurse infinitely.
+import * as realClient from '../../../packages/client/src/index';
+import type { SyncState } from '../../../packages/client/src/index';
+
+export * from '../../../packages/client/src/index';
+
+const RealTopGunClient = realClient.TopGunClient;
+
+/** Every client instantiated since the last reset, for assertion + teardown. */
+const tracked: InstanceType<typeof RealTopGunClient>[] = [];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+class TrackedTopGunClient extends (RealTopGunClient as any) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(...args: any[]) {
+    super(...args);
+    tracked.push(this as unknown as InstanceType<typeof RealTopGunClient>);
+  }
+}
+
+// Override the named export with the tracking subclass.
+export { TrackedTopGunClient as TopGunClient };
+
+/** Clients created since the last reset. */
+export function __doctestTrackedClients(): InstanceType<typeof RealTopGunClient>[] {
+  return tracked.slice();
+}
+
+/** Closes every tracked client (clearing reconnect timers) and resets tracking. */
+export async function __doctestResetClients(): Promise<void> {
+  const clients = tracked.splice(0, tracked.length);
+  await Promise.all(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    clients.map((c) => (c as any).close?.().catch(() => {})),
+  );
+}
+
+/**
+ * Waits until at least one tracked client reaches CONNECTED — proof that a
+ * documented `new TopGunClient({ serverUrl })` actually handshook with the live
+ * server. Resolves immediately if no client opened a connection (e.g. a
+ * local-only example with no serverUrl).
+ */
+export async function __doctestAwaitConnected(timeoutMs: number): Promise<void> {
+  if (tracked.length === 0) return;
+  const connectedState: SyncState = realClient.SyncState.CONNECTED;
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    for (const c of tracked) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const state = (c as any).getConnectionState?.() as SyncState | undefined;
+      if (state === connectedState || state === realClient.SyncState.SYNCING) return;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  // Surface the last seen states so a genuine handshake failure is a clear error.
+  const states = tracked
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((c, i) => `client[${i}]=${(c as any).getConnectionState?.()}`)
+    .join(', ');
+  throw new Error(`no tracked client reached CONNECTED within ${timeoutMs}ms (${states})`);
+}

--- a/tests/doc-tests/helpers/doc-scope.d.ts
+++ b/tests/doc-tests/helpers/doc-scope.d.ts
@@ -1,0 +1,50 @@
+/**
+ * Ambient "doc vocabulary" for the typecheck tier.
+ *
+ * Documentation fragments routinely use a handful of canonical identifiers
+ * WITHOUT an import line — most commonly `client` (an instantiated
+ * `TopGunClient`) and the bare value exports the docs lean on (`Predicates`,
+ * `HLC`, …). Declaring those here, with their REAL types pulled from the
+ * published packages, lets the typecheck tier verify member access on them:
+ *
+ *   client.searchSubscribe('a', 'b')   // ✅ checked against the real TopGunClient
+ *   client.searchSubscrib('a', 'b')    // ❌ TS2339 — caught as API drift
+ *
+ * This is NOT an allowlist of snippets — it is a typed glossary of the names
+ * the docs treat as ambient. Snippet-local symbols the docs invent on the spot
+ * (`Article`, `todos`, `hlc`, …) stay undeclared; the typecheck tier ignores
+ * "cannot find name" for those so illustrative fragments don't fail falsely,
+ * while still catching misuse of the REAL API surface above.
+ *
+ * Keep this in sync with the public package exports. If a name here stops being
+ * exported, the import below fails to compile and the whole doc-test suite goes
+ * red — which is the correct signal.
+ */
+
+import type { TopGunClient } from '@topgunbuild/client';
+import type { Predicates } from '@topgunbuild/client';
+import type { HLC, LWWMap, ORMap, IndexedORMap, IndexedLWWMap } from '@topgunbuild/core';
+
+declare global {
+  /** The canonical instantiated client the docs reference ambiently. */
+  const client: TopGunClient;
+
+  // Bare value-exports the docs use without an import line. Typed as their real
+  // shapes so member access is verified, surfacing drift if an export is
+  // renamed or its signature changes.
+  const Predicates: typeof import('@topgunbuild/client').Predicates;
+  const HLC: typeof import('@topgunbuild/core').HLC;
+  const LWWMap: typeof import('@topgunbuild/core').LWWMap;
+  const ORMap: typeof import('@topgunbuild/core').ORMap;
+  const IndexedORMap: typeof import('@topgunbuild/core').IndexedORMap;
+  const IndexedLWWMap: typeof import('@topgunbuild/core').IndexedLWWMap;
+
+  // Silence references to these unavoidable globals in run-tier snippets without
+  // weakening API checks (they are environment, not TopGun API).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type DocAny = any;
+}
+
+// Reference the imported types so they are not elided, keeping the module form
+// required for `declare global` to take effect.
+export type _DocScopeTypes = TopGunClient | Predicates | HLC | LWWMap | ORMap | IndexedORMap | IndexedLWWMap;

--- a/tests/doc-tests/helpers/extract.ts
+++ b/tests/doc-tests/helpers/extract.ts
@@ -1,0 +1,274 @@
+/**
+ * Documentation snippet extractor — the source of truth for the G2 doc-test gate.
+ *
+ * Walks every published documentation source (README + apps/docs-astro MDX) and
+ * yields one structured record per fenced code block, together with any
+ * `doctest` directive that governs how the block is treated. The runner
+ * (manifest.test.ts) consumes these records and either EXECUTES the snippet
+ * against a live Rust server or records an EXPLICIT skip — never a silent one.
+ *
+ * WHY extract from MDX sources and not the rendered site or llms-full.txt:
+ *   - llms-full.txt is a GENERATED artifact (scripts/build-llms-full.mjs) whose
+ *     code blocks are a strict subset of the MDX it is built from. Testing the
+ *     MDX sources subsumes it; re-extracting the derived file would double-count
+ *     the same snippets and drift the moment the allowlist changes.
+ *   - The rendered HTML loses the fence info-string and the authoring comments
+ *     that carry doctest directives.
+ *
+ * Directive model (see tests/doc-tests/README.md for the authoring contract):
+ *   - DEFAULT = RUN. Every ts / tsx / typescript / js / javascript / bash / sh
+ *     block is executable by default, so a newly-added snippet is picked up
+ *     automatically — there is no allowlist of "tested" snippets.
+ *   - To opt a block OUT, the author writes an explicit directive carrying a
+ *     reason. Skips are therefore always visible in the manifest, never silent.
+ *   - Non-executable languages (json, text, rust, http, nginx, …) are
+ *     classified `skip` with an auto-filled reason, again surfaced in the
+ *     manifest.
+ *
+ * Directive carriers (any of, checked in this order):
+ *   1. A comment line IMMEDIATELY above the fence (one optional blank line
+ *      allowed). Render-invisible in both flavors:
+ *        MDX:  {/* doctest skip reason="needs a browser DOM" *␣/}
+ *        md:   <!-- doctest skip reason="needs a browser DOM" -->
+ *   2. Tokens appended to the fence info string:
+ *        ```ts doctest-skip reason="needs a browser DOM"
+ *
+ * Grammar: the keyword `doctest` followed by space-separated tokens. Recognised
+ * tokens: `skip`, `setup`, `vector`, `expect-error`, and `reason="..."`
+ * (`reason='...'` and bare trailing text after `skip:` also accepted).
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+/** Repository root — three levels up from tests/doc-tests/helpers/. */
+export const REPO_ROOT = join(__dirname, '..', '..', '..');
+
+/** Languages whose blocks the harness can execute. */
+export const TS_LANGS = new Set(['ts', 'tsx', 'typescript', 'js', 'javascript', 'jsx']);
+export const BASH_LANGS = new Set(['bash', 'sh', 'shell']);
+
+export type SnippetKind = 'ts' | 'bash' | 'other';
+
+export interface DoctestDirective {
+  /** Author explicitly marked the block illustrative — do not execute. */
+  skip: boolean;
+  /** Block establishes shared page scope consumed by later blocks on the page. */
+  setup: boolean;
+  /** Block is forced into the run tier (executed; not a shared preamble). */
+  run: boolean;
+  /** Block requires the vector/embedding-enabled server profile. */
+  vector: boolean;
+  /** Block is a negative example: executing it is expected to throw. */
+  expectError: boolean;
+  /** Human-readable reason (required when skip is true). */
+  reason: string | null;
+  /** Where the directive came from, for diagnostics. */
+  source: 'comment' | 'fence' | 'none';
+}
+
+export interface Snippet {
+  /** Repo-relative source path. */
+  file: string;
+  /** 1-based line number of the opening fence. */
+  line: number;
+  /** Lower-cased fence language (`` ``` `` with no language → ''). */
+  lang: string;
+  /** Raw fence info string after the language token. */
+  meta: string;
+  /** The code between the fences, verbatim. */
+  code: string;
+  /** Coarse routing bucket. */
+  kind: SnippetKind;
+  /** Parsed doctest directive (defaults to run). */
+  directive: DoctestDirective;
+  /** Stable identifier: `${file}:${line}`. */
+  id: string;
+}
+
+const NO_DIRECTIVE: DoctestDirective = {
+  skip: false,
+  setup: false,
+  run: false,
+  vector: false,
+  expectError: false,
+  reason: null,
+  source: 'none',
+};
+
+/** Default doc roots, relative to the repo root. */
+export const DOC_SOURCES = {
+  readme: 'README.md',
+  docsContent: join('apps', 'docs-astro', 'src', 'content'),
+};
+
+function langKind(lang: string): SnippetKind {
+  if (TS_LANGS.has(lang)) return 'ts';
+  if (BASH_LANGS.has(lang)) return 'bash';
+  return 'other';
+}
+
+/** Recursively collect .md / .mdx files under a directory. */
+function collectMarkdown(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      collectMarkdown(full, out);
+    } else if (entry.endsWith('.md') || entry.endsWith('.mdx')) {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * Returns the absolute paths of every documentation source file, in a stable
+ * (sorted) order so the manifest is deterministic.
+ */
+export function docFiles(): string[] {
+  const files: string[] = [join(REPO_ROOT, DOC_SOURCES.readme)];
+  collectMarkdown(join(REPO_ROOT, DOC_SOURCES.docsContent), files);
+  return files.sort();
+}
+
+/**
+ * Parses a `doctest …` directive body (the text after the `doctest` keyword)
+ * into a structured directive. `source` records where it was found.
+ */
+function parseDirectiveBody(body: string, source: 'comment' | 'fence'): DoctestDirective {
+  const directive: DoctestDirective = { ...NO_DIRECTIVE, source };
+
+  // Pull out reason="…" / reason='…' first, then strip it so the remaining
+  // tokens parse cleanly.
+  const reasonMatch = body.match(/reason\s*=\s*("([^"]*)"|'([^']*)')/);
+  if (reasonMatch) {
+    directive.reason = (reasonMatch[2] ?? reasonMatch[3] ?? '').trim();
+    body = body.replace(reasonMatch[0], ' ');
+  }
+
+  // `skip: free text reason` shorthand — everything after the colon is the reason.
+  const skipColon = body.match(/\bskip\s*:\s*(.+)$/);
+  if (skipColon && !directive.reason) {
+    directive.reason = skipColon[1].trim();
+  }
+
+  const tokens = body.split(/\s+/).filter(Boolean);
+  for (const tok of tokens) {
+    const t = tok.replace(/[:].*$/, '').toLowerCase();
+    if (t === 'skip' || t === 'doctest-skip') directive.skip = true;
+    else if (t === 'setup' || t === 'doctest-setup') directive.setup = true;
+    else if (t === 'run' || t === 'doctest-run') directive.run = true;
+    else if (t === 'vector' || t === 'doctest-vector') directive.vector = true;
+    else if (t === 'expect-error' || t === 'expecterror') directive.expectError = true;
+  }
+
+  return directive;
+}
+
+/**
+ * Looks for a doctest directive in the fence info string. Recognises the
+ * `doctest …` keyword form and the dash forms (`doctest-skip`, `doctest-setup`,
+ * `doctest-vector`).
+ */
+function directiveFromMeta(meta: string): DoctestDirective | null {
+  if (!/\bdoctest/.test(meta)) return null;
+  // Normalise `doctest-skip` → `doctest skip` so a single parser handles both.
+  const normalised = meta.replace(/doctest-(\w+)/g, 'doctest $1');
+  const m = normalised.match(/\bdoctest\b(.*)$/);
+  return parseDirectiveBody(m ? m[1] : '', 'fence');
+}
+
+/**
+ * Looks backwards from the fence for a directive comment on the nearest
+ * preceding non-blank line (one optional blank line allowed between the comment
+ * and the fence). Matches both MDX `{/* … *␣/}` and HTML `<!-- … -->` comments
+ * that contain a `doctest` keyword.
+ */
+function directiveFromComment(lines: string[], fenceIndex: number): DoctestDirective | null {
+  for (let i = fenceIndex - 1; i >= 0 && i >= fenceIndex - 2; i--) {
+    const line = lines[i].trim();
+    if (line === '') continue;
+    const mdx = line.match(/^\{\/\*\s*(.*?)\s*\*\/\}$/);
+    const html = line.match(/^<!--\s*(.*?)\s*-->$/);
+    const inner = mdx ? mdx[1] : html ? html[1] : null;
+    if (inner && /\bdoctest\b/.test(inner)) {
+      const m = inner.match(/\bdoctest\b(.*)$/);
+      return parseDirectiveBody(m ? m[1] : '', 'comment');
+    }
+    // First non-blank, non-directive line ends the search.
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Extracts every fenced code block from a single file's text.
+ */
+export function extractFromText(text: string, fileLabel: string): Snippet[] {
+  const lines = text.split('\n');
+  const snippets: Snippet[] = [];
+
+  let i = 0;
+  while (i < lines.length) {
+    const open = lines[i].match(/^(\s*)(```+|~~~+)\s*([^\s`]*)\s*(.*)$/);
+    if (!open) {
+      i++;
+      continue;
+    }
+    const indent = open[1];
+    const fence = open[2][0]; // ` or ~
+    const fenceLen = open[2].length;
+    const lang = open[3].toLowerCase();
+    const meta = open[4].trim();
+    const openLine = i;
+
+    // Find the matching closing fence (same char, >= length, same-ish indent).
+    let j = i + 1;
+    const body: string[] = [];
+    let closed = false;
+    const closeRe = new RegExp(`^\\s*${fence === '`' ? '`' : '~'}{${fenceLen},}\\s*$`);
+    while (j < lines.length) {
+      if (closeRe.test(lines[j])) {
+        closed = true;
+        break;
+      }
+      body.push(lines[j]);
+      j++;
+    }
+
+    // Strip the common indent of the opening fence from body lines.
+    const code = body
+      .map((l) => (indent && l.startsWith(indent) ? l.slice(indent.length) : l))
+      .join('\n');
+
+    const fenceDirective = directiveFromMeta(meta);
+    const commentDirective = fenceDirective ? null : directiveFromComment(lines, openLine);
+    const directive = fenceDirective ?? commentDirective ?? { ...NO_DIRECTIVE };
+
+    snippets.push({
+      file: fileLabel,
+      line: openLine + 1,
+      lang,
+      meta,
+      code,
+      kind: langKind(lang),
+      directive,
+      id: `${fileLabel}:${openLine + 1}`,
+    });
+
+    i = closed ? j + 1 : j;
+  }
+
+  return snippets;
+}
+
+/** Extracts snippets from every documentation source. */
+export function extractAll(): Snippet[] {
+  const out: Snippet[] = [];
+  for (const abs of docFiles()) {
+    const label = relative(REPO_ROOT, abs);
+    const text = readFileSync(abs, 'utf8');
+    out.push(...extractFromText(text, label));
+  }
+  return out;
+}

--- a/tests/doc-tests/helpers/memory-adapter.ts
+++ b/tests/doc-tests/helpers/memory-adapter.ts
@@ -1,0 +1,76 @@
+/**
+ * In-memory IStorageAdapter so documentation snippets that wire up the real SDK
+ * (`new TopGunClient({ storage: ... })`) run headless in Node — there is no
+ * IndexedDB outside a browser. Mirrors the adapter the integration-rust suite
+ * uses (tests/integration-rust/reconnect.test.ts); kept in lock-step with the
+ * IStorageAdapter contract so a contract change breaks compilation here too.
+ */
+import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
+
+export class MemoryStorageAdapter implements IStorageAdapter {
+  private kv = new Map<string, unknown>();
+  private meta = new Map<string, unknown>();
+  private opLog: OpLogEntry[] = [];
+  private pending: OpLogEntry[] = [];
+
+  async initialize(): Promise<void> {}
+  async close(): Promise<void> {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async get(key: string): Promise<any> {
+    return this.kv.get(key);
+  }
+  async put(key: string, value: unknown): Promise<void> {
+    this.kv.set(key, value);
+  }
+  async remove(key: string): Promise<void> {
+    this.kv.delete(key);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getMeta(key: string): Promise<any> {
+    return this.meta.get(key);
+  }
+  async setMeta(key: string, value: unknown): Promise<void> {
+    this.meta.set(key, value);
+  }
+  async batchPut(entries: Map<string, unknown>): Promise<void> {
+    for (const [k, v] of entries) this.kv.set(k, v);
+  }
+  async appendOpLog(entry: Omit<OpLogEntry, 'id'>): Promise<number> {
+    const id = this.opLog.length + 1;
+    const e = { ...entry, id, synced: 0 } as OpLogEntry;
+    this.opLog.push(e);
+    this.pending.push(e);
+    return id;
+  }
+  async getPendingOps(): Promise<OpLogEntry[]> {
+    return this.pending;
+  }
+  async markOpsSynced(lastId: number): Promise<void> {
+    this.pending = this.pending.filter((op) => (op.id ?? 0) > lastId);
+    this.opLog.forEach((op) => {
+      if ((op.id ?? 0) <= lastId) op.synced = 1;
+    });
+  }
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+  async commitWrite(
+    mutations: Array<{
+      store: 'kv' | 'meta';
+      type: 'put' | 'remove';
+      key: string;
+      value?: unknown;
+    }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.kv;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value as never);
+    }
+    return this.appendOpLog(op);
+  }
+  async getAllKeys(): Promise<string[]> {
+    return Array.from(this.kv.keys());
+  }
+}

--- a/tests/doc-tests/helpers/server.ts
+++ b/tests/doc-tests/helpers/server.ts
@@ -1,0 +1,43 @@
+/**
+ * Boots the real Rust server for the run tier, reusing the integration-rust
+ * spawner so the doc-tests exercise the exact same binary/orchestration as the
+ * cross-boundary suite (RUST_SERVER_BINARY in CI, cargo run locally; ephemeral
+ * port via the `PORT=` stdout protocol; SIGTERM/SIGKILL process-group cleanup).
+ *
+ * Profile differences from the integration suite:
+ *   - TOPGUN_NO_AUTH=1 so a documented `new TopGunClient({ serverUrl })` with no
+ *     token connects anonymously, exactly as the quick-start promises.
+ *   - Deterministic embeddings + a vector-map declaration so the hybrid/vector
+ *     search docs run reproducibly in CI without a network embedding provider.
+ */
+import { spawnRustServer, SpawnedServer } from '../../integration-rust/helpers';
+
+/** Maps the docs auto-embed for semantic/hybrid examples. */
+const DOC_VECTOR_MAPS = JSON.stringify({
+  docs: { fields: ['title', 'body'], dimension: 64 },
+  articles: { fields: ['title', 'body'], dimension: 64 },
+  products: { fields: ['title', 'description'], dimension: 64 },
+});
+
+export interface DocServer {
+  port: number;
+  /** host:port the assembler substitutes for the documented `localhost:8080`. */
+  authority: string;
+  cleanup: () => Promise<void>;
+}
+
+export async function startDocServer(): Promise<DocServer> {
+  const server: SpawnedServer = await spawnRustServer({
+    env: {
+      TOPGUN_NO_AUTH: '1',
+      TOPGUN_EMBEDDING_PROVIDER: 'deterministic',
+      TOPGUN_EMBEDDING_DIMENSION: '64',
+      TOPGUN_VECTOR_MAPS: DOC_VECTOR_MAPS,
+    },
+  });
+  return {
+    port: server.port,
+    authority: `localhost:${server.port}`,
+    cleanup: server.cleanup,
+  };
+}

--- a/tests/doc-tests/helpers/tsc.ts
+++ b/tests/doc-tests/helpers/tsc.ts
@@ -1,0 +1,222 @@
+/**
+ * Typecheck tier — compiles documentation snippets against the REAL published
+ * package types and reports only the diagnostics that indicate genuine API
+ * drift (the dominant docs-overpromise vector).
+ *
+ * A doc fragment is not a complete program: it references symbols it never
+ * declares (`Article`, `todos`, `hlc`) and imports modules that don't exist
+ * outside the snippet's imagined file (`./types`). Failing on those would make
+ * every illustrative fragment red and teach authors to disable the gate. So the
+ * compiler runs in a deliberately split mode:
+ *
+ *   IGNORE  — "you referenced something you didn't declare here" (TS2304 et al).
+ *             That is the nature of a fragment, not a doc bug.
+ *   FAIL    — "you used the REAL API wrong": a method that doesn't exist on a
+ *             TopGun type, a wrong argument, an import of a non-exported member.
+ *             That is exactly the drift the gate exists to catch.
+ *
+ * Self-containment detection reuses the same compile: a snippet that produces
+ * ZERO diagnostics of ANY kind (including the ignored fragment codes) and pulls
+ * in at least one @topgunbuild import is a complete program and is eligible for
+ * the run tier.
+ */
+
+import * as ts from 'typescript';
+import { join } from 'path';
+
+import { REPO_ROOT } from './extract';
+
+/**
+ * Diagnostic codes that signal real API misuse / drift. These FAIL the gate.
+ * Everything else (notably "cannot find name/module/namespace") is treated as
+ * the expected shape of an illustrative fragment and ignored.
+ */
+export const DRIFT_CODES = new Set<number>([
+  2305, // Module '"X"' has no exported member 'Y'.        — import renamed/removed
+  2614, // Module '"X"' has no exported member 'Y'. (namespace import variant)
+  2724, // '"X"' has no exported member named 'Y'. Did you mean 'Z'?
+  2339, // Property 'x' does not exist on type 'Y'.          — method renamed/removed
+  2551, // Property 'x' does not exist on type 'Y'. Did you mean 'z'?
+  2345, // Argument of type 'A' is not assignable to parameter of type 'B'.
+  2554, // Expected N arguments, but got M.
+  2555, // Expected at least N arguments, but got M.
+  2353, // Object literal may only specify known properties.
+  2559, // Type 'A' has no properties in common with type 'B'.
+  2769, // No overload matches this call.
+  2741, // Property 'x' is missing in type 'A' but required in type 'B'.
+]);
+
+/**
+ * Codes that are syntax-level: a snippet producing these is not parseable as a
+ * standalone TS module (e.g. a bare object-literal fragment). Such snippets are
+ * auto-classified `skip` (illustrative, surfaced in the manifest) rather than
+ * failed — unless the author forced a tier.
+ */
+export function isSyntaxError(code: number): boolean {
+  return code >= 1000 && code < 2000;
+}
+
+const PRELUDE = `/// <reference path="./doc-scope.d.ts" />\n`;
+const PRELUDE_LINES = PRELUDE.split('\n').length - 1;
+
+export interface CheckOptions {
+  /**
+   * When true, the doc-scope ambient (`client`, `Predicates`, …) is in scope.
+   * Use this for DRIFT detection — fragments that reference ambient `client`
+   * get their real-API member access checked.
+   *
+   * When false, the snippet is compiled with no ambient crutch. Use this for
+   * SELF-CONTAINMENT: a snippet is runnable standalone only if it compiles
+   * clean WITHOUT the ambient (i.e. it declares its own `client` etc.). A
+   * fragment that leans on ambient `client` is not standalone-runnable — the
+   * run tier has no ambient — so it must stay typecheck-only.
+   */
+  ambient: boolean;
+}
+
+export interface SnippetInput {
+  id: string;
+  code: string;
+}
+
+export interface SnippetDiagnostics {
+  id: string;
+  /** Drift diagnostics — these must be empty for a typecheck PASS. */
+  drift: string[];
+  /** Syntax errors — snippet is not standalone-parseable. */
+  syntax: string[];
+  /** True when the snippet compiled with ZERO diagnostics of any kind. */
+  selfContained: boolean;
+  /** True when the snippet imports at least one @topgunbuild package. */
+  importsTopgun: boolean;
+}
+
+function compilerOptions(): ts.CompilerOptions {
+  const pkg = (name: string) => join(REPO_ROOT, 'packages', name, 'src', 'index.ts');
+  return {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    jsx: ts.JsxEmit.ReactJSX,
+    lib: ['lib.esnext.d.ts', 'lib.dom.d.ts'],
+    strict: false,
+    noImplicitAny: false,
+    skipLibCheck: true,
+    noEmit: true,
+    allowJs: true,
+    esModuleInterop: true,
+    allowImportingTsExtensions: true,
+    types: [],
+    baseUrl: REPO_ROOT,
+    paths: {
+      '@topgunbuild/client': [pkg('client')],
+      '@topgunbuild/core': [pkg('core')],
+      '@topgunbuild/react': [pkg('react')],
+      '@topgunbuild/adapters': [pkg('adapters')],
+      '@topgunbuild/mcp-server': [pkg('mcp-server')],
+      '@topgunbuild/schema': [pkg('schema')],
+    },
+  };
+}
+
+const HELPERS_DIR = __dirname;
+
+/**
+ * Compiles a batch of snippets in a single program and returns per-snippet
+ * diagnostics. Batching shares the lib + package-types load across all
+ * snippets, so checking ~200 fragments costs roughly one program build.
+ */
+export function checkSnippets(
+  snippets: SnippetInput[],
+  opts: CheckOptions = { ambient: true },
+): Map<string, SnippetDiagnostics> {
+  const options = compilerOptions();
+  const prelude = opts.ambient ? PRELUDE : '';
+  const preludeLines = opts.ambient ? PRELUDE_LINES : 0;
+  const virtualName = (i: number) => join(HELPERS_DIR, `__doc_snippet_${i}.tsx`);
+  const sources = new Map<string, string>();
+  snippets.forEach((s, i) => {
+    // Force MODULE scope with a trailing `export {}`. Without it, a snippet that
+    // has no import/export is a SCRIPT, and its top-level `const client = …`
+    // leaks as a program-wide GLOBAL — contaminating sibling snippets (bare
+    // `client` would wrongly resolve, masking both drift and self-containment).
+    // As a module, every snippet's top-level bindings are isolated.
+    sources.set(virtualName(i), prelude + s.code + '\nexport {};\n');
+  });
+
+  const host = ts.createCompilerHost(options, true);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
+    if (sources.has(fileName)) {
+      return ts.createSourceFile(
+        fileName,
+        sources.get(fileName)!,
+        languageVersion,
+        true,
+        ts.ScriptKind.TSX,
+      );
+    }
+    return originalGetSourceFile(fileName, languageVersion, onError, shouldCreate);
+  };
+  const originalFileExists = host.fileExists.bind(host);
+  host.fileExists = (fileName) => sources.has(fileName) || originalFileExists(fileName);
+  const originalReadFile = host.readFile.bind(host);
+  host.readFile = (fileName) =>
+    sources.has(fileName) ? sources.get(fileName) : originalReadFile(fileName);
+
+  const program = ts.createProgram([...sources.keys()], options, host);
+
+  const result = new Map<string, SnippetDiagnostics>();
+  snippets.forEach((s, i) => {
+    const file = program.getSourceFile(virtualName(i));
+    const diags = file
+      ? [...program.getSyntacticDiagnostics(file), ...program.getSemanticDiagnostics(file)]
+      : [];
+
+    const drift: string[] = [];
+    const syntax: string[] = [];
+    let anyDiag = false;
+    for (const d of diags) {
+      anyDiag = true;
+      const msg = formatDiag(d, preludeLines);
+      if (isSyntaxError(d.code)) syntax.push(msg);
+      else if (DRIFT_CODES.has(d.code) && !isFragmentNoise(d)) drift.push(msg);
+    }
+
+    result.set(s.id, {
+      id: s.id,
+      drift,
+      syntax,
+      selfContained: !anyDiag,
+      importsTopgun: /from\s+['"]@topgunbuild\//.test(s.code),
+    });
+  });
+
+  return result;
+}
+
+/**
+ * Property-access diagnostics (2339/2551) are only meaningful when the target
+ * is a REAL package type. When the target is `unknown` (a loosely-typed
+ * callback param the fragment never annotated) or an inline object literal the
+ * snippet invented locally, the access says nothing about TopGun's API — it is
+ * fragment noise, not drift.
+ */
+function isFragmentNoise(d: ts.Diagnostic): boolean {
+  if (d.code !== 2339 && d.code !== 2551) return false;
+  const text = ts.flattenDiagnosticMessageText(d.messageText, '\n');
+  // "...does not exist on type 'unknown'" — untyped local, not the public API.
+  if (/type '(unknown|any|never|\{)/.test(text)) return true;
+  return false;
+}
+
+function formatDiag(d: ts.Diagnostic, preludeLines: number): string {
+  const text = ts.flattenDiagnosticMessageText(d.messageText, '\n');
+  if (d.file && d.start != null) {
+    const { line, character } = d.file.getLineAndCharacterOfPosition(d.start);
+    // Subtract the injected prelude so the line maps to the snippet body.
+    const snippetLine = line - preludeLines + 1;
+    return `TS${d.code} (snippet line ${snippetLine}, col ${character + 1}): ${text}`;
+  }
+  return `TS${d.code}: ${text}`;
+}

--- a/tests/doc-tests/jest.config.js
+++ b/tests/doc-tests/jest.config.js
@@ -1,0 +1,28 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['<rootDir>/**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '\\.d\\.ts$'],
+  moduleNameMapper: {
+    // Resolve the SDK from workspace source (no build needed), matching the
+    // integration-rust harness so the doc-tests drive the same code users get.
+    '^@topgunbuild/core$': '<rootDir>/../../packages/core/src/index.ts',
+    // Tracking wrapper over the real client: records instances so the run tier
+    // can assert the WS handshake and tear clients down (clears reconnect
+    // timers). The shim imports the real client by relative path.
+    '^@topgunbuild/client$': '<rootDir>/helpers/client-shim.ts',
+    '^@topgunbuild/react$': '<rootDir>/../../packages/react/src/index.ts',
+    // Execution-time stand-in: IndexedDB does not exist in Node, so run-tier
+    // snippets that import IDBAdapter get an in-memory adapter. The TYPECHECK
+    // tier resolves the real package types separately (see helpers/tsc.ts).
+    '^@topgunbuild/adapters$': '<rootDir>/helpers/adapters-shim.ts',
+  },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
+  },
+  // Generous: the exec suite boots a real Rust server (and may cargo-build on a
+  // dev machine) before running snippets against it.
+  testTimeout: 120000,
+};

--- a/tests/doc-tests/negative-control.test.ts
+++ b/tests/doc-tests/negative-control.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Negative control — proves the gate actually fails when documentation breaks.
+ *
+ * A green doc-test suite is only meaningful if a broken snippet would turn it
+ * red. Rather than commit a broken doc (which would block the PR), these tests
+ * feed deliberately-broken snippets through the SAME extraction / classification
+ * / typecheck / execution pipeline the real suites use, and assert the harness
+ * reports a failure. If any of these stops failing, the gate has gone blind.
+ *
+ * To verify by hand: introduce a typo in any doc snippet (e.g. `client.getMap`
+ * → `client.getMapp`) and the typecheck suite reddens on that snippet.
+ */
+import { checkSnippets } from './helpers/tsc';
+import { classifyAll } from './helpers/classify';
+import { assembleRunModule, executeModule } from './helpers/assemble';
+import { Snippet } from './helpers/extract';
+import { __doctestResetClients } from './helpers/client-shim';
+
+function synthetic(code: string, overrides: Partial<Snippet> = {}): Snippet {
+  return {
+    file: 'negative-control',
+    line: 1,
+    lang: 'ts',
+    meta: '',
+    code,
+    kind: 'ts',
+    directive: {
+      skip: false,
+      setup: false,
+      run: false,
+      vector: false,
+      expectError: false,
+      reason: null,
+      source: 'none',
+    },
+    id: 'negative-control:1',
+    ...overrides,
+  };
+}
+
+describe('negative control — the gate fails on broken docs', () => {
+  it('TYPECHECK catches a renamed method on a real type (TS2339)', () => {
+    const d = checkSnippets([{ id: 'x', code: `client.getMapTYPO('todos').set('a', {});` }], {
+      ambient: true,
+    }).get('x')!;
+    expect(d.drift.length).toBeGreaterThan(0);
+    expect(d.drift.join('\n')).toMatch(/getMapTYPO|does not exist/);
+  });
+
+  it('TYPECHECK catches an import of a non-existent export (TS2305)', () => {
+    const d = checkSnippets(
+      [
+        {
+          id: 'x',
+          code: `import { NotARealExport } from '@topgunbuild/client';\nconsole.log(NotARealExport);`,
+        },
+      ],
+      { ambient: true },
+    ).get('x')!;
+    expect(d.drift.length).toBeGreaterThan(0);
+    expect(d.drift.join('\n')).toMatch(/no exported member|NotARealExport/);
+  });
+
+  it('TYPECHECK catches a wrong argument count on a real API (TS2554)', () => {
+    const d = checkSnippets(
+      [
+        {
+          id: 'x',
+          code: `import { HLC } from '@topgunbuild/core';\nnew HLC('n', {}, 'extra-arg');`,
+        },
+      ],
+      { ambient: true },
+    ).get('x')!;
+    expect(d.drift.length).toBeGreaterThan(0);
+  });
+
+  it('a CORRECT snippet produces no drift (control for the controls)', () => {
+    const d = checkSnippets(
+      [
+        {
+          id: 'x',
+          code: `import { HLC } from '@topgunbuild/core';\nconst h = new HLC('node-1');\nh.now();`,
+        },
+      ],
+      { ambient: true },
+    ).get('x')!;
+    expect(d.drift).toHaveLength(0);
+  });
+
+  it('RUN catches a snippet that throws at runtime', async () => {
+    const assembled = assembleRunModule([], `throw new Error('intentional doc-test failure');`, {
+      authority: 'localhost:0',
+    });
+    await expect(executeModule(assembled, require, 5_000)).rejects.toThrow(
+      /intentional doc-test failure/,
+    );
+    await __doctestResetClients();
+  });
+
+  it('MANIFEST refuses an explicit skip with no reason', () => {
+    const s = synthetic(`const a = 1;`, {
+      lang: 'ts',
+      directive: {
+        skip: true,
+        setup: false,
+        run: false,
+        vector: false,
+        expectError: false,
+        reason: null,
+        source: 'fence',
+      },
+    });
+    const [classified] = classifyAll([s]);
+    expect(classified.verdict).toBe('skip');
+    // A reasonless skip surfaces the sentinel the manifest integrity test rejects.
+    expect(classified.reason).toBe('(no reason given)');
+  });
+});

--- a/tests/doc-tests/tsconfig.json
+++ b/tests/doc-tests/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "declaration": false,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "baseUrl": "../..",
+    "paths": {
+      "@topgunbuild/core": ["packages/core/src"],
+      "@topgunbuild/client": ["packages/client/src"],
+      "@topgunbuild/react": ["packages/react/src"],
+      "@topgunbuild/adapters": ["packages/adapters/src"]
+    }
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## G2 gate — executable documentation

Closes the stabilization program's **G2** criterion: a blocking CI job extracts **every** code snippet from `README.md` + `apps/docs-astro/` and exercises it against reality. New snippets are picked up automatically — **no allowlist**, **no silent skips**.

### Three tiers (`tests/doc-tests/`)

| Tier | What | Count |
|------|------|-------|
| **run** | Executed against a **live Rust server** (reuses the integration-rust spawner; no-auth + deterministic embeddings). A wired-up client must reach `CONNECTED`, so the README flagship snippet proves a real client↔server handshake. Pure-core CRDT examples run too. | 4 |
| **typecheck** | Compiled against the **real `@topgunbuild/*` types**. A renamed export/method, wrong argument, or bad import — docs-overpromise — fails here. | 158 |
| **skip** | Explicit, **always with a reason** in the manifest (non-exec languages, illustrative class-method notation, side-effecting shell commands → reason names the CI that *does* validate them). | 121 |

Authoring contract: [`tests/doc-tests/README.md`](tests/doc-tests/README.md). Run locally: `pnpm test:docs`.

### Negative control

`negative-control.test.ts` proves the gate reddens on broken docs — it feeds deliberately-broken snippets (renamed method → TS2339, bad import → TS2305, wrong arity → TS2554, runtime throw, reasonless skip) through the real pipeline and asserts each is caught. Manual check: typo any doc snippet and the suite goes red.

### 10 real docs-overpromise drifts caught + fixed

The harness immediately found (and this PR fixes) drift that shipped to the live docs:

- `new IDBAdapter('my-app')` → `new IDBAdapter()` (0-arg ctor)
- `useHybridQuery().data` → `.results`
- `getMap().onChange(...)` → `.subscribe(...)` (firebase **and** yjs guides, incl. prose)
- `client.query('todos')` → `client.query('todos', {})` (filter required)
- `searchSubscribe(..., { sort })` — option doesn't exist, dropped
- `EncryptedStorageAdapter(a, { passphrase })` → real `CryptoKey` PBKDF2 derivation
- `HLC.MAX_DRIFT` → real `maxDriftMs` option
- `QueryResultItem` now re-exported from `@topgunbuild/react`
- `onBackpressure` union access narrowed

Two SDK follow-ups filed (local `.specflow` TODOs): **TODO-527** `EncryptedStorageAdapter.fromPassphrase()` (ergonomic passphrase encryption, done with full crypto checklist), **TODO-528** `onBackpressure` event-typed overloads.

### Surface
- New blocking workflow `.github/workflows/doc-tests.yml` (build-server → doc-tests, mirrors integration-rust).
- `pnpm test:docs` script; CLAUDE.md test notes updated.
- Only SDK change: `packages/react/src/index.ts` re-exports `QueryResultItem` (a public return-type's element type, previously un-nameable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)