### PR TITLE
feat(server,client): honest typed FEATURE_DISABLED for SQL + e2e gate (TODO-463/464)

### DIFF
--- a/apps/docs-astro/src/content/blog/rust-server-release.mdx
+++ b/apps/docs-astro/src/content/blog/rust-server-release.mdx
@@ -107,7 +107,7 @@ Full docs at [topgun.build/docs](https://topgun.build/docs).
 ## What's Next
 
 - **Schema validation** — define and enforce record shapes
-- **SQL queries** — DataFusion-powered SQL over CRDT data
+- **SQL queries** — DataFusion-powered SQL over CRDT data, as an opt-in, compile-time feature flag (off by default to keep the standard build lean)
 - **WASM client** — same Rust CRDT engine running in the browser
 - **Multi-tenancy** — isolated namespaces on a shared cluster
 

--- a/apps/docs-astro/src/content/docs/reference/client.mdx
+++ b/apps/docs-astro/src/content/docs/reference/client.mdx
@@ -428,17 +428,40 @@ const unsubscribe = handle.subscribe((results) => setResults(results));
 handle.dispose();
 ```
 
-### `sql(query)` — opt-in, server-feature-gated
+### `sql(query)` — not yet available (preview API)
 
 ```typescript
 public async sql(query: string): Promise<SqlQueryResult>
 ```
 
-Execute a one-shot SQL query server-side via the DataFusion engine. Map names are used as table names; the server must have schemas registered for them.
+:::caution[Not functional yet]
+SQL is **not wired into the server today** — calling `client.sql()` against any current build (including one compiled with `--features datafusion`) rejects with a `SqlError` whose `code` is `'FEATURE_DISABLED'`. The method and its types ship so the surface is stable for early adopters, but the server-side query engine is not yet connected. Enablement (plus per-table authorization for SQL) is tracked in the roadmap; until then, use the structured query API.
+:::
 
-**Off by default.** The server's DataFusion feature is a compile-time opt-in (`--features datafusion`). The default server build (`default = ["redb"]`) does NOT include DataFusion. If you send a SQL query to a server built without this feature, the server returns an error.
+When it lands, `client.sql()` will execute a one-shot SQL query server-side via the DataFusion engine — an **opt-in, compile-time-gated** feature (`--features datafusion`; the default build is `default = ["redb"]` and does not include it). Map names are used as table names.
 
-**Niche — use only for what the structured query API cannot express.** `client.sql()` exists for queries that genuinely require SQL: multi-map **joins**, **window functions**, **HAVING** clauses, and **DISTINCT** aggregation. For everything else — filtering, sorting, full-text search, group-by, aggregate functions — use the structured query API (`client.query()`, `client.queryOnce()`, `client.queryOncePaged()`) backed by the canonical DAG engine. Reaching for SQL when the structured API suffices adds a server-side dependency and bypasses the local-first offline path.
+**Niche — only for what the structured query API cannot express.** SQL is intended for queries that genuinely require it: multi-map **joins**, **window functions**, **HAVING** clauses, and **DISTINCT** aggregation. For everything else — filtering, sorting, full-text search, group-by, aggregate functions — use the structured query API (`client.query()`, `client.queryOnce()`, `client.queryOncePaged()`) backed by the canonical DAG engine, which keeps the local-first offline path.
+
+Detect a server without SQL enabled by checking the error `code`:
+
+```typescript
+import { SqlError } from '@topgunbuild/client';
+
+try {
+  const result = await client.sql('SELECT 1');
+  console.log(result.columns, result.rows);
+} catch (err) {
+  if (err instanceof SqlError && err.code === 'FEATURE_DISABLED') {
+    // This server build has no SQL engine — fall back to client.query().
+  } else {
+    throw err;
+  }
+}
+```
+
+The intended shape once enabled (cross-map join, illustrative):
+
+{/* doctest skip reason="SQL is not yet wired into the server (returns FEATURE_DISABLED); shown as the planned API surface" */}
 
 ```typescript
 // Only appropriate for cross-map joins or window/HAVING/DISTINCT queries

--- a/packages/client/src/__tests__/SqlClient.test.ts
+++ b/packages/client/src/__tests__/SqlClient.test.ts
@@ -8,6 +8,7 @@ import { SyncEngine } from '../SyncEngine';
 import { TopGunClient } from '../TopGunClient';
 import { SyncState } from '../SyncState';
 import { SingleServerProvider } from '../connection/SingleServerProvider';
+import { SqlError } from '../errors/SqlError';
 import type { SqlQueryResult } from '../sync/types';
 
 // Mock storage adapter
@@ -133,6 +134,52 @@ describe('Client SQL', () => {
       });
 
       await expect(sqlPromise).rejects.toThrow('Table not found: nonexistent');
+    });
+
+    it('should reject a query error as SqlError without a code', async () => {
+      (syncEngine as any).stateMachine.state = SyncState.CONNECTED;
+
+      const sqlPromise = syncEngine.sql('SELECT * FROM nonexistent');
+
+      const sentMessage = mockSendMessage.mock.calls[0][0];
+      (syncEngine as any).handleServerMessage({
+        type: 'SQL_QUERY_RESP',
+        payload: {
+          queryId: sentMessage.payload.queryId,
+          columns: [],
+          rows: [],
+          error: 'Table not found: nonexistent',
+        },
+      });
+
+      const err = await sqlPromise.catch((e) => e);
+      expect(err).toBeInstanceOf(SqlError);
+      expect((err as SqlError).code).toBeUndefined();
+    });
+
+    it('should surface FEATURE_DISABLED as a typed, machine-distinguishable SqlError', async () => {
+      (syncEngine as any).stateMachine.state = SyncState.CONNECTED;
+
+      const sqlPromise = syncEngine.sql('SELECT * FROM users');
+
+      const sentMessage = mockSendMessage.mock.calls[0][0];
+      // Server built without the datafusion feature replies promptly with a typed
+      // code instead of leaving the request to hang until the 30s timeout.
+      (syncEngine as any).handleServerMessage({
+        type: 'SQL_QUERY_RESP',
+        payload: {
+          queryId: sentMessage.payload.queryId,
+          columns: [],
+          rows: [],
+          error: 'SQL is not available: this server was built without the datafusion feature',
+          code: 'FEATURE_DISABLED',
+        },
+      });
+
+      const err = await sqlPromise.catch((e) => e);
+      expect(err).toBeInstanceOf(SqlError);
+      expect((err as SqlError).code).toBe('FEATURE_DISABLED');
+      expect((err as SqlError).message).toContain('datafusion');
     });
 
     it('should timeout if no response', async () => {

--- a/packages/client/src/errors/SqlError.ts
+++ b/packages/client/src/errors/SqlError.ts
@@ -1,0 +1,37 @@
+/**
+ * Machine-distinguishable error code for a server SQL query failure.
+ *
+ * - `FEATURE_DISABLED`: the server cannot run SQL at all — it was built without
+ *   the `datafusion` feature, or compiled with it but no SQL backend is wired.
+ *   This is a deployment/build fact, not a problem with the query string;
+ *   retrying or rewriting the SQL will not help.
+ * - `undefined`: a query/execution failure (parse error, unknown table, type
+ *   mismatch, …). The human-readable {@link SqlError.message} describes it.
+ */
+export type SqlErrorCode = 'FEATURE_DISABLED';
+
+/**
+ * Thrown by `TopGunClient.sql()` / `SyncEngine.sql()` when the server rejects a
+ * SQL query.
+ *
+ * The {@link code} field makes the failure class machine-distinguishable without
+ * string-matching the message: a caller can branch on
+ * `err.code === 'FEATURE_DISABLED'` to detect a server that simply does not have
+ * SQL enabled (compile-time opt-in via `--features datafusion`) versus an actual
+ * query error. Crucially, a disabled server now returns this typed error
+ * promptly instead of leaving the request to hang until its timeout.
+ */
+export class SqlError extends Error {
+  public readonly name = 'SqlError';
+  /** Machine-distinguishable error class; `undefined` for query/execution errors. */
+  public readonly code?: SqlErrorCode | string;
+
+  constructor(message: string, code?: SqlErrorCode | string) {
+    super(message);
+    this.code = code;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, SqlError);
+    }
+  }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -158,6 +158,10 @@ export { DEFAULT_QUERY_ONCE_TIMEOUT_MS } from './TopGunClient';
 export { QueryOnceUnsettledError, QueryOnceLocalError } from './errors/QueryOnceError';
 export type { QueryOnceUnsettledReason } from './errors/QueryOnceError';
 
+// Server SQL query error (carries a machine-distinguishable `code`, e.g. FEATURE_DISABLED)
+export { SqlError } from './errors/SqlError';
+export type { SqlErrorCode } from './errors/SqlError';
+
 // Auth provider exports
 export { ClerkAuthProvider } from './auth/ClerkAuthProvider';
 export { FirebaseAuthProvider } from './auth/FirebaseAuthProvider';

--- a/packages/client/src/sync/ClientMessageHandlers.ts
+++ b/packages/client/src/sync/ClientMessageHandlers.ts
@@ -86,6 +86,7 @@ export interface ManagerDelegates {
       columns: string[];
       rows: unknown[][];
       error?: string;
+      code?: string;
     }): void;
   };
   vectorSearchClient: {

--- a/packages/client/src/sync/SqlClient.ts
+++ b/packages/client/src/sync/SqlClient.ts
@@ -8,6 +8,7 @@
  * - Cleanup on close
  */
 
+import { SqlError } from '../errors/SqlError';
 import { logger } from '../utils/logger';
 import type { ISqlClient, SqlClientConfig, SqlQueryResult } from './types';
 
@@ -107,13 +108,17 @@ export class SqlClient implements ISqlClient {
     columns: string[];
     rows: unknown[][];
     error?: string;
+    code?: string;
   }): void {
     const pending = this.pendingSqlRequests.get(payload.queryId);
     if (pending) {
       this.pendingSqlRequests.delete(payload.queryId);
 
       if (payload.error) {
-        pending.reject(new Error(payload.error));
+        // Surface the server's machine-distinguishable code (e.g. FEATURE_DISABLED
+        // when the server has no SQL backend) so callers can branch on err.code
+        // instead of string-matching the message.
+        pending.reject(new SqlError(payload.error, payload.code));
       } else {
         pending.resolve({ columns: payload.columns, rows: payload.rows });
       }

--- a/packages/client/src/sync/types.ts
+++ b/packages/client/src/sync/types.ts
@@ -794,6 +794,7 @@ export interface ISqlClient {
     columns: string[];
     rows: unknown[][];
     error?: string;
+    code?: string;
   }): void;
 
   /**

--- a/packages/core-rust/src/messages/query.rs
+++ b/packages/core-rust/src/messages/query.rs
@@ -193,6 +193,13 @@ pub struct SqlQueryRespPayload {
     /// Error message if the query failed; `None` on success.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub error: Option<String>,
+    /// Machine-distinguishable error class when `error` is set; `None` on success.
+    ///
+    /// Lets a client tell apart, e.g., a disabled server feature
+    /// (`"FEATURE_DISABLED"`) from a query/execution failure (no code) without
+    /// string-matching the human-readable `error` message.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub code: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -595,6 +602,7 @@ mod tests {
                 ],
             ],
             error: None,
+            code: None,
         };
         assert_eq!(roundtrip_named(&payload), payload);
     }
@@ -606,6 +614,19 @@ mod tests {
             columns: vec![],
             rows: vec![],
             error: Some("syntax error near 'SELCT'".to_string()),
+            code: None,
+        };
+        assert_eq!(roundtrip_named(&payload), payload);
+    }
+
+    #[test]
+    fn sql_query_resp_payload_code_roundtrip() {
+        let payload = SqlQueryRespPayload {
+            query_id: "sq-disabled".to_string(),
+            columns: vec![],
+            rows: vec![],
+            error: Some("SQL is not available on this server".to_string()),
+            code: Some("FEATURE_DISABLED".to_string()),
         };
         assert_eq!(roundtrip_named(&payload), payload);
     }
@@ -617,12 +638,15 @@ mod tests {
             columns: vec!["id".to_string()],
             rows: vec![vec![rmpv::Value::Integer(1.into())]],
             error: None,
+            code: None,
         };
         let bytes = rmp_serde::to_vec_named(&payload).expect("serialize");
         let val: rmpv::Value = rmp_serde::from_slice(&bytes).expect("deserialize");
         let map = val.as_map().expect("should be a map");
         let has_error = map.iter().any(|(k, _)| k.as_str() == Some("error"));
         assert!(!has_error, "error field should be omitted when None");
+        let has_code = map.iter().any(|(k, _)| k.as_str() == Some("code"));
+        assert!(!has_code, "code field should be omitted when None");
     }
 
     #[test]
@@ -632,6 +656,7 @@ mod tests {
             columns: vec![],
             rows: vec![],
             error: None,
+            code: None,
         };
         let bytes = rmp_serde::to_vec_named(&payload).expect("serialize");
         let val: rmpv::Value = rmp_serde::from_slice(&bytes).expect("deserialize");

--- a/packages/core/src/schemas/sql-schemas.ts
+++ b/packages/core/src/schemas/sql-schemas.ts
@@ -20,6 +20,9 @@ export const SqlQueryRespPayloadSchema = z.object({
   columns: z.array(z.string()),
   rows: z.array(z.array(z.unknown())),
   error: z.string().optional(),
+  // Machine-distinguishable error class when `error` is set (e.g. 'FEATURE_DISABLED'
+  // when the server has no SQL/DataFusion backend). Absent on success.
+  code: z.string().optional(),
 });
 export type SqlQueryRespPayload = z.infer<typeof SqlQueryRespPayloadSchema>;
 

--- a/packages/server-rust/src/service/domain/query.rs
+++ b/packages/server-rust/src/service/domain/query.rs
@@ -46,6 +46,11 @@ use crate::storage::mutation_observer::MutationObserver;
 use crate::storage::record::{Record, RecordValue};
 use crate::storage::RecordStoreFactory;
 
+/// Machine-distinguishable `SqlQueryResp.code` returned when SQL is unavailable
+/// (the `datafusion` feature is compiled out, or compiled in without a wired
+/// backend). Clients match on this code rather than the human-readable message.
+pub const SQL_FEATURE_DISABLED_CODE: &str = "FEATURE_DISABLED";
+
 // ---------------------------------------------------------------------------
 // QuerySubscription
 // ---------------------------------------------------------------------------
@@ -1009,17 +1014,29 @@ impl QueryService {
     ///
     /// When the `datafusion` feature is enabled and a `SqlQueryBackend` is
     /// configured, executes the SQL string and converts Arrow `RecordBatch`es
-    /// to `rmpv::Value` rows for wire transport. Without the feature or backend,
-    /// returns an error indicating SQL is not available.
+    /// to `rmpv::Value` rows for wire transport.
+    ///
+    /// When SQL is not available — the `datafusion` feature is compiled out, or
+    /// it is compiled in but no `SqlQueryBackend` is wired — this returns a
+    /// `SqlQueryResp` carrying `code = FEATURE_DISABLED` rather than an
+    /// `OperationError`. That distinction matters: a single-message dispatch
+    /// error is logged and dropped (the client would hang until its request
+    /// timeout, indistinguishable from a network stall), whereas a `SqlQueryResp`
+    /// is correlated back to the caller by `query_id` and surfaces immediately as
+    /// a machine-distinguishable "feature disabled" signal — not an opaque
+    /// "internal error".
     #[cfg(feature = "datafusion")]
     async fn handle_sql_query(
         &self,
         _ctx: &crate::service::operation::OperationContext,
         payload: &topgun_core::messages::query::SqlQueryPayload,
     ) -> Result<OperationResponse, OperationError> {
-        let sql_backend = self.sql_query_backend.as_ref().ok_or_else(|| {
-            OperationError::Internal(anyhow::anyhow!("SQL requires datafusion feature"))
-        })?;
+        let Some(sql_backend) = self.sql_query_backend.as_ref() else {
+            return Ok(Self::sql_feature_disabled_resp(
+                &payload.query_id,
+                "SQL is not available: the DataFusion backend is not configured on this server",
+            ));
+        };
 
         match sql_backend.execute_sql(&payload.sql).await {
             Ok(batches) => {
@@ -1029,6 +1046,7 @@ impl QueryService {
                     columns,
                     rows,
                     error: None,
+                    code: None,
                 };
                 Ok(OperationResponse::Message(Box::new(
                     Message::SqlQueryResp {
@@ -1042,6 +1060,7 @@ impl QueryService {
                     columns: vec![],
                     rows: vec![],
                     error: Some(e.to_string()),
+                    code: None,
                 };
                 Ok(OperationResponse::Message(Box::new(
                     Message::SqlQueryResp {
@@ -1053,16 +1072,36 @@ impl QueryService {
     }
 
     /// Handles a `SqlQuery` operation when the `datafusion` feature is disabled.
+    ///
+    /// Returns a `SqlQueryResp` with `code = FEATURE_DISABLED` (see the
+    /// feature-enabled variant for why this is a response, not an error).
     #[cfg(not(feature = "datafusion"))]
     #[allow(clippy::unused_async)]
     async fn handle_sql_query(
         &self,
         _ctx: &crate::service::operation::OperationContext,
-        _payload: &topgun_core::messages::query::SqlQueryPayload,
+        payload: &topgun_core::messages::query::SqlQueryPayload,
     ) -> Result<OperationResponse, OperationError> {
-        Err(OperationError::Internal(anyhow::anyhow!(
-            "SQL requires datafusion feature"
-        )))
+        Ok(Self::sql_feature_disabled_resp(
+            &payload.query_id,
+            "SQL is not available: this server was built without the datafusion feature",
+        ))
+    }
+
+    /// Builds a `SqlQueryResp` signalling that SQL is unavailable, tagged with the
+    /// machine-distinguishable `FEATURE_DISABLED` code so the client can tell a
+    /// disabled feature apart from a query/execution failure without string
+    /// matching the human-readable message.
+    fn sql_feature_disabled_resp(query_id: &str, message: &str) -> OperationResponse {
+        OperationResponse::Message(Box::new(Message::SqlQueryResp {
+            payload: topgun_core::messages::query::SqlQueryRespPayload {
+                query_id: query_id.to_string(),
+                columns: vec![],
+                rows: vec![],
+                error: Some(message.to_string()),
+                code: Some(SQL_FEATURE_DISABLED_CODE.to_string()),
+            },
+        }))
     }
 
     /// Handles a `VectorSearch` operation.
@@ -2014,6 +2053,53 @@ mod tests {
             None,
         );
         assert_eq!(svc.name(), "query");
+    }
+
+    /// SQL is not wired by default (no `SqlQueryBackend`), and the default build
+    /// has the `datafusion` feature compiled out. Either way `handle_sql_query`
+    /// must return a `SqlQueryResp` tagged `FEATURE_DISABLED` — correlated by
+    /// `query_id` — rather than an `OperationError` that single-message dispatch
+    /// would silently drop (leaving the client to hang until its timeout).
+    #[tokio::test]
+    async fn sql_query_unavailable_returns_feature_disabled_resp() {
+        let registry = Arc::new(QueryRegistry::new());
+        let factory = make_factory();
+        let conn_registry = Arc::new(ConnectionRegistry::new());
+        let svc = QueryService::new(
+            registry,
+            factory,
+            conn_registry,
+            None,
+            10_000,
+            None,
+            #[cfg(feature = "datafusion")]
+            None,
+        );
+
+        let ctx = make_ctx(None);
+        let payload = topgun_core::messages::query::SqlQueryPayload {
+            sql: "SELECT * FROM users".to_string(),
+            query_id: "sq-test-1".to_string(),
+        };
+
+        let resp = svc
+            .handle_sql_query(&ctx, &payload)
+            .await
+            .expect("unavailable SQL must be a response, not an error");
+
+        match resp {
+            OperationResponse::Message(msg) => match *msg {
+                Message::SqlQueryResp { payload: p } => {
+                    assert_eq!(p.query_id, "sq-test-1");
+                    assert!(p.columns.is_empty());
+                    assert!(p.rows.is_empty());
+                    assert_eq!(p.code.as_deref(), Some(SQL_FEATURE_DISABLED_CODE));
+                    assert!(p.error.is_some(), "human-readable message must be set");
+                }
+                other => panic!("expected SqlQueryResp, got: {other:?}"),
+            },
+            other => panic!("expected a single Message response, got: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/tests/integration-rust/helpers/index.ts
+++ b/tests/integration-rust/helpers/index.ts
@@ -309,6 +309,7 @@ function makeCleanup(proc: child_process.ChildProcess): () => Promise<void> {
     });
 }
 
+export { MemoryStorageAdapter } from './memory-storage';
 export { TestClient } from './test-client';
 export {
   createTestToken,

--- a/tests/integration-rust/helpers/memory-storage.ts
+++ b/tests/integration-rust/helpers/memory-storage.ts
@@ -1,0 +1,68 @@
+/**
+ * In-memory IStorageAdapter so the @topgunbuild/client SDK runs headless in Node
+ * (no IndexedDB). Shared across cross-boundary integration tests that drive a
+ * real TopGunClient against the Rust server.
+ */
+
+import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
+
+export class MemoryStorageAdapter implements IStorageAdapter {
+  private kv = new Map<string, unknown>();
+  private meta = new Map<string, unknown>();
+  private opLog: OpLogEntry[] = [];
+  private pending: OpLogEntry[] = [];
+
+  async initialize(): Promise<void> {}
+  async close(): Promise<void> {}
+  async get(key: string): Promise<any> {
+    return this.kv.get(key);
+  }
+  async put(key: string, value: unknown): Promise<void> {
+    this.kv.set(key, value);
+  }
+  async remove(key: string): Promise<void> {
+    this.kv.delete(key);
+  }
+  async getMeta(key: string): Promise<any> {
+    return this.meta.get(key);
+  }
+  async setMeta(key: string, value: unknown): Promise<void> {
+    this.meta.set(key, value);
+  }
+  async batchPut(entries: Map<string, unknown>): Promise<void> {
+    for (const [k, v] of entries) this.kv.set(k, v);
+  }
+  async appendOpLog(entry: Omit<OpLogEntry, 'id'>): Promise<number> {
+    const id = this.opLog.length + 1;
+    const e = { ...entry, id, synced: 0 } as OpLogEntry;
+    this.opLog.push(e);
+    this.pending.push(e);
+    return id;
+  }
+  async getPendingOps(): Promise<OpLogEntry[]> {
+    return this.pending;
+  }
+  async markOpsSynced(lastId: number): Promise<void> {
+    this.pending = this.pending.filter((op) => (op.id ?? 0) > lastId);
+    this.opLog.forEach((op) => {
+      if ((op.id ?? 0) <= lastId) op.synced = 1;
+    });
+  }
+  async deleteOp(id: number): Promise<void> {
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: any }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.meta : this.kv;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value as never);
+    }
+    return this.appendOpLog(op);
+  }
+  async getAllKeys(): Promise<string[]> {
+    return Array.from(this.kv.keys());
+  }
+}

