### PR TITLE
feat(server): G4b soak harness — churn + kill -9 crash loop + convergence/recovery/memory/panic assertions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -392,6 +392,82 @@ jobs:
           # target (src/sim/*); keep them gating via the path filter.
           cargo test --profile ci-sim --features simulation -p topgun-server --lib -- sim
 
+  soak-smoke:
+    name: Soak Harness Smoke (G4b)
+    needs: [check]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # Blocking: the soak harness (TODO-484) must keep compiling AND its fault
+    # detection must keep working. We run the two negative controls (which MUST
+    # go RED) plus a short no-crash convergence/churn/memory soak (which MUST be
+    # green). The full 72h crash-loop soak runs on a Hetzner scratch box, not in
+    # CI. The crash-loop path is also currently RED by design against TODO-530
+    # (post-restart rehydration gap), so CI deliberately exercises the no-crash
+    # mode here — see packages/server-rust/benches/soak_harness/README.md.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-soak-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-soak-
+            ${{ runner.os }}-cargo-
+
+      - name: Build server binary + soak bench
+        run: cargo build --bin topgun-server --bench soak_harness
+
+      - name: Locate soak bench binary
+        id: soak
+        run: |
+          BIN=$(ls -t target/debug/deps/soak_harness-* | grep -vE '\.(d|o|rcgu)' | head -1)
+          test -x "$BIN" || { echo "soak bench binary not found"; exit 1; }
+          echo "bin=$BIN" >> "$GITHUB_OUTPUT"
+
+      - name: Negative control — divergence must go RED
+        run: |
+          set +e
+          OUT=$(${{ steps.soak.outputs.bin }} --inject-divergence); CODE=$?
+          echo "$OUT"
+          if [ "$CODE" -eq 0 ]; then echo "FAIL: divergence control did not go RED"; exit 1; fi
+          echo "$OUT" | grep -q "divergence correctly detected" || { echo "FAIL: wrong divergence outcome (code $CODE)"; exit 1; }
+          echo "OK: divergence detection RED as required (exit $CODE)"
+
+      - name: Negative control — panic must go RED
+        run: |
+          set +e
+          OUT=$(${{ steps.soak.outputs.bin }} --inject-panic); CODE=$?
+          echo "$OUT"
+          if [ "$CODE" -eq 0 ]; then echo "FAIL: panic control did not go RED"; exit 1; fi
+          echo "$OUT" | grep -q "panic correctly captured" || { echo "FAIL: wrong panic outcome (code $CODE)"; exit 1; }
+          echo "OK: panic detection RED as required (exit $CODE)"
+
+      - name: Short no-crash soak must be GREEN
+        run: |
+          ${{ steps.soak.outputs.bin }} \
+            --duration 25 --crash-interval 0 --steady-interval 6 \
+            --churn-clients 6 --keyspace 48 --quiesce 3 \
+            --json-output soak-smoke.json
+          jq -e '.passed == true' soak-smoke.json >/dev/null \
+            || { echo "FAIL: no-crash soak did not pass"; cat soak-smoke.json; exit 1; }
+          echo "OK: no-crash soak passed"
+
+      - name: Upload soak smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: soak-smoke-${{ github.run_id }}
+          path: soak-smoke.json
+          retention-days: 30
+
   audit:
     name: Cargo Audit (RustSec advisories)
     runs-on: ubuntu-latest

--- a/packages/server-rust/Cargo.toml
+++ b/packages/server-rust/Cargo.toml
@@ -73,7 +73,7 @@ name = "topgun-server"
 path = "src/bin/topgun_server.rs"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util", "time", "process"] }
 tokio-tungstenite = "0.26"
 hdrhistogram = "7"
 proptest = "1"
@@ -83,4 +83,14 @@ tempfile = "3"
 [[bench]]
 name = "load_harness"
 path = "benches/load_harness/main.rs"
+harness = false
+
+# Long-duration soak harness (G4b): drives the REAL out-of-process topgun-server
+# binary against an on-disk redb + WAL, exercising client churn, kill -9 crash
+# loops (real WAL recovery), convergence/divergence detection, memory-growth
+# monitoring, and panic capture. Distinct from load_harness, which boots the
+# server in-process on a NullDataStore and therefore cannot kill -9 or recover.
+[[bench]]
+name = "soak_harness"
+path = "benches/soak_harness/main.rs"
 harness = false

