### PR TITLE
feat(client): passphrase encryption, typed backpressure overloads, FTS JSDoc honesty (TODO-527/528/466)

### DIFF
--- a/apps/docs-astro/src/content/docs/reference/adapters.mdx
+++ b/apps/docs-astro/src/content/docs/reference/adapters.mdx
@@ -121,34 +121,22 @@ An at-rest-encryption wrapper around any `IStorageAdapter`. Exported from `@topg
 import { TopGunClient, EncryptedStorageAdapter } from '@topgunbuild/client';
 import { IDBAdapter } from '@topgunbuild/adapters';
 
-// EncryptedStorageAdapter takes a pre-derived AES-GCM CryptoKey. Derive one
-// from a user passphrase with PBKDF2 (Web Crypto). Persist `salt` with your app
-// config — the same salt must be reused to unseal on the next session.
-const salt = crypto.getRandomValues(new Uint8Array(16));
-const baseKey = await crypto.subtle.importKey(
-  'raw',
-  new TextEncoder().encode('user-provided-secret'),
-  'PBKDF2',
-  false,
-  ['deriveKey'],
+// fromPassphrase derives a non-extractable AES-GCM key from the passphrase
+// (PBKDF2, 600k iterations) and manages the per-store salt for you: a random
+// salt is generated on first use, persisted alongside your data, and reused on
+// every later session so the same passphrase reopens the same store.
+const encrypted = await EncryptedStorageAdapter.fromPassphrase(
+  new IDBAdapter(),
+  'user-provided-secret',
 );
-const key = await crypto.subtle.deriveKey(
-  { name: 'PBKDF2', salt, iterations: 600_000, hash: 'SHA-256' },
-  baseKey,
-  { name: 'AES-GCM', length: 256 },
-  false,
-  ['encrypt', 'decrypt'],
-);
-
-const encrypted = new EncryptedStorageAdapter(new IDBAdapter(), key);
 
 const client = new TopGunClient({
   storage: encrypted,
 });
 ```
 
-> A `fromPassphrase()` convenience that performs this derivation for you is on
-> the roadmap — see TODO-527.
+If you already hold a derived key, pass it straight to the constructor instead:
+`new EncryptedStorageAdapter(new IDBAdapter(), cryptoKey)`.
 
 Values are AES-GCM-encrypted before they hit the underlying adapter. Keys and metadata stay plaintext so the sync engine and Merkle tree can still iterate without unsealing every record.
 

--- a/apps/docs-astro/src/content/docs/reference/client.mdx
+++ b/apps/docs-astro/src/content/docs/reference/client.mdx
@@ -659,20 +659,21 @@ True when the writer is currently paused under the pause strategy.
 ### `onBackpressure(event, listener)`
 
 ```typescript
-public onBackpressure(
-  event: 'backpressure:high' | 'backpressure:low' | 'backpressure:paused' | 'backpressure:resumed' | 'operation:dropped',
-  listener: (data?: BackpressureThresholdEvent | OperationDroppedEvent) => void
-): () => void
+public onBackpressure(event: 'backpressure:high' | 'backpressure:low', listener: (event: BackpressureThresholdEvent) => void): () => void
+public onBackpressure(event: 'operation:dropped', listener: (event: OperationDroppedEvent) => void): () => void
+public onBackpressure(event: 'backpressure:paused' | 'backpressure:resumed', listener: () => void): () => void
 ```
 
 Subscribe to backpressure transitions.
 
