### PR TITLE
fix(server,client,ci): gate-integrity + degraded-state honesty + live-query determinism

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -374,7 +374,23 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Run simulation tests
-        run: cargo test --profile ci-sim --features simulation -p topgun-server -- sim
+        # Run the simulation + sim_smoke integration binaries IN FULL so EVERY
+        # hand-written sim module gates merges. The previous `-- sim` substring
+        # filter only matched test PATHS containing "sim" — that caught
+        # proptest_sim::*, the sim_smoke `sim_*` names, and the src::sim lib
+        # paths, but silently SKIPPED the crdt_convergence::*, merkle_sync::*,
+        # cluster_membership::*, and event_journal::* modules. Those are the
+        # convergence/durability/journal correctness gates (G3/G4a) that MUST
+        # block; an under-selecting filter is a silent gate hole, the same
+        # "test exists but isn't in the gate" class that let the F2 convergence
+        # regression slip. Selecting the binaries by name (rather than dropping
+        # the filter entirely) keeps the job scoped to simulation tests and out
+        # of the unrelated, non-feature-gated integration binaries.
+        run: |
+          cargo test --profile ci-sim --features simulation -p topgun-server --test simulation --test sim_smoke
+          # The SimCluster/SimNetwork harness's own unit tests live in the lib
+          # target (src/sim/*); keep them gating via the path filter.
+          cargo test --profile ci-sim --features simulation -p topgun-server --lib -- sim
 
   audit:
     name: Cargo Audit (RustSec advisories)

--- a/packages/server-rust/src/service/domain/embedding/hook.rs
+++ b/packages/server-rust/src/service/domain/embedding/hook.rs
@@ -10,6 +10,7 @@
 //! `SearchMutationObserver` in `search.rs`, swapping tantivy indexing for
 //! embedding generation and `RecordStore` write-back.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -50,6 +51,143 @@ impl Default for EmbeddingConfig {
         Self {
             batch_interval_ms: 100,
             batch_flush_threshold: 500,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EmbeddingHealth — observable degraded state
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct EmbeddingHealthInner {
+    batches_ok: AtomicU64,
+    batches_failed: AtomicU64,
+    records_embedded: AtomicU64,
+    records_skipped: AtomicU64,
+    records_writeback_failed: AtomicU64,
+    consecutive_batch_failures: AtomicU64,
+}
+
+/// Shared, cloneable handle to the embedding write-back health counters.
+///
+/// Makes provider degradation observable as STATE, not just a log line. When the
+/// configured embedding provider fails at runtime (e.g. Ollama down, HTTP
+/// timeout) the affected records are still persisted — `OP_ACK` is returned
+/// before write-back runs — but receive no `_embedding`, so semantic search
+/// silently loses coverage for them. These counters let an operator (or a test)
+/// detect and quantify that coverage gap rather than inferring it from logs.
+///
+/// **Write-back failure semantics: mark-and-skip (no retry/backoff).** A failed
+/// `batch_embed` call drops only the `_embedding` write-back for that batch; the
+/// records remain acknowledged and durable. We deliberately do NOT retry: a retry loop
+/// against a down provider would either block the write path or grow unbounded
+/// in-memory work, trading a silent-coverage gap for a liveness/OOM risk. The
+/// affected records stay un-embedded until the provider recovers AND those
+/// records are written again (which re-enqueues them through the observer). The
+/// degraded state is surfaced via these counters plus a transition `warn!`.
+#[derive(Clone, Debug)]
+pub struct EmbeddingHealth {
+    inner: Arc<EmbeddingHealthInner>,
+}
+
+/// Point-in-time snapshot of the embedding write-back health counters.
+///
+/// The counters are read with independent `Relaxed` loads, so the snapshot is
+/// eventually-consistent ACROSS fields: a reader can observe a sub-millisecond
+/// window where, say, `batches_failed` has incremented but
+/// `consecutive_batch_failures` has not yet. Each individual counter is always
+/// monotonic and exact; only cross-field invariants are approximate, and they
+/// self-correct on the next poll. Treat `is_degraded()` as a sampled signal, not
+/// a transactional one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmbeddingHealthSnapshot {
+    /// Batches whose `batch_embed` call succeeded.
+    pub batches_ok: u64,
+    /// Batches whose `batch_embed` call failed (the whole batch's write-back skipped).
+    pub batches_failed: u64,
+    /// Records that received an `_embedding` write-back.
+    pub records_embedded: u64,
+    /// Records dropped from write-back because the PROVIDER call failed — these
+    /// are persisted WITHOUT an `_embedding` and are invisible to semantic search.
+    pub records_skipped: u64,
+    /// Records whose write-back failed for a NON-provider reason after a healthy
+    /// `batch_embed` (record store read/serialize/put error). Like `records_skipped`
+    /// these leave the record without an `_embedding`, but the provider itself is up,
+    /// so they do not flip `is_degraded`. A record that simply no longer exists at
+    /// write-back time is NOT counted here (nothing to embed — not a coverage gap).
+    pub records_writeback_failed: u64,
+    /// Consecutive failed batches with no intervening success. `0` means the last
+    /// batch succeeded (or none has run); `>0` means the provider is currently degraded.
+    pub consecutive_batch_failures: u64,
+}
+
+impl EmbeddingHealthSnapshot {
+    /// True when the most recent batch flush failed — i.e. the provider is
+    /// currently unable to embed and write-backs are being dropped.
+    #[must_use]
+    pub fn is_degraded(&self) -> bool {
+        self.consecutive_batch_failures > 0
+    }
+}
+
+impl EmbeddingHealth {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(EmbeddingHealthInner::default()),
+        }
+    }
+
+    /// Records a successful batch flush that embedded `records` write-backs.
+    /// Returns the consecutive-failure count that preceded this success — a
+    /// non-zero value means the provider just RECOVERED.
+    fn record_success(&self, records: u64) -> u64 {
+        self.inner.batches_ok.fetch_add(1, Ordering::Relaxed);
+        self.inner
+            .records_embedded
+            .fetch_add(records, Ordering::Relaxed);
+        self.inner
+            .consecutive_batch_failures
+            .swap(0, Ordering::Relaxed)
+    }
+
+    /// Records `n` per-record write-back failures that occurred AFTER a healthy
+    /// `batch_embed` (record store errors, not a provider outage). Does not touch
+    /// the provider-degraded streak — the provider is up.
+    fn record_writeback_failures(&self, n: u64) {
+        if n > 0 {
+            self.inner
+                .records_writeback_failed
+                .fetch_add(n, Ordering::Relaxed);
+        }
+    }
+
+    /// Records a failed batch flush that skipped `records` write-backs. Returns
+    /// the new consecutive-failure count (`1` means the provider just STARTED degrading).
+    fn record_failure(&self, records: u64) -> u64 {
+        self.inner.batches_failed.fetch_add(1, Ordering::Relaxed);
+        self.inner
+            .records_skipped
+            .fetch_add(records, Ordering::Relaxed);
+        self.inner
+            .consecutive_batch_failures
+            .fetch_add(1, Ordering::Relaxed)
+            + 1
+    }
+
+    /// Returns a snapshot of the current counters.
+    #[must_use]
+    pub fn snapshot(&self) -> EmbeddingHealthSnapshot {
+        EmbeddingHealthSnapshot {
+            batches_ok: self.inner.batches_ok.load(Ordering::Relaxed),
+            batches_failed: self.inner.batches_failed.load(Ordering::Relaxed),
+            records_embedded: self.inner.records_embedded.load(Ordering::Relaxed),
+            records_skipped: self.inner.records_skipped.load(Ordering::Relaxed),
+            records_writeback_failed: self.inner.records_writeback_failed.load(Ordering::Relaxed),
+            consecutive_batch_failures: self
+                .inner
+                .consecutive_batch_failures
+                .load(Ordering::Relaxed),
         }
     }
 }