--- a/tests/integration-rust/sql.test.ts
+++ b/tests/integration-rust/sql.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Cross-boundary SQL honesty test against the real Rust server.
+ *
+ * SQL (DataFusion) is a compile-time opt-in (`--features datafusion`) and the
+ * default server build does NOT include it. Even a datafusion build does not yet
+ * wire a SQL backend, so `client.sql()` is not functional on any current server.
+ *
+ * This suite proves the HONEST GATE on the DEFAULT binary (the one the rest of
+ * the integration suite already builds — no extra datafusion build needed):
+ *
+ *   1. `client.sql()` rejects with a typed `SqlError` whose `code` is
+ *      `FEATURE_DISABLED` — a machine-distinguishable "feature off" signal, not
+ *      an opaque "internal error".
+ *   2. It rejects PROMPTLY (server replies with a correlated SQL_QUERY_RESP)
+ *      rather than hanging until the client's request timeout. A single-message
+ *      dispatch error used to be logged-and-dropped server-side, leaving the
+ *      client to stall — indistinguishable from a network failure. The fast
+ *      rejection here is the regression guard for that.
+ *
+ * The positive path (real SELECT/WHERE/GROUP BY over data on a datafusion
+ * binary) is intentionally NOT covered here: wiring the SQL engine end-to-end —
+ * and giving SQL per-table authorization — is deferred (see TODO-444). When that
+ * lands, a positive suite built against a `--features datafusion` binary joins
+ * this gate.
+ */
+
+import { TopGunClient, SqlError, SyncState } from '@topgunbuild/client';
+
+import { spawnRustServer, createTestToken, MemoryStorageAdapter, SpawnedServer } from './helpers';
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForState(
+  client: TopGunClient,
+  state: SyncState,
+  timeoutMs = 20_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (client.getConnectionState() === state) return;
+    await waitMs(50);
+  }
+  throw new Error(`Timed out waiting for ${state}; last state = ${client.getConnectionState()}`);
+}
+
+function makeClient(port: number, userId: string): TopGunClient {
+  const token = createTestToken(userId, ['ADMIN']);
+  return new TopGunClient({
+    serverUrl: `ws://localhost:${port}/ws`,
+    storage: new MemoryStorageAdapter(),
+    auth: { getToken: async () => token },
+    backoff: { initialDelayMs: 200, maxDelayMs: 400, jitter: true },
+  });
+}
+
+describe('Integration: SQL honesty (client <-> Rust server)', () => {
+  let server: SpawnedServer | null = null;
+  let client: TopGunClient | null = null;
+
+  beforeAll(async () => {
+    server = await spawnRustServer();
+  });
+
+  afterEach(async () => {
+    if (client) {
+      await client.close().catch(() => {});
+      client = null;
+    }
+  });
+
+  afterAll(async () => {
+    if (server) {
+      await server.cleanup();
+      server = null;
+    }
+  });
+
+  test('client.sql() rejects with a typed FEATURE_DISABLED SqlError on a server without datafusion', async () => {
+    client = makeClient(server!.port, 'sql-user-1');
+    await client.start();
+    await waitForState(client, SyncState.CONNECTED);
+
+    const err = await client.sql('SELECT 1').then(
+      () => {
+        throw new Error('expected client.sql() to reject on a server without SQL enabled');
+      },
+      (e) => e,
+    );
+
+    expect(err).toBeInstanceOf(SqlError);
+    expect((err as SqlError).code).toBe('FEATURE_DISABLED');
+    // Honest, human-readable message — not "internal error".
+    expect((err as SqlError).message.toLowerCase()).toContain('sql is not available');
+    expect((err as SqlError).message.toLowerCase()).not.toContain('internal error');
+  });
+
+  test('client.sql() rejects promptly rather than hanging until the request timeout', async () => {
+    client = makeClient(server!.port, 'sql-user-2');
+    await client.start();
+    await waitForState(client, SyncState.CONNECTED);
+
+    const start = Date.now();
+    await client.sql('SELECT * FROM whatever').catch(() => {});
+    const elapsedMs = Date.now() - start;
+
+    // The default SQL request timeout is 30s; a correlated server reply lands in
+    // well under a second. Use a generous ceiling so the assertion is about
+    // "did NOT time out", not raw latency.
+    expect(elapsedMs).toBeLessThan(5_000);
+  });
+});


