### PR TITLE
fix(server): net-transport hygiene — dead send_timeout, proxy-aware rate-limit key, env injection (TODO-511/513/473)

### DIFF
--- a/packages/server-rust/benches/load_harness/main.rs
+++ b/packages/server-rust/benches/load_harness/main.rs
@@ -250,6 +250,8 @@ async fn main() {
                 search_registry: None,
                 hybrid_search_registry: None,
                 admin_enabled: true,
+                // Load harness never creates vector indexes; default path is fine.
+                vector_index_path: None,
             };
 
             let ws_handler = get(topgun_server::network::handlers::ws_upgrade_handler);

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -851,6 +851,13 @@ async fn main() -> anyhow::Result<()> {
         .map(|v| matches!(v.to_lowercase().as_str(), "true" | "1"))
         .unwrap_or(false);
 
+    // Trust reverse-proxy forwarding headers when keying the admin/login rate
+    // limiter. Off by default: a client can forge X-Forwarded-For, so enable only
+    // when a trusted proxy that overwrites the header sits in front (audit F8).
+    let trust_forwarded_for = std::env::var("TOPGUN_TRUSTED_PROXY")
+        .map(|v| matches!(v.to_lowercase().as_str(), "true" | "1"))
+        .unwrap_or(false);
+
     // Optional request-path JWT issuer/audience enforcement (audit F7). Unset =>
     // not checked (TopGun-minted tokens). Set these when jwt_secret is an IdP key.
     let jwt_issuer = std::env::var("TOPGUN_JWT_ISSUER")
@@ -905,6 +912,7 @@ async fn main() -> anyhow::Result<()> {
             cors_origins,
             jwt_issuer,
             jwt_audience,
+            trust_forwarded_for,
             ..NetworkConfig::default()
         }),
         start_time: Instant::now(),
@@ -936,6 +944,11 @@ async fn main() -> anyhow::Result<()> {
         search_registry: Some(search_registry),
         hybrid_search_registry: Some(hybrid_search_registry),
         admin_enabled,
+        // Resolve the vector-index sidecar path from env once here, at the
+        // construction boundary, so request handlers stay env-free.
+        vector_index_path: Some(
+            topgun_server::network::handlers::admin::vector_index_path_from_env(),
+        ),
     };
 
     // Mirror NetworkModule::serve()'s scalar index rebuild for the topgun_server
@@ -997,6 +1010,7 @@ async fn main() -> anyhow::Result<()> {
         state.config.rate_limit_per_ip,
         state.config.rate_limit_burst,
         mount_admin,
+        state.config.trust_forwarded_for,
     )
     // Browser WS dual-mount: /ws is already in admin_routes(); / is the
     // binary-only extra for clients that connect to the root path.

--- a/packages/server-rust/src/lib.rs
+++ b/packages/server-rust/src/lib.rs
@@ -31,6 +31,78 @@ mod tests {
     }
 }
 