@@ -217,6 +355,10 @@ fn extract_fields_text(value: &rmpv::Value, fields: &[String]) -> String {
 /// flushes when `batch_interval` elapses or `batch_flush_threshold` events
 /// have been accumulated, whichever comes first. On shutdown signal, drains
 /// remaining events and processes them before exiting.
+// Task-plumbing fn: each arg is an independent shared dependency injected at
+// spawn time (mirrors `run_batch_processor` in search/mod.rs, which carries the
+// same allow for the same reason).
+#[allow(clippy::too_many_arguments)]
 async fn run_embedding_batch_processor(
     mut event_rx: mpsc::UnboundedReceiver<EmbeddingEvent>,
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
@@ -225,6 +367,7 @@ async fn run_embedding_batch_processor(
     batch_interval: Duration,
     batch_flush_threshold: usize,
     in_flight: Arc<DashSet<(String, String)>>,
+    health: EmbeddingHealth,
 ) {
     let mut batch: Vec<EmbeddingEvent> = Vec::new();
 
@@ -241,7 +384,7 @@ async fn run_embedding_batch_processor(
                             batch.push(evt);
                         }
                         if !batch.is_empty() {
-                            flush_batch(batch, &provider, &record_store_factory, &in_flight).await;
+                            flush_batch(batch, &provider, &record_store_factory, &in_flight, &health).await;
                         }
                         return;
                     }
@@ -278,7 +421,7 @@ async fn run_embedding_batch_processor(
                                 batch.push(evt);
                             }
                             if !batch.is_empty() {
-                                flush_batch(batch, &provider, &record_store_factory, &in_flight).await;
+                                flush_batch(batch, &provider, &record_store_factory, &in_flight, &health).await;
                             }
                             return;
                         }
@@ -294,7 +437,14 @@ async fn run_embedding_batch_processor(
 
         if !batch.is_empty() {
             let current_batch = std::mem::take(&mut batch);
-            flush_batch(current_batch, &provider, &record_store_factory, &in_flight).await;
+            flush_batch(
+                current_batch,
+                &provider,
+                &record_store_factory,
+                &in_flight,
+                &health,
+            )
+            .await;
         }
     }
 }