+The listener type narrows by event name — threshold events carry `{ pending, max }`, `'operation:dropped'` carries the dropped-op descriptor, and the paused/resumed transitions carry no payload:
+
 ```typescript
-client.onBackpressure('backpressure:high', (e) => {
-  // Threshold events carry `pending` / `max` counts.
-  if (e && 'pending' in e) {
-    console.warn(`Warning: ${e.pending}/${e.max} pending ops`);
-  }
+client.onBackpressure('backpressure:high', ({ pending, max }) => {
+  console.warn(`Warning: ${pending}/${max} pending ops`);
+});
+client.onBackpressure('operation:dropped', ({ mapName, key }) => {
+  console.warn(`Dropped ${mapName}:${key} under backpressure`);
 });
 client.onBackpressure('backpressure:paused', () => showLoadingSpinner());
 client.onBackpressure('backpressure:resumed', () => hideLoadingSpinner());

--- a/packages/client/src/SyncEngine.ts
+++ b/packages/client/src/SyncEngine.ts
@@ -1516,12 +1516,22 @@ export class SyncEngine {
   }
 
   /**
-   * Subscribe to backpressure events.
-   * Delegates to BackpressureController.
-   * @param event Event name: 'backpressure:high', 'backpressure:low', 'backpressure:paused', 'backpressure:resumed', 'operation:dropped'
-   * @param listener Callback function
+   * Subscribe to backpressure events. Delegates to BackpressureController.
+   * The listener type narrows by event name (see overloads).
    * @returns Unsubscribe function
    */
+  public onBackpressure(
+    event: 'backpressure:high' | 'backpressure:low',
+    listener: (event: BackpressureThresholdEvent) => void,
+  ): () => void;
+  public onBackpressure(
+    event: 'operation:dropped',
+    listener: (event: OperationDroppedEvent) => void,
+  ): () => void;
+  public onBackpressure(
+    event: 'backpressure:paused' | 'backpressure:resumed',
+    listener: () => void,
+  ): () => void;
   public onBackpressure(
     event:
       | 'backpressure:high'
@@ -1529,9 +1539,11 @@ export class SyncEngine {
       | 'backpressure:paused'
       | 'backpressure:resumed'
       | 'operation:dropped',
-    listener: (data?: BackpressureThresholdEvent | OperationDroppedEvent) => void,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- implementation signature must be broad enough to cover all narrowing overloads
+    listener: (event?: any) => void,
   ): () => void {
-    return this.backpressureController.onBackpressure(event, listener);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- delegating across the overloaded boundary; runtime dispatch is purely by event string
+    return this.backpressureController.onBackpressure(event as any, listener as any);
   }
 
   // ============================================

--- a/packages/client/src/TopGunClient.ts
+++ b/packages/client/src/TopGunClient.ts
@@ -1112,6 +1112,10 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
    * - 'backpressure:resumed': Emitted when writes resume after being paused
    * - 'operation:dropped': Emitted when an operation is dropped (drop-oldest strategy)
    *
+   * The listener type narrows by event name: threshold events carry
+   * `{ pending, max }`, `'operation:dropped'` carries the dropped-op descriptor,
+   * and the paused/resumed transitions carry no payload.
+   *
    * @param event Event name
    * @param listener Callback function
    * @returns Unsubscribe function
@@ -1120,6 +1124,10 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
    * ```typescript
    * client.onBackpressure('backpressure:high', ({ pending, max }) => {
    *   console.warn(`Warning: ${pending}/${max} pending ops`);
+   * });
+   *
+   * client.onBackpressure('operation:dropped', ({ mapName, key }) => {
+   *   console.warn(`Dropped ${mapName}:${key} under backpressure`);
    * });
    *
    * client.onBackpressure('backpressure:paused', () => {
@@ -1132,15 +1140,29 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
    * ```
    */
   public onBackpressure(
+    event: 'backpressure:high' | 'backpressure:low',
+    listener: (event: BackpressureThresholdEvent) => void,
+  ): () => void;
+  public onBackpressure(
+    event: 'operation:dropped',
+    listener: (event: OperationDroppedEvent) => void,
+  ): () => void;
+  public onBackpressure(
+    event: 'backpressure:paused' | 'backpressure:resumed',
+    listener: () => void,
+  ): () => void;
+  public onBackpressure(
     event:
       | 'backpressure:high'
       | 'backpressure:low'
       | 'backpressure:paused'
       | 'backpressure:resumed'
       | 'operation:dropped',
-    listener: (data?: BackpressureThresholdEvent | OperationDroppedEvent) => void,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- implementation signature must be broad enough to cover all narrowing overloads
+    listener: (event?: any) => void,
   ): () => void {
-    return this.syncEngine.onBackpressure(event, listener);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- delegating across the overloaded boundary; runtime dispatch is purely by event string
+    return this.syncEngine.onBackpressure(event as any, listener as any);
   }
 
   // ============================================
@@ -1150,8 +1172,9 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
   /**
    * Perform a one-shot BM25 search on the server.
    *
-   * Searches the specified map using BM25 ranking algorithm.
-   * Requires FTS to be enabled for the map on the server.
+   * Searches the specified map using the BM25 ranking algorithm. Every map is
+   * full-text indexed automatically on the server — there is no per-map enable
+   * flag to set.
    *
    * @param mapName Name of the map to search
    * @param query Search query text

--- a/packages/client/src/__tests__/EncryptedStorageAdapter.test.ts
+++ b/packages/client/src/__tests__/EncryptedStorageAdapter.test.ts
@@ -175,6 +175,179 @@ describe('EncryptedStorageAdapter', () => {
     await expect(wrongAdapter.get('secret-key')).rejects.toThrow('Failed to decrypt data');
   });
 
+  it('should derive a working key from a passphrase (round-trip)', async () => {
+    const adapter = await EncryptedStorageAdapter.fromPassphrase(
+      mockAdapter,
+      'correct horse battery staple',
+    );
+    await adapter.initialize('test-db');
+
+    const value = { foo: 'bar', n: 123 };
+    await adapter.put('k1', value);
+
+    // Stored blob is ciphertext, not the original.
+    const raw = await mockAdapter.get('k1');
+    expect(raw.iv).toBeInstanceOf(Uint8Array);
+    expect(raw.data).toBeInstanceOf(Uint8Array);
+    expect(raw.foo).toBeUndefined();
+
+    expect(await adapter.get('k1')).toEqual(value);
+  });
+
+  it('should persist the salt so the same passphrase reopens the store', async () => {
+    const passphrase = 'reopen-me';
+    const writer = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, passphrase);
+    await writer.initialize('test-db');
+    await writer.put('k1', { secret: 42 });
+
+    // A fresh adapter over the same underlying store + same passphrase must
+    // re-derive the identical key from the persisted salt and decrypt.
+    const reopened = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, passphrase);
+    await reopened.initialize('test-db');
+    expect(await reopened.get('k1')).toEqual({ secret: 42 });
+  });
+
+  it('should reject the wrong passphrase on reopen', async () => {
+    const writer = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'right');
+    await writer.initialize('test-db');
+    await writer.put('k1', { secret: 'sensitive' });
+
+    const wrong = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'wrong');
+    await wrong.initialize('test-db');
+    await expect(wrong.get('k1')).rejects.toThrow('Failed to decrypt data');
+  });
+
+  it('should generate a unique salt per store', async () => {
+    const a1 = await EncryptedStorageAdapter.fromPassphrase(new MockStorageAdapter(), 'pw');
+    const a2 = await EncryptedStorageAdapter.fromPassphrase(new MockStorageAdapter(), 'pw');
+    // Force derivation (and thus salt persistence) on each.
+    await a1.put('k', 1);
+    await a2.put('k', 1);
+
+    const meta1 = (a1 as any).wrapped.meta.get('__topgun_enc_kdf__');
+    const meta2 = (a2 as any).wrapped.meta.get('__topgun_enc_kdf__');
+    expect(meta1.salt).toBeInstanceOf(Uint8Array);
+    expect(meta2.salt).toBeInstanceOf(Uint8Array);
+    expect(Array.from(meta1.salt)).not.toEqual(Array.from(meta2.salt));
+  });
+
+  it('should use a fresh IV per write', async () => {
+    const adapter = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw');
+    await adapter.put('k1', { v: 1 });
+    await adapter.put('k2', { v: 1 });
+
+    const iv1 = (await mockAdapter.get('k1')).iv as Uint8Array;
+    const iv2 = (await mockAdapter.get('k2')).iv as Uint8Array;
+    expect(Array.from(iv1)).not.toEqual(Array.from(iv2));
+  });
+
+  it('should detect tampering (AES-GCM auth tag)', async () => {
+    const adapter = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw');
+    await adapter.put('k1', { secret: 'do not flip' });
+
+    // Flip a byte in the ciphertext; GCM verification must fail on read.
+    const raw = await mockAdapter.get('k1');
+    raw.data[0] ^= 0xff;
+    await mockAdapter.put('k1', raw);
+
+    await expect(adapter.get('k1')).rejects.toThrow('Failed to decrypt data');
+  });
+
+  it('should reject iterations below the OWASP floor', async () => {
+    await expect(
+      EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw', { iterations: 1000 }),
+    ).rejects.toThrow('iterations must be an integer >= 600000');
+  });
+
+  it('should reopen when the persisted salt was JSON-serialised (not a Uint8Array)', async () => {
+    const writer = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw');
+    await writer.put('k1', { secret: 1 });
+
+    // Simulate a JSON-backed adapter that lost the Uint8Array type on the salt.
+    const params = mockAdapter.meta.get('__topgun_enc_kdf__');
+    const jsonRoundTripped = JSON.parse(JSON.stringify(params));
+    expect(jsonRoundTripped.salt).not.toBeInstanceOf(Uint8Array);
+    mockAdapter.meta.set('__topgun_enc_kdf__', jsonRoundTripped);
+
+    const reopened = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw');
+    expect(await reopened.get('k1')).toEqual({ secret: 1 });
+  });
+
+  it('should fail closed (not regenerate) when the persisted salt is unreadable', async () => {
+    const writer = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw');
+    await writer.put('k1', { secret: 1 });
+
+    // Corrupt the salt into something coerceSalt cannot interpret.
+    mockAdapter.meta.set('__topgun_enc_kdf__', { v: 1, salt: 'not-bytes', iterations: 600000 });
+
+    const reopened = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw');
+    await expect(reopened.get('k1')).rejects.toThrow('corrupted or unreadable');
+  });
+
+  it('should reject a persisted iteration count below the floor on reopen', async () => {
+    // A tampered/corrupted record must not downgrade the KDF on reopen.
+    mockAdapter.meta.set('__topgun_enc_kdf__', {
+      v: 1,
+      salt: new Uint8Array(16).fill(7),
+      iterations: 1,
+    });
+    const reopened = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw');
+    await expect(reopened.put('k1', { v: 1 })).rejects.toThrow('floor');
+  });
+
+  it('should reject an unsupported persisted KDF version on reopen', async () => {
+    mockAdapter.meta.set('__topgun_enc_kdf__', {
+      v: 2,
+      salt: new Uint8Array(16).fill(7),
+      iterations: 600000,
+    });
+    const reopened = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw');
+    await expect(reopened.put('k1', { v: 1 })).rejects.toThrow('unsupported version');
+  });
+
+  it('should reject a persisted salt shorter than 16 bytes on reopen', async () => {
+    mockAdapter.meta.set('__topgun_enc_kdf__', {
+      v: 1,
+      salt: new Uint8Array(8).fill(7),
+      iterations: 600000,
+    });
+    const reopened = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw');
+    await expect(reopened.put('k1', { v: 1 })).rejects.toThrow('corrupted or unreadable');
+  });
+
+  it('should reserve the salt meta key from the public meta API', async () => {
+    const adapter = await EncryptedStorageAdapter.fromPassphrase(mockAdapter, 'pw');
+    await expect(adapter.setMeta('__topgun_enc_kdf__', { evil: true })).rejects.toThrow(
+      'is reserved',
+    );
+    await expect(adapter.getMeta('__topgun_enc_kdf__')).rejects.toThrow('is reserved');
+  });
+
+  it('should recover after a transient derivation failure (no permanent brick)', async () => {
+    const flaky = new MockStorageAdapter();
+    const original = flaky.getMeta.bind(flaky);
+    let calls = 0;
+    flaky.getMeta = async (key: string) => {
+      // Fail only the first salt read, then behave normally.
+      if (key === '__topgun_enc_kdf__' && calls++ === 0) {
+        throw new Error('transient IDB failure');
+      }
+      return original(key);
+    };
+
+    const adapter = await EncryptedStorageAdapter.fromPassphrase(flaky, 'pw');
+    await expect(adapter.put('k1', { v: 1 })).rejects.toThrow('transient IDB failure');
+    // The cached rejection must not brick the adapter — a retry succeeds.
+    await adapter.put('k1', { v: 1 });
+    expect(await adapter.get('k1')).toEqual({ v: 1 });
+  });
+
+  it('should reject an empty passphrase', async () => {
+    await expect(EncryptedStorageAdapter.fromPassphrase(mockAdapter, '')).rejects.toThrow(
+      'non-empty string',
+    );
+  });
+
   it('should encrypt all entries in batchPut', async () => {
     // 1. Call batchPut with multiple entries
     const entries = new Map<string, any>([

--- a/packages/client/src/__tests__/backpressure-overloads.test.ts
+++ b/packages/client/src/__tests__/backpressure-overloads.test.ts
@@ -1,0 +1,105 @@
+import { BackpressureController } from '../sync/BackpressureController';
+import type { BackpressureConfig } from '../BackpressureConfig';
+import type { OpLogEntry } from '../SyncEngine';
+import type { BackpressureThresholdEvent, OperationDroppedEvent } from '../BackpressureConfig';
+
+function makeOp(id: number): OpLogEntry {
+  return {
+    id: String(id),
+    mapName: 'users',
+    opType: 'PUT',
+    key: `k${id}`,
+    synced: false,
+  } as unknown as OpLogEntry;
+}
+
+function makeController(
+  opLog: OpLogEntry[],
+  overrides: Partial<BackpressureConfig> = {},
+): BackpressureController {
+  const config: BackpressureConfig = {
+    maxPendingOps: 10,
+    strategy: 'pause',
+    highWaterMark: 0.8,
+    lowWaterMark: 0.5,
+    ...overrides,
+  };
+  return new BackpressureController({ config, opLog });
+}
+
+describe('onBackpressure typed overloads', () => {
+  // Each test subscribes with a listener whose parameter is destructured/typed
+  // per the documented overload. If the overloads did not narrow, these would
+  // fail to compile (TS2339/TS2459) — so this suite is both a runtime and a
+  // type-level check.
+
+  it("'backpressure:high' narrows to BackpressureThresholdEvent", () => {
+    const opLog: OpLogEntry[] = [];
+    const controller = makeController(opLog);
+    let received: BackpressureThresholdEvent | undefined;
+
+    controller.onBackpressure('backpressure:high', ({ pending, max }) => {
+      received = { pending, max };
+    });
+
+    for (let i = 0; i < 8; i++) opLog.push(makeOp(i)); // threshold = floor(10 * 0.8) = 8
+    controller.checkHighWaterMark();
+
+    expect(received).toEqual({ pending: 8, max: 10 });
+  });
+
+  it("'backpressure:low' narrows to BackpressureThresholdEvent and resumes", () => {
+    const opLog: OpLogEntry[] = [];
+    const controller = makeController(opLog);
+    let low: BackpressureThresholdEvent | undefined;
+    let resumed = false;
+
+    controller.onBackpressure('backpressure:low', ({ pending, max }) => {
+      low = { pending, max };
+    });
+    controller.onBackpressure('backpressure:resumed', () => {
+      resumed = true;
+    });
+
+    // Saturate to trip the pause strategy, then drain below the low water mark.
+    for (let i = 0; i < 10; i++) opLog.push(makeOp(i));
+    void controller.checkBackpressure(); // strategy 'pause' → backpressurePaused = true
+    opLog.length = 4; // below floor(10 * 0.5) = 5
+    controller.checkLowWaterMark();
+
+    expect(low).toEqual({ pending: 4, max: 10 });
+    expect(resumed).toBe(true);
+  });
+
+  it("'backpressure:paused' takes a payload-free listener", async () => {
+    const opLog: OpLogEntry[] = [];
+    const controller = makeController(opLog);
+    let paused = false;
+
+    controller.onBackpressure('backpressure:paused', () => {
+      paused = true;
+    });
+
+    for (let i = 0; i < 10; i++) opLog.push(makeOp(i));
+    // 'pause' strategy blocks until capacity; don't await (it resolves on drain).
+    void controller.checkBackpressure();
+
+    expect(paused).toBe(true);
+  });
+
+  it("'operation:dropped' narrows to OperationDroppedEvent", async () => {
+    const opLog: OpLogEntry[] = [];
+    const controller = makeController(opLog, { maxPendingOps: 2, strategy: 'drop-oldest' });
+    let dropped: OperationDroppedEvent | undefined;
+
+    controller.onBackpressure('operation:dropped', ({ opId, mapName, opType, key }) => {
+      dropped = { opId, mapName, opType, key };
+    });
+
+    opLog.push(makeOp(0));
+    opLog.push(makeOp(1));
+    await controller.checkBackpressure(); // at capacity → drop oldest (id "0")
+
+    expect(dropped).toEqual({ opId: '0', mapName: 'users', opType: 'PUT', key: 'k0' });
+  });
+});

--- a/packages/client/src/adapters/EncryptedStorageAdapter.ts
+++ b/packages/client/src/adapters/EncryptedStorageAdapter.ts
@@ -1,14 +1,244 @@
 import { IStorageAdapter, OpLogEntry, StorageMutation } from '../IStorageAdapter';
 import { EncryptionManager } from '../crypto/EncryptionManager';
+import { getWebCrypto } from '../crypto/webcrypto';
+
+/** OWASP 2023 minimum for PBKDF2-HMAC-SHA256; also the enforced floor. */
+const DEFAULT_PBKDF2_ITERATIONS = 600_000;
+/**
+ * Hard lower bound on PBKDF2 iterations. A caller-supplied `iterations` below
+ * this is rejected rather than silently honoured, because a weak count would be
+ * persisted and reused on every reopen — a permanent, invisible downgrade of the
+ * only secret protecting the data.
+ */
+const MIN_PBKDF2_ITERATIONS = 600_000;
+/** 128-bit salt — comfortably above the 16-byte NIST SP 800-132 floor. */
+const SALT_BYTES = 16;
+
+/**
+ * Coerce a persisted salt back to a `Uint8Array`. Adapters that round-trip meta
+ * through structured clone preserve the type, but a JSON-backed adapter turns it
+ * into a plain `{ "0": .., "1": .. }` object or a number[]. Returns null when the
+ * value cannot be interpreted as bytes — the caller MUST fail closed rather than
+ * regenerate, or it would orphan the existing ciphertext.
+ */
+function coerceSalt(value: unknown): Uint8Array | null {
+  if (value instanceof Uint8Array) return value.length > 0 ? value : null;
+  if (value instanceof ArrayBuffer) {
+    return value.byteLength > 0 ? new Uint8Array(value) : null;
+  }
+  // number[] or a JSON-serialised Uint8Array ({ "0": n, "1": n, ... }). Validate
+  // every byte strictly — reject holes (sparse arrays) and out-of-range values
+  // rather than letting Uint8Array.from coerce them to 0.
+  const bytes = Array.isArray(value)
+    ? value
+    : value && typeof value === 'object'
+      ? Object.values(value as Record<string, unknown>)
+      : null;
+  if (!bytes || bytes.length === 0) return null;
+  for (const b of bytes) {
+    if (typeof b !== 'number' || !Number.isInteger(b) || b < 0 || b > 255) return null;
+  }
+  return Uint8Array.from(bytes as number[]);
+}
+/**
+ * Plaintext meta key under which the per-adapter KDF salt is persisted in the
+ * wrapped adapter. Stored unencrypted by necessity: it is the input needed to
+ * re-derive the key that unseals everything else (a salt is not secret).
+ */
+const SALT_META_KEY = '__topgun_enc_kdf__';
+
+interface PassphraseDerivation {
+  passphrase: string;
+  iterations: number;
+}
+
+interface PersistedKdfParams {
+  v: 1;
+  salt: Uint8Array;
+  iterations: number;
+}
+
+/**
+ * Validate a persisted KDF record read back from the wrapped adapter. A record
+ * that exists but is malformed in ANY way (unknown version, missing/short salt,
+ * iteration count below the floor) is rejected by throwing — never silently
+ * repaired or regenerated, because deriving from a different/weaker input would
+ * orphan or downgrade the existing ciphertext. The floor is therefore enforced
+ * on reopen, not just at creation.
+ */
+function parsePersistedKdf(value: unknown): { salt: Uint8Array; iterations: number } {
+  const corrupt = (detail: string) =>
+    new Error(
+      `EncryptedStorageAdapter: persisted KDF params are ${detail}; refusing to regenerate (would orphan existing ciphertext)`,
+    );
+
+  if (!value || typeof value !== 'object') throw corrupt('corrupted or unreadable');
+  const rec = value as Partial<PersistedKdfParams>;
+  if (rec.v !== 1) throw corrupt(`an unsupported version (${String(rec.v)})`);
+
+  const salt = coerceSalt(rec.salt);
+  if (!salt || salt.length < SALT_BYTES) throw corrupt('corrupted or unreadable (salt)');
+
+  if (
+    typeof rec.iterations !== 'number' ||
+    !Number.isInteger(rec.iterations) ||
+    rec.iterations < MIN_PBKDF2_ITERATIONS
+  ) {
+    throw corrupt(`below the ${MIN_PBKDF2_ITERATIONS}-iteration floor (${String(rec.iterations)})`);
+  }
+
+  return { salt, iterations: rec.iterations };
+}
 
 /**
  * Wraps an underlying storage adapter and encrypts data at rest using AES-GCM.
+ *
+ * Construct with a pre-derived `CryptoKey`, or use the {@link fromPassphrase}
+ * convenience to derive one from a user passphrase (PBKDF2) with the salt
+ * managed and persisted for you.
  */
 export class EncryptedStorageAdapter implements IStorageAdapter {
+  private key?: CryptoKey;
+  private derivation?: PassphraseDerivation;
+  // Memoises the first derivation so concurrent reads/writes derive exactly once.
+  private keyReady?: Promise<CryptoKey>;
+
   constructor(
     private wrapped: IStorageAdapter,
-    private key: CryptoKey,
-  ) {}
+    key: CryptoKey,
+  ) {
+    this.key = key;
+  }
+
+  /**
+   * Derive an at-rest encryption key from a human passphrase and wrap `adapter`.
+   *
+   * Handles the full Web Crypto KDF dance for you: a random per-adapter salt is
+   * generated on first use and persisted (plaintext — a salt is not a secret)
+   * alongside your data, then reused on every later session so the same
+   * passphrase unseals the same store. The derived AES-GCM key is
+   * non-extractable.
+   *
+   * Works in browsers and Node ≥ 20 (any runtime exposing `globalThis.crypto`).
+   *
+   * @param adapter    The underlying storage adapter to encrypt (e.g. `IDBAdapter`).
+   * @param passphrase The user-provided secret. Stronger is better — this is the
+   *                   sole input protecting the data.
+   * @param options.iterations PBKDF2 iteration count for a NEW store. Defaults to
+   *                   600,000 (OWASP 2023); values below 600,000 are rejected. The
+   *                   count is persisted with the salt on first use and reused
+   *                   verbatim on reopen, so changing it later has no effect on an
+   *                   existing store (re-keying would require re-encrypting).
+   *
+   * @example
+   * ```typescript
+   * const encrypted = await EncryptedStorageAdapter.fromPassphrase(
+   *   new IDBAdapter(),
+   *   'correct horse battery staple',
+   * );
+   * const client = new TopGunClient({ storage: encrypted });
+   * ```
+   */
+  static async fromPassphrase(
+    adapter: IStorageAdapter,
+    passphrase: string,
+    options?: { iterations?: number },
+  ): Promise<EncryptedStorageAdapter> {
+    if (typeof passphrase !== 'string' || passphrase.length === 0) {
+      throw new Error(
+        'EncryptedStorageAdapter.fromPassphrase: passphrase must be a non-empty string',
+      );
+    }
+    const iterations = options?.iterations ?? DEFAULT_PBKDF2_ITERATIONS;
+    if (!Number.isInteger(iterations) || iterations < MIN_PBKDF2_ITERATIONS) {
+      throw new Error(
+        `EncryptedStorageAdapter.fromPassphrase: iterations must be an integer >= ${MIN_PBKDF2_ITERATIONS} (OWASP 2023 floor); got ${iterations}`,
+      );
+    }
+    // Surface a missing Web Crypto implementation eagerly at call time rather
+    // than on the first deferred read/write.
+    getWebCrypto();
+
+    // Construct in deferred-key mode: the real key is derived lazily on first
+    // use, after the wrapped adapter has been initialised (so the salt meta is
+    // reachable). `key` stays undefined until then.
+    const instance = new EncryptedStorageAdapter(adapter, undefined as unknown as CryptoKey);
+    instance.key = undefined;
+    instance.derivation = { passphrase, iterations };
+    return instance;
+  }
+
+  /**
+   * Resolve the AES-GCM key, deriving it from the passphrase on first use.
+   * Direct-key mode returns the constructor-supplied key immediately.
+   */
+  private async resolveKey(): Promise<CryptoKey> {
+    if (this.key) return this.key;
+    if (!this.derivation) {
+      throw new Error('EncryptedStorageAdapter: no encryption key configured');
+    }
+    if (!this.keyReady) {
+      // Clear the memo on failure so a transient cause (adapter not yet
+      // initialised, a flaky IDB transaction) does not permanently brick the
+      // adapter — the next call re-attempts derivation.
+      this.keyReady = this.deriveKeyFromPassphrase(this.derivation).catch((err) => {
+        this.keyReady = undefined;
+        throw err;
+      });
+    }
+    this.key = await this.keyReady;
+    return this.key;
+  }
+
+  /**
+   * Load-or-create the per-adapter salt (plaintext, via the wrapped adapter) and
+   * run PBKDF2 to derive a non-extractable AES-GCM key.
+   */
+  private async deriveKeyFromPassphrase(derivation: PassphraseDerivation): Promise<CryptoKey> {
+    const webcrypto = getWebCrypto();
+    const { salt, iterations } = await this.loadOrCreateKdfParams(webcrypto, derivation.iterations);
+
+    const baseKey = await webcrypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode(derivation.passphrase),
+      'PBKDF2',
+      false,
+      ['deriveKey'],
+    );
+
+    return webcrypto.subtle.deriveKey(
+      { name: 'PBKDF2', salt: salt as unknown as ArrayBuffer, iterations, hash: 'SHA-256' },
+      baseKey,
+      { name: 'AES-GCM', length: 256 },
+      false, // non-extractable: the key never leaves the SubtleCrypto boundary
+      ['encrypt', 'decrypt'],
+    );
+  }
+
+  /**
+   * Resolve the KDF salt + iteration count. An existing record must validate or
+   * we fail closed (never regenerate over it). On genuine first use we create and
+   * persist a random salt, then re-read it: if a concurrent instance won the
+   * write (last-write-wins adapters), we adopt the persisted params so both
+   * instances converge on the same key instead of orphaning each other's data.
+   */
+  private async loadOrCreateKdfParams(
+    webcrypto: Crypto,
+    defaultIterations: number,
+  ): Promise<{ salt: Uint8Array; iterations: number }> {
+    const persisted = await this.wrapped.getMeta(SALT_META_KEY);
+    if (persisted != null) {
+      // Reopen: reuse exactly the salt+iterations the store was sealed with.
+      return parsePersistedKdf(persisted);
+    }
+
+    // Genuine first use: create, persist, then re-read to settle any race.
+    const salt = webcrypto.getRandomValues(new Uint8Array(SALT_BYTES));
+    const params: PersistedKdfParams = { v: 1, salt, iterations: defaultIterations };
+    await this.wrapped.setMeta(SALT_META_KEY, params);
+    const confirmed = await this.wrapped.getMeta(SALT_META_KEY);
+    return parsePersistedKdf(confirmed ?? params);
+  }
 
   async initialize(dbName: string): Promise<void> {
     return this.wrapped.initialize(dbName);
@@ -34,7 +264,7 @@ export class EncryptedStorageAdapter implements IStorageAdapter {
     // Note: In a real app we might want a stricter check or a version tag.
     if (this.isEncryptedRecord(raw)) {
       try {
-        return await EncryptionManager.decrypt(this.key, raw);
+        return await EncryptionManager.decrypt(await this.resolveKey(), raw);
       } catch (e) {
         // Fallback for migration or corruption?
         // For now, fail loud as per spec.
@@ -48,7 +278,7 @@ export class EncryptedStorageAdapter implements IStorageAdapter {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- IStorageAdapter.put contract accepts any serialisable value; encrypted wrapper does not know the original value type
   async put(key: string, value: any): Promise<void> {
-    const encrypted = await EncryptionManager.encrypt(this.key, value);
+    const encrypted = await EncryptionManager.encrypt(await this.resolveKey(), value);
     // Store as plain object to be compatible with structured clone algorithm of IndexedDB
     const storedValue = {
       iv: encrypted.iv,
@@ -65,22 +295,35 @@ export class EncryptedStorageAdapter implements IStorageAdapter {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- meta values have no fixed schema; mirrors IStorageAdapter.getMeta contract
   async getMeta(key: string): Promise<any> {
+    this.assertNotReserved(key);
     const raw = await this.wrapped.getMeta(key);
     if (!raw) return undefined;
 
     if (this.isEncryptedRecord(raw)) {
-      return EncryptionManager.decrypt(this.key, raw);
+      return EncryptionManager.decrypt(await this.resolveKey(), raw);
     }
     return raw;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- meta values have no fixed schema; mirrors IStorageAdapter.setMeta contract
   async setMeta(key: string, value: any): Promise<void> {
-    const encrypted = await EncryptionManager.encrypt(this.key, value);
+    this.assertNotReserved(key);
+    const encrypted = await EncryptionManager.encrypt(await this.resolveKey(), value);
     return this.wrapped.setMeta(key, {
       iv: encrypted.iv,
       data: encrypted.data,
     });
+  }
+
+  /**
+   * Guards the reserved KDF-salt meta key from the public meta API: an external
+   * `setMeta(SALT_META_KEY, …)` would encrypt over the plaintext salt and silently
+   * orphan the store on reopen, so we reject access outright.
+   */
+  private assertNotReserved(key: string): void {
+    if (key === SALT_META_KEY) {
+      throw new Error(`EncryptedStorageAdapter: meta key "${SALT_META_KEY}" is reserved`);
+    }
   }
 
   // --- Batch ---
@@ -89,10 +332,11 @@ export class EncryptedStorageAdapter implements IStorageAdapter {
   async batchPut(entries: Map<string, any>): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- encrypted entries map holds blobs of varying shape before being passed to wrapped adapter
     const encryptedEntries = new Map<string, any>();
+    const key = await this.resolveKey();
 
-    for (const [key, value] of entries.entries()) {
-      const encrypted = await EncryptionManager.encrypt(this.key, value);
-      encryptedEntries.set(key, {
+    for (const [entryKey, value] of entries.entries()) {
+      const encrypted = await EncryptionManager.encrypt(key, value);
+      encryptedEntries.set(entryKey, {
         iv: encrypted.iv,
         data: encrypted.data,
       });
@@ -113,20 +357,21 @@ export class EncryptedStorageAdapter implements IStorageAdapter {
    */
   private async encryptOpEntry(entry: Omit<OpLogEntry, 'id'>): Promise<Omit<OpLogEntry, 'id'>> {
     const encryptedEntry = { ...entry };
+    const key = await this.resolveKey();
 
     if (entry.value !== undefined) {
-      const enc = await EncryptionManager.encrypt(this.key, entry.value);
+      const enc = await EncryptionManager.encrypt(key, entry.value);
       encryptedEntry.value = { iv: enc.iv, data: enc.data };
     }
 
     if (entry.record !== undefined) {
-      const enc = await EncryptionManager.encrypt(this.key, entry.record);
+      const enc = await EncryptionManager.encrypt(key, entry.record);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- record field is typed as LWWRecord<any> in OpLogEntry; cast to any to replace with encrypted blob shape
       encryptedEntry.record = { iv: enc.iv, data: enc.data } as any;
     }
 
     if (entry.orRecord !== undefined) {
-      const enc = await EncryptionManager.encrypt(this.key, entry.orRecord);
+      const enc = await EncryptionManager.encrypt(key, entry.orRecord);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- orRecord field is typed as ORMapRecord<any> in OpLogEntry; cast to any to replace with encrypted blob shape
       encryptedEntry.orRecord = { iv: enc.iv, data: enc.data } as any;
     }
@@ -137,10 +382,11 @@ export class EncryptedStorageAdapter implements IStorageAdapter {
   async commitWrite(mutations: StorageMutation[], op: Omit<OpLogEntry, 'id'>): Promise<number> {
     // Encrypt each put mutation's value (removes carry no value); the wrapped adapter
     // provides the atomic single-transaction guarantee over the encrypted blobs.
+    const key = await this.resolveKey();
     const encryptedMutations: StorageMutation[] = await Promise.all(
       mutations.map(async (m) => {
         if (m.type === 'put' && m.value !== undefined) {
-          const enc = await EncryptionManager.encrypt(this.key, m.value);
+          const enc = await EncryptionManager.encrypt(key, m.value);
           return { ...m, value: { iv: enc.iv, data: enc.data } };
         }
         return m;
@@ -155,6 +401,8 @@ export class EncryptedStorageAdapter implements IStorageAdapter {
 
   async getPendingOps(): Promise<OpLogEntry[]> {
     const ops = await this.wrapped.getPendingOps();
+    if (ops.length === 0) return ops;
+    const key = await this.resolveKey();
 
     // Decrypt in place
     // We map concurrently for performance
@@ -163,17 +411,17 @@ export class EncryptedStorageAdapter implements IStorageAdapter {
         const decryptedOp = { ...op };
 
         if (this.isEncryptedRecord(op.value)) {
-          decryptedOp.value = await EncryptionManager.decrypt(this.key, op.value);
+          decryptedOp.value = await EncryptionManager.decrypt(key, op.value);
         }
 
         if (this.isEncryptedRecord(op.record)) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any -- op.record is typed as LWWRecord<any> but holds an encrypted blob; cast to any to pass to decrypt
-          decryptedOp.record = await EncryptionManager.decrypt(this.key, op.record as any);
+          decryptedOp.record = await EncryptionManager.decrypt(key, op.record as any);
         }
 
         if (this.isEncryptedRecord(op.orRecord)) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any -- op.orRecord is typed as ORMapRecord<any> but holds an encrypted blob; cast to any to pass to decrypt
-          decryptedOp.orRecord = await EncryptionManager.decrypt(this.key, op.orRecord as any);
+          decryptedOp.orRecord = await EncryptionManager.decrypt(key, op.orRecord as any);
         }
 
         return decryptedOp;

--- a/packages/client/src/crypto/EncryptionManager.ts
+++ b/packages/client/src/crypto/EncryptionManager.ts
@@ -1,5 +1,6 @@
 import { serialize, deserialize } from '@topgunbuild/core';
 import { logger } from '../utils/logger';
+import { getWebCrypto } from './webcrypto';
 
 export class EncryptionManager {
   private static ALGORITHM = 'AES-GCM';
@@ -12,12 +13,13 @@ export class EncryptionManager {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- encrypt accepts any serialisable value; the adapter is encryption-layer agnostic about the value schema
   static async encrypt(key: CryptoKey, data: any): Promise<{ iv: Uint8Array; data: Uint8Array }> {
     const encoded = serialize(data);
+    const webcrypto = getWebCrypto();
 
-    // Generate IV
-    const iv = window.crypto.getRandomValues(new Uint8Array(EncryptionManager.IV_LENGTH));
+    // Generate a fresh random IV for every write (AES-GCM nonce must never repeat under one key).
+    const iv = webcrypto.getRandomValues(new Uint8Array(EncryptionManager.IV_LENGTH));
 
     // Encrypt
-    const ciphertext = await window.crypto.subtle.encrypt(
+    const ciphertext = await webcrypto.subtle.encrypt(
       {
         name: EncryptionManager.ALGORITHM,
         iv: iv,
@@ -40,7 +42,8 @@ export class EncryptionManager {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- decrypt returns a deserialized msgpack value; the concrete type is known only to the caller who originally encrypted it
   static async decrypt(key: CryptoKey, record: { iv: Uint8Array; data: Uint8Array }): Promise<any> {
     try {
-      const plaintextBuffer = await window.crypto.subtle.decrypt(
+      const webcrypto = getWebCrypto();
+      const plaintextBuffer = await webcrypto.subtle.decrypt(
         {
           name: EncryptionManager.ALGORITHM,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SubtleCrypto IV param expects BufferSource; Uint8Array satisfies that but requires cast for strict lib typings

--- a/packages/client/src/crypto/webcrypto.ts
+++ b/packages/client/src/crypto/webcrypto.ts
@@ -1,0 +1,25 @@
+/**
+ * Resolves the Web Crypto API (`SubtleCrypto`) across browser and Node.
+ *
+ * Browsers expose it on `window.crypto` / `globalThis.crypto`; Node ≥ 20, Deno,
+ * Bun, and edge runtimes expose it on `globalThis.crypto`. We resolve lazily (at
+ * call time, not module load) so bundlers never need a Node built-in and SSR /
+ * edge runtimes pick up their own global. Throws a clear, actionable error when
+ * no implementation is available rather than failing later inside `subtle.*`.
+ */
+export function getWebCrypto(): Crypto {
+  const candidate =
+    (typeof globalThis !== 'undefined' && globalThis.crypto) ||
+    (typeof window !== 'undefined' && window.crypto) ||
+    undefined;
+
+  if (!candidate?.subtle) {
+    throw new Error(
+      'Web Crypto API unavailable: EncryptedStorageAdapter requires ' +
+        'globalThis.crypto.subtle (browsers, Node ≥ 20, Deno, Bun, or a ' +
+        'WebCrypto polyfill installed on globalThis.crypto).',
+    );
+  }
+
+  return candidate;
+}

--- a/packages/client/src/sync/BackpressureController.ts
+++ b/packages/client/src/sync/BackpressureController.ts
@@ -166,11 +166,24 @@ export class BackpressureController implements IBackpressureController {
   // ============================================
 
   /**
-   * Subscribe to backpressure events.
-   * @param event Event name: 'backpressure:high', 'backpressure:low', 'backpressure:paused', 'backpressure:resumed', 'operation:dropped'
-   * @param listener Callback function
+   * Subscribe to backpressure events. The listener type narrows by event name:
+   * threshold events ('backpressure:high'/'backpressure:low') carry
+   * `{ pending, max }`, 'operation:dropped' carries the dropped-op descriptor,
+   * and the paused/resumed transitions carry no payload.
    * @returns Unsubscribe function
    */
+  public onBackpressure(
+    event: 'backpressure:high' | 'backpressure:low',
+    listener: (event: BackpressureThresholdEvent) => void,
+  ): () => void;
+  public onBackpressure(
+    event: 'operation:dropped',
+    listener: (event: OperationDroppedEvent) => void,
+  ): () => void;
+  public onBackpressure(
+    event: 'backpressure:paused' | 'backpressure:resumed',
+    listener: () => void,
+  ): () => void;
   public onBackpressure(
     event:
       | 'backpressure:high'
@@ -178,7 +191,8 @@ export class BackpressureController implements IBackpressureController {
       | 'backpressure:paused'
       | 'backpressure:resumed'
       | 'operation:dropped',
-    listener: (data?: BackpressureThresholdEvent | OperationDroppedEvent) => void,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- implementation signature must be broad enough to cover all narrowing overloads (required-param listeners are not assignable to an optional-union listener)
+    listener: (event?: any) => void,
   ): () => void {
     if (!this.backpressureListeners.has(event)) {
       this.backpressureListeners.set(event, new Set());


### PR DESCRIPTION
## Summary

Low-sweep Batch B — SDK DX, three G2-doc-test-driven fixes. Each restores the docs to the ergonomic form the harness originally rejected, backed by a real SDK change + tests.

### TODO-527 — `EncryptedStorageAdapter.fromPassphrase()`
G2 caught that the docs showed `EncryptedStorageAdapter({ passphrase })` while the real constructor took a pre-derived `CryptoKey`. That was a missing-feature signal (passphrase is the right surface for non-technical users), not a doc bug.

- New `static async fromPassphrase(adapter, passphrase, { iterations? })` — derives a **non-extractable** AES-GCM key via PBKDF2 (600k iters, OWASP 2023) with a random per-store salt generated on first use, persisted plaintext via the wrapped adapter, and reused verbatim on reopen.
- Derivation is lazy (after `initialize()`) and memoised; the memo is cleared on failure so a transient error can't permanently brick the adapter.
- Web Crypto resolved via a new `getWebCrypto()` helper → works in browsers and Node ≥ 20.
- `adapters.mdx` snippet restored to the passphrase form (G2: **typecheck** tier, not skip).

**Hardening from two cross-vendor adversarial review passes (GLM-5.2):** persisted KDF params are strictly validated on reopen and **fail closed** (never silently regenerated/downgraded) — covers iteration-floor-on-reopen, malformed/missing salt, salt-length, version drift, and JSON-serialised-salt round-trip; reserved salt meta key guarded from the public meta API; concurrent-instance salt race mitigated by re-read-and-adopt.

### TODO-528 — `onBackpressure()` typed overloads
The listener was typed as the full union regardless of `event`, so even the source's own destructured example didn't type-check. Added event-name overloads (threshold → `BackpressureThresholdEvent`, `operation:dropped` → `OperationDroppedEvent`, paused/resumed → no payload) across `TopGunClient`, `SyncEngine`, `BackpressureController`. `client.mdx` snippet restored to the clean destructured form.

### TODO-466 — FTS JSDoc honesty
Removed the false "Requires FTS to be enabled" gate from `search()` JSDoc — every map is full-text indexed automatically (`create_observer` returns `Some` unconditionally); there is no per-map flag.

## Tests
- `EncryptedStorageAdapter.test.ts`: round-trip, salt persistence/reopen, wrong-passphrase rejection, salt+IV uniqueness, tamper detection, iteration-floor (create + reopen), version/short-salt/unreadable-salt fail-closed, JSON-serialised salt reopen, reserved-key guard, transient-failure recovery.
- `backpressure-overloads.test.ts`: one test per overload branch (compile-time narrowing + runtime payload).

## Gates (all green locally)
- `@topgunbuild/client` + `@topgunbuild/react` build
- jest (client): **681 passed**
- doc-tests (blocking): **177 passed**; 527/528 snippets confirmed `typecheck` (not skip)
- integration-rust (blocking): all suites pass except the known non-blocking `cluster-routing` cold join-race flake (TODO-504), which passes on isolated re-run
- lint: 0 errors · prettier: clean