--- a/packages/server-rust/benches/soak_harness/README.md
+++ b/packages/server-rust/benches/soak_harness/README.md
@@ -1,0 +1,103 @@
+# Soak harness (G4b / TODO-484)
+
+A long-duration **endurance** test for the TopGun server. Where `load_harness`
+measures latency/throughput by booting the server **in-process** on a
+`NullDataStore`, the soak harness drives the **real out-of-process
+`topgun-server` binary** against an **on-disk redb + WAL**, so it can `kill -9`
+the process and watch it recover real data — repeatedly, for hours.
+
+It continuously asserts four endurance properties and fails, with captured
+context, the moment any breaks:
+
+| Property | What it checks | How |
+|----------|----------------|-----|
+| **Convergence** | Under client churn, every acked write is faithfully stored/served | Quiesce churn → read every key back via `QUERY_SUB` → compare against the harness's authoritative model (exact, single-writer-per-key) + cross-client Merkle-root agreement |
+| **Crash recovery** | A `kill -9` + restart restores the *exact* pre-crash state | Quiesce → snapshot Merkle root + all values → `kill -9` → restart (WAL recovery) → snapshot again → assert byte-for-byte identical |
+| **Bounded memory** | A fixed keyspace overwritten in place must plateau in RSS | Sample server RSS over time (`ps`); fail on slope > threshold (with a min-growth guard) or peak > ceiling. OR-Map add/remove churn drives tombstone growth (TODO-479/480) |
+| **Zero panics** | No panic anywhere in the run | Live-scan server stdout/stderr for panic markers + flag any un-requested exit, with surrounding log context |
+
+## Why a separate binary, not a `load_harness` flag
+
+Crash recovery requires a real OS process and a real disk. The in-process load
+harness cannot `kill -9` itself, and its `NullDataStore` has nothing to recover.
+The soak harness spawns the actual server binary (resolved via
+`CARGO_BIN_EXE_topgun-server`, overridable with `SOAK_SERVER_BINARY`), pins it to
+a stable loopback port, and points it at a persistent data directory so restarts
+recover from the same redb + WAL.
+
+## Negative controls (prove the harness can fail)
+
+A soak that cannot fail proves nothing. Two built-in negative controls exercise
+the real detection code and **must exit non-zero (assertion RED)**:
+
+```bash
+# Convergence detection: record an op in the model that is NOT applied to the
+# server ("skip applying one op on a replica"), then assert the read-back compare
+# detects the divergence.
+soak_harness --inject-divergence      # -> exit 1, "divergence correctly detected"
+
+# Panic detection: feed a synthetic Rust panic line + exit-101 through the same
+# PanicWatch the supervisor uses, and assert it trips.
+soak_harness --inject-panic           # -> exit 1, "panic correctly captured"
+```
+
+If either *fails to detect* (a blind check), it exits 3 instead — that is the
+real failure the controls guard against.
+
+## Running
+
+```bash
+# Build the server binary + the bench (debug is fine for functional runs).
+cargo build --bin topgun-server --bench soak_harness
+
+# Convenience preset: short but full-feature (churn + crash loop + checks).
+cargo bench --bench soak_harness -- --smoke
+
+# 1-2h smoke soak to validate the harness on a stabilized build, with reports.
+# caffeinate is REQUIRED on macOS so sleep does not break continuity.
+caffeinate -dimsu cargo bench --bench soak_harness -- \
+  --duration 5400 --crash-interval 180 --steady-interval 60 \
+  --churn-clients 16 --keyspace 200 \
+  --json-output soak.json --progress-output soak-progress.jsonl
+```
+
+A bare invocation (no mode flag) prints usage and exits 0 — this is deliberate
+so `cargo test --all-targets`, which runs `harness=false` benches, never launches
+a multi-hour default soak.
+
+### Key flags
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--duration <secs>` | 3600 | Total run time (smoke 1–2h, full 72h = 259200) |
+| `--crash-interval <secs>` | 120 | Seconds between `kill -9` + restart recovery checkpoints; `0` disables the crash loop |
+| `--steady-interval <secs>` | 30 | Seconds between steady-state convergence checkpoints |
+| `--churn-clients <n>` | 16 | Concurrent churn clients (each owns a disjoint key slice) |
+| `--keyspace <n>` | 200 | Distinct keys (bounded → legitimate memory is bounded) |
+| `--quiesce <secs>` | 3 | Pause+settle before a checkpoint reads or kills (≥ write-behind flush window) |
+| `--wal-fsync <policy>` | perop | `perop` \| `batched` \| `none`; `perop` makes recovery assertions crisp |
+| `--or-churn <bool>` | true | Drive OR-Map add/remove to grow tombstones (memory watch) |
+| `--mem-threshold-mb-per-hour <f>` | 50 | Fail if RSS slope exceeds this (with `--mem-min-growth-mb` guard, default 150) |
+| `--mem-ceiling-mb <f>` | 1800 | Fail if peak RSS exceeds this |
+| `--data-dir <path>` | tempdir | Persistent data dir (kept for forensics; default tempdir is cleaned on exit) |
+| `--json-output <path>` | — | Final structured report |
+| `--progress-output <path>` | — | Append one JSON line per checkpoint (tail-able during a 72h run) |
+
+Exit code: `0` pass, `1` an assertion failed (convergence/recovery/memory/panic),
+`2` setup error, `3` a negative control failed to detect its injected fault.
+
+## Known finding surfaced by this harness
+
+On its first crash-recovery checkpoint, the soak found **TODO-530** (HIGH):
+after `kill -9` + restart the redb-backed server serves an **empty** map
+(Merkle root `0`) although the data is durably on disk — the query full-scan and
+Merkle-sync paths read only the in-memory `StorageEngine` and persisted records
+are not rehydrated on restart (also latent under eviction). Until TODO-530 is
+fixed the **crash-loop path is RED by design**. CI therefore runs the no-crash
+convergence/churn/memory mode + both negative controls (all green); the crash
+loop is run locally and on the Hetzner 72h runner as the TODO-530 reproducer.
+
+## 72h run on Hetzner
+
+See [`hetzner-soak-runner.sh`](./hetzner-soak-runner.sh) and the
+"Hetzner 72h runner" section in [`SOAK_RUNNER.md`](./SOAK_RUNNER.md).

--- a/packages/server-rust/benches/soak_harness/SOAK_RUNNER.md
+++ b/packages/server-rust/benches/soak_harness/SOAK_RUNNER.md
@@ -1,0 +1,128 @@
+# G4b 72h soak — operator runbook
+
+The full 72-hour soak is the **final G4b gate**, run on a stabilized build by an
+operator on a Hetzner **scratch** box — not in CI, and not on the live demo VPS.
+This runbook covers provisioning, launching, monitoring remotely, and reading
+the result. The harness itself and its short smoke run are validated separately
+(see [`README.md`](./README.md)); this is purely the long endurance run.
+
+## 0. Prerequisites
+
+- A **dedicated scratch** Hetzner instance (Linux). Do **not** use the box that
+  serves `demo.topgun.build` — a crash-looping soak would disrupt it. Access and
+  provisioning helpers live in `~/Projects/hetzner` (`access.txt`, `dokploy`).
+- Rust toolchain on the box (`rustup`), `jq`, and `git`.
+- Disk: the soak writes a redb + WAL under the run dir; a few GB of free space is
+  ample for the default keyspace.
+
+## 1. Provision a scratch box
+
+Use the helpers in `~/Projects/hetzner` (or the Hetzner console / `dokploy`) to
+spin up a fresh instance. Confirm it is **not** the demo box:
+
+```bash
+ssh root@<scratch-box> 'hostname -f; curl -fsS --max-time 2 http://127.0.0.1:8080/ || echo "no server on 8080 (good)"'
+```
+
+## 2. Get the code onto the box
+
+```bash
+ssh root@<scratch-box>
+git clone https://github.com/TopGunBuild/topgun.git && cd topgun
+# or rsync your working tree if testing an unmerged branch
+```
+
+## 3. Launch the soak (detached)
+
+The runner builds release binaries, runs the two negative controls as a
+pre-flight (aborting if the harness cannot fail), then launches the soak under
+`nohup` so it survives your SSH session.
+
+```bash
+cd topgun
+# 72h defaults; override any knob via env (see the script header).
+DURATION=259200 CRASH_INTERVAL=300 \
+  packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
+```
+
+It prints the run directory (`/var/soak/run-<UTC>/`), the PID, and the monitor
+commands. The PID is also saved to `<run-dir>/soak.pid`.
+
+### systemd alternative (survives reboots, auto-restart of the *driver*)
+
+If you want the soak driver itself supervised (e.g. so a box reboot resumes it),
+wrap the same command in a unit. Note this supervises the harness process, which
+in turn supervises the server child:
+
+```ini
+# /etc/systemd/system/topgun-soak.service
+[Unit]
+Description=TopGun G4b 72h soak
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/root/topgun
+Environment=DURATION=259200 CRASH_INTERVAL=300
+ExecStart=/root/topgun/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
+Restart=no
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+systemctl daemon-reload && systemctl start topgun-soak
+journalctl -u topgun-soak -f
+```
+
+## 4. Monitor remotely while it runs
+
+The harness appends one JSON line per checkpoint to `progress.jsonl`, so you can
+watch a 72h run in real time from your laptop without attaching:
+
+```bash
+# Live progress stream (one line per steady/recovery checkpoint):
+ssh root@<scratch-box> 'tail -f /var/soak/run-*/progress.jsonl'
+
+# Human-readable summary of the latest checkpoint:
+ssh root@<scratch-box> 'tail -1 /var/soak/run-*/progress.jsonl | jq "{elapsedSecs, phase, totalWrites, crashes, lastConvergenceOk, peakRssMb, panicsSeen}"'
+
+# Watch RSS trend (memory plateau check):
+ssh root@<scratch-box> 'jq -r "[.elapsedSecs, .lastRssMb] | @tsv" /var/soak/run-*/progress.jsonl' | tail -50
+```
+
+Each progress line carries: `elapsedSecs`, `phase` (`steady`/`recovery`),
+`totalWrites`, `writeErrors`, `reconnects`, `crashes`, checkpoint counts,
+`lastConvergenceOk`, `peakRssMb`, `lastRssMb`, `panicsSeen`.
+
+## 5. Read the result
+
+When the run ends, the final report is written to `<run-dir>/report.json`:
+
+```bash
+ssh root@<scratch-box> 'cat /var/soak/run-*/report.json | jq "{passed, finishedReason, totalWrites, crashes, recoveryCheckpoints, memory, convergenceFailures, recoveryFailures, panicReport}"'
+
+# One-line verdict + exit-style check:
+ssh root@<scratch-box> 'jq -e .passed /var/soak/run-*/report.json >/dev/null && echo "G4b SOAK PASS" || echo "G4b SOAK FAIL"'
+```
+
+Interpretation:
+
+- `passed: true`, `finishedReason: "duration reached"` → **G4b green**: 72h of
+  churn + crash loops with zero divergence, zero recovery mismatch, bounded
+  memory (`memory.passed`), zero panics.
+- `passed: false` → inspect `convergenceFailures` / `recoveryFailures` /
+  `memory.reason` / `panicReport`. Each carries the offending keys, Merkle
+  roots, RSS slope, or panic context. A failure here is a **real finding** —
+  capture the `run-dir` (it holds the log, progress stream, and the on-disk
+  redb + WAL for forensics) and file it.
+
+## 6. Known caveat for the current build (TODO-530)
+
+On the current build the crash-loop path is **RED by design** because of
+TODO-530 (after `kill -9` + restart the server serves an empty map although the
+data is durably on disk — query/Merkle read only the in-memory layer, which is
+not rehydrated on restart). Run the full crash-loop 72h soak only **after**
+TODO-530 lands. To exercise everything *except* recovery in the meantime, set
+`CRASH_INTERVAL=0` (churn + steady convergence + memory + panic watch).

--- a/packages/server-rust/benches/soak_harness/client.rs
+++ b/packages/server-rust/benches/soak_harness/client.rs
@@ -1,0 +1,310 @@
+//! Minimal WebSocket client for the soak harness.
+//!
+//! Connects to the real out-of-process `topgun-server`, completes the JWT auth
+//! handshake, and exposes the four operations the soak loop needs:
+//!
+//! - `write_lww` — PUT an LWW record and wait for `OP_ACK` (durable write).
+//! - `read_all` — `QUERY_SUB` with an empty query → full map snapshot, used by
+//!   the convergence verifier to read every key back.
+//! - `merkle_root` — `SYNC_INIT` → `SYNC_RESP_ROOT`, the single-`u32` Merkle
+//!   fingerprint compared across clients and across a crash/recovery boundary.
+//!
+//! Unlike the load harness `ConnectionPool`, a `SoakClient` owns a single
+//! connection that is opened and dropped repeatedly by the churn driver, so the
+//! type is deliberately small and cheap to construct.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use futures_util::{SinkExt, StreamExt};
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+use topgun_core::hlc::{LWWRecord, ORMapRecord, Timestamp};
+use topgun_core::messages::{
+    AuthMessage, ClientOp, Message, OpBatchMessage, OpBatchPayload, Query, QuerySubMessage,
+    QuerySubPayload, QueryUnsubMessage, QueryUnsubPayload, SyncInitMessage, WriteConcern,
+};
+
+type Ws = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// How long a single request/response exchange may take before giving up.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// JWT claims for a soak connection. Mirrors the load harness shape so the same
+/// `JWT_SECRET=test-e2e-secret` validates.
+#[derive(Debug, Serialize, Deserialize)]
+struct SoakClaims {
+    sub: String,
+    iat: u64,
+    exp: u64,
+}
+
+/// A single authenticated WebSocket connection to the soak server.
+pub struct SoakClient {
+    ws: Ws,
+    /// Stable subject id, reused for log correlation.
+    user: String,
+}
+
+impl SoakClient {
+    /// Open a connection to `addr` and complete the auth handshake as
+    /// `soak-user-{user_idx}`.
+    pub async fn connect(addr: SocketAddr, user_idx: usize, jwt_secret: &str) -> Result<Self> {
+        let url = format!("ws://{addr}/ws");
+        let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
+            .await
+            .map_err(|e| anyhow!("user {user_idx}: ws connect failed: {e}"))?;
+
+        // AUTH_REQUIRED → AUTH(jwt) → AUTH_ACK
+        let _auth_required = recv_decoded(&mut ws, "AUTH_REQUIRED").await?;
+
+        let token = generate_jwt(user_idx, jwt_secret)?;
+        let auth = Message::Auth(AuthMessage {
+            token,
+            protocol_version: None,
+        });
+        send_encoded(&mut ws, &auth).await?;
+
+        match recv_decoded(&mut ws, "AUTH_ACK").await? {
+            Message::AuthAck(_) => {}
+            Message::AuthFail(fail) => {
+                let reason = fail.error.unwrap_or_else(|| "unknown".to_string());
+                bail!("user {user_idx}: auth failed: {reason}");
+            }
+            other => bail!("user {user_idx}: expected AUTH_ACK, got {other:?}"),
+        }
+
+        Ok(Self {
+            ws,
+            user: format!("soak-{user_idx}"),
+        })
+    }
+
+    /// PUT `value` at `map`/`key` with `APPLIED` write concern and wait for the
+    /// `OP_ACK`. The `(millis, counter)` pair must be monotonically increasing
+    /// per key so Last-Write-Wins keeps the latest value; the caller owns that.
+    pub async fn write_lww(
+        &mut self,
+        map: &str,
+        key: &str,
+        value: i64,
+        millis: u64,
+        counter: u32,
+    ) -> Result<()> {
+        let record = LWWRecord {
+            value: Some(rmpv::Value::Map(vec![(
+                rmpv::Value::from("v"),
+                rmpv::Value::from(value),
+            )])),
+            timestamp: Timestamp {
+                millis,
+                counter,
+                node_id: self.user.clone(),
+            },
+            ttl_ms: None,
+        };
+        let op = ClientOp {
+            map_name: map.to_string(),
+            key: key.to_string(),
+            op_type: Some("PUT".to_string()),
+            record: Some(Some(record)),
+            ..Default::default()
+        };
+        self.send_op_await_ack(op).await
+    }
+
+    /// Add an OR-Map tag at `map`/`key`. Paired with `or_remove`, this drives
+    /// per-key tombstone accumulation — the unbounded-growth memory candidate
+    /// the soak watches (TODO-479/480). Waits for `OP_ACK`.
+    pub async fn or_add(
+        &mut self,
+        map: &str,
+        key: &str,
+        tag: &str,
+        millis: u64,
+        counter: u32,
+    ) -> Result<()> {
+        let or_record = ORMapRecord {
+            value: rmpv::Value::from(counter),
+            timestamp: Timestamp {
+                millis,
+                counter,
+                node_id: self.user.clone(),
+            },
+            tag: tag.to_string(),
+            ttl_ms: None,
+        };
+        let op = ClientOp {
+            map_name: map.to_string(),
+            key: key.to_string(),
+            or_record: Some(Some(or_record)),
+            ..Default::default()
+        };
+        self.send_op_await_ack(op).await
+    }
+
+    /// Remove an OR-Map tag previously added at `map`/`key`, appending a
+    /// tombstone server-side. Waits for `OP_ACK`.
+    pub async fn or_remove(&mut self, map: &str, key: &str, tag: &str) -> Result<()> {
+        let op = ClientOp {
+            map_name: map.to_string(),
+            key: key.to_string(),
+            or_tag: Some(Some(tag.to_string())),
+            ..Default::default()
+        };
+        self.send_op_await_ack(op).await
+    }
+
+    /// Send a single op in an `APPLIED` batch and wait for its `OP_ACK`.
+    async fn send_op_await_ack(&mut self, op: ClientOp) -> Result<()> {
+        let msg = Message::OpBatch(OpBatchMessage {
+            payload: OpBatchPayload {
+                ops: vec![op],
+                write_concern: Some(WriteConcern::APPLIED),
+                timeout: Some(5000),
+            },
+        });
+        send_encoded(&mut self.ws, &msg).await?;
+        match recv_decoded(&mut self.ws, "OP_ACK").await? {
+            Message::OpAck(_) => Ok(()),
+            Message::OpRejected(r) => bail!("op rejected: {}", r.payload.reason),
+            other => bail!("expected OP_ACK, got {other:?}"),
+        }
+    }
+
+    /// Read every record of `map` back via an empty `QUERY_SUB`, returning a
+    /// `key -> v` map. Values are decoded from the `{ "v": <int> }` shape the
+    /// soak writes. Unsubscribes afterwards so the live subscription does not
+    /// leak across repeated checkpoint reads.
+    pub async fn read_all(&mut self, map: &str) -> Result<HashMap<String, i64>> {
+        let query_id = format!("soak-read-{}-{map}", self.user);
+        let sub = Message::QuerySub(QuerySubMessage {
+            payload: QuerySubPayload {
+                query_id: query_id.clone(),
+                map_name: map.to_string(),
+                query: Query::default(),
+                fields: None,
+            },
+        });
+        send_encoded(&mut self.ws, &sub).await?;
+
+        let resp = recv_decoded(&mut self.ws, "QUERY_RESP").await?;
+        let Message::QueryResp(qr) = resp else {
+            bail!("expected QUERY_RESP, got {resp:?}");
+        };
+
+        if qr.payload.has_more == Some(true) {
+            bail!(
+                "QUERY_RESP for '{map}' was paginated (has_more) — soak keyspace exceeds the \
+                 single-page max_query_records cap; lower --keyspace"
+            );
+        }
+
+        let mut out = HashMap::with_capacity(qr.payload.results.len());
+        for entry in qr.payload.results {
+            if let Some(v) = extract_v(&entry.value) {
+                out.insert(entry.key, v);
+            }
+        }
+
+        // Best-effort unsubscribe; ignore the (rare) send error on a dying conn.
+        let unsub = Message::QueryUnsub(QueryUnsubMessage {
+            payload: QueryUnsubPayload { query_id },
+        });
+        let _ = send_encoded(&mut self.ws, &unsub).await;
+
+        Ok(out)
+    }
+
+    /// Fetch the server's Merkle root hash for `map` via `SYNC_INIT`. Two
+    /// clients reading the same single-node server must agree; the value must
+    /// also be identical before a quiesced `kill -9` and after WAL recovery.
+    pub async fn merkle_root(&mut self, map: &str) -> Result<u32> {
+        let init = Message::SyncInit(SyncInitMessage {
+            map_name: map.to_string(),
+            last_sync_timestamp: None,
+        });
+        send_encoded(&mut self.ws, &init).await?;
+
+        match recv_decoded(&mut self.ws, "SYNC_RESP_ROOT").await? {
+            Message::SyncRespRoot(r) => Ok(r.payload.root_hash),
+            other => bail!("expected SYNC_RESP_ROOT, got {other:?}"),
+        }
+    }
+}
+
+/// Decode the soak value shape `{ "v": <int> }` back to an `i64`.
+fn extract_v(value: &rmpv::Value) -> Option<i64> {
+    value
+        .as_map()?
+        .iter()
+        .find(|(k, _)| k.as_str() == Some("v"))
+        .and_then(|(_, v)| v.as_i64())
+}
+
+/// Send a `Message` as a binary MsgPack frame.
+async fn send_encoded(ws: &mut Ws, msg: &Message) -> Result<()> {
+    let bytes = rmp_serde::to_vec_named(msg).map_err(|e| anyhow!("encode failed: {e}"))?;
+    ws.send(WsMessage::Binary(bytes.into()))
+        .await
+        .map_err(|e| anyhow!("ws send failed: {e}"))
+}
+
+/// Receive the next decodable `Message`, skipping control frames and unrelated
+/// server pushes (e.g. `QUERY_UPDATE`, `SERVER_EVENT`) until a frame decodes to
+/// a `Message`. `what` names the awaited message for error context. Bounded by
+/// `REQUEST_TIMEOUT` so a wedged server surfaces as an error, not a hang.
+async fn recv_decoded(ws: &mut Ws, what: &str) -> Result<Message> {
+    let deadline = tokio::time::Instant::now() + REQUEST_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            bail!("timed out waiting for {what}");
+        }
+        let frame = match tokio::time::timeout(remaining, ws.next()).await {
+            Ok(Some(Ok(frame))) => frame,
+            Ok(Some(Err(e))) => bail!("ws error while waiting for {what}: {e}"),
+            Ok(None) => bail!("connection closed while waiting for {what}"),
+            Err(_) => bail!("timed out waiting for {what}"),
+        };
+        match frame {
+            WsMessage::Binary(data) => {
+                if let Ok(msg) = rmp_serde::from_slice::<Message>(&data) {
+                    return Ok(msg);
+                }
+                // Undecodable frame — skip and keep waiting.
+            }
+            WsMessage::Text(text) => {
+                if let Ok(msg) = rmp_serde::from_slice::<Message>(text.as_bytes()) {
+                    return Ok(msg);
+                }
+            }
+            WsMessage::Close(_) => bail!("server closed connection while waiting for {what}"),
+            WsMessage::Ping(_) | WsMessage::Pong(_) | WsMessage::Frame(_) => {}
+        }
+    }
+}
+
+/// Mint an HS256 JWT for `soak-user-{idx}` valid for one hour.
+fn generate_jwt(idx: usize, jwt_secret: &str) -> Result<String> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| anyhow!("system time error: {e}"))?
+        .as_secs();
+    let claims = SoakClaims {
+        sub: format!("soak-user-{idx}"),
+        iat: now,
+        exp: now + 3600,
+    };
+    jsonwebtoken::encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(jwt_secret.as_bytes()),
+    )
+    .map_err(|e| anyhow!("JWT encode failed for user {idx}: {e}"))
+}

--- a/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
+++ b/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Hetzner 72h soak runner (G4b / TODO-484).
+#
+# Runs ON a Hetzner *scratch* instance (NOT the live demo-VPS), launching the
+# soak harness detached via nohup so it survives the SSH session, with a JSON
+# progress stream you can tail remotely and a final JSON report.
+#
+# Usage (on the box, from the repo root):
+#   packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
+#
+# Override any knob via env, e.g.:
+#   DURATION=259200 CRASH_INTERVAL=300 ./hetzner-soak-runner.sh   # 72h
+#
+# Monitoring from your laptop:
+#   ssh root@<box> 'tail -f /var/soak/run-*/progress.jsonl'
+#   ssh root@<box> 'cat /var/soak/run-*/report.json | jq .passed'
+#
+set -euo pipefail
+
+# --- Tunables (env-overridable) ---------------------------------------------
+DURATION="${DURATION:-259200}"            # 72h
+CRASH_INTERVAL="${CRASH_INTERVAL:-300}"   # kill -9 + restart every 5 min
+STEADY_INTERVAL="${STEADY_INTERVAL:-120}" # steady convergence check every 2 min
+CHURN_CLIENTS="${CHURN_CLIENTS:-32}"
+KEYSPACE="${KEYSPACE:-500}"
+QUIESCE="${QUIESCE:-4}"
+WAL_FSYNC="${WAL_FSYNC:-perop}"
+MEM_THRESHOLD="${MEM_THRESHOLD:-25}"      # MB/hour slope ceiling over a 72h run
+MEM_CEILING="${MEM_CEILING:-2048}"
+OUT_ROOT="${OUT_ROOT:-/var/soak}"
+
+# --- Sanity: refuse to run on the live demo box -----------------------------
+# The live demo VPS serves demo.topgun.build; a crash-looping soak there would
+# take it down. Set ALLOW_DEMO_BOX=1 only if you are CERTAIN this is a scratch box.
+if [[ "${ALLOW_DEMO_BOX:-0}" != "1" ]]; then
+  if hostname -f 2>/dev/null | grep -qiE 'demo|topgun\.build' \
+     || curl -fsS --max-time 2 http://127.0.0.1:8080/ >/dev/null 2>&1; then
+    echo "REFUSING: this looks like a live/demo box (a soak crash-loop would disrupt it)." >&2
+    echo "Run on a dedicated scratch instance, or set ALLOW_DEMO_BOX=1 if you are sure." >&2
+    exit 1
+  fi
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$REPO_ROOT"
+echo "repo root: $REPO_ROOT"
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="${OUT_ROOT}/run-${STAMP}"
+mkdir -p "$RUN_DIR"
+DATA_DIR="${RUN_DIR}/data"
+mkdir -p "$DATA_DIR"
+
+# --- Build release bin + bench ----------------------------------------------
+echo "building release server binary + soak bench ..."
+cargo build --release --bin topgun-server --bench soak_harness 2>&1 | tail -3
+
+SOAK_BIN="$(ls -t target/release/deps/soak_harness-* 2>/dev/null | grep -vE '\.(d|o|rcgu)' | head -1)"
+if [[ -z "${SOAK_BIN}" || ! -x "${SOAK_BIN}" ]]; then
+  echo "FATAL: could not locate built soak_harness binary" >&2
+  exit 1
+fi
+echo "soak binary: ${SOAK_BIN}"
+
+# --- Pre-flight: prove the harness can fail before the long run -------------
+echo "pre-flight negative controls (must report RED / exit non-zero) ..."
+if "${SOAK_BIN}" --inject-panic; then
+  echo "FATAL: inject-panic did not go RED — aborting (harness cannot detect panics)" >&2
+  exit 1
+fi
+if "${SOAK_BIN}" --inject-divergence; then
+  echo "FATAL: inject-divergence did not go RED — aborting (harness cannot detect divergence)" >&2
+  exit 1
+fi
+echo "negative controls OK (both went RED as required)."
+
+# --- Launch the soak detached ------------------------------------------------
+LOG="${RUN_DIR}/soak.log"
+PROGRESS="${RUN_DIR}/progress.jsonl"
+REPORT="${RUN_DIR}/report.json"
+
+echo "launching ${DURATION}s soak (crash every ${CRASH_INTERVAL}s) ..."
+echo "  run dir:  ${RUN_DIR}"
+echo "  log:      ${LOG}"
+echo "  progress: ${PROGRESS}"
+echo "  report:   ${REPORT}"
+
+nohup "${SOAK_BIN}" \
+  --duration "${DURATION}" \
+  --crash-interval "${CRASH_INTERVAL}" \
+  --steady-interval "${STEADY_INTERVAL}" \
+  --churn-clients "${CHURN_CLIENTS}" \
+  --keyspace "${KEYSPACE}" \
+  --quiesce "${QUIESCE}" \
+  --wal-fsync "${WAL_FSYNC}" \
+  --mem-threshold-mb-per-hour "${MEM_THRESHOLD}" \
+  --mem-ceiling-mb "${MEM_CEILING}" \
+  --data-dir "${DATA_DIR}" \
+  --json-output "${REPORT}" \
+  --progress-output "${PROGRESS}" \
+  >"${LOG}" 2>&1 &
+
+SOAK_PID=$!
+echo "${SOAK_PID}" > "${RUN_DIR}/soak.pid"
+echo
+echo "soak running as PID ${SOAK_PID}."
+echo "monitor:   tail -f ${PROGRESS}"
+echo "live log:  tail -f ${LOG}"
+echo "result:    jq .passed ${REPORT}   (written when the run ends)"
+echo "stop:      kill ${SOAK_PID}"

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -1,0 +1,1225 @@
+//! Soak harness (G4b) — long-duration endurance test for the TopGun server.
+//!
+//! Unlike `load_harness` (which boots the server in-process on a `NullDataStore`
+//! to measure latency/throughput), the soak harness drives the **real
+//! out-of-process `topgun-server` binary** against an on-disk redb + WAL so it
+//! can `kill -9` the process and watch it recover. It exercises four endurance
+//! properties continuously and fails — with context — the moment any breaks:
+//!
+//! 1. **Convergence:** under client churn, a quiesced read-back of every key
+//!    must equal the harness's authoritative model (no lost/garbled writes).
+//! 2. **Crash recovery:** a quiesced-then-`kill -9`-then-restart cycle must
+//!    restore the *exact* pre-crash state (Merkle root + every value), proving
+//!    WAL recovery is correct, repeated many times across a run.
+//! 3. **Bounded memory:** with a fixed keyspace overwritten in place, the
+//!    server RSS must plateau; a sustained upward slope flags a leak (e.g.
+//!    unbounded OR-Map tombstone growth, TODO-479/480).
+//! 4. **Zero panics:** any panic marker in server output, or any un-requested
+//!    exit, fails the run with the captured context.
+//!
+//! Two **negative controls** prove the harness can actually fail:
+//! `--inject-divergence` makes the convergence check go red, and
+//! `--inject-panic` makes the panic capture go red. A soak that cannot fail
+//! proves nothing.
+//!
+//! See `benches/soak_harness/README.md` for usage and the Hetzner 72h runner.
+
+#![allow(
+    clippy::too_many_lines,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::struct_excessive_bools,
+    // Subjective style lints not worth contorting a bench harness for: many
+    // local snapshot pairs read naturally as pre_/post_ etc., and prose like
+    // "TopGun"/"kill -9" should not be backtick-quoted.
+    clippy::similar_names,
+    clippy::doc_markdown
+)]
+
+mod client;
+mod model;
+mod monitor;
+mod process;
+mod report;
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use parking_lot::Mutex;
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+use client::SoakClient;
+use model::{compare, next_stamp, Model};
+use monitor::{assess, sample_rss_mb, MemSample};
+use process::{resolve_server_binary, ServerConfig, ServerSupervisor};
+use report::{
+    append_progress, utc_timestamp_now, write_report, MemoryReport, ProgressSnapshot, SoakReport,
+};
+
+/// Subject index used by the orchestrator's verifier connections. Far above the
+/// churn-client range so it never owns keys or collides with churn auth.
+const VERIFIER_IDX: usize = 1_000_000;
+
+const LWW_MAP: &str = "soak_lww";
+const OR_MAP: &str = "soak_or";
+
+/// Parsed CLI configuration.
+struct Config {
+    duration: Duration,
+    churn_clients: usize,
+    keyspace: usize,
+    write_interval: Duration,
+    writes_per_life: usize,
+    offline_keys: usize,
+    crash_interval: Option<Duration>,
+    steady_interval: Duration,
+    quiesce: Duration,
+    ready_timeout: Duration,
+    mem_sample_interval: Duration,
+    mem_threshold_mb_per_hour: f64,
+    mem_min_growth_mb: f64,
+    mem_ceiling_mb: f64,
+    server_port: u16,
+    data_dir: Option<PathBuf>,
+    wal_fsync: String,
+    or_churn: bool,
+    or_keyspace: usize,
+    or_every: u64,
+    json_output: Option<PathBuf>,
+    progress_output: Option<PathBuf>,
+    inject_divergence: bool,
+    inject_panic: bool,
+    /// True once any soak-controlling flag is parsed. A bare invocation (or one
+    /// carrying only foreign libtest args, as `cargo test --all-targets` passes)
+    /// leaves this false so the harness prints usage and exits 0 instead of
+    /// launching a multi-hour default soak inside the test runner.
+    mode_requested: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            duration: Duration::from_secs(3600),
+            churn_clients: 16,
+            keyspace: 200,
+            write_interval: Duration::from_millis(20),
+            writes_per_life: 200,
+            offline_keys: 3,
+            crash_interval: Some(Duration::from_secs(120)),
+            steady_interval: Duration::from_secs(30),
+            quiesce: Duration::from_secs(3),
+            ready_timeout: Duration::from_secs(40),
+            mem_sample_interval: Duration::from_secs(5),
+            mem_threshold_mb_per_hour: 50.0,
+            mem_min_growth_mb: 150.0,
+            mem_ceiling_mb: 1800.0,
+            server_port: 0,
+            data_dir: None,
+            wal_fsync: "perop".to_string(),
+            or_churn: true,
+            or_keyspace: 32,
+            or_every: 5,
+            json_output: None,
+            progress_output: None,
+            inject_divergence: false,
+            inject_panic: false,
+            mode_requested: false,
+        }
+    }
+}
+
+/// Shared atomic counters mutated by churn clients.
+#[derive(Default)]
+struct SoakMetrics {
+    total_writes: AtomicU64,
+    write_errors: AtomicU64,
+    reconnects: AtomicU64,
+    resends: AtomicU64,
+}
+
+/// Context shared with every churn client task.
+struct ChurnCtx {
+    supervisor: Arc<ServerSupervisor>,
+    model: Arc<Model>,
+    metrics: Arc<SoakMetrics>,
+    paused: Arc<AtomicBool>,
+    stop: Arc<AtomicBool>,
+    jwt_secret: String,
+    or_churn: bool,
+    or_keyspace: usize,
+    or_every: u64,
+    write_interval: Duration,
+    writes_per_life: usize,
+    offline_keys: usize,
+}
+
+#[tokio::main]
+async fn main() {
+    let config = parse_args();
+
+    // Guard: a bare invocation (e.g. `cargo test --all-targets` running this
+    // harness=false bench, which passes only foreign libtest args) must not
+    // launch a multi-hour soak. Require an explicit mode flag.
+    if !config.mode_requested {
+        print_usage();
+        std::process::exit(0);
+    }
+
+    let code = if config.inject_panic {
+        run_inject_panic().await
+    } else if config.inject_divergence {
+        run_inject_divergence(&config).await
+    } else {
+        run_soak(&config).await
+    };
+
+    std::process::exit(code);
+}
+
+// ---------------------------------------------------------------------------
+// Main soak run
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::cognitive_complexity)]
+async fn run_soak(config: &Config) -> i32 {
+    println!("=== TopGun soak harness (G4b / TODO-484) ===");
+    println!(
+        "duration={}s churn_clients={} keyspace={} crash_interval={:?} steady_interval={}s \
+         wal_fsync={} or_churn={}",
+        config.duration.as_secs(),
+        config.churn_clients,
+        config.keyspace,
+        config.crash_interval.map(|d| d.as_secs()),
+        config.steady_interval.as_secs(),
+        config.wal_fsync,
+        config.or_churn,
+    );
+
+    let binary = resolve_server_binary();
+
+    // Persistent on-disk data dir. A caller-supplied dir survives the run for
+    // forensics; otherwise a tempdir is created and kept for the process lifetime.
+    let (data_dir, _tempdir_guard) = match &config.data_dir {
+        Some(d) => {
+            if let Err(e) = std::fs::create_dir_all(d) {
+                eprintln!("FATAL: cannot create data dir {}: {e}", d.display());
+                return 2;
+            }
+            (d.clone(), None)
+        }
+        None => match tempfile::tempdir() {
+            Ok(td) => (td.path().to_path_buf(), Some(td)),
+            Err(e) => {
+                eprintln!("FATAL: cannot create tempdir: {e}");
+                return 2;
+            }
+        },
+    };
+
+    let port = if config.server_port == 0 {
+        match ServerSupervisor::pick_free_port() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("FATAL: cannot pick free port: {e}");
+                return 2;
+            }
+        }
+    } else {
+        config.server_port
+    };
+
+    let jwt_secret = "test-e2e-secret".to_string();
+    let supervisor = ServerSupervisor::new(ServerConfig {
+        binary,
+        data_dir: data_dir.clone(),
+        port,
+        jwt_secret: jwt_secret.clone(),
+        wal_fsync_policy: config.wal_fsync.clone(),
+    });
+
+    println!(
+        "starting server (port {port}, data {}) ...",
+        data_dir.display()
+    );
+    if let Err(e) = supervisor.start(config.ready_timeout).await {
+        eprintln!("FATAL: server failed to start: {e}");
+        return 2;
+    }
+    let panic_watch = supervisor.panic_watch();
+
+    let model = Arc::new(Model::new(config.keyspace, config.churn_clients));
+    let metrics = Arc::new(SoakMetrics::default());
+    let paused = Arc::new(AtomicBool::new(false));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // --- Spawn churn clients ---
+    let mut churn_handles = Vec::with_capacity(config.churn_clients);
+    for idx in 0..config.churn_clients {
+        let ctx = ChurnCtx {
+            supervisor: Arc::clone(&supervisor),
+            model: Arc::clone(&model),
+            metrics: Arc::clone(&metrics),
+            paused: Arc::clone(&paused),
+            stop: Arc::clone(&stop),
+            jwt_secret: jwt_secret.clone(),
+            or_churn: config.or_churn,
+            or_keyspace: config.or_keyspace,
+            or_every: config.or_every,
+            write_interval: config.write_interval,
+            writes_per_life: config.writes_per_life,
+            offline_keys: config.offline_keys,
+        };
+        churn_handles.push(tokio::spawn(run_churn_client(idx, ctx)));
+    }
+
+    // --- Spawn memory sampler ---
+    let samples: Arc<Mutex<Vec<MemSample>>> = Arc::new(Mutex::new(Vec::new()));
+    let peak_rss = Arc::new(Mutex::new(0.0_f64));
+    {
+        let supervisor = Arc::clone(&supervisor);
+        let samples = Arc::clone(&samples);
+        let peak_rss = Arc::clone(&peak_rss);
+        let stop = Arc::clone(&stop);
+        let interval = config.mem_sample_interval;
+        let start = Instant::now();
+        tokio::spawn(async move {
+            loop {
+                if stop.load(Ordering::SeqCst) {
+                    return;
+                }
+                if let Some(pid) = supervisor.current_pid() {
+                    if let Some(mb) = sample_rss_mb(pid) {
+                        let elapsed = start.elapsed().as_secs_f64();
+                        samples.lock().push(MemSample {
+                            elapsed_secs: elapsed,
+                            rss_mb: mb,
+                        });
+                        let mut p = peak_rss.lock();
+                        if mb > *p {
+                            *p = mb;
+                        }
+                    }
+                }
+                tokio::time::sleep(interval).await;
+            }
+        });
+    }
+
+    // --- Orchestration loop ---
+    let start = Instant::now();
+    let deadline = start + config.duration;
+    let mut next_steady = start + config.steady_interval;
+    let mut next_crash = config
+        .crash_interval
+        .map_or(deadline + Duration::from_secs(86400), |d| start + d);
+
+    let mut steady_checkpoints = 0u64;
+    let mut recovery_checkpoints = 0u64;
+    let mut crashes = 0u64;
+    let mut convergence_failures: Vec<String> = Vec::new();
+    let mut recovery_failures: Vec<String> = Vec::new();
+    let mut last_convergence_ok = true;
+    let mut finished_reason = "duration reached".to_string();
+
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            break;
+        }
+        let wake = next_steady.min(next_crash).min(deadline);
+        tokio::time::sleep_until(tokio::time::Instant::from_std(wake)).await;
+
+        if panic_watch.tripped() {
+            finished_reason = "server panic detected".to_string();
+            break;
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            break;
+        }
+
+        let phase;
+        if now >= next_crash {
+            phase = "recovery";
+            match recovery_checkpoint(&supervisor, &model, &jwt_secret, config, &paused).await {
+                Ok(failures) => {
+                    recovery_checkpoints += 1;
+                    crashes += 1;
+                    if failures.is_empty() {
+                        last_convergence_ok = true;
+                    } else {
+                        last_convergence_ok = false;
+                        recovery_failures.extend(failures);
+                    }
+                }
+                Err(e) => {
+                    recovery_failures.push(format!("recovery checkpoint error: {e}"));
+                }
+            }
+            next_crash = now + config.crash_interval.unwrap_or(config.steady_interval);
+        } else {
+            phase = "steady";
+            match steady_checkpoint(&supervisor, &model, &jwt_secret, config, &paused).await {
+                Ok(failures) => {
+                    steady_checkpoints += 1;
+                    if failures.is_empty() {
+                        last_convergence_ok = true;
+                    } else {
+                        last_convergence_ok = false;
+                        convergence_failures.extend(failures);
+                    }
+                }
+                Err(e) => {
+                    convergence_failures.push(format!("steady checkpoint error: {e}"));
+                }
+            }
+            next_steady = now + config.steady_interval;
+        }
+
+        // Progress snapshot for live monitoring of long runs.
+        let peak = *peak_rss.lock();
+        let last = samples.lock().last().map_or(0.0, |s| s.rss_mb);
+        if let Some(path) = &config.progress_output {
+            append_progress(
+                path,
+                &ProgressSnapshot {
+                    timestamp: utc_timestamp_now(),
+                    elapsed_secs: start.elapsed().as_secs(),
+                    phase: phase.to_string(),
+                    total_writes: metrics.total_writes.load(Ordering::Relaxed),
+                    write_errors: metrics.write_errors.load(Ordering::Relaxed),
+                    reconnects: metrics.reconnects.load(Ordering::Relaxed),
+                    crashes,
+                    steady_checkpoints,
+                    recovery_checkpoints,
+                    last_convergence_ok,
+                    peak_rss_mb: peak,
+                    last_rss_mb: last,
+                    panics_seen: panic_watch.tripped(),
+                },
+            );
+        }
+        println!(
+            "[{:>6}s] {phase:<8} writes={} errs={} reconnects={} crashes={} steady={} recovery={} \
+             converged={} rss={:.0}MB(peak {:.0})",
+            start.elapsed().as_secs(),
+            metrics.total_writes.load(Ordering::Relaxed),
+            metrics.write_errors.load(Ordering::Relaxed),
+            metrics.reconnects.load(Ordering::Relaxed),
+            crashes,
+            steady_checkpoints,
+            recovery_checkpoints,
+            last_convergence_ok,
+            last,
+            peak,
+        );
+
+        // Fail fast: a real divergence/recovery miss IS the finding.
+        if !convergence_failures.is_empty() {
+            finished_reason = "convergence divergence detected".to_string();
+            break;
+        }
+        if !recovery_failures.is_empty() {
+            finished_reason = "crash recovery mismatch detected".to_string();
+            break;
+        }
+        if panic_watch.tripped() {
+            finished_reason = "server panic detected".to_string();
+            break;
+        }
+    }
+
+    // --- Tear down ---
+    stop.store(true, Ordering::SeqCst);
+    paused.store(false, Ordering::SeqCst);
+    for h in churn_handles {
+        let _ = tokio::time::timeout(Duration::from_secs(5), h).await;
+    }
+    supervisor.shutdown().await;
+
+    // --- Assess memory ---
+    let mem_samples = samples.lock().clone();
+    let mem = assess(
+        &mem_samples,
+        config.mem_threshold_mb_per_hour,
+        config.mem_min_growth_mb,
+        config.mem_ceiling_mb,
+    );
+
+    let panic_report = panic_watch.report();
+    let passed = convergence_failures.is_empty()
+        && recovery_failures.is_empty()
+        && mem.passed
+        && panic_report.is_none();
+
+    if !mem.passed {
+        finished_reason = format!(
+            "memory growth assertion failed: {}",
+            mem.reason.clone().unwrap_or_default()
+        );
+    }
+    if let Some(pr) = &panic_report {
+        if passed {
+            // unreachable, but keep finished_reason informative
+        }
+        eprintln!("PANIC CONTEXT:\n{pr}");
+    }
+
+    let report = SoakReport {
+        mode: "soak".to_string(),
+        duration_secs_target: config.duration.as_secs(),
+        duration_secs_actual: start.elapsed().as_secs(),
+        churn_clients: config.churn_clients,
+        keyspace: config.keyspace,
+        total_writes: metrics.total_writes.load(Ordering::Relaxed),
+        write_errors: metrics.write_errors.load(Ordering::Relaxed),
+        reconnects: metrics.reconnects.load(Ordering::Relaxed),
+        resends: metrics.resends.load(Ordering::Relaxed),
+        steady_checkpoints,
+        recovery_checkpoints,
+        crashes,
+        convergence_failures: convergence_failures.clone(),
+        recovery_failures: recovery_failures.clone(),
+        memory: MemoryReport {
+            samples: mem.samples,
+            first_mb: mem.first_mb,
+            peak_mb: mem.peak_mb,
+            last_mb: mem.last_mb,
+            slope_mb_per_hour: mem.slope_mb_per_hour,
+            passed: mem.passed,
+            reason: mem.reason.clone(),
+        },
+        panic_report,
+        passed,
+        finished_reason: finished_reason.clone(),
+        timestamp: utc_timestamp_now(),
+    };
+
+    print_summary(&report);
+    if let Some(path) = &config.json_output {
+        write_report(path, &report);
+        println!("wrote JSON report to {}", path.display());
+    }
+
+    i32::from(!passed)
+}
+
+fn print_summary(r: &SoakReport) {
+    println!("\n=== SOAK SUMMARY ===");
+    println!(
+        "result:            {}",
+        if r.passed { "PASS" } else { "FAIL" }
+    );
+    println!("finished_reason:   {}", r.finished_reason);
+    println!("actual_duration:   {}s", r.duration_secs_actual);
+    println!("total_writes:      {}", r.total_writes);
+    println!("write_errors:      {}", r.write_errors);
+    println!("reconnects:        {}", r.reconnects);
+    println!("resends:           {}", r.resends);
+    println!("steady_checkpts:   {}", r.steady_checkpoints);
+    println!(
+        "recovery_checkpts: {} (crashes {})",
+        r.recovery_checkpoints, r.crashes
+    );
+    println!(
+        "memory:            first={:.0}MB peak={:.0}MB last={:.0}MB slope={:.1}MB/h -> {}",
+        r.memory.first_mb,
+        r.memory.peak_mb,
+        r.memory.last_mb,
+        r.memory.slope_mb_per_hour,
+        if r.memory.passed { "ok" } else { "FAIL" }
+    );
+    if !r.convergence_failures.is_empty() {
+        println!("convergence_failures:");
+        for f in r.convergence_failures.iter().take(10) {
+            println!("  - {f}");
+        }
+    }
+    if !r.recovery_failures.is_empty() {
+        println!("recovery_failures:");
+        for f in r.recovery_failures.iter().take(10) {
+            println!("  - {f}");
+        }
+    }
+    if let Some(pr) = &r.panic_report {
+        println!("panic_report:      {pr}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoints
+// ---------------------------------------------------------------------------
+
+/// Quiesce churn, then verify the server read-back equals the model exactly and
+/// that two client connections agree on the Merkle root. No re-assertion of
+/// state, so this genuinely tests that the server stored every acked write.
+async fn steady_checkpoint(
+    supervisor: &Arc<ServerSupervisor>,
+    model: &Arc<Model>,
+    jwt: &str,
+    config: &Config,
+    paused: &Arc<AtomicBool>,
+) -> Result<Vec<String>> {
+    paused.store(true, Ordering::SeqCst);
+    tokio::time::sleep(config.quiesce).await;
+    let result = steady_checkpoint_inner(supervisor, model, jwt).await;
+    paused.store(false, Ordering::SeqCst);
+    result
+}
+
+async fn steady_checkpoint_inner(
+    supervisor: &Arc<ServerSupervisor>,
+    model: &Arc<Model>,
+    jwt: &str,
+) -> Result<Vec<String>> {
+    let mut failures = Vec::new();
+    let expected = model.snapshot();
+
+    let mut v1 = SoakClient::connect(supervisor.addr(), VERIFIER_IDX, jwt).await?;
+    let actual = v1.read_all(LWW_MAP).await?;
+    let diffs = compare(&expected, &actual);
+    if !diffs.is_empty() {
+        failures.push(format!(
+            "steady convergence: {} key(s) diverged (e.g. {})",
+            diffs.len(),
+            diffs
+                .iter()
+                .take(5)
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    // Client-vs-client Merkle agreement on the same single-node server.
+    let root1 = v1.merkle_root(LWW_MAP).await?;
+    let mut v2 = SoakClient::connect(supervisor.addr(), VERIFIER_IDX + 1, jwt).await?;
+    let root2 = v2.merkle_root(LWW_MAP).await?;
+    if root1 != root2 {
+        failures.push(format!(
+            "merkle disagreement between two clients: {root1} != {root2}"
+        ));
+    }
+
+    Ok(failures)
+}
+
+/// Quiesce + capture pre-crash state, `kill -9` + restart (WAL recovery), then
+/// verify the recovered state is byte-for-byte the pre-crash state. This tests
+/// crash recovery in isolation: no client writes occur across the boundary, so
+/// any post != pre is a recovery defect, not a lost-in-flight write.
+async fn recovery_checkpoint(
+    supervisor: &Arc<ServerSupervisor>,
+    model: &Arc<Model>,
+    jwt: &str,
+    config: &Config,
+    paused: &Arc<AtomicBool>,
+) -> Result<Vec<String>> {
+    paused.store(true, Ordering::SeqCst);
+    // Let in-flight acks settle and the write-behind buffer flush to redb+WAL.
+    tokio::time::sleep(config.quiesce).await;
+
+    let mut failures = Vec::new();
+
+    // Pre-crash snapshot (also a steady convergence check).
+    let (pre_lww, pre_root, pre_or_root) = {
+        let mut v = SoakClient::connect(supervisor.addr(), VERIFIER_IDX, jwt).await?;
+        let lww = v.read_all(LWW_MAP).await?;
+        let root = v.merkle_root(LWW_MAP).await?;
+        let or_root = if config.or_churn {
+            Some(v.merkle_root(OR_MAP).await?)
+        } else {
+            None
+        };
+        (lww, root, or_root)
+    };
+    let expected = model.snapshot();
+    let pre_diffs = compare(&expected, &pre_lww);
+    if !pre_diffs.is_empty() {
+        failures.push(format!(
+            "pre-crash convergence: {} key(s) diverged (e.g. {})",
+            pre_diffs.len(),
+            pre_diffs
+                .iter()
+                .take(5)
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    // kill -9 + restart against the same redb + WAL.
+    if let Err(e) = supervisor.restart(config.ready_timeout).await {
+        failures.push(format!("server failed to restart after kill -9: {e}"));
+        paused.store(false, Ordering::SeqCst);
+        return Ok(failures);
+    }
+
+    // Post-recovery snapshot — no writes happened in between.
+    let (post_lww, post_root, post_or_root) = {
+        let mut v = SoakClient::connect(supervisor.addr(), VERIFIER_IDX, jwt).await?;
+        let lww = v.read_all(LWW_MAP).await?;
+        let root = v.merkle_root(LWW_MAP).await?;
+        let or_root = if config.or_churn {
+            Some(v.merkle_root(OR_MAP).await?)
+        } else {
+            None
+        };
+        (lww, root, or_root)
+    };
+
+    if post_root != pre_root {
+        failures.push(format!(
+            "LWW merkle root changed across recovery: pre={pre_root} post={post_root}"
+        ));
+    }
+    let recov_diffs = compare(&pre_lww, &post_lww);
+    if !recov_diffs.is_empty() {
+        failures.push(format!(
+            "LWW state changed across recovery: {} key(s) (e.g. {})",
+            recov_diffs.len(),
+            recov_diffs
+                .iter()
+                .take(5)
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if pre_or_root != post_or_root {
+        failures.push(format!(
+            "OR-Map merkle root changed across recovery: pre={pre_or_root:?} post={post_or_root:?}"
+        ));
+    }
+
+    paused.store(false, Ordering::SeqCst);
+    Ok(failures)
+}
+
+// ---------------------------------------------------------------------------
+// Churn client
+// ---------------------------------------------------------------------------
+
+/// A single churn client: connects, replays its owned keys (durability +
+/// offline-buffer flush), writes a burst, disconnects, optionally buffers
+/// offline writes, and repeats. Each key is owned by exactly one client, so its
+/// expected value is unambiguous.
+async fn run_churn_client(idx: usize, ctx: ChurnCtx) {
+    let owned = ctx.model.keys_owned_by(idx);
+    if owned.is_empty() {
+        return;
+    }
+    // Client-local latest intended value per owned slot. Ahead of the model only
+    // while an offline-buffered write is pending; the model is updated solely on ack.
+    let mut local: std::collections::HashMap<usize, i64> = std::collections::HashMap::new();
+    let mut write_count: u64 = 0;
+    let mut rr: usize = 0;
+
+    loop {
+        if ctx.stop.load(Ordering::SeqCst) {
+            return;
+        }
+        // Do not (re)connect during a checkpoint quiesce.
+        while ctx.paused.load(Ordering::SeqCst) && !ctx.stop.load(Ordering::SeqCst) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        if ctx.stop.load(Ordering::SeqCst) {
+            return;
+        }
+
+        let Some(mut client) = connect_with_retry(&ctx, idx).await else {
+            continue;
+        };
+
+        // Replay: resend every owned key's latest local value. Restores any
+        // kill-window loss and flushes offline-buffered writes; idempotent under
+        // LWW (a fresh, higher HLC stamp always wins). Model updated on ack.
+        let mut session_alive = true;
+        for &slot in &owned {
+            if ctx.stop.load(Ordering::SeqCst) {
+                return;
+            }
+            if let Some(&v) = local.get(&slot) {
+                let key = Model::key_for(slot);
+                let (ms, ctr) = next_stamp();
+                if client.write_lww(LWW_MAP, &key, v, ms, ctr).await.is_ok() {
+                    ctx.model.record(&key, v);
+                    ctx.metrics.resends.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    session_alive = false;
+                    break;
+                }
+            }
+        }
+
+        // Active write burst.
+        let life = ctx.writes_per_life;
+        let mut n = 0;
+        while session_alive && n < life {
+            if ctx.stop.load(Ordering::SeqCst) {
+                return;
+            }
+            // Hold (without disconnecting) during a checkpoint quiesce.
+            while ctx.paused.load(Ordering::SeqCst) && !ctx.stop.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            if ctx.stop.load(Ordering::SeqCst) {
+                return;
+            }
+
+            let slot = owned[rr % owned.len()];
+            rr += 1;
+            let key = Model::key_for(slot);
+            let v = local.get(&slot).copied().unwrap_or(0) + 1;
+            let (ms, ctr) = next_stamp();
+            if client.write_lww(LWW_MAP, &key, v, ms, ctr).await.is_ok() {
+                local.insert(slot, v);
+                ctx.model.record(&key, v);
+                ctx.metrics.total_writes.fetch_add(1, Ordering::Relaxed);
+            } else {
+                ctx.metrics.write_errors.fetch_add(1, Ordering::Relaxed);
+                session_alive = false;
+                break;
+            }
+
+            // OR-Map add/remove to drive tombstone growth (memory watch).
+            write_count += 1;
+            if ctx.or_churn && write_count.is_multiple_of(ctx.or_every) {
+                let or_key = format!("ork-{}", slot % ctx.or_keyspace.max(1));
+                let tag = format!("{ms}:{ctr}:{idx}");
+                if client.or_add(OR_MAP, &or_key, &tag, ms, ctr).await.is_ok() {
+                    if client.or_remove(OR_MAP, &or_key, &tag).await.is_err() {
+                        session_alive = false;
+                        break;
+                    }
+                } else {
+                    session_alive = false;
+                    break;
+                }
+            }
+
+            tokio::time::sleep(ctx.write_interval).await;
+            n += 1;
+        }
+
+        // Churn: disconnect.
+        drop(client);
+
+        // Offline-write-then-reconnect: buffer a few increments locally. They are
+        // NOT recorded into the model until the next reconnect resends and acks
+        // them, so a crash while offline cannot manufacture a false divergence.
+        if ctx.offline_keys > 0 && session_alive {
+            for &slot in owned.iter().take(ctx.offline_keys) {
+                let v = local.get(&slot).copied().unwrap_or(0) + 1;
+                local.insert(slot, v);
+            }
+        }
+
+        // Brief disconnected gap (deterministic per-client jitter).
+        let jitter = 100 + (idx as u64 % 7) * 30;
+        tokio::time::sleep(Duration::from_millis(jitter)).await;
+    }
+}
+
+/// Connect with bounded retry, honoring the pause flag and stop signal.
+async fn connect_with_retry(ctx: &ChurnCtx, idx: usize) -> Option<SoakClient> {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        if ctx.stop.load(Ordering::SeqCst) {
+            return None;
+        }
+        while ctx.paused.load(Ordering::SeqCst) && !ctx.stop.load(Ordering::SeqCst) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        if ctx.stop.load(Ordering::SeqCst) {
+            return None;
+        }
+        if let Ok(c) = SoakClient::connect(ctx.supervisor.addr(), idx, &ctx.jwt_secret).await {
+            ctx.metrics.reconnects.fetch_add(1, Ordering::Relaxed);
+            return Some(c);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Negative control: divergence
+// ---------------------------------------------------------------------------
+
+/// Prove the convergence check can go red. Writes a handful of keys (server and
+/// model agree), then injects an op into the model that is deliberately NOT
+/// applied to the server ("skip applying one op on a replica"), and asserts the
+/// real convergence comparison detects the resulting divergence.
+async fn run_inject_divergence(config: &Config) -> i32 {
+    println!("=== NEGATIVE CONTROL: inject-divergence ===");
+    let binary = resolve_server_binary();
+    let tempdir = match tempfile::tempdir() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("FATAL: {e}");
+            return 2;
+        }
+    };
+    let port = match ServerSupervisor::pick_free_port() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("FATAL: {e}");
+            return 2;
+        }
+    };
+    let jwt = "test-e2e-secret".to_string();
+    let supervisor = ServerSupervisor::new(ServerConfig {
+        binary,
+        data_dir: tempdir.path().to_path_buf(),
+        port,
+        jwt_secret: jwt.clone(),
+        wal_fsync_policy: config.wal_fsync.clone(),
+    });
+    if let Err(e) = supervisor.start(config.ready_timeout).await {
+        eprintln!("FATAL: server start: {e}");
+        return 2;
+    }
+
+    let model = Model::new(16, 1);
+    let mut client = match SoakClient::connect(supervisor.addr(), 0, &jwt).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("FATAL: connect: {e}");
+            supervisor.shutdown().await;
+            return 2;
+        }
+    };
+
+    // Honest baseline: write k-0..k-9, recording each into the model.
+    for i in 0..10 {
+        let key = Model::key_for(i);
+        let (ms, ctr) = next_stamp();
+        if let Err(e) = client.write_lww(LWW_MAP, &key, i as i64, ms, ctr).await {
+            eprintln!("FATAL: baseline write: {e}");
+            supervisor.shutdown().await;
+            return 2;
+        }
+        model.record(&key, i as i64);
+    }
+
+    // INJECTION: record an op in the model that the server never sees.
+    let injected_key = Model::key_for(0);
+    model.record(&injected_key, 999_999);
+    println!("injected: model[{injected_key}]=999999 was NOT applied to the server");
+
+    tokio::time::sleep(config.quiesce).await;
+
+    let actual = match client.read_all(LWW_MAP).await {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("FATAL: read_all: {e}");
+            supervisor.shutdown().await;
+            return 2;
+        }
+    };
+    supervisor.shutdown().await;
+
+    let diffs = compare(&model.snapshot(), &actual);
+    if diffs.is_empty() {
+        eprintln!(
+            "NEGATIVE CONTROL FAILED: harness did NOT detect the injected divergence — \
+             the convergence check is blind and proves nothing"
+        );
+        return 3;
+    }
+    println!(
+        "NEGATIVE CONTROL PASSED: divergence correctly detected (assertion RED as expected): {}",
+        diffs
+            .iter()
+            .take(3)
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    // Exit non-zero: a detected divergence means the soak assertion is RED.
+    1
+}
+
+// ---------------------------------------------------------------------------
+// Negative control: panic
+// ---------------------------------------------------------------------------
+
+/// Prove the panic capture can go red. Runs a synthetic child that prints a Rust
+/// panic line and exits 101, feeds its output through the SAME `PanicWatch`
+/// detection code the supervisor uses, and asserts the watch tripped. This keeps
+/// the production server free of any test-only panic hook while still exercising
+/// the real detection path end-to-end.
+async fn run_inject_panic() -> i32 {
+    println!("=== NEGATIVE CONTROL: inject-panic ===");
+
+    let watch = process::PanicWatch::new_standalone();
+
+    let mut child = match tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg("echo \"thread 'main' panicked at src/synthetic.rs:1:1: injected soak panic\" 1>&2; exit 101")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("FATAL: cannot spawn synthetic panic process: {e}");
+            return 2;
+        }
+    };
+
+    if let Some(stderr) = child.stderr.take() {
+        let mut lines = BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            watch.record_line(&line);
+        }
+    }
+    if let Ok(status) = child.wait().await {
+        if !status.success() {
+            let detail = format!("synthetic exit status {status:?}");
+            watch.record_unexpected_exit(&detail);
+        }
+    }
+
+    if watch.tripped() {
+        println!(
+            "NEGATIVE CONTROL PASSED: panic correctly captured (assertion RED as expected):\n{}",
+            watch.report().unwrap_or_default()
+        );
+        1
+    } else {
+        eprintln!(
+            "NEGATIVE CONTROL FAILED: harness did NOT capture the synthetic panic — \
+             the panic watch is blind and proves nothing"
+        );
+        3
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+/// Every flag the soak recognizes. Presence of any one marks an explicit run
+/// mode (so foreign libtest args from `cargo test` do not trigger a default soak).
+const KNOWN_FLAGS: &[&str] = &[
+    "--duration",
+    "--churn-clients",
+    "--keyspace",
+    "--write-interval-ms",
+    "--writes-per-life",
+    "--offline-keys",
+    "--crash-interval",
+    "--steady-interval",
+    "--quiesce",
+    "--ready-timeout",
+    "--mem-sample-interval",
+    "--mem-threshold-mb-per-hour",
+    "--mem-min-growth-mb",
+    "--mem-ceiling-mb",
+    "--server-port",
+    "--data-dir",
+    "--wal-fsync",
+    "--or-churn",
+    "--or-keyspace",
+    "--or-every",
+    "--json-output",
+    "--progress-output",
+    "--inject-divergence",
+    "--inject-panic",
+    "--smoke",
+];
+
+fn print_usage() {
+    println!(
+        "TopGun soak harness (G4b / TODO-484)\n\n\
+         Drives the real out-of-process topgun-server against an on-disk redb + WAL,\n\
+         exercising churn, kill -9 crash loops, convergence/recovery assertions,\n\
+         memory-growth monitoring, and panic capture.\n\n\
+         No mode flag was given, so nothing ran. Examples:\n\
+         \x20 # 1h smoke soak with crash loop + JSON report\n\
+         \x20 soak_harness --duration 3600 --crash-interval 120 --json-output soak.json \\\n\
+         \x20              --progress-output soak-progress.jsonl\n\
+         \x20 # convenience preset (short, full-feature)\n\
+         \x20 soak_harness --smoke\n\
+         \x20 # negative controls (must exit non-zero == assertion RED)\n\
+         \x20 soak_harness --inject-divergence\n\
+         \x20 soak_harness --inject-panic\n\n\
+         See packages/server-rust/benches/soak_harness/README.md for the full flag list\n\
+         and the Hetzner 72h runner."
+    );
+}
+
+fn parse_args() -> Config {
+    let mut c = Config::default();
+    let args: Vec<String> = std::env::args().collect();
+    c.mode_requested = args
+        .iter()
+        .skip(1)
+        .any(|a| KNOWN_FLAGS.contains(&a.as_str()));
+    let mut i = 1;
+    let need = |i: usize, args: &[String], name: &str| -> String {
+        if i + 1 >= args.len() {
+            eprintln!("{name} requires a value");
+            std::process::exit(2);
+        }
+        args[i + 1].clone()
+    };
+    while i < args.len() {
+        match args[i].as_str() {
+            "--duration" => {
+                c.duration = Duration::from_secs(parse_u64(&need(i, &args, "--duration")));
+                i += 2;
+            }
+            "--churn-clients" => {
+                c.churn_clients = parse_usize(&need(i, &args, "--churn-clients")).max(1);
+                i += 2;
+            }
+            "--keyspace" => {
+                c.keyspace = parse_usize(&need(i, &args, "--keyspace")).max(1);
+                i += 2;
+            }
+            "--write-interval-ms" => {
+                c.write_interval =
+                    Duration::from_millis(parse_u64(&need(i, &args, "--write-interval-ms")));
+                i += 2;
+            }
+            "--writes-per-life" => {
+                c.writes_per_life = parse_usize(&need(i, &args, "--writes-per-life")).max(1);
+                i += 2;
+            }
+            "--offline-keys" => {
+                c.offline_keys = parse_usize(&need(i, &args, "--offline-keys"));
+                i += 2;
+            }
+            "--crash-interval" => {
+                let v = parse_u64(&need(i, &args, "--crash-interval"));
+                c.crash_interval = if v == 0 {
+                    None
+                } else {
+                    Some(Duration::from_secs(v))
+                };
+                i += 2;
+            }
+            "--steady-interval" => {
+                c.steady_interval =
+                    Duration::from_secs(parse_u64(&need(i, &args, "--steady-interval")).max(1));
+                i += 2;
+            }
+            "--quiesce" => {
+                c.quiesce = Duration::from_secs(parse_u64(&need(i, &args, "--quiesce")).max(1));
+                i += 2;
+            }
+            "--ready-timeout" => {
+                c.ready_timeout =
+                    Duration::from_secs(parse_u64(&need(i, &args, "--ready-timeout")).max(1));
+                i += 2;
+            }
+            "--mem-sample-interval" => {
+                c.mem_sample_interval =
+                    Duration::from_secs(parse_u64(&need(i, &args, "--mem-sample-interval")).max(1));
+                i += 2;
+            }
+            "--mem-threshold-mb-per-hour" => {
+                c.mem_threshold_mb_per_hour =
+                    parse_f64(&need(i, &args, "--mem-threshold-mb-per-hour"));
+                i += 2;
+            }
+            "--mem-min-growth-mb" => {
+                c.mem_min_growth_mb = parse_f64(&need(i, &args, "--mem-min-growth-mb"));
+                i += 2;
+            }
+            "--mem-ceiling-mb" => {
+                c.mem_ceiling_mb = parse_f64(&need(i, &args, "--mem-ceiling-mb"));
+                i += 2;
+            }
+            "--server-port" => {
+                c.server_port = parse_u64(&need(i, &args, "--server-port")) as u16;
+                i += 2;
+            }
+            "--data-dir" => {
+                c.data_dir = Some(PathBuf::from(need(i, &args, "--data-dir")));
+                i += 2;
+            }
+            "--wal-fsync" => {
+                c.wal_fsync = need(i, &args, "--wal-fsync");
+                i += 2;
+            }
+            "--or-churn" => {
+                c.or_churn = matches!(need(i, &args, "--or-churn").as_str(), "true" | "1" | "on");
+                i += 2;
+            }
+            "--or-keyspace" => {
+                c.or_keyspace = parse_usize(&need(i, &args, "--or-keyspace")).max(1);
+                i += 2;
+            }
+            "--or-every" => {
+                c.or_every = parse_u64(&need(i, &args, "--or-every")).max(1);
+                i += 2;
+            }
+            "--json-output" => {
+                c.json_output = Some(PathBuf::from(need(i, &args, "--json-output")));
+                i += 2;
+            }
+            "--progress-output" => {
+                c.progress_output = Some(PathBuf::from(need(i, &args, "--progress-output")));
+                i += 2;
+            }
+            "--inject-divergence" => {
+                c.inject_divergence = true;
+                i += 1;
+            }
+            "--inject-panic" => {
+                c.inject_panic = true;
+                i += 1;
+            }
+            "--smoke" => {
+                // Convenience preset: short but full-feature (used by CI + local).
+                c.duration = Duration::from_secs(25);
+                c.crash_interval = Some(Duration::from_secs(8));
+                c.steady_interval = Duration::from_secs(5);
+                c.churn_clients = 8;
+                c.keyspace = 64;
+                c.quiesce = Duration::from_secs(3);
+                c.or_keyspace = 16;
+                i += 1;
+            }
+            // Ignore cargo-injected bench args (e.g. the bench-name filter).
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    c
+}
+
+fn parse_u64(s: &str) -> u64 {
+    s.parse().unwrap_or_else(|_| {
+        eprintln!("expected an integer, got '{s}'");
+        std::process::exit(2);
+    })
+}
+
+fn parse_usize(s: &str) -> usize {
+    s.parse().unwrap_or_else(|_| {
+        eprintln!("expected an integer, got '{s}'");
+        std::process::exit(2);
+    })
+}
+
+fn parse_f64(s: &str) -> f64 {
+    s.parse().unwrap_or_else(|_| {
+        eprintln!("expected a number, got '{s}'");
+        std::process::exit(2);
+    })
+}

--- a/packages/server-rust/benches/soak_harness/model.rs
+++ b/packages/server-rust/benches/soak_harness/model.rs
@@ -1,0 +1,130 @@
+//! Authoritative client-side state model and convergence comparison.
+//!
+//! The soak uses a **bounded, single-writer-per-key** keyspace: key `k-{i}` is
+//! owned exclusively by churn client `i % clients`. Single-writer ownership
+//! makes the expected value of every key unambiguous (no concurrent-writer
+//! race), which is what lets the convergence check be exact rather than
+//! best-effort.
+//!
+//! Two properties fall out of this design:
+//!
+//! 1. **Convergence is decidable.** After a quiesced checkpoint the server's
+//!    read-back must equal this model for every touched key. Any mismatch is a
+//!    real divergence — the heart of the soak.
+//! 2. **Memory is bounded by construction.** A fixed keyspace overwritten in
+//!    place means legitimate data does not grow, so a rising RSS implicates a
+//!    leak (e.g. unbounded OR-Map tombstone accumulation, TODO-479/480) rather
+//!    than legitimate dataset growth.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use dashmap::DashMap;
+
+/// Process-wide logical counter feeding the HLC `counter` field. Strictly
+/// increasing, so successive writes (including post-reconnect resends) always
+/// win Last-Write-Wins against any earlier value for the same key.
+static LOGICAL_CLOCK: AtomicU64 = AtomicU64::new(1);
+
+/// Allocate the next monotonic `(millis, counter)` HLC pair for a write.
+#[allow(clippy::cast_possible_truncation)]
+pub fn next_stamp() -> (u64, u32) {
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let counter = LOGICAL_CLOCK.fetch_add(1, Ordering::Relaxed) as u32;
+    (millis, counter)
+}
+
+/// The harness's authoritative view of what every key's value should be: the
+/// latest value it has successfully acked. Shared across all churn clients and
+/// the convergence verifier.
+pub struct Model {
+    /// `key -> latest acked value`.
+    values: DashMap<String, i64>,
+    keyspace: usize,
+    clients: usize,
+}
+
+impl Model {
+    pub fn new(keyspace: usize, clients: usize) -> Self {
+        Self {
+            values: DashMap::new(),
+            keyspace,
+            clients: clients.max(1),
+        }
+    }
+
+    /// Key name for slot `i`.
+    pub fn key_for(i: usize) -> String {
+        format!("k-{i}")
+    }
+
+    /// The slots owned (solely written) by churn client `client_idx`.
+    pub fn keys_owned_by(&self, client_idx: usize) -> Vec<usize> {
+        (0..self.keyspace)
+            .filter(|i| i % self.clients == client_idx % self.clients)
+            .collect()
+    }
+
+    /// Record an acked write so the model reflects the new expected value.
+    pub fn record(&self, key: &str, value: i64) {
+        self.values.insert(key.to_string(), value);
+    }
+
+    /// Snapshot the full expected state. Taken while churn is quiesced, so it is
+    /// a consistent point-in-time view.
+    pub fn snapshot(&self) -> HashMap<String, i64> {
+        self.values
+            .iter()
+            .map(|e| (e.key().clone(), *e.value()))
+            .collect()
+    }
+}
+
+/// One disagreement between the model and the server's read-back.
+#[derive(Debug, Clone)]
+pub struct Divergence {
+    pub key: String,
+    pub expected: Option<i64>,
+    pub actual: Option<i64>,
+}
+
+impl std::fmt::Display for Divergence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "key={} expected={:?} actual={:?}",
+            self.key, self.expected, self.actual
+        )
+    }
+}
+
+/// Compare the harness model against a server read-back. Every key the harness
+/// has written must be present on the server with the identical value, and the
+/// server must hold no key the harness never wrote. Returns all disagreements.
+pub fn compare(expected: &HashMap<String, i64>, actual: &HashMap<String, i64>) -> Vec<Divergence> {
+    let mut diffs = Vec::new();
+    for (key, exp) in expected {
+        match actual.get(key) {
+            Some(act) if act == exp => {}
+            other => diffs.push(Divergence {
+                key: key.clone(),
+                expected: Some(*exp),
+                actual: other.copied(),
+            }),
+        }
+    }
+    for (key, act) in actual {
+        if !expected.contains_key(key) {
+            diffs.push(Divergence {
+                key: key.clone(),
+                expected: None,
+                actual: Some(*act),
+            });
+        }
+    }
+    diffs.sort_by(|a, b| a.key.cmp(&b.key));
+    diffs
+}

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -1,0 +1,137 @@
+//! Server memory monitoring for leak / unbounded-growth detection.
+//!
+//! The soak runs a fixed keyspace overwritten in place, so the server's
+//! resident set should plateau. A sustained upward trend implicates a leak —
+//! most plausibly unbounded OR-Map tombstone accumulation (TODO-479/480), which
+//! the soak deliberately drives via add/remove churn on an OR-Map.
+//!
+//! RSS is sampled by shelling out to `ps -o rss= -p <pid>` (KiB on both macOS
+//! and Linux), avoiding a platform-specific dependency. The assessment fits a
+//! least-squares line to `(elapsed_hours, rss_mb)` and fails if either the
+//! slope exceeds a per-hour threshold (with a minimum absolute growth guard to
+//! ignore short-run noise) or the peak exceeds a hard ceiling.
+
+use std::process::Command;
+
+/// One resident-set sample.
+#[derive(Debug, Clone, Copy)]
+pub struct MemSample {
+    pub elapsed_secs: f64,
+    pub rss_mb: f64,
+}
+
+/// Verdict of a memory-growth assessment.
+#[derive(Debug, Clone)]
+pub struct MemoryAssessment {
+    pub samples: usize,
+    pub first_mb: f64,
+    pub peak_mb: f64,
+    pub last_mb: f64,
+    pub slope_mb_per_hour: f64,
+    pub passed: bool,
+    pub reason: Option<String>,
+}
+
+/// Sample the resident set of `pid` in megabytes via `ps`. Returns `None` if
+/// the process is gone or `ps` output cannot be parsed (e.g. mid-restart).
+pub fn sample_rss_mb(pid: u32) -> Option<f64> {
+    let out = Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let kib: f64 = text.trim().parse().ok()?;
+    Some(kib / 1024.0)
+}
+
+/// Assess a series of samples for bounded memory.
+///
+/// * `threshold_mb_per_hour` — maximum tolerated growth slope.
+/// * `min_growth_mb` — absolute growth (peak − first) below which slope is
+///   treated as noise regardless of fit (guards tiny/short runs).
+/// * `ceiling_mb` — hard cap on peak RSS.
+#[allow(clippy::cast_precision_loss)]
+pub fn assess(
+    samples: &[MemSample],
+    threshold_mb_per_hour: f64,
+    min_growth_mb: f64,
+    ceiling_mb: f64,
+) -> MemoryAssessment {
+    if samples.is_empty() {
+        return MemoryAssessment {
+            samples: 0,
+            first_mb: 0.0,
+            peak_mb: 0.0,
+            last_mb: 0.0,
+            slope_mb_per_hour: 0.0,
+            passed: true,
+            reason: None,
+        };
+    }
+
+    let first_mb = samples[0].rss_mb;
+    let last_mb = samples[samples.len() - 1].rss_mb;
+    let peak_mb = samples.iter().fold(0.0_f64, |m, s| m.max(s.rss_mb));
+
+    let slope_mb_per_hour = least_squares_slope_per_hour(samples);
+
+    let growth = peak_mb - first_mb;
+    let mut reasons = Vec::new();
+
+    if peak_mb > ceiling_mb {
+        reasons.push(format!(
+            "peak RSS {peak_mb:.1}MB exceeds ceiling {ceiling_mb:.1}MB"
+        ));
+    }
+    if growth >= min_growth_mb && slope_mb_per_hour > threshold_mb_per_hour {
+        reasons.push(format!(
+            "growth slope {slope_mb_per_hour:.1}MB/h exceeds {threshold_mb_per_hour:.1}MB/h \
+             (total growth {growth:.1}MB over {} samples)",
+            samples.len()
+        ));
+    }
+
+    let passed = reasons.is_empty();
+    MemoryAssessment {
+        samples: samples.len(),
+        first_mb,
+        peak_mb,
+        last_mb,
+        slope_mb_per_hour,
+        passed,
+        reason: if passed {
+            None
+        } else {
+            Some(reasons.join("; "))
+        },
+    }
+}
+
+/// Least-squares slope of `rss_mb` vs. time, expressed in MB per hour. Returns
+/// 0 when there is insufficient variance in the time axis (e.g. one sample).
+#[allow(clippy::cast_precision_loss)]
+fn least_squares_slope_per_hour(samples: &[MemSample]) -> f64 {
+    let n = samples.len() as f64;
+    if n < 2.0 {
+        return 0.0;
+    }
+    // x in hours so the slope is directly MB/hour.
+    let xs: Vec<f64> = samples.iter().map(|s| s.elapsed_secs / 3600.0).collect();
+    let ys: Vec<f64> = samples.iter().map(|s| s.rss_mb).collect();
+    let mean_x = xs.iter().sum::<f64>() / n;
+    let mean_y = ys.iter().sum::<f64>() / n;
+    let mut num = 0.0;
+    let mut den = 0.0;
+    for (x, y) in xs.iter().zip(ys.iter()) {
+        num += (x - mean_x) * (y - mean_y);
+        den += (x - mean_x) * (x - mean_x);
+    }
+    if den.abs() < f64::EPSILON {
+        0.0
+    } else {
+        num / den
+    }
+}

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -61,14 +61,21 @@ pub fn assess(
     ceiling_mb: f64,
 ) -> MemoryAssessment {
     if samples.is_empty() {
+        // Zero samples over a real run means the monitor was BLIND (ps failing or
+        // the server pid never resolved) — a leak would be invisible. Fail rather
+        // than silently pass: an assertion that cannot observe must not report ok.
         return MemoryAssessment {
             samples: 0,
             first_mb: 0.0,
             peak_mb: 0.0,
             last_mb: 0.0,
             slope_mb_per_hour: 0.0,
-            passed: true,
-            reason: None,
+            passed: false,
+            reason: Some(
+                "no RSS samples collected — memory monitoring was blind (ps failed or server \
+                 pid never available); cannot assert bounded memory"
+                    .to_string(),
+            ),
         };
     }
 

--- a/packages/server-rust/benches/soak_harness/process.rs
+++ b/packages/server-rust/benches/soak_harness/process.rs
@@ -1,0 +1,360 @@
+//! Out-of-process `topgun-server` supervisor.
+//!
+//! The soak harness must `kill -9` the server and watch it recover real data
+//! from a real redb + WAL on disk — neither is possible with the in-process
+//! load-harness server (which runs on a `NullDataStore` inside the test
+//! process). This supervisor therefore launches the actual `topgun-server`
+//! binary (located via `CARGO_BIN_EXE_topgun-server`) as a child process,
+//! pointed at a fixed port and a persistent data directory, and can SIGKILL +
+//! relaunch it against the same files to exercise WAL recovery repeatedly.
+//!
+//! Every line the child writes to stdout/stderr is mirrored into a bounded ring
+//! buffer and scanned for panic markers as it arrives, so a panic anywhere in a
+//! 72-hour run is captured with surrounding context — not silently swallowed.
+
+use std::collections::VecDeque;
+use std::net::{SocketAddr, TcpListener};
+use std::os::unix::process::ExitStatusExt;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use parking_lot::Mutex;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::oneshot;
+
+/// Substrings that mark a Rust panic / abnormal runtime abort in server output.
+const PANIC_MARKERS: &[&str] = &[
+    "panicked at",
+    "fatal runtime error",
+    "stack backtrace:",
+    "Aborted (core dumped)",
+    "SIGABRT",
+];
+
+/// Number of recent log lines retained for crash-context reporting.
+const LOG_RING_CAPACITY: usize = 400;
+
+/// Configuration for launching the server child.
+#[derive(Clone)]
+pub struct ServerConfig {
+    /// Absolute path to the `topgun-server` binary.
+    pub binary: PathBuf,
+    /// Persistent data directory (holds the redb file and WAL subdir).
+    pub data_dir: PathBuf,
+    /// Loopback port the server binds; stable across restarts so clients
+    /// reconnect to the same address.
+    pub port: u16,
+    /// JWT signing secret shared with `SoakClient`.
+    pub jwt_secret: String,
+    /// WAL fsync policy (`perop` | `batched` | `none`).
+    pub wal_fsync_policy: String,
+}
+
+/// Captured server output plus a tripwire set the instant a panic marker is seen.
+pub struct PanicWatch {
+    tripped: AtomicBool,
+    /// The first panic line observed, with a few preceding lines for context.
+    report: Mutex<Option<String>>,
+    ring: Mutex<VecDeque<String>>,
+}
+
+impl PanicWatch {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            tripped: AtomicBool::new(false),
+            report: Mutex::new(None),
+            ring: Mutex::new(VecDeque::with_capacity(LOG_RING_CAPACITY)),
+        })
+    }
+
+    /// Construct a standalone watch not attached to a server, used by the
+    /// `--inject-panic` negative control to drive the real detection code
+    /// against synthetic panic output.
+    pub fn new_standalone() -> Arc<Self> {
+        Self::new()
+    }
+
+    /// Record one output line: append to the ring and, if it matches a panic
+    /// marker, trip the watch and snapshot recent context. This is the function
+    /// the `--inject-panic` negative control exercises directly.
+    pub fn record_line(&self, line: &str) {
+        {
+            let mut ring = self.ring.lock();
+            if ring.len() == LOG_RING_CAPACITY {
+                ring.pop_front();
+            }
+            ring.push_back(line.to_string());
+        }
+        if PANIC_MARKERS.iter().any(|m| line.contains(m))
+            && !self.tripped.swap(true, Ordering::SeqCst)
+        {
+            let ring = self.ring.lock();
+            let context: Vec<String> = ring.iter().rev().take(20).rev().cloned().collect();
+            *self.report.lock() = Some(format!(
+                "panic marker in server output:\n  >>> {line}\n  context (most recent lines):\n{}",
+                context
+                    .iter()
+                    .map(|l| format!("    {l}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ));
+        }
+    }
+
+    /// True once any panic marker has been seen.
+    pub fn tripped(&self) -> bool {
+        self.tripped.load(Ordering::SeqCst)
+    }
+
+    /// The captured panic report, if any.
+    pub fn report(&self) -> Option<String> {
+        self.report.lock().clone()
+    }
+
+    /// Force a report from an unexpected (un-requested) child exit, e.g. exit
+    /// code 101 (panic=unwind) or a non-SIGKILL termination signal.
+    pub fn record_unexpected_exit(&self, detail: &str) {
+        if !self.tripped.swap(true, Ordering::SeqCst) {
+            let ring = self.ring.lock();
+            let context: Vec<String> = ring.iter().rev().take(20).rev().cloned().collect();
+            *self.report.lock() = Some(format!(
+                "unexpected server exit: {detail}\n  context (most recent lines):\n{}",
+                context
+                    .iter()
+                    .map(|l| format!("    {l}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ));
+        }
+    }
+}
+
+/// Supervises one server child at a time, restarting it on demand.
+pub struct ServerSupervisor {
+    config: ServerConfig,
+    child: Mutex<Option<Child>>,
+    /// Set true immediately before a deliberate SIGKILL so the exit watcher does
+    /// not misreport our own `kill -9` as a crash.
+    intentional_kill: Arc<AtomicBool>,
+    panic_watch: Arc<PanicWatch>,
+}
+
+impl ServerSupervisor {
+    /// Build a supervisor; does not start the child yet.
+    pub fn new(config: ServerConfig) -> Arc<Self> {
+        Arc::new(Self {
+            config,
+            child: Mutex::new(None),
+            intentional_kill: Arc::new(AtomicBool::new(false)),
+            panic_watch: PanicWatch::new(),
+        })
+    }
+
+    /// Address clients connect to (stable across restarts).
+    pub fn addr(&self) -> SocketAddr {
+        SocketAddr::from(([127, 0, 0, 1], self.config.port))
+    }
+
+    pub fn panic_watch(&self) -> Arc<PanicWatch> {
+        Arc::clone(&self.panic_watch)
+    }
+
+    /// PID of the currently running child, if any. Changes across restarts, so
+    /// the memory sampler must re-read it every tick.
+    pub fn current_pid(&self) -> Option<u32> {
+        self.child
+            .lock()
+            .as_ref()
+            .and_then(tokio::process::Child::id)
+    }
+
+    /// Pick a free loopback port by binding `:0` and immediately releasing it.
+    /// Used when the caller passes `--server-port 0` so restarts reuse one port.
+    pub fn pick_free_port() -> Result<u16> {
+        let listener = TcpListener::bind("127.0.0.1:0").context("probe free port")?;
+        let port = listener.local_addr()?.port();
+        drop(listener);
+        Ok(port)
+    }
+
+    /// Launch the child and block until it prints its `PORT=` readiness line
+    /// (which the server emits only after WAL recovery completes and the
+    /// listener is bound). Returns an error if the child dies or the line does
+    /// not appear within `ready_timeout`.
+    pub async fn start(self: &Arc<Self>, ready_timeout: Duration) -> Result<()> {
+        let mut cmd = Command::new(&self.config.binary);
+        cmd.arg("--port")
+            .arg(self.config.port.to_string())
+            .env("STORAGE_BACKEND", "redb")
+            .env("TOPGUN_REDB_PATH", self.config.data_dir.join("topgun.redb"))
+            .env("TOPGUN_WAL_DIR", self.config.data_dir.join("wal"))
+            .env("TOPGUN_WAL_FSYNC_POLICY", &self.config.wal_fsync_policy)
+            .env("TOPGUN_BIND_ADDR", "127.0.0.1")
+            .env("JWT_SECRET", &self.config.jwt_secret)
+            // Keep journal on (production default) so the soak measures the real
+            // write path; capacity small since the soak never reads the journal.
+            .env("TOPGUN_JOURNAL_ENABLED", "true")
+            .env("RUST_BACKTRACE", "1")
+            // Quiet the server's own logs unless the operator opts in.
+            .env(
+                "RUST_LOG",
+                std::env::var("SOAK_SERVER_LOG").unwrap_or_else(|_| "warn".to_string()),
+            )
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = cmd.spawn().context("spawn topgun-server")?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("child stdout not captured"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("child stderr not captured"))?;
+
+        // `PORT=` arrives on stdout; deliver it once via a oneshot.
+        let (ready_tx, ready_rx) = oneshot::channel::<()>();
+        let ready_tx = Arc::new(Mutex::new(Some(ready_tx)));
+
+        spawn_line_reader(stdout, Arc::clone(&self.panic_watch), Some(ready_tx));
+        spawn_line_reader(stderr, Arc::clone(&self.panic_watch), None);
+
+        // Reset the intentional-kill flag for the new child generation.
+        self.intentional_kill.store(false, Ordering::SeqCst);
+        *self.child.lock() = Some(child);
+
+        // Watch for an unexpected exit of THIS generation.
+        self.spawn_exit_watcher();
+
+        match tokio::time::timeout(ready_timeout, ready_rx).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(_)) => bail!("server exited before signalling readiness"),
+            Err(_) => bail!("server did not become ready within {ready_timeout:?}"),
+        }
+    }
+
+    /// SIGKILL the current child (unclean shutdown — no graceful drain) and wait
+    /// for it to reap. Marks the kill intentional so the exit watcher stays quiet.
+    pub async fn kill9(&self) {
+        self.intentional_kill.store(true, Ordering::SeqCst);
+        // Take the child out from under the lock, then await its reap without
+        // holding the (non-async) lock across the await point.
+        let child = self.child.lock().take();
+        if let Some(mut child) = child {
+            // start_kill sends SIGKILL on Unix — the un-catchable kill -9.
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+        }
+    }
+
+    /// `kill -9` then relaunch against the same data dir, exercising one full
+    /// WAL-recovery cycle.
+    pub async fn restart(self: &Arc<Self>, ready_timeout: Duration) -> Result<()> {
+        self.kill9().await;
+        // Brief gap so the OS releases the listening socket before rebind.
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        self.start(ready_timeout).await
+    }
+
+    /// Final teardown: SIGKILL without restart.
+    pub async fn shutdown(&self) {
+        self.kill9().await;
+    }
+
+    /// Spawn a task that reaps the current child and, if it died without an
+    /// intentional kill, records an unexpected-exit panic report.
+    ///
+    /// tokio's `Child` is not `Clone` and cannot be awaited from two places, so
+    /// this polls `try_wait` periodically. All lock access is confined to the
+    /// synchronous `poll_child_exit` helper so no guard is held across an await.
+    fn spawn_exit_watcher(self: &Arc<Self>) {
+        let this = Arc::clone(self);
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                match this.poll_child_exit() {
+                    ChildOutcome::Exited(detail) => {
+                        if !this.intentional_kill.load(Ordering::SeqCst) {
+                            this.panic_watch.record_unexpected_exit(&detail);
+                        }
+                        return;
+                    }
+                    ChildOutcome::Gone => return,
+                    ChildOutcome::Running => {}
+                }
+            }
+        });
+    }
+
+    /// Synchronously poll the current child's status, clearing the slot on exit.
+    /// Holds the lock only for the duration of this call (no awaits inside).
+    fn poll_child_exit(&self) -> ChildOutcome {
+        let mut guard = self.child.lock();
+        let Some(child) = guard.as_mut() else {
+            return ChildOutcome::Gone;
+        };
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let detail = match (status.code(), status.signal()) {
+                    (Some(c), _) => format!("exited with code {c}"),
+                    (None, Some(s)) => format!("terminated by signal {s}"),
+                    _ => "exited (unknown status)".to_string(),
+                };
+                *guard = None;
+                ChildOutcome::Exited(detail)
+            }
+            Ok(None) => ChildOutcome::Running,
+            Err(_) => ChildOutcome::Gone,
+        }
+    }
+}
+
+/// Result of polling the supervised child's status.
+enum ChildOutcome {
+    Running,
+    Exited(String),
+    Gone,
+}
+
+/// Spawn a task that reads `reader` line-by-line, mirroring each line into the
+/// panic watch and (for stdout) signalling readiness on the first `PORT=` line.
+fn spawn_line_reader<R>(
+    reader: R,
+    panic_watch: Arc<PanicWatch>,
+    ready_tx: Option<Arc<Mutex<Option<oneshot::Sender<()>>>>>,
+) where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(reader).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            panic_watch.record_line(&line);
+            if let Some(tx) = &ready_tx {
+                if line.starts_with("PORT=") {
+                    if let Some(sender) = tx.lock().take() {
+                        let _ = sender.send(());
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Resolve the `topgun-server` binary path. Prefers the Cargo-provided
+/// `CARGO_BIN_EXE_topgun-server` (set for benches), falling back to the
+/// `SOAK_SERVER_BINARY` env override for ad-hoc runs against a prebuilt binary.
+pub fn resolve_server_binary() -> PathBuf {
+    if let Ok(p) = std::env::var("SOAK_SERVER_BINARY") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(env!("CARGO_BIN_EXE_topgun-server"))
+}

--- a/packages/server-rust/benches/soak_harness/report.rs
+++ b/packages/server-rust/benches/soak_harness/report.rs
@@ -1,0 +1,151 @@
+//! JSON report + live progress snapshots.
+//!
+//! A 72-hour run must be observable while it is in flight, so the harness
+//! appends a one-line JSON snapshot to a progress file on every checkpoint
+//! (tail-able by the operator) and writes a final structured report at the end
+//! for CI/ops consumption.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+use serde::Serialize;
+
+/// Memory section of the final report.
+#[derive(Debug, Clone, Serialize)]
+pub struct MemoryReport {
+    pub samples: usize,
+    pub first_mb: f64,
+    pub peak_mb: f64,
+    pub last_mb: f64,
+    pub slope_mb_per_hour: f64,
+    pub passed: bool,
+    pub reason: Option<String>,
+}
+
+/// Final structured outcome of a soak run.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SoakReport {
+    pub mode: String,
+    pub duration_secs_target: u64,
+    pub duration_secs_actual: u64,
+    pub churn_clients: usize,
+    pub keyspace: usize,
+    pub total_writes: u64,
+    pub write_errors: u64,
+    pub reconnects: u64,
+    pub resends: u64,
+    pub steady_checkpoints: u64,
+    pub recovery_checkpoints: u64,
+    pub crashes: u64,
+    pub convergence_failures: Vec<String>,
+    pub recovery_failures: Vec<String>,
+    pub memory: MemoryReport,
+    pub panic_report: Option<String>,
+    pub passed: bool,
+    pub finished_reason: String,
+    pub timestamp: String,
+}
+
+/// One progress snapshot line (JSONL).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgressSnapshot {
+    pub timestamp: String,
+    pub elapsed_secs: u64,
+    pub phase: String,
+    pub total_writes: u64,
+    pub write_errors: u64,
+    pub reconnects: u64,
+    pub crashes: u64,
+    pub steady_checkpoints: u64,
+    pub recovery_checkpoints: u64,
+    pub last_convergence_ok: bool,
+    pub peak_rss_mb: f64,
+    pub last_rss_mb: f64,
+    pub panics_seen: bool,
+}
+
+/// Append a progress snapshot as a single JSON line. Best-effort: a write error
+/// is logged but never aborts the soak.
+pub fn append_progress(path: &Path, snap: &ProgressSnapshot) {
+    let line = match serde_json::to_string(snap) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("progress serialize failed: {e}");
+            return;
+        }
+    };
+    match OpenOptions::new().create(true).append(true).open(path) {
+        Ok(mut f) => {
+            if let Err(e) = writeln!(f, "{line}") {
+                eprintln!("progress write failed: {e}");
+            }
+        }
+        Err(e) => eprintln!("progress open failed for {}: {e}", path.display()),
+    }
+}
+
+/// Write the final report as pretty JSON.
+pub fn write_report(path: &Path, report: &SoakReport) {
+    match std::fs::File::create(path) {
+        Ok(f) => {
+            if let Err(e) = serde_json::to_writer_pretty(f, report) {
+                eprintln!("report write failed: {e}");
+            }
+        }
+        Err(e) => eprintln!("report create failed for {}: {e}", path.display()),
+    }
+}
+
+/// `YYYY-MM-DDTHH:MM:SSZ` from `SystemTime`, no external date crate.
+#[allow(clippy::cast_possible_truncation)]
+pub fn utc_timestamp_now() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let hh = (secs % 86400) / 3600;
+    let mm = (secs % 3600) / 60;
+    let ss = secs % 60;
+    let mut days = secs / 86400;
+    let mut year: u64 = 1970;
+    loop {
+        let diy = if is_leap(year) { 366 } else { 365 };
+        if days < diy {
+            break;
+        }
+        days -= diy;
+        year += 1;
+    }
+    let leap = is_leap(year);
+    let md: [u64; 12] = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut month = 1;
+    for &m in &md {
+        if days < m {
+            break;
+        }
+        days -= m;
+        month += 1;
+    }
+    let day = days + 1;
+    format!("{year:04}-{month:02}-{day:02}T{hh:02}:{mm:02}:{ss:02}Z")
+}
+
+fn is_leap(y: u64) -> bool {
+    (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)
+}


### PR DESCRIPTION
## What

Adds `packages/server-rust/benches/soak_harness/` (TODO-484, G4b): a long-duration **endurance** harness that drives the **real out-of-process `topgun-server`** against an **on-disk redb + WAL**. The in-process `load_harness` runs on a `NullDataStore` and so can neither `kill -9` nor recover — this is a separate bench binary.

It continuously asserts four properties and fails with context the moment any breaks:

| Property | Check |
|---|---|
| **Convergence** | quiesce churn → read every key back (`QUERY_SUB`) → compare to an authoritative single-writer-per-key model + cross-client Merkle-root agreement |
| **Crash recovery** | quiesce → snapshot (Merkle root + all values) → `kill -9` → restart (WAL recovery) → snapshot → assert identical |
| **Bounded memory** | sample server RSS (`ps`); fail on slope > threshold (min-growth guarded) or peak > ceiling; OR-Map add/remove churn drives tombstone growth (TODO-479/480) |
| **Zero panics** | live stdout/stderr panic scan + unexpected-exit capture with log context |

## Negative controls (prove the harness can fail)

- `--inject-divergence` — records an op in the model that is **not** applied to the server ("skip applying one op on a replica"); the real read-back compare must detect it. Verified **exit 1 (RED)**.
- `--inject-panic` — feeds a synthetic Rust panic line + exit-101 through the **same** `PanicWatch` the supervisor uses. Verified **exit 1 (RED)**.

A soak that cannot fail proves nothing — both controls are wired into CI and must go RED.

## Validation (local, under `caffeinate`)

- Negative controls: both RED ✅
- No-crash soak (churn + steady convergence + memory + OR churn): **PASS** (4561 writes, 7 converged checkpoints, bounded memory, 0 panics) ✅
- Crash-loop soak: correctly **FAILED**, surfacing a real recovery defect (below) ✅

## Real finding surfaced (tracked locally as TODO-530, HIGH)

On its first crash-recovery checkpoint the soak found: after `kill -9` + restart, the redb-backed server serves an **empty** map (Merkle root `0`) although `topgun.redb` holds 1.5 MB of durable data. Root cause: `QueryService` full-scan (`get_all_for_map` + `for_each_boxed`) and Merkle sync read **only** the in-memory `StorageEngine`, which is **not rehydrated** on restart (only point-`get` lazy-loads). Also latent under eviction. WAL replay restores the datastore but not the in-memory stores. This is exactly the class of defect a crash-loop + convergence soak exists to catch. Fix is a separate spec.

Until TODO-530 lands the **crash-loop path is RED by design**; CI runs the no-crash convergence/churn/memory mode + both negative controls (all green). The full 72h crash-loop runs on a Hetzner scratch box.

## CI / ops

- New blocking `soak-smoke` job: builds the bin + bench, runs both negative controls (must go RED) + a 25s no-crash soak (must be green).
- Bare invocation no-ops (prints usage) so `cargo test --all-targets` never launches a default soak.
- `hetzner-soak-runner.sh` + `SOAK_RUNNER.md`: 72h runner on a scratch box (refuses the demo box), `nohup`/systemd, JSONL progress for remote `tail -f`, final JSON report.

## Gate

- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets --all-features -p topgun-server -- -D warnings` ✅
- Negative controls + no-crash soak validated locally ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)