@@ -310,111 +460,191 @@ async fn flush_batch(
     provider: &Arc<dyn EmbeddingProvider>,
     record_store_factory: &Arc<RecordStoreFactory>,
     in_flight: &Arc<DashSet<(String, String)>>,
+    health: &EmbeddingHealth,
 ) {
     let texts: Vec<String> = batch.iter().map(|e| e.text.clone()).collect();
+    let batch_len = batch.len() as u64;
 
     let embeddings = match provider.batch_embed(&texts).await {
         Ok(v) => v,
         Err(err) => {
-            tracing::warn!("embedding batch failed: {err}");
+            // Mark-and-skip: the records are already ACKed and persisted; we drop
+            // only the `_embedding` write-back (no retry — see `EmbeddingHealth`
+            // docs for why). Record the failure so the degraded state is observable
+            // beyond this log line, and emit a transition `warn!` the first time the
+            // provider goes down (and one per subsequent failed batch, bounded by
+            // batch cadence, so a sustained outage stays visible without spamming).
+            let consecutive = health.record_failure(batch_len);
+            if consecutive == 1 {
+                tracing::warn!(
+                    skipped_records = batch_len,
+                    "embedding provider degraded: batch_embed failed, write-back skipped — \
+                     {batch_len} record(s) persisted WITHOUT _embedding; semantic search \
+                     coverage is now incomplete until the provider recovers and the \
+                     record(s) are re-written (mark-and-skip, no automatic retry). error: {err}"
+                );
+            } else {
+                tracing::warn!(
+                    consecutive_batch_failures = consecutive,
+                    skipped_records = batch_len,
+                    "embedding provider still degraded: batch_embed failed again. error: {err}"
+                );
+            }
             return;
         }
     };
 
+    let mut records_embedded: u64 = 0;
+    let mut writeback_failed: u64 = 0;
     for (evt, embedding) in batch.into_iter().zip(embeddings.into_iter()) {
-        let store = record_store_factory.get_or_create(&evt.map_name, evt.partition_id);
+        match write_back_one_embedding(&evt, embedding, record_store_factory, in_flight).await {
+            WriteBackOutcome::Embedded => records_embedded += 1,
+            WriteBackOutcome::Failed => writeback_failed += 1,
+            WriteBackOutcome::Skipped => {}
+        }
+    }
 
-        // Read existing record to perform a complete read-modify-write.
-        // Write-back must preserve all existing user fields.
-        let existing = match store.get(&evt.key, false).await {
-            Ok(Some(record)) => record,
-            Ok(None) => {
-                tracing::warn!(
-                    "embedding write-back skipped for {}/{}: record not found",
-                    evt.map_name,
-                    evt.key
-                );
-                continue;
-            }
-            Err(err) => {
-                tracing::warn!(
-                    "embedding write-back failed for {}/{}: read error: {err}",
-                    evt.map_name,
-                    evt.key
-                );
-                continue;
-            }
-        };
+    // Per-record write-back errors after a healthy batch_embed (store read/put
+    // errors) still leave records without an `_embedding`, so count them — but
+    // they do NOT mean the provider is down, so they go to a separate counter and
+    // never flip is_degraded().
+    health.record_writeback_failures(writeback_failed);
 
-        // Serialize the embedding in the canonical `Vector` wire form
-        // (`{"type":"f32","data":<LE bytes>}`) so the vector index's
-        // `decode_vector_from_record` can read it back. A bare `Vec<f32>` would
-        // serialize as a plain MsgPack array and silently fail to decode as a
-        // `Vector`, leaving the HNSW index empty.
-        let embedding_vector = topgun_core::vector::Vector::F32(embedding);
-        let embedding_bytes = match rmp_serde::to_vec_named(&embedding_vector) {
-            Ok(b) => b,
-            Err(err) => {
-                tracing::warn!(
-                    "embedding write-back failed for {}/{}: serialize error: {err}",
-                    evt.map_name,
-                    evt.key
-                );
-                continue;
-            }
-        };
+    // The provider call succeeded for this batch, so the provider is healthy even
+    // if some individual write-backs failed for non-provider reasons (record gone,
+    // serialize error). Reset the consecutive-failure streak and, if we were
+    // degraded, log the recovery so the transition is operator-visible.
+    let recovered_after = health.record_success(records_embedded);
+    if recovered_after > 0 {
+        tracing::info!(
+            recovered_after_failed_batches = recovered_after,
+            records_embedded,
+            "embedding provider recovered: write-back resumed"
+        );
+    }
+}
 