+/// Regression guard against process-global env mutation creeping back into the
+/// codebase.
+///
+/// `std::env::set_var` mutates shared process state; Rust runs unit tests in one
+/// process in parallel, so a test that sets an env var can be observed by an
+/// unrelated test calling `from_env()` mid-run (a real latent flake source). The
+/// project policy is: parse config from an injected source (`from_source` seam /
+/// an `AppState` field) and never `set_var` in a handler/config path. The only
+/// sanctioned exceptions are the two wiring-only smoke tests that prove the
+/// `from_env` → `std::env` seam itself works, each gated with `#[serial]`.
+///
+/// This test scans the crate source and fails if a `set_var` call appears
+/// anywhere outside that allow-list, so new code cannot silently reintroduce
+/// the anti-pattern. The allow-listed files must keep their `#[serial]` gate.
+#[cfg(test)]
+mod env_isolation_guard {
+    use std::path::{Path, PathBuf};
+
+    /// Files permitted to call `std::env::set_var`, by path suffix. Both are the
+    /// single `#[serial]` `from_env_reads_process_environment` smoke tests.
+    const ALLOWLIST: &[&str] = &[
+        "storage/eviction_config.rs",
+        "storage/datastores/write_behind.rs",
+    ];
+
+    fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir)
+            .expect("src dir is readable")
+            .flatten()
+        {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_rs_files(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    #[test]
+    fn no_set_var_outside_allowlist() {
+        let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        collect_rs_files(&src, &mut files);
+
+        let mut offenders = Vec::new();
+        for file in &files {
+            let rel = file.strip_prefix(&src).unwrap_or(file);
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            let allowed = ALLOWLIST.iter().any(|a| rel_str.ends_with(a));
+            let contents = std::fs::read_to_string(file).expect("source file is readable");
+            // Match the call form (name followed by an open paren) so prose
+            // mentions of the bare name in comments/docs do not trip the guard.
+            // The needle is assembled at runtime so this guard's own source does
+            // not contain the literal pattern it scans for.
+            let needle = concat!("set_var", "(");
+            if contents.contains(needle) && !allowed {
+                offenders.push(rel_str);
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "std::env::set_var found outside the sanctioned #[serial] from_env smoke \
+             tests: {offenders:?}. Inject config via an injected source (from_source / \
+             an AppState field) instead of mutating process-global env; if a real \
+             from_env seam smoke test is unavoidable, gate it with #[serial] and add \
+             the file to ALLOWLIST in this guard."
+        );
+    }
+}
+
 /// Integration tests for the full operation pipeline.
 ///
 /// Tests the end-to-end flow: Message -> classify -> pipeline -> router -> stub -> response.

--- a/packages/server-rust/src/network/config.rs
+++ b/packages/server-rust/src/network/config.rs
@@ -41,6 +41,19 @@ pub struct NetworkConfig {
     /// `rate_limit_burst` requests in a short window before throttling.
     /// Defaults to 50.
     pub rate_limit_burst: u32,
+    /// Whether to trust reverse-proxy forwarding headers (rightmost
+    /// `X-Forwarded-For` entry, then `X-Real-IP`) when keying the admin/login
+    /// rate limiter.
+    ///
+    /// When `false` (default), the rate-limit bucket is keyed on the socket peer
+    /// address and forwarded headers are ignored — the safe default, since any
+    /// client can forge `X-Forwarded-For` to evade or poison rate buckets. When
+    /// `true`, each real client behind a trusted reverse proxy is bucketed by the
+    /// rightmost forwarded IP (the entry the closest proxy appended, which the
+    /// client cannot forge) instead of all clients sharing the proxy's single IP.
+    /// Enable (`TOPGUN_TRUSTED_PROXY=1`) only when a trusted proxy that
+    /// appends/overwrites the forwarding header sits in front of the server.
+    pub trust_forwarded_for: bool,
     /// External auth providers for token exchange at POST /api/auth/token.
     /// An empty list disables the endpoint (returns 404 on all requests).
     /// Constructed programmatically from environment variables or config in
@@ -80,6 +93,7 @@ impl Default for NetworkConfig {
             jwt_clock_skew_secs: 60,
             rate_limit_per_ip: 100,
             rate_limit_burst: 50,
+            trust_forwarded_for: false,
             auth_providers: vec![],
             insecure_forward_auth_errors: false,
             jwt_issuer: None,
@@ -106,8 +120,6 @@ pub struct TlsConfig {
 pub struct ConnectionConfig {
     /// Bounded mpsc channel capacity for outbound messages per connection.
     pub outbound_channel_capacity: usize,
-    /// Maximum time to wait when sending a message to a connection.
-    pub send_timeout: Duration,
     /// Duration after which an idle connection is considered stale.
     ///
     /// Enforced by the connection reaper: an authenticated connection whose
@@ -166,7 +178,6 @@ impl Default for ConnectionConfig {
     fn default() -> Self {
         Self {
             outbound_channel_capacity: 256,
-            send_timeout: Duration::from_secs(5),
             idle_timeout: Duration::from_secs(60),
             auth_timeout: Duration::from_secs(10),
             reaper_interval: Duration::from_secs(10),
@@ -201,6 +212,9 @@ mod tests {
         assert_eq!(config.jwt_clock_skew_secs, 60);
         assert_eq!(config.rate_limit_per_ip, 100);
         assert_eq!(config.rate_limit_burst, 50);
+        // Default is false — forwarded headers are not trusted unless an operator
+        // asserts a trusted proxy via TOPGUN_TRUSTED_PROXY (anti-spoof default).
+        assert!(!config.trust_forwarded_for);
         // Default is false — production-safe by default.
         assert!(!config.insecure_forward_auth_errors);
     }
@@ -209,7 +223,6 @@ mod tests {
     fn connection_config_defaults() {
         let config = ConnectionConfig::default();
         assert_eq!(config.outbound_channel_capacity, 256);
-        assert_eq!(config.send_timeout, Duration::from_secs(5));
         assert_eq!(config.idle_timeout, Duration::from_secs(60));
         assert_eq!(config.auth_timeout, Duration::from_secs(10));
         assert_eq!(config.reaper_interval, Duration::from_secs(10));

--- a/packages/server-rust/src/network/connection.rs
+++ b/packages/server-rust/src/network/connection.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use dashmap::DashMap;
 use tokio::sync::mpsc::error::TrySendError;
@@ -38,17 +38,6 @@ pub enum OutboundMessage {
     Binary(Vec<u8>),
     /// A close frame with an optional reason.
     Close(Option<String>),
-}
-
-/// Error returned when sending a message to a connection fails.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SendError {
-    /// The send operation timed out (channel is full and remained full).
-    Timeout,
-    /// The connection has been closed; the receiver was dropped.
-    Disconnected,
-    /// The channel is full (non-blocking `try_send` only).
-    Full,
 }
 
 /// Outcome of a best-effort broadcast send to a (possibly slow) consumer.
@@ -177,25 +166,6 @@ impl ConnectionHandle {
     #[must_use]
     pub fn dropped_broadcasts(&self) -> u64 {
         self.dropped_broadcasts.load(Ordering::Relaxed)
-    }
-
-    /// Sends a message with a timeout.
-    ///
-    /// # Errors
-    ///
-    /// Returns `SendError::Timeout` if the channel remains full for the
-    /// entire timeout duration. Returns `SendError::Disconnected` if the
-    /// receiver has been dropped (connection closed).
-    pub async fn send_timeout(
-        &self,
-        msg: OutboundMessage,
-        timeout: Duration,
-    ) -> Result<(), SendError> {
-        match tokio::time::timeout(timeout, self.tx.send(msg)).await {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(_)) => Err(SendError::Disconnected),
-            Err(_) => Err(SendError::Timeout),
-        }
     }
 
     /// Checks whether the connection is still open.
@@ -564,37 +534,6 @@ mod tests {
 
         drop(rx);
         assert!(!handle.is_connected());
-    }
-
-    #[tokio::test]
-    async fn connection_handle_send_timeout_success() {
-        let config = test_config();
-        let registry = ConnectionRegistry::new();
-        let (handle, _rx) = registry.register(ConnectionKind::Client, &config);
-
-        let result = handle
-            .send_timeout(
-                OutboundMessage::Binary(vec![1, 2, 3]),
-                Duration::from_secs(1),
-            )
-            .await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn connection_handle_send_timeout_disconnected() {
-        let config = test_config();
-        let registry = ConnectionRegistry::new();
-        let (handle, rx) = registry.register(ConnectionKind::Client, &config);
-        drop(rx);
-
-        let result = handle
-            .send_timeout(
-                OutboundMessage::Binary(vec![1, 2, 3]),
-                Duration::from_secs(1),
-            )
-            .await;
-        assert_eq!(result, Err(SendError::Disconnected));
     }
 
     #[test]

--- a/packages/server-rust/src/network/handlers/admin.rs
+++ b/packages/server-rust/src/network/handlers/admin.rs
@@ -1163,14 +1163,36 @@ pub fn save_scalar_descriptors(
 
 // ── Vector index descriptor persistence ──────────────────────────────────────
 
-/// Path for the vector index descriptor sidecar JSON file.
+/// Default vector-index descriptor sidecar path used when none is configured.
+const DEFAULT_VECTOR_INDEX_PATH: &str = "./vector_indexes.json";
+
+/// Resolves the vector-index descriptor sidecar path from the environment at the
+/// construction boundary.
+///
+/// Production `AppState` wiring calls this once (`module.rs`, `topgun_server.rs`,
+/// the load harness) and stores the result in `AppState::vector_index_path`, so
+/// the request handlers themselves never touch process-global env — that keeps
+/// them testable by direct field injection rather than `set_var`.
 ///
 /// Configured via `TOPGUN_VECTOR_INDEX_PATH`; defaults to `./vector_indexes.json`.
-fn descriptor_path() -> std::path::PathBuf {
+#[must_use]
+pub fn vector_index_path_from_env() -> std::path::PathBuf {
     std::path::PathBuf::from(
         std::env::var("TOPGUN_VECTOR_INDEX_PATH")
-            .unwrap_or_else(|_| "./vector_indexes.json".to_string()),
+            .unwrap_or_else(|_| DEFAULT_VECTOR_INDEX_PATH.to_string()),
     )
+}
+
+/// Path for the vector index descriptor sidecar JSON file for this request.
+///
+/// Reads the injected `AppState::vector_index_path` (resolved from env at the
+/// construction boundary), falling back to the default when unset. No env read
+/// happens here so the path is fully determined by the injected state.
+fn descriptor_path(state: &AppState) -> std::path::PathBuf {
+    state
+        .vector_index_path
+        .clone()
+        .unwrap_or_else(|| std::path::PathBuf::from(DEFAULT_VECTOR_INDEX_PATH))
 }
 
 /// Loads all persisted `VectorIndexDescriptor` entries from the sidecar JSON file.
@@ -1313,7 +1335,7 @@ pub async fn create_vector_index(
     );
 
     // Persist the descriptor so startup rebuild can re-register this index.
-    let path = descriptor_path();
+    let path = descriptor_path(&state);
     let mut descriptors = load_vector_descriptors(&path);
     let now_iso = {
         let secs = SystemTime::now()
@@ -1440,7 +1462,7 @@ pub async fn remove_vector_index_handler(
     let _ = registry.remove_index(&attribute);
 
     // Remove from persistent descriptor file.
-    let path = descriptor_path();
+    let path = descriptor_path(&state);
     let mut descriptors = load_vector_descriptors(&path);
     descriptors.retain(|d| !(d.map_name == map_name && d.index_name == index_name));
     save_vector_descriptors(&path, &descriptors);
@@ -1816,10 +1838,14 @@ mod vector_admin_tests {
     #[tokio::test]
     async fn create_vector_index_201_on_valid_request() {
         // Use temp dir for descriptor file to avoid polluting the workspace.
+        // Inject the path via AppState instead of mutating process env, so this
+        // test cannot race a parallel test reading TOPGUN_VECTOR_INDEX_PATH.
         let tmp = std::env::temp_dir().join(format!("vi_test_{}.json", uuid::Uuid::new_v4()));
-        std::env::set_var("TOPGUN_VECTOR_INDEX_PATH", tmp.to_str().unwrap());
 
-        let state = make_state_with_factory();
+        let state = AppState {
+            vector_index_path: Some(tmp.clone()),
+            ..make_state_with_factory()
+        };
         let req = CreateVectorIndexRequest {
             map_name: "users".to_string(),
             attribute: "_embedding".to_string(),
@@ -1839,15 +1865,16 @@ mod vector_admin_tests {
 
         // Clean up temp file.
         let _ = std::fs::remove_file(&tmp);
-        std::env::remove_var("TOPGUN_VECTOR_INDEX_PATH");
     }
 
     #[tokio::test]
     async fn create_vector_index_409_on_duplicate() {
         let tmp = std::env::temp_dir().join(format!("vi_test_{}.json", uuid::Uuid::new_v4()));
-        std::env::set_var("TOPGUN_VECTOR_INDEX_PATH", tmp.to_str().unwrap());
 
-        let state = make_state_with_factory();
+        let state = AppState {
+            vector_index_path: Some(tmp.clone()),
+            ..make_state_with_factory()
+        };
         let req = CreateVectorIndexRequest {
             map_name: "users".to_string(),
             attribute: "_embedding".to_string(),
@@ -1866,7 +1893,6 @@ mod vector_admin_tests {
         assert_eq!(code, StatusCode::CONFLICT);
 
         let _ = std::fs::remove_file(&tmp);
-        std::env::remove_var("TOPGUN_VECTOR_INDEX_PATH");
     }
 
     #[tokio::test]
@@ -1893,9 +1919,11 @@ mod vector_admin_tests {
         use crate::service::domain::index::Index;
 
         let tmp = std::env::temp_dir().join(format!("vi_list_{}.json", uuid::Uuid::new_v4()));
-        std::env::set_var("TOPGUN_VECTOR_INDEX_PATH", tmp.to_str().unwrap());
 
-        let state = make_state_with_factory();
+        let state = AppState {
+            vector_index_path: Some(tmp.clone()),
+            ..make_state_with_factory()
+        };
         let req = CreateVectorIndexRequest {
             map_name: "users".to_string(),
             attribute: "_embedding".to_string(),
@@ -1931,7 +1959,6 @@ mod vector_admin_tests {
         assert_eq!(indexes[0]["vectorCount"].as_u64().unwrap(), 1);
 
         let _ = std::fs::remove_file(&tmp);
-        std::env::remove_var("TOPGUN_VECTOR_INDEX_PATH");
     }
 
     #[tokio::test]
@@ -2050,9 +2077,11 @@ mod vector_admin_tests {
     #[tokio::test]
     async fn optimize_vector_index_202_happy_path() {
         let tmp = std::env::temp_dir().join(format!("vi_opt_{}.json", uuid::Uuid::new_v4()));
-        std::env::set_var("TOPGUN_VECTOR_INDEX_PATH", tmp.to_str().unwrap());
 
-        let state = make_state_with_factory();
+        let state = AppState {
+            vector_index_path: Some(tmp.clone()),
+            ..make_state_with_factory()
+        };
         // First create the index.
         let req = CreateVectorIndexRequest {
             map_name: "users".to_string(),
@@ -2085,15 +2114,15 @@ mod vector_admin_tests {
         );
 
         let _ = std::fs::remove_file(&tmp);
-        std::env::remove_var("TOPGUN_VECTOR_INDEX_PATH");
     }
 
     // ── cancel_vector_index_optimize_handler tests ──────────────────────────────
 
+    /// Creates an index and starts an optimize against the descriptor path
+    /// already injected into `state` (`state.vector_index_path`), returning the
+    /// optimization id. Callers inject a temp path so no two parallel tests share
+    /// a descriptor file; the temp file is cleaned up here.
     async fn setup_index_with_optimize(state: &AppState) -> String {
-        let tmp = std::env::temp_dir().join(format!("vi_cancel_{}.json", uuid::Uuid::new_v4()));
-        std::env::set_var("TOPGUN_VECTOR_INDEX_PATH", tmp.to_str().unwrap());
-
         let req = CreateVectorIndexRequest {
             map_name: "users".to_string(),
             attribute: "_embedding".to_string(),
@@ -2113,7 +2142,9 @@ mod vector_admin_tests {
         .await
         .expect("optimize should succeed");
         let (_, Json(resp)) = result;
-        let _ = std::fs::remove_file(tmp);
+        if let Some(path) = &state.vector_index_path {
+            let _ = std::fs::remove_file(path);
+        }
         resp.optimization_id
     }
 
@@ -2138,9 +2169,11 @@ mod vector_admin_tests {
     #[tokio::test]
     async fn cancel_optimize_409_when_no_in_flight_optimize() {
         let tmp = std::env::temp_dir().join(format!("vi_409_{}.json", uuid::Uuid::new_v4()));
-        std::env::set_var("TOPGUN_VECTOR_INDEX_PATH", tmp.to_str().unwrap());
 
-        let state = make_state_with_factory();
+        let state = AppState {
+            vector_index_path: Some(tmp.clone()),
+            ..make_state_with_factory()
+        };
         // Create index but do NOT start an optimize.
         let req = CreateVectorIndexRequest {
             map_name: "users".to_string(),
@@ -2168,12 +2201,15 @@ mod vector_admin_tests {
         assert_eq!(code, StatusCode::CONFLICT);
 
         let _ = std::fs::remove_file(tmp);
-        std::env::remove_var("TOPGUN_VECTOR_INDEX_PATH");
     }
 
     #[tokio::test]
     async fn cancel_optimize_404_when_mismatched_optimization_id() {
-        let state = make_state_with_factory();
+        let tmp = std::env::temp_dir().join(format!("vi_c404_{}.json", uuid::Uuid::new_v4()));
+        let state = AppState {
+            vector_index_path: Some(tmp.clone()),
+            ..make_state_with_factory()
+        };
         let _ = setup_index_with_optimize(&state).await;
 
         // Use a wrong optimization_id.
@@ -2194,7 +2230,11 @@ mod vector_admin_tests {
 
     #[tokio::test]
     async fn cancel_optimize_200_happy_path_and_idempotent() {
-        let state = make_state_with_factory();
+        let tmp = std::env::temp_dir().join(format!("vi_c200_{}.json", uuid::Uuid::new_v4()));
+        let state = AppState {
+            vector_index_path: Some(tmp.clone()),
+            ..make_state_with_factory()
+        };
         let optimization_id = setup_index_with_optimize(&state).await;
 
         // First cancel — should return 200.

--- a/packages/server-rust/src/network/handlers/mod.rs
+++ b/packages/server-rust/src/network/handlers/mod.rs
@@ -159,6 +159,12 @@ pub struct AppState {
     /// future route-mounting regression cannot re-expose the unauthenticated
     /// admin control plane on a non-loopback bind.
     pub admin_enabled: bool,
+    /// Filesystem path of the vector-index descriptor sidecar JSON, resolved
+    /// from `TOPGUN_VECTOR_INDEX_PATH` once at the construction boundary so the
+    /// admin handlers never read process-global env directly. `None` falls back
+    /// to the default `./vector_indexes.json`; tests inject a temp path here
+    /// instead of mutating the process environment (test-isolation seam).
+    pub vector_index_path: Option<std::path::PathBuf>,
 }
 
 impl AppState {
@@ -214,6 +220,9 @@ impl AppState {
             // Default-safe: tests exercise the admin plane as enabled unless they
             // explicitly override this to assert the disabled-plane guard.
             admin_enabled: true,
+            // None → default path. Tests that persist descriptors override this
+            // with a temp path instead of mutating TOPGUN_VECTOR_INDEX_PATH.
+            vector_index_path: None,
         }
     }
 }

--- a/packages/server-rust/src/network/module.rs
+++ b/packages/server-rust/src/network/module.rs
@@ -33,7 +33,7 @@ use axum::routing::{delete, get, post};
 use axum::Router;
 use tokio::net::TcpListener;
 use tower_governor::governor::GovernorConfigBuilder;
-use tower_governor::key_extractor::PeerIpKeyExtractor;
+use tower_governor::key_extractor::{KeyExtractor, PeerIpKeyExtractor};
 use tower_governor::GovernorLayer;
 use tower_http::services::{ServeDir, ServeFile};
 use tracing::{info, warn};
@@ -541,6 +541,73 @@ struct AppServices {
     >,
 }
 
+/// Extracts the client IP a trusted proxy attributed to the request, reading
+/// the **rightmost** `X-Forwarded-For` entry (then `X-Real-IP`).
+///
+/// This is the security-critical detail. A reverse proxy that appends to XFF
+/// (nginx's `$proxy_add_x_forwarded_for`) produces
+/// `<client-forgeable values…>, <real peer the proxy saw>`: the entry the
+/// closest trusted proxy appended is the **last** one, and the client controls
+/// only the entries to its left. Reading the rightmost entry therefore bounds an
+/// attacker — they cannot move their own request into another IP's bucket or
+/// spin up fresh buckets by rotating a forged value, because anything they put
+/// in the header lands to the left of the proxy's appended IP and is ignored.
+/// (`tower_governor`'s `SmartIpKeyExtractor` reads the *leftmost* entry, which is
+/// exactly the forgeable position, so it is unsafe for rate-limit keying behind
+/// an appending proxy — hence this bespoke extractor.)
+///
+/// Returns `None` when no forwarding header carries a parseable IP, so the
+/// caller falls back to the socket peer address.
+fn trusted_forwarded_ip<T>(req: &http::Request<T>) -> Option<std::net::IpAddr> {
+    let headers = req.headers();
+    headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        // rsplit → rightmost parseable entry (appended by the closest proxy).
+        .and_then(|s| s.rsplit(',').find_map(|p| p.trim().parse().ok()))
+        .or_else(|| {
+            // X-Real-IP is a single value the proxy overwrites, not a client-
+            // appendable list, so it is safe to take as-is when present.
+            headers
+                .get("x-real-ip")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.trim().parse().ok())
+        })
+}
+
+/// Governor rate-limit key extractor that is aware of reverse-proxy headers
+/// only when the operator asserts a trusted proxy sits in front.
+///
+/// When `trust_forwarded_for` is `false` the key is the socket peer address
+/// (`PeerIpKeyExtractor` behaviour) and any client-supplied `X-Forwarded-For` is
+/// ignored — otherwise an attacker could forge that header to dodge their own
+/// rate bucket or exhaust someone else's. When `true` (operator-configured
+/// trusted proxy) it keys on the rightmost forwarded IP (see
+/// [`trusted_forwarded_ip`]), falling back to the peer address when no
+/// forwarding header is present, so each real client behind the proxy is
+/// bucketed independently instead of all sharing the proxy's IP.
+#[derive(Debug, Clone, Copy)]
+struct ProxyAwareIpKeyExtractor {
+    trust_forwarded_for: bool,
+}
+
+impl KeyExtractor for ProxyAwareIpKeyExtractor {
+    type Key = std::net::IpAddr;
+
+    fn extract<T>(
+        &self,
+        req: &http::Request<T>,
+    ) -> Result<Self::Key, tower_governor::GovernorError> {
+        if self.trust_forwarded_for {
+            if let Some(ip) = trusted_forwarded_ip(req) {
+                return Ok(ip);
+            }
+        }
+        // Untrusted, or trusted but no forwarding header: key on the socket peer.
+        PeerIpKeyExtractor.extract(req)
+    }
+}
+
 /// Single source of truth for the `topgun-server` HTTP route set.
 ///
 /// Returns a generic `Router<AppState>` with state NOT yet applied, so any
@@ -564,6 +631,15 @@ struct AppServices {
 ///   they return 404 instead of exposing an unauthenticated superuser on a public
 ///   no-auth bind. The data plane (`/health` + probes, `/ws`, `/sync`,
 ///   `/metrics`, `/api/status`, `/api/auth/status`, `OpenAPI`) is always mounted.
+/// - `trust_forwarded_for`: when `true`, the rate-limit key is derived from the
+///   rightmost `X-Forwarded-For` entry (then `X-Real-IP`), falling back to the
+///   socket peer when absent, so clients behind a trusted reverse proxy are
+///   bucketed by their real IP instead of all sharing the proxy's. When `false`
+///   (the default) the socket peer address is used and forwarded headers are
+///   ignored — a client could otherwise spoof `X-Forwarded-For` to evade or
+///   poison another IP's rate bucket, so this must only be enabled when a
+///   trusted proxy that appends/overwrites the header sits in front of the
+///   server.
 ///
 /// Neither rate-limit parameter has an internal default: callers pass the values
 /// they read from their own `NetworkConfig` so the production rate-limit policy is
@@ -578,6 +654,7 @@ pub fn admin_routes(
     rate_limit_per_ip: u32,
     rate_limit_burst: u32,
     mount_admin: bool,
+    trust_forwarded_for: bool,
 ) -> Router<AppState> {
     // Build a per-IP rate limiter for admin and login endpoints.
     // Replenishment interval derived from rate_limit_per_ip: for 100 req/s the
@@ -622,7 +699,9 @@ pub fn admin_routes(
         // operation-level load shedding instead of HTTP-layer rate limiting.
         let replenish_interval_ms = (1000 / u64::from(rate_limit_per_ip).max(1)).max(1);
         let governor_config = GovernorConfigBuilder::default()
-            .key_extractor(PeerIpKeyExtractor)
+            .key_extractor(ProxyAwareIpKeyExtractor {
+                trust_forwarded_for,
+            })
             .per_millisecond(replenish_interval_ms)
             .burst_size(rate_limit_burst)
             .finish()
@@ -795,6 +874,7 @@ fn build_app(
     // Extract rate limit config before config is moved into Arc<AppState>.
     let rate_limit_per_ip = config.rate_limit_per_ip;
     let rate_limit_burst = config.rate_limit_burst;
+    let trust_forwarded_for = config.trust_forwarded_for;
 
     // Build a single shared HTTP client for all JWKS/OIDC providers so that
     // connection pooling is shared rather than fragmented across providers.
@@ -879,6 +959,9 @@ fn build_app(
         // This NetworkModule-managed path always mounts the admin plane and
         // enforces auth, so the extractor guard is enabled to match.
         admin_enabled: true,
+        // Resolve the vector-index sidecar path from env once here, at the
+        // construction boundary, so request handlers stay env-free.
+        vector_index_path: Some(crate::network::handlers::admin::vector_index_path_from_env()),
     };
 
     // Delegate all route wiring to admin_routes() — the single source of truth
@@ -889,9 +972,14 @@ fn build_app(
     // decision (the listener is bound elsewhere), so it always mounts the admin
     // plane; auth is enforced on this path, so the admin routes are JWT-protected.
     // The binary serve path computes posture and passes the gated flag itself.
-    admin_routes(rate_limit_per_ip, rate_limit_burst, true)
-        .layer(layers)
-        .with_state(state)
+    admin_routes(
+        rate_limit_per_ip,
+        rate_limit_burst,
+        true,
+        trust_forwarded_for,
+    )
+    .layer(layers)
+    .with_state(state)
 }
 
 /// Serves plain HTTP/WS connections using axum's built-in server.
@@ -992,6 +1080,128 @@ async fn drain_connections(
 mod tests {
     use super::*;
     use crate::network::HealthState;
+
+    // ── Proxy-aware rate-limit key extractor (audit F8 / TODO-513) ────
+
+    /// Builds a request carrying a `ConnectInfo` peer address and an optional
+    /// `X-Forwarded-For` header, mirroring what the governor layer sees.
+    fn request_with(peer: std::net::IpAddr, xff: Option<&str>) -> http::Request<()> {
+        let mut req = http::Request::new(());
+        req.extensions_mut()
+            .insert(axum::extract::ConnectInfo(std::net::SocketAddr::new(
+                peer, 5000,
+            )));
+        if let Some(value) = xff {
+            req.headers_mut()
+                .insert("x-forwarded-for", value.parse().unwrap());
+        }
+        req
+    }
+
+    /// Untrusted (default): a spoofable `X-Forwarded-For` is ignored and the key
+    /// is the socket peer address. This is the security-critical negative
+    /// control — without it, any client could forge XFF to dodge or poison
+    /// another IP's rate bucket.
+    #[test]
+    fn proxy_aware_extractor_ignores_forwarded_header_when_untrusted() {
+        let peer = std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1));
+        let req = request_with(peer, Some("203.0.113.7"));
+        let key = ProxyAwareIpKeyExtractor {
+            trust_forwarded_for: false,
+        }
+        .extract(&req)
+        .expect("peer addr is present");
+        assert_eq!(
+            key, peer,
+            "untrusted mode must key on the socket peer, not XFF"
+        );
+    }
+
+    /// Trusted proxy configured: distinct `X-Forwarded-For` values key into
+    /// distinct buckets, so clients behind the proxy are throttled
+    /// independently instead of all sharing the proxy's single IP.
+    #[test]
+    fn proxy_aware_extractor_uses_forwarded_header_when_trusted() {
+        let proxy = std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1));
+        let extractor = ProxyAwareIpKeyExtractor {
+            trust_forwarded_for: true,
+        };
+
+        let client_a = extractor
+            .extract(&request_with(proxy, Some("203.0.113.7")))
+            .expect("XFF present");
+        let client_b = extractor
+            .extract(&request_with(proxy, Some("198.51.100.9")))
+            .expect("XFF present");
+
+        assert_eq!(
+            client_a,
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 7))
+        );
+        assert_eq!(
+            client_b,
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(198, 51, 100, 9))
+        );
+        assert_ne!(
+            client_a, client_b,
+            "two clients behind the same proxy must land in separate buckets"
+        );
+    }
+
+    /// Trusted mode still falls back to the peer address when no forwarding
+    /// header is present (direct connection to a proxy-configured server).
+    #[test]
+    fn proxy_aware_extractor_trusted_falls_back_to_peer_without_header() {
+        let peer = std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 2));
+        let key = ProxyAwareIpKeyExtractor {
+            trust_forwarded_for: true,
+        }
+        .extract(&request_with(peer, None))
+        .expect("peer addr is present");
+        assert_eq!(key, peer);
+    }
+
+    /// Security-critical: with an appending proxy (`$proxy_add_x_forwarded_for`),
+    /// the header is `<client-forgeable…>, <real peer>`. The extractor must key
+    /// on the **rightmost** entry (appended by the trusted proxy), not the
+    /// leftmost (attacker-controlled). Two attackers forging different leftmost
+    /// values but routed through the same proxy hop must collapse into the SAME
+    /// bucket — otherwise rate limiting is trivially evaded by rotating the
+    /// forged value, and another IP's bucket can be poisoned.
+    #[test]
+    fn proxy_aware_extractor_keys_on_rightmost_forwarded_entry() {
+        let proxy = std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1));
+        let extractor = ProxyAwareIpKeyExtractor {
+            trust_forwarded_for: true,
+        };
+        let real_client = std::net::IpAddr::V4(std::net::Ipv4Addr::new(198, 51, 100, 9));
+
+        // Attacker forges a different leftmost value on each request; the proxy
+        // appends the same real peer IP on the right.
+        let key1 = extractor
+            .extract(&request_with(proxy, Some("203.0.113.7, 198.51.100.9")))
+            .expect("XFF present");
+        let key2 = extractor
+            .extract(&request_with(proxy, Some("8.8.8.8, 198.51.100.9")))
+            .expect("XFF present");
+
+        assert_eq!(key1, real_client, "must key on the rightmost (proxy) entry");
+        assert_eq!(key2, real_client, "must key on the rightmost (proxy) entry");
+        assert_eq!(
+            key1, key2,
+            "rotating the forged leftmost value must not create fresh buckets"
+        );
+
+        // Poisoning attempt: attacker tries to bill a victim by forging the
+        // victim's IP on the left — still ignored in favour of the proxy entry.
+        let victim_forge = extractor
+            .extract(&request_with(proxy, Some("192.0.2.123, 198.51.100.9")))
+            .expect("XFF present");
+        assert_eq!(
+            victim_forge, real_client,
+            "a forged leftmost victim IP must not move the request into the victim's bucket"
+        );
+    }
 
     // ── Test helper ───────────────────────────────────────────────────
 

--- a/packages/server-rust/tests/router_contract.rs
+++ b/packages/server-rust/tests/router_contract.rs
@@ -77,6 +77,7 @@ fn build_binary_router(mount_admin: bool) -> axum::Router {
         default_config.rate_limit_per_ip,
         default_config.rate_limit_burst,
         mount_admin,
+        default_config.trust_forwarded_for,
     )
     // Browser WS dual-mount: the binary's only extra route beyond admin_routes().
     .route(


### PR DESCRIPTION
Low-sweep micro-batch of three server-rust hygiene/hardening items from the G9 network/transport depth-audit (F6/F8) plus a test-isolation follow-up. All `server-rust`-only.

## TODO-511 (F6) — dead `send_timeout` → **removed**
`ConnectionConfig.send_timeout` + `ConnectionHandle::send_timeout` lived only in `#[cfg(test)]`. Co-author call was **remove, not wire**:
- Broadcast path is already bounded with slow-consumer disconnect (TODO-509).
- Own-write `tx.send().await` is correct blocking backpressure via the `MAX_IN_FLIGHT` semaphore (audit verdict "Good"). Wiring a timeout would replace lossless backpressure with a **lossy dropped op-ack** — the exact silent divergence TODO-509 prevents. A wedged writer is already bounded by the reaper + 2 s outbound-join + TCP.
- Deleted the field, method, two tests, and the now-orphaned `SendError` enum (only that method produced it). Pure dead-code removal, no behaviour change.

## TODO-513 (F8) — governor not proxy-aware → **fixed, gated by trusted-proxy flag**
Replaced the bare `PeerIpKeyExtractor` on the admin/login governor with `ProxyAwareIpKeyExtractor` gated by `NetworkConfig.trust_forwarded_for` (`TOPGUN_TRUSTED_PROXY`):
- **Default off:** keys on the socket peer addr, ignores spoofable `X-Forwarded-For` (anti-spoof default).
- **Trusted on:** keys on the **rightmost** XFF entry (then `X-Real-IP`) — the entry the closest proxy appended, which the client cannot forge — falling back to peer when no header.

A cross-vendor adversarial review caught a **real HIGH** in the first cut (which delegated to `tower_governor::SmartIpKeyExtractor`): SmartIp reads the **leftmost** XFF entry, which under the standard nginx `$proxy_add_x_forwarded_for` (append) model is attacker-controlled — letting an attacker rotate a forged value to evade limiting or set a victim IP to poison a bucket *even with the trust flag on*. Fixed by reading the rightmost entry. Tests cover bucket split, peer fallback, rightmost selection, and a spoofed-leftmost negative control.

## TODO-473 — env anti-pattern → **injected + repo-wide guard**
- Vector-index descriptor path now flows through `AppState.vector_index_path`, resolved from `TOPGUN_VECTOR_INDEX_PATH` once at the construction boundary; handlers never read process-global env.
- All 6 `set_var("TOPGUN_VECTOR_INDEX_PATH")` test sites in `admin.rs` converted to direct field injection.
- **Regression guard:** new lib test `env_isolation_guard::no_set_var_outside_allowlist` fails if a `set_var` call appears outside the two sanctioned `#[serial]` `from_env` smoke tests (runs under `cargo test --lib`).

## Gate (local, all green)
- `cargo fmt --check` ✓ · `cargo clippy --all-targets --all-features -D warnings` ✓
- `cargo test --release -p topgun-server --lib` → **1431 passed**
- `pnpm test:sim` → **11 sim tests passed** (cluster + fault-injection + proptest convergence/completeness incl. concurrent OR-remove)
- `integration-rust` blocking subset → **15 suites / 94 tests passed**. The one cluster-routing failover-timing failure is the documented non-blocking cold-join-race flake (TODO-504), unrelated to this change (admin/config-plane only).

Each change has a test + negative control. TODO files updated to `done` (local-only `.specflow/`, not committed).