### PR DESCRIPTION
## What & why

SQL (DataFusion) is opt-in at compile time (`--features datafusion`) and stays **off by default**. This PR makes the *SQL-unavailable* path honest end-to-end and adds the cross-boundary gate that proves it.

### The real bug
The disabled handler returned `Err(OperationError::Internal("SQL requires datafusion feature"))`. For a single (non-batch) message, dispatch **logs and drops** an `Err` — so `client.sql()` received nothing and **hung until its 30s request timeout**, indistinguishable from a network stall. (Audit aside: SQL is in fact dead even *with* `--features datafusion` — the backend is never wired; both construction sites pass `None` — so every build hit this path.)

## Changes (honesty-only; enablement deferred)
- **server** `query.rs`: both `handle_sql_query` branches (feature-off, and feature-on but no backend) now return `Ok(SqlQueryResp { error, code: "FEATURE_DISABLED" })`, correlated by `query_id`, so the client gets a **prompt, machine-distinguishable** signal — not an opaque "internal error". New const `SQL_FEATURE_DISABLED_CODE`; unit test covers both cfg variants.
- **wire**: optional `code` field on `SqlQueryRespPayload` (core-rust struct + core Zod schema), additive / backward-compatible.
- **client**: new exported `SqlError { code }`; `SqlClient` rejects with it; unit tests for typed `FEATURE_DISABLED` vs codeless query errors.
- **docs**: `reference/client.mdx` marks SQL **not-yet-functional** (preview API + a `SqlError`/`code` detection snippet; the planned-API example carries a `doctest skip reason`); blog "What's Next" SQL line gets the opt-in/compile-flag clarifier.
- **e2e**: `tests/integration-rust/sql.test.ts` — real client → default Rust server: `client.sql()` rejects with typed `FEATURE_DISABLED` **and rejects promptly** (regression guard for the silent-drop → 30s-hang). Runs in the existing blocking `integration` job; **no separate datafusion CI build** needed for the honesty gate. Shared `MemoryStorageAdapter` extracted to `helpers/memory-storage.ts`.

## Scope decision
Honesty-only was chosen deliberately. Actually turning SQL on requires (a) wiring the backend + a table-registration lifecycle and (b) **per-table SQL authorization** — today `SqlQuery` authorizes against an *empty* resource name (`authorization.rs`), which would bypass per-map ACLs if enabled. Both are tracked in **TODO-444**; the positive e2e suite (real `SELECT/WHERE/GROUP BY` on a `--features datafusion` binary) joins this gate when they land.

Closes TODO-463 and the SQL slice of TODO-464.

## Local verification (all green)
- `cargo fmt --check`; `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --release -p topgun-server --lib` → 1426 passed; `--features datafusion` SQL test → pass (both cfg variants)
- `cargo test -p topgun-core` query messages incl. new `code` roundtrip
- client `662` / core `2074` TS tests; doc-tests typecheck/exec/negative-control green
- `tests/integration-rust/sql.test.ts` → 2 passed (typed FEATURE_DISABLED + no-hang)
- `pnpm lint` (0 errors) / `pnpm format:check` clean