-        // Merge `_embedding` into the existing Value::Map.
-        let merged_value = if let RecordValue::Lww { value, .. } = existing.value {
-            merge_embedding_into_value(value, embedding_bytes)
-        } else {
+/// Outcome of a single record's `_embedding` write-back, so the caller can keep
+/// the health counters honest: a genuine error (`Failed`) is a coverage gap worth
+/// surfacing, whereas a record that simply no longer exists (`Skipped`) is a
+/// legitimate no-op, not a gap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WriteBackOutcome {
+    /// `_embedding` was written.
+    Embedded,
+    /// Nothing to do — the record was gone or not an LWW value at write-back time.
+    Skipped,
+    /// Write-back failed on a real error (read / serialize / put) — the record is
+    /// left without an `_embedding` despite a healthy provider.
+    Failed,
+}
+
+/// Writes one record's `_embedding` back via read-modify-write, preserving all
+/// existing user fields. Inserts `(map_name, key)` into `in_flight` around the
+/// write so the observer's re-entrancy guard fires for the hook's own write.
+async fn write_back_one_embedding(
+    evt: &EmbeddingEvent,
+    embedding: Vec<f32>,
+    record_store_factory: &Arc<RecordStoreFactory>,
+    in_flight: &Arc<DashSet<(String, String)>>,
+) -> WriteBackOutcome {
+    let store = record_store_factory.get_or_create(&evt.map_name, evt.partition_id);
+
+    // Read existing record to perform a complete read-modify-write.
+    // Write-back must preserve all existing user fields.
+    let existing = match store.get(&evt.key, false).await {
+        Ok(Some(record)) => record,
+        Ok(None) => {
             tracing::warn!(
-                "embedding write-back skipped for {}/{}: non-LWW record",
+                "embedding write-back skipped for {}/{}: record not found",
                 evt.map_name,
                 evt.key
             );
-            continue;
-        };
+            return WriteBackOutcome::Skipped;
+        }
+        Err(err) => {
+            tracing::warn!(
+                "embedding write-back failed for {}/{}: read error: {err}",
+                evt.map_name,
+                evt.key
+            );
+            return WriteBackOutcome::Failed;
+        }
+    };
 
-        // Construct a synthetic timestamp for the write-back.
-        // Truncation from u128 to u64 is acceptable: ms since epoch fits in u64 until year 584,542,046.
-        #[allow(clippy::cast_possible_truncation)]
-        let now_millis = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+    // Serialize the embedding in the canonical `Vector` wire form
+    // (`{"type":"f32","data":<LE bytes>}`) so the vector index's
+    // `decode_vector_from_record` can read it back. A bare `Vec<f32>` would
+    // serialize as a plain MsgPack array and silently fail to decode as a
+    // `Vector`, leaving the HNSW index empty.
+    let embedding_vector = topgun_core::vector::Vector::F32(embedding);
+    let embedding_bytes = match rmp_serde::to_vec_named(&embedding_vector) {
+        Ok(b) => b,
+        Err(err) => {
+            tracing::warn!(
+                "embedding write-back failed for {}/{}: serialize error: {err}",
+                evt.map_name,
+                evt.key
+            );
+            return WriteBackOutcome::Failed;
+        }
+    };
 
-        let record_value = RecordValue::Lww {
-            value: merged_value,
-            timestamp: Timestamp {
-                millis: now_millis,
-                counter: 0,
-                node_id: "_embedding_hook".to_string(),
-            },
-        };
+    // Merge `_embedding` into the existing Value::Map.
+    let merged_value = if let RecordValue::Lww { value, .. } = existing.value {
+        merge_embedding_into_value(value, embedding_bytes)
+    } else {
+        tracing::warn!(
+            "embedding write-back skipped for {}/{}: non-LWW record",
+            evt.map_name,
+            evt.key
+        );
+        return WriteBackOutcome::Skipped;
+    };
 
-        // Mark in-flight before write so the observer's re-entrancy guard fires.
-        in_flight.insert((evt.map_name.clone(), evt.key.clone()));
+    // Construct a synthetic timestamp for the write-back.
+    // Truncation from u128 to u64 is acceptable: ms since epoch fits in u64 until year 584,542,046.
+    #[allow(clippy::cast_possible_truncation)]
+    let now_millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
 
-        if let Err(err) = store
-            .put(
-                &evt.key,
-                record_value,
-                ExpiryPolicy::NONE,
-                CallerProvenance::CrdtMerge,
-            )
-            .await
-        {
+    let record_value = RecordValue::Lww {
+        value: merged_value,
+        timestamp: Timestamp {
+            millis: now_millis,
+            counter: 0,
+            node_id: "_embedding_hook".to_string(),
+        },
+    };
+
+    // Mark in-flight before write so the observer's re-entrancy guard fires.
+    in_flight.insert((evt.map_name.clone(), evt.key.clone()));
+
+    let outcome = match store
+        .put(
+            &evt.key,
+            record_value,
+            ExpiryPolicy::NONE,
+            CallerProvenance::CrdtMerge,
+        )
+        .await
+    {
+        Ok(_) => WriteBackOutcome::Embedded,
+        Err(err) => {
             tracing::warn!(
                 "embedding write-back failed for {}/{}: put error: {err}",
                 evt.map_name,
                 evt.key
             );
+            WriteBackOutcome::Failed
         }
+    };
 
-        // Always remove from in-flight even on error to prevent permanent block.
-        in_flight.remove(&(evt.map_name.clone(), evt.key.clone()));
-    }
+    // Always remove from in-flight even on error to prevent permanent block.
+    in_flight.remove(&(evt.map_name.clone(), evt.key.clone()));
+    outcome
 }
 
 /// Merges the `_embedding` bytes into an existing `Value::Map`.
@@ -464,6 +694,9 @@ pub struct EmbeddingObserverFactory {
     event_rx: Mutex<Option<mpsc::UnboundedReceiver<EmbeddingEvent>>>,
     shutdown_tx: Arc<tokio::sync::watch::Sender<bool>>,
     in_flight: Arc<DashSet<(String, String)>>,
+    /// Shared write-back health counters; surfaced via [`Self::health`] so a
+    /// provider outage is observable as state, not just a log line.
+    health: EmbeddingHealth,
     /// Set during `init()`. Panics on double-init.
     record_store_factory: OnceLock<Arc<RecordStoreFactory>>,
 }
@@ -490,8 +723,20 @@ impl EmbeddingObserverFactory {
             event_rx: Mutex::new(Some(event_rx)),
             shutdown_tx: Arc::new(shutdown_tx),
             in_flight: Arc::new(DashSet::new()),
+            health: EmbeddingHealth::new(),
             record_store_factory: OnceLock::new(),
         }
+    }
+
+    /// Returns a snapshot of the embedding write-back health counters.
+    ///
+    /// Operators and tests use this to detect a degraded embedding provider:
+    /// when the provider is failing, `batches_failed` / `records_skipped` climb
+    /// and [`EmbeddingHealthSnapshot::is_degraded`] is `true` while records are
+    /// still being persisted (without `_embedding`).
+    #[must_use]
+    pub fn health(&self) -> EmbeddingHealthSnapshot {
+        self.health.snapshot()
     }
 
     /// Phase 2: post-wiring init.
@@ -524,6 +769,7 @@ impl EmbeddingObserverFactory {
             Duration::from_millis(self.config.batch_interval_ms),
             self.config.batch_flush_threshold,
             Arc::clone(&self.in_flight),
+            self.health.clone(),
         ));
     }
 
@@ -581,6 +827,36 @@ mod tests {
 
     fn make_noop_provider(dim: u16) -> Arc<dyn EmbeddingProvider> {
         Arc::new(NoopEmbeddingProvider::new(&NoopConfig { dimension: dim }))
+    }
+
+    /// Always-failing provider, simulating a down/timed-out embedding backend
+    /// (e.g. Ollama killed). Every `batch_embed`/`embed` call returns `Err`.
+    struct FailingProvider {
+        dimension: u16,
+    }
+
+    #[async_trait::async_trait]
+    impl EmbeddingProvider for FailingProvider {
+        fn name(&self) -> &'static str {
+            "failing"
+        }
+        fn dimension(&self) -> u16 {
+            self.dimension
+        }
+        async fn embed(
+            &self,
+            _text: &str,
+        ) -> Result<Vec<f32>, crate::service::domain::embedding::EmbeddingError> {
+            Err(
+                crate::service::domain::embedding::EmbeddingError::Unavailable(
+                    "provider is down (test)".to_string(),
+                ),
+            )
+        }
+    }
+
+    fn make_failing_provider(dim: u16) -> Arc<dyn EmbeddingProvider> {
+        Arc::new(FailingProvider { dimension: dim })
     }
 
     fn make_vector_config(map_name: &str, fields: Vec<String>) -> Arc<VectorConfig> {
@@ -883,5 +1159,199 @@ mod tests {
                 panic!("record value should be a LWW Map");
             }
         }
+    }
+
+    // --- Degraded-state honesty: provider outage is observable, not silent ---
+
+    /// Behavioral test (TODO-526): when the embedding provider is DOWN, the write
+    /// still succeeds and persists, but the record gets NO `_embedding` AND the
+    /// factory's health surface reports the degradation — not just a log line.
+    #[tokio::test]
+    async fn provider_outage_persists_write_and_surfaces_degraded_state() {
+        let vector_config = make_vector_config("docs", vec!["title".to_string()]);
+        let provider = make_failing_provider(4);
+
+        let embedding_factory = Arc::new(EmbeddingObserverFactory::new(
+            EmbeddingConfig {
+                batch_interval_ms: 50,
+                batch_flush_threshold: 500,
+            },
+            Arc::clone(&vector_config),
+            Arc::clone(&provider),
+        ));
+
+        let record_store_factory = Arc::new(
+            RecordStoreFactory::new(
+                StorageConfig::default(),
+                Arc::new(NullDataStore),
+                Vec::new(),
+            )
+            .with_observer_factories(vec![embedding_factory.clone() as Arc<dyn ObserverFactory>]),
+        );
+        embedding_factory.init(Arc::clone(&record_store_factory));
+
+        // Health is clean before any write.
+        let before = embedding_factory.health();
+        assert!(
+            !before.is_degraded(),
+            "should not be degraded before any batch"
+        );
+        assert_eq!(before.batches_failed, 0);
+
+        // Write a record to a configured map — this is ACKed/persisted regardless
+        // of the embedding provider's health.
+        let store = record_store_factory.get_or_create("docs", 0);
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "title".to_string(),
+            Value::String("hello world".to_string()),
+        );
+        let record_value = RecordValue::Lww {
+            value: Value::Map(fields),
+            timestamp: Timestamp {
+                millis: 1_000_000,
+                counter: 0,
+                node_id: "client".to_string(),
+            },
+        };
+        store
+            .put(
+                "doc1",
+                record_value,
+                ExpiryPolicy::NONE,
+                CallerProvenance::Client,
+            )
+            .await
+            .unwrap();
+
+        // Let the batch processor run and FAIL against the down provider.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // 1. The write survived: record still present.
+        let record = store.get("doc1", false).await.unwrap();
+        assert!(
+            record.is_some(),
+            "write must persist even when the provider is down"
+        );
+
+        // 2. But it carries NO embedding (write-back was skipped).
+        if let RecordValue::Lww {
+            value: Value::Map(ref m),
+            ..
+        } = record.unwrap().value
+        {
+            assert!(
+                !m.contains_key("_embedding"),
+                "record must NOT have _embedding when the provider failed"
+            );
+            assert!(m.contains_key("title"), "user fields must be preserved");
+        } else {
+            panic!("record value should be a LWW Map");
+        }
+
+        // 3. The degraded state is OBSERVABLE — the whole point of this fix.
+        let after = embedding_factory.health();
+        assert!(
+            after.is_degraded(),
+            "health must report degraded after a provider failure; got {after:?}"
+        );
+        assert!(
+            after.batches_failed >= 1,
+            "failed batch must be counted; got {after:?}"
+        );
+        assert!(
+            after.records_skipped >= 1,
+            "skipped record must be counted; got {after:?}"
+        );
+        assert_eq!(
+            after.records_embedded, 0,
+            "nothing should embed while down; got {after:?}"
+        );
+        assert!(after.consecutive_batch_failures >= 1, "got {after:?}");
+        // A provider outage routes to records_skipped, NOT the non-provider
+        // per-record write-back-failure counter.
+        assert_eq!(
+            after.records_writeback_failed, 0,
+            "provider outage must not count as a per-record write-back failure; got {after:?}"
+        );
+    }
+
+    /// Negative control (TODO-526): a HEALTHY provider must NOT report degraded
+    /// state — proving `is_degraded`/the counters track real failures, not noise.
+    #[tokio::test]
+    async fn healthy_provider_reports_clean_health() {
+        let vector_config = make_vector_config("docs", vec!["title".to_string()]);
+        let provider = make_noop_provider(4);
+
+        let embedding_factory = Arc::new(EmbeddingObserverFactory::new(
+            EmbeddingConfig {
+                batch_interval_ms: 50,
+                batch_flush_threshold: 500,
+            },
+            Arc::clone(&vector_config),
+            Arc::clone(&provider),
+        ));
+
+        let record_store_factory = Arc::new(
+            RecordStoreFactory::new(
+                StorageConfig::default(),
+                Arc::new(NullDataStore),
+                Vec::new(),
+            )
+            .with_observer_factories(vec![embedding_factory.clone() as Arc<dyn ObserverFactory>]),
+        );
+        embedding_factory.init(Arc::clone(&record_store_factory));
+
+        let store = record_store_factory.get_or_create("docs", 0);
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "title".to_string(),
+            Value::String("hello world".to_string()),
+        );
+        let record_value = RecordValue::Lww {
+            value: Value::Map(fields),
+            timestamp: Timestamp {
+                millis: 1_000_000,
+                counter: 0,
+                node_id: "client".to_string(),
+            },
+        };
+        store
+            .put(
+                "doc1",
+                record_value,
+                ExpiryPolicy::NONE,
+                CallerProvenance::Client,
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let health = embedding_factory.health();
+        assert!(
+            !health.is_degraded(),
+            "healthy provider must not be degraded; got {health:?}"
+        );
+        assert_eq!(
+            health.batches_failed, 0,
+            "no failures expected; got {health:?}"
+        );
+        assert_eq!(
+            health.records_skipped, 0,
+            "no skips expected; got {health:?}"
+        );
+        assert!(
+            health.batches_ok >= 1,
+            "a batch should have succeeded; got {health:?}"
+        );
+        assert!(
+            health.records_embedded >= 1,
+            "the record should have been embedded; got {health:?}"
+        );
+        assert_eq!(
+            health.records_writeback_failed, 0,
+            "a successful write-back must not be counted as a failure; got {health:?}"
+        );
     }
 }

--- a/packages/server-rust/src/service/domain/embedding/mod.rs
+++ b/packages/server-rust/src/service/domain/embedding/mod.rs
@@ -14,7 +14,9 @@ pub mod http;
 pub mod noop;
 pub mod ollama;
 
-pub use hook::{EmbeddingConfig, EmbeddingObserverFactory};
+pub use hook::{
+    EmbeddingConfig, EmbeddingHealth, EmbeddingHealthSnapshot, EmbeddingObserverFactory,
+};
 
 // ---------------------------------------------------------------------------
 // Trait

--- a/tests/integration-rust/live-query-limit-clamp.test.ts
+++ b/tests/integration-rust/live-query-limit-clamp.test.ts
@@ -17,14 +17,25 @@
  * window slice composes with those deltas so the FINAL rendered set nets to exactly
  * N in sort order. This mirrors the AC1/AC2/AC3 unit scenarios at integration scale.
  *
- * Determinism: the writer's `set()` calls are optimistic and batched, so the seed
- * is gated behind waitForSynced(writer) — the QUERY_SUB is sent only once all seed
- * writes have drained and been APPLIED on the server. Without this gate the
- * subscriber's QUERY_SUB can race ahead of the seed reaching the server, and on a
- * cold first spawn a seed write can land in the gap between the server taking the
- * snapshot and activating the live subscription — surfacing in neither the snapshot
- * nor a delta. That race (not a client replay gap — the server replays pre-seeded
- * data on subscribe, verified independently) was the intermittent PR #65 red.
+ * Determinism (startup-speed independent): the writer's `set()` calls are
+ * optimistic and batched, so the seed is first gated behind waitForSynced(writer)
+ * — every seed op has drained and been OP_ACKed. But OP_ACK only proves the op was
+ * accepted, not that it is already VISIBLE to a query scan: on a cold/slow start
+ * the per-record apply into the partition RecordStore can lag the ack, and
+ * `handle_query_subscribe` scans the snapshot BEFORE it registers the subscription
+ * — so a not-yet-applied seed can land in the gap and surface in neither the
+ * initial snapshot nor a delta, freezing a live handle at an incomplete window
+ * forever (the intermittent PR #65 red: got `[]`, or `["a"]` after the first fix).
+ *
+ * The fix gates the real subscribe on the seed being CONFIRMED QUERY-VISIBLE via
+ * waitForServerQuery(): a poll loop over `queryOnce`, which opens a FRESH server
+ * subscription each call, waits for the authoritative QUERY_RESP, reads it, and
+ * auto-unsubscribes. Because every poll is a new server-side scan (not a frozen
+ * snapshot), it converges to the full seed set as soon as the writes are stably
+ * applied — independent of how slow the server started. Once the top-2 is
+ * server-visible the store is stable, so the subsequent live subscribe's initial
+ * snapshot is deterministically `[a, b]`. (This is not a client replay gap — the
+ * server replays pre-seeded data on subscribe, verified independently.)
  *
  * Scope note (honesty): against the real server, every observed path is already
  * net-N correct on its own — the initial QUERY_RESP is itself limit-clamped to N,
@@ -44,7 +55,7 @@
  */
 
 import { TopGunClient, SyncState } from '@topgunbuild/client';
-import type { IStorageAdapter, OpLogEntry } from '@topgunbuild/client';
+import type { IStorageAdapter, OpLogEntry, QueryFilter } from '@topgunbuild/client';
 
 import { spawnRustServer, createTestToken, SpawnedServer } from './helpers';
 
@@ -165,6 +176,44 @@ async function waitForSynced(client: TopGunClient, timeoutMs = 20_000): Promise<
   );
 }
 
+/**
+ * Deterministically waits until the SERVER's query result for (mapName, filter)
+ * satisfies `predicate`, independent of server startup speed.
+ *
+ * Each poll issues a fresh `queryOnce` — which opens a new server subscription,
+ * waits for the AUTHORITATIVE QUERY_RESP, reads the snapshot, then
+ * auto-unsubscribes. A live QueryHandle freezes its first snapshot and can never
+ * recover if a seed write lands in the server's scan-vs-subscription-activation
+ * gap on a cold start; re-scanning with a fresh subscription each poll sidesteps
+ * that entirely, converging as soon as the seed writes are stably applied. Once
+ * this resolves, the store is stable, so a subsequent live subscribe sees a
+ * complete, deterministic initial snapshot.
+ */
+async function waitForServerQuery<T>(
+  client: TopGunClient,
+  mapName: string,
+  filter: QueryFilter,
+  predicate: (rows: Array<T & { _key: string }>) => boolean,
+  describe: () => string,
+  timeoutMs = 20_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastSeen = '<none>';
+  while (Date.now() < deadline) {
+    try {
+      const rows = (await client.queryOnce<T>(mapName, filter, {
+        timeoutMs: 5_000,
+      })) as Array<T & { _key: string }>;
+      if (predicate(rows)) return;
+      lastSeen = JSON.stringify(rows.map((r) => r._key));
+    } catch {
+      // Offline / settle timeout on this poll — retry until the outer deadline.
+    }
+    await waitMs(100);
+  }
+  throw new Error(`Timed out waiting for server query: ${describe()}; last = ${lastSeen}`);
+}
+
 function makeClient(port: number, userId: string): TopGunClient {
   const token = createTestToken(userId, ['ADMIN']);
   return new TopGunClient({
@@ -222,10 +271,23 @@ describe('Integration: live top-N clamp end-to-end (client <-> Rust server)', ()
     writerMap.set('d', { n: 3 });
 
     // Gate the subscribe on the writer fully draining its pending ops, so all
-    // three seed rows are APPLIED server-side BEFORE the QUERY_SUB. This removes
-    // the snapshot-vs-write race that otherwise lets the subscriber observe an
-    // empty initial window on a cold spawn (the original flake on PR #65).
+    // three seed rows are OP_ACKed server-side BEFORE the QUERY_SUB.
     await waitForSynced(writer);
+
+    // OP_ACK proves acceptance, not query-visibility: on a cold/slow start the
+    // per-record apply can lag the ack, and a seed could land in the server's
+    // scan-vs-activation gap, freezing a live handle at an incomplete window.
+    // Confirm the over-full seed is CONFIRMED QUERY-VISIBLE (top-2 clamped to
+    // [a, b], with d below the window) by re-scanning the server until it
+    // converges. After this the store is stable, so the live subscribe below is
+    // deterministic at any startup speed.
+    await waitForServerQuery<{ n: number }>(
+      subscriber,
+      mapName,
+      { limit: 2, sort: { n: 'asc' } },
+      (rows) => rows.length === 2 && rows[0]?._key === 'a' && rows[1]?._key === 'b',
+      () => 'seed top-2 [a, b] server-visible before live subscribe',
+    );
 
     // Capture the latest emitted (rendered) result set from the live subscription.
     let last: Array<{ n: number; _key: string }> = [];


### PR DESCRIPTION
Low-sweep batch A — three independent robustness/integrity fixes, each with a behavioral test **and** a negative control.

## TODO-483 — CI sim gate hole (integrity-critical)
The `simulation` CI job ran `cargo test … -- sim`. The `-- sim` substring filter only matched test **paths** containing `"sim"` — `proptest_sim::*`, the `sim_smoke` `sim_*` names, and the `src::sim` lib paths — and **silently skipped** the hand-written `crdt_convergence::*`, `merkle_sync::*`, `cluster_membership::*`, and `event_journal::*` modules. **10 of 14** simulation-binary tests never gated merges, so G3/G4a convergence/durability were partly riding on non-blocking tests — the same "test exists but isn't in the gate" class that let the F2 convergence regression slip.

**Fix:** run the `simulation` + `sim_smoke` binaries **in full** (selected by name, so the job stays scoped to simulation tests and out of the unrelated integration binaries), plus the `src::sim` lib harness tests via the path filter.

**Negative control (proves the gate is real):** a deliberately inverted `crdt_convergence::concurrent_writes_converge` assertion makes the **old** filter exit `0` (green — the hole) but the **new** gate exit `101` (red). Reverted after verification.

## TODO-526 — embedding provider degraded-state honesty
When the embedding provider fails at runtime (Ollama down / HTTP timeout), the record is still ACKed and persisted but gets **no `_embedding`**, silently losing semantic-search coverage with only a log line.

- `EmbeddingHealth` success/failure counters surfaced via `EmbeddingObserverFactory::health()`.
- Transition `warn!` on degrade, `info!` on recover.
- Documented **mark-and-skip** (no-retry) semantics — a retry loop against a down provider would trade silent-coverage for a liveness/OOM risk.
- Cross-vendor review (glm-5.2) flagged a per-record write-back-failure observability gap → added a separate `records_writeback_failed` counter (genuine store errors only; a record that no longer exists is a legitimate no-op, not a gap), and documented the snapshot's cross-field eventual-consistency.

**Behavioral test:** provider down → write persists **without** `_embedding` **and** health reports degraded. **Negative control:** healthy provider stays clean (`is_degraded() == false`, no false-positive write-back failures).

## TODO-505 — live-query integration determinism (cold cargo-run)
`OP_ACK` proves acceptance, not query-visibility: on a cold/slow start a seed can land in the server's scan-before-register gap and freeze a live handle at an incomplete window (the intermittent PR #65 red).

**Fix:** gate the real subscribe on the seed being **confirmed query-visible** via a `queryOnce` re-scan loop — each poll opens a fresh server subscription that converges once writes are stably applied, making the live snapshot deterministic at any startup speed. Verified green **5×** under cold `cargo run`.

## Gate
- `cargo fmt --check` ✅ · `cargo clippy --all-targets --all-features -- -D warnings` ✅ (exit 0)
- `cargo test --release -p topgun-server --lib` ✅ (1428 passed)
- Full sim matrix (new gate commands) ✅ (7 + 14 + 12 passed)
- Blocking integration-rust (cluster-routing excluded as CI does) ✅ (15 suites / 94 tests)
- `cluster-routing` remains the known **non-blocking** TODO-504 join-race (untouched here).