### PR TITLE
fix(sf-325b): tree-walk delta SYNC on durable Merkle index (close TODO-530/539 residency coupling)

### DIFF
--- a/packages/server-rust/benches/load_harness/main.rs
+++ b/packages/server-rust/benches/load_harness/main.rs
@@ -669,6 +669,11 @@ fn build_services() -> (
         )
         .with_journal(Arc::clone(&journal_store)),
     );
+    // No durable index here on purpose: this harness runs on a NullDataStore,
+    // which persists nothing, so a durable session would always be empty. The
+    // in-memory MerkleSyncManager fallback is the only valid SYNC source for an
+    // in-process NullDataStore run. The production binary (which runs on redb /
+    // postgres) wires the durable index via `with_durable_index`.
     let sync_svc = Arc::new(SyncService::new(
         merkle_manager,
         Arc::clone(&record_store_factory),

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -577,8 +577,8 @@ fn print_summary(r: &SoakReport) {
 /// Quiesce churn, then verify the server read-back equals the model exactly and
 /// that two client connections agree on the Merkle root. No re-assertion of
 /// state, so this genuinely tests that the server stored every acked write.
-/// Returns `(hard, pending)` failures. `hard` reddens the run; `pending` is the
-/// TODO-530 residency-coupled Merkle track, logged but non-fatal.
+/// Returns `(hard, pending)` failures. `hard` reddens the run; `pending` is
+/// reserved for future expected-fail gates (currently empty).
 async fn steady_checkpoint(
     supervisor: &Arc<ServerSupervisor>,
     model: &Arc<Model>,
@@ -599,7 +599,7 @@ async fn steady_checkpoint_inner(
     jwt: &str,
 ) -> Result<(Vec<String>, Vec<String>)> {
     let mut hard = Vec::new();
-    let mut pending = Vec::new();
+    let pending = Vec::new();
     let expected = model.snapshot();
 
     // HARD: full-scan read-your-writes convergence — the read surface this spec
@@ -620,16 +620,15 @@ async fn steady_checkpoint_inner(
         ));
     }
 
-    // PENDING (TODO-530): two clients can read different Merkle roots from the
-    // SAME live server because the root reflects the *resident* set, which active
-    // eviction mutates between the two reads. This is the residency-coupled Merkle
-    // index (SYNC-treewalk track), NOT the read-surface buffer-awareness above.
+    // HARD: two clients must agree on the Merkle root. DurableMerkleIndex
+    // (SPEC-325b / SYNC-treewalk) now builds from the datastore rather than the
+    // resident set, so eviction no longer mutates the root between reads.
     let root1 = v1.merkle_root(LWW_MAP).await?;
     let mut v2 = SoakClient::connect(supervisor.addr(), VERIFIER_IDX + 1, jwt).await?;
     let root2 = v2.merkle_root(LWW_MAP).await?;
     if root1 != root2 {
-        pending.push(format!(
-            "[TODO-530] merkle disagreement between two clients under eviction: {root1} != {root2}"
+        hard.push(format!(
+            "merkle disagreement between two clients under eviction: {root1} != {root2}"
         ));
     }
 
@@ -639,19 +638,14 @@ async fn steady_checkpoint_inner(
 /// Outcome of a recovery checkpoint, split into required vs known-pending gates.
 ///
 /// `hard` failures fail the run. `pending_gates` records capabilities that are
-/// owned by a separate, tracked track and whose failure is *expected* on this
-/// branch — they are logged (never silently dropped) but must not redden the
-/// soak. Each carries strict-xfail → xpass semantics: if a pending gate ever
-/// turns green, it is promoted to a `hard` failure so a maintainer flips it to
-/// required and it can never silently regress. Two tracks live here:
-///   - SPEC-322b: the QUERY-path full-scan post-restart read-back.
-///   - TODO-530 (residency-coupled Merkle / SYNC-treewalk track): the Merkle
-///     root + delta-sync leaf read-back across restart. The Merkle root/index is
-///     computed from the *resident* set, so a `kill -9` (which drops the in-memory
-///     index) and active eviction (which mutates residency) both change it. The
-///     fix is a datastore-backed, residency-independent Merkle index, owned by
-///     the SYNC-treewalk track — NOT the read-surface buffer-awareness this
-///     soak's read paths now verify.
+/// owned by a separate, tracked track and whose failure is *expected* — they are
+/// logged (never silently dropped) but must not redden the soak. Each carries
+/// strict-xfail → xpass semantics: if a pending gate turns green it is promoted
+/// to a `hard` failure so a maintainer flips it to required and it can never
+/// silently regress. All prior TODO-530 gates (Merkle root + delta-sync +
+/// QUERY-path full-scan) have been promoted to `hard` by SPEC-325b; this struct
+/// is preserved so new expected-fail gates can be added without changing the
+/// checkpoint interface.
 #[derive(Default)]
 struct RecoveryOutcome {
     hard: Vec<String>,
@@ -733,31 +727,26 @@ async fn recovery_checkpoint(
         (query, delta, root, or_root)
     };
 
-    // PENDING (TODO-530, residency-coupled Merkle / SYNC-treewalk track): the
-    // Merkle root/index is built from the *resident* set, which a `kill -9`
-    // discards. Until a datastore-backed, residency-independent Merkle index
-    // lands, the root legitimately changes across restart. Logged, not fatal —
-    // this is NOT the read-surface buffer-awareness the convergence gate (above)
-    // verifies. When SYNC-treewalk lands, re-promote these to `hard`.
+    // HARD: DurableMerkleIndex (SPEC-325b) builds from the datastore, not the
+    // resident set, so the Merkle root must survive a kill -9 + restart unchanged.
     if post_root != pre_root {
-        out.pending_gates.push(format!(
-            "[TODO-530] LWW merkle root changed across recovery: pre={pre_root} post={post_root}"
+        out.hard.push(format!(
+            "LWW merkle root changed across recovery: pre={pre_root} post={post_root}"
         ));
     }
     if pre_or_root != post_or_root {
-        out.pending_gates.push(format!(
-            "[TODO-530] OR-Map merkle root changed across recovery: pre={pre_or_root:?} post={post_or_root:?}"
+        out.hard.push(format!(
+            "OR-Map merkle root changed across recovery: pre={pre_or_root:?} post={post_or_root:?}"
         ));
     }
 
-    // PENDING (TODO-530): the delta-sync leaf-fetch path drills the Merkle tree
-    // and lazy-loads each leaf. Post-restart it inherits the same residency
-    // coupling as the root above (the index is not rehydrated from the datastore),
-    // so durable-but-non-resident leaves read stale/missing until SYNC-treewalk.
+    // HARD: the delta-sync leaf-fetch path drills the DurableMerkleIndex, which
+    // now reads from the datastore. Post-restart the index is rebuilt from durable
+    // storage, so every leaf must be reachable regardless of residency.
     let delta_diffs = compare(&pre_lww, &post_delta);
     if !delta_diffs.is_empty() {
-        out.pending_gates.push(format!(
-            "[TODO-530] LWW delta-sync read-back changed across recovery: {} key(s) (e.g. {})",
+        out.hard.push(format!(
+            "LWW delta-sync read-back changed across recovery: {} key(s) (e.g. {})",
             delta_diffs.len(),
             delta_diffs
                 .iter()
@@ -768,13 +757,13 @@ async fn recovery_checkpoint(
         ));
     }
 
-    // PENDING (TODO-530): the full-scan QUERY path post-restart reads whatever the
-    // datastore-backed scan rehydrates; under the same residency coupling it can
-    // read stale/missing until SYNC-treewalk. Tracked, not fatal.
+    // HARD: SPEC-322c wired FullScanPager with a datastore-backed streaming scan,
+    // so the full-scan QUERY path must return the complete persisted dataset after
+    // restart with no residency dependency.
     let query_diffs = compare(&pre_lww, &post_query);
     if !query_diffs.is_empty() {
-        out.pending_gates.push(format!(
-            "[TODO-530] QUERY-path full-scan read-back not recovered post-restart: {} key(s) (e.g. {})",
+        out.hard.push(format!(
+            "QUERY-path full-scan read-back not recovered post-restart: {} key(s) (e.g. {})",
             query_diffs.len(),
             query_diffs
                 .iter()

--- a/packages/server-rust/benches/soak_harness/process.rs
+++ b/packages/server-rust/benches/soak_harness/process.rs
@@ -196,6 +196,27 @@ impl ServerSupervisor {
             .env("TOPGUN_WAL_FSYNC_POLICY", &self.config.wal_fsync_policy)
             .env("TOPGUN_BIND_ADDR", "127.0.0.1")
             .env("JWT_SECRET", &self.config.jwt_secret)
+            // Crash recovery (AC1/G4b) asserts that DURABLE state survives a
+            // `kill -9` and is re-served residency-independently. It does NOT
+            // assert the in-flight write-behind window is durable — acked writes
+            // buffer ~1s before persisting, and losing that window on an unclean
+            // kill is an accepted demo-tier tradeoff tracked separately (TODO-339).
+            // So the buffer must be flushed to redb+WAL before the kill, otherwise
+            // the recovery checkpoint races the flush and reports phantom one-behind
+            // losses. The checkpoint pauses churn and quiesces; a fast flush
+            // interval guarantees the (now-static) backlog drains inside that
+            // window regardless of load. Operator can override to exercise the
+            // production-default flush cadence explicitly.
+            .env(
+                "TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS",
+                std::env::var("TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS")
+                    .unwrap_or_else(|_| "100".to_string()),
+            )
+            .env(
+                "TOPGUN_WRITEBEHIND_BATCH_SIZE",
+                std::env::var("TOPGUN_WRITEBEHIND_BATCH_SIZE")
+                    .unwrap_or_else(|_| "5000".to_string()),
+            )
             // Keep journal on (production default) so the soak measures the real
             // write path; capacity small since the soak never reads the journal.
             .env("TOPGUN_JOURNAL_ENABLED", "true")

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -87,6 +87,7 @@ use topgun_server::storage::datastores::RedbDataStore;
 use topgun_server::storage::datastores::{
     NullDataStore, WalBootstrap, WriteBehindConfig, WriteBehindDataStore,
 };
+use topgun_server::storage::durable_merkle::DurableMerkle;
 use topgun_server::storage::eviction_config::EvictionConfig;
 use topgun_server::storage::eviction_orchestrator::EvictionOrchestrator;
 use topgun_server::storage::factory::{ObserverFactory, RecordStoreFactory};
@@ -1702,11 +1703,30 @@ fn build_services(
         )
         .with_journal(Arc::clone(&journal_store)),
     );
-    let sync_svc = Arc::new(SyncService::new(
+    // Wire the durable Merkle index so SYNC tree-walk reads resolve from the
+    // persisted backend, not the eviction-coupled in-memory tree.
+    // `datastore_for_merkle_seed` is the same write-behind-wrapped durable
+    // backend the write path persists to, so the enumerated leaf set is
+    // authoritative over records that are durable but not resident.
+    // `build_services` always runs on the multi-threaded runtime, so
+    // `build_session`'s internal `block_in_place` is safe.
+    //
+    // Only wire it for durable backends: the Null backend persists nothing, so a
+    // durable session would always be empty — the in-memory MerkleSyncManager is
+    // the only valid SYNC source there. This mirrors the merkle-seed guard below.
+    let sync_base = SyncService::new(
         merkle_manager,
         Arc::clone(&record_store_factory),
         Arc::clone(&connection_registry),
-    ));
+    );
+    let sync_svc = Arc::new(if datastore_for_merkle_seed.is_null() {
+        sync_base
+    } else {
+        sync_base.with_durable_index(
+            Arc::new(DurableMerkle),
+            Arc::clone(&datastore_for_merkle_seed),
+        )
+    });
     let query_svc_base = QueryService::new(
         Arc::clone(&query_registry),
         Arc::clone(&record_store_factory),

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -305,9 +305,13 @@ impl SyncService {
             // Check for internal node (has children in the LWW trie at this path).
             let lww_children = session.lww_nodes.get(&path).cloned().unwrap_or_default();
             if !lww_children.is_empty() {
+                // Aggregate mode: bucket keys are single hex chars. The client
+                // extends its current path by each char, so returning a full
+                // path here would double-prefix (e.g. at path "a" the child 'b'
+                // must be sent as "b", not "ab", or the client drills to "ab"+"b").
                 let buckets: HashMap<String, u32> = lww_children
                     .into_iter()
-                    .map(|(c, h)| (format!("{path}{c}"), h))
+                    .map(|(c, h)| (c.to_string(), h))
                     .collect();
                 return Ok(OperationResponse::Message(Box::new(
                     Message::SyncRespBuckets(SyncRespBucketsMessage {
@@ -600,9 +604,11 @@ impl SyncService {
             // Check for OR-Map internal node at this path.
             let ormap_children = session.ormap_nodes.get(&path).cloned().unwrap_or_default();
             if !ormap_children.is_empty() {
+                // Aggregate mode: single-char bucket keys (see the LWW handler) —
+                // the client appends each char to its current path itself.
                 let buckets: HashMap<String, u32> = ormap_children
                     .into_iter()
-                    .map(|(c, h)| (format!("{path}{c}"), h))
+                    .map(|(c, h)| (c.to_string(), h))
                     .collect();
                 return Ok(OperationResponse::Message(Box::new(
                     Message::ORMapSyncRespBuckets(ORMapSyncRespBuckets {
@@ -2324,6 +2330,139 @@ mod tests {
                 OperationResponse::Message(_) | OperationResponse::Empty
             ),
             "expected Message or Empty response after session-cached bucket request"
+        );
+    }
+
+    /// End-to-end durable tree-walk: drive the exact reconnecting-client protocol
+    /// (`SYNC_INIT` root → `MerkleReqBucket` DFS from `""` → `SYNC_RESP_LEAF`)
+    /// against a `SyncService` whose durable index AND record-store factory are
+    /// both backed by the SAME real redb store, and assert every seeded key is
+    /// recovered through the walk. This is the machine check the soak harness'
+    /// recovery checkpoint performs; the AC9 tests stop at "didn't panic / not
+    /// the in-memory path" and never assert leaf delivery.
+    #[tokio::test(flavor = "multi_thread")]
+    #[allow(clippy::too_many_lines)]
+    async fn durable_tree_walk_recovers_all_seeded_keys() {
+        use crate::storage::datastores::RedbDataStore;
+        use crate::storage::durable_merkle::DurableMerkle;
+        use std::collections::HashMap;
+        use tower::ServiceExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(RedbDataStore::new(dir.path().join("walk.redb")).expect("redb open"));
+
+        // Seed enough keys to force a multi-level trie (internal nodes + leaves).
+        let mut expected: HashMap<String, i64> = HashMap::new();
+        for i in 0..64u32 {
+            let key = format!("walk-key-{i:04}");
+            store
+                .add(
+                    "wmap",
+                    &key,
+                    &RecordValue::Lww {
+                        value: Value::Int(i64::from(i)),
+                        timestamp: Timestamp {
+                            millis: u64::from(i) + 1,
+                            counter: i,
+                            node_id: "n1".to_string(),
+                        },
+                    },
+                    0,
+                    1,
+                )
+                .await
+                .expect("seed");
+            expected.insert(key, i64::from(i));
+        }
+
+        // Record factory backed by the SAME store so leaf fetches lazy-load
+        // the durable values — exactly the production wiring.
+        let factory = Arc::new(RecordStoreFactory::new(
+            StorageConfig::default(),
+            Arc::clone(&store) as Arc<dyn crate::storage::map_data_store::MapDataStore>,
+            Vec::new(),
+        ));
+        let durable_index: Arc<
+            dyn crate::storage::map_data_store::DurableMerkleIndex + Send + Sync,
+        > = Arc::new(DurableMerkle);
+        let durable_store: Arc<dyn crate::storage::map_data_store::MapDataStore> =
+            Arc::clone(&store) as Arc<dyn crate::storage::map_data_store::MapDataStore>;
+        let svc = Arc::new(
+            SyncService::new(
+                Arc::new(MerkleSyncManager::default()),
+                factory,
+                Arc::new(ConnectionRegistry::new()),
+            )
+            .with_durable_index(durable_index, durable_store),
+        );
+
+        // SYNC_INIT — root must be non-zero (data present).
+        let init_resp = Arc::clone(&svc)
+            .oneshot(Operation::SyncInit {
+                ctx: make_ctx(service_names::SYNC),
+                payload: topgun_core::messages::SyncInitMessage {
+                    map_name: "wmap".to_string(),
+                    last_sync_timestamp: None,
+                },
+            })
+            .await
+            .expect("SyncInit");
+        let root = match init_resp {
+            OperationResponse::Message(msg) => match *msg {
+                topgun_core::messages::Message::SyncRespRoot(m) => m.payload.root_hash,
+                other => panic!("expected SyncRespRoot, got {other:?}"),
+            },
+            other => panic!("expected Message, got {other:?}"),
+        };
+        assert_ne!(root, 0, "root must be non-zero over 64 seeded keys");
+
+        // DFS walk from "" exactly like SoakClient::delta_sync_all.
+        let mut found: HashMap<String, i64> = HashMap::new();
+        let mut stack = vec![String::new()];
+        let mut visited = 0usize;
+        while let Some(path) = stack.pop() {
+            visited += 1;
+            assert!(visited < 10_000, "walk did not terminate");
+            let resp = Arc::clone(&svc)
+                .oneshot(Operation::MerkleReqBucket {
+                    ctx: make_ctx(service_names::SYNC),
+                    payload: topgun_core::messages::MerkleReqBucketMessage {
+                        payload: topgun_core::messages::MerkleReqBucketPayload {
+                            map_name: "wmap".to_string(),
+                            path: path.clone(),
+                        },
+                    },
+                })
+                .await
+                .expect("MerkleReqBucket");
+            match resp {
+                OperationResponse::Message(msg) => match *msg {
+                    topgun_core::messages::Message::SyncRespBuckets(b) => {
+                        for child in b.payload.buckets.keys() {
+                            stack.push(format!("{path}{child}"));
+                        }
+                    }
+                    topgun_core::messages::Message::SyncRespLeaf(l) => {
+                        for rec in l.payload.records {
+                            if let Some(v) = rec.record.value.as_ref().and_then(rmpv::Value::as_i64)
+                            {
+                                found.insert(rec.key, v);
+                            }
+                        }
+                    }
+                    other => panic!("unexpected message in walk: {other:?}"),
+                },
+                OperationResponse::Empty => panic!(
+                    "durable walk returned Empty at path {path:?} — the reconnecting client \
+                     would hang waiting for SYNC_RESP_BUCKETS|SYNC_RESP_LEAF"
+                ),
+                other => panic!("unexpected response in walk: {other:?}"),
+            }
+        }
+
+        assert_eq!(
+            found, expected,
+            "durable tree-walk must recover every seeded key/value"
         );
     }
 }

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -57,11 +57,13 @@ fn parse_partition_prefix(path: &str) -> Option<(u32, String)> {
     }
 }
 
+use dashmap::DashMap;
 use tracing::Instrument;
 
 use crate::network::connection::{ConnectionKind, ConnectionRegistry};
 use crate::service::operation::{service_names, Operation, OperationError, OperationResponse};
 use crate::service::registry::{ManagedService, ServiceContext};
+use crate::storage::map_data_store::{DurableMerkleIndex, MapDataStore, MerkleSession};
 use crate::storage::merkle_sync::MerkleSyncManager;
 use crate::storage::record::RecordValue;
 use crate::storage::{CallerProvenance, ExpiryPolicy, RecordStoreFactory};
@@ -106,10 +108,33 @@ pub(crate) fn value_to_rmpv(v: &Value) -> rmpv::Value {
 /// Handles LWW-Map and OR-Map synchronization using Merkle tree comparison
 /// so clients receive only the changed records when reconnecting after
 /// an offline period.
+///
+/// When wired with a durable index via [`SyncService::with_durable_index`],
+/// the 4 Merkle tree-walk handlers resolve root/buckets/leaf-keys from the
+/// [`DurableMerkleIndex`] rather than the in-memory [`MerkleSyncManager`].
+/// This makes SYNC reads authoritative over persisted-but-not-resident records.
+///
+/// ## Session lifecycle
+///
+/// `build_session` does a full `enumerate_leaves` pass over the whole map
+/// and returns a point-in-time snapshot. To keep the per-round cost to one
+/// enumeration pass (not one per handler call), each `SYNC_INIT` builds a
+/// fresh session for the map and stores it in `session_cache`. Every subsequent
+/// `MerkleReqBucket` / `ORMapMerkleReqBucket` call reuses the cached snapshot
+/// for that map without touching storage again. `SYNC_INIT` always replaces
+/// any existing entry so a new sync round sees the current durable state.
 pub struct SyncService {
     merkle_manager: Arc<MerkleSyncManager>,
     record_store_factory: Arc<RecordStoreFactory>,
     connection_registry: Arc<ConnectionRegistry>,
+    /// Durable Merkle index: when present, tree-walk handlers resolve
+    /// root/buckets/leaf-keys from this index instead of the in-memory manager.
+    durable_index: Option<Arc<dyn DurableMerkleIndex + Send + Sync>>,
+    /// The durable backing store passed to `build_session`.
+    durable_store: Option<Arc<dyn MapDataStore>>,
+    /// Per-map session cache: keyed by map name, one session per active sync round.
+    /// `SYNC_INIT` inserts/replaces; bucket handlers read from the same entry.
+    session_cache: DashMap<String, Arc<MerkleSession>>,
 }
 
 impl SyncService {
@@ -124,6 +149,84 @@ impl SyncService {
             merkle_manager,
             record_store_factory,
             connection_registry,
+            durable_index: None,
+            durable_store: None,
+            session_cache: DashMap::new(),
+        }
+    }
+
+    /// Wire the durable Merkle index into this `SyncService`.
+    ///
+    /// Once set, the four Merkle tree-walk handlers (`SyncInit`,
+    /// `MerkleReqBucket`, `ORMapSyncInit`, `ORMapMerkleReqBucket`) resolve
+    /// their root / bucket / leaf-key results from the durable index rather
+    /// than the in-memory `MerkleSyncManager`. This makes SYNC reads
+    /// authoritative over records that are persisted but not resident in memory,
+    /// fixing the residency-coupling defect (TODO-530).
+    ///
+    /// The `store` must be the same durable backend the write path persists to
+    /// so the enumerated leaf set is the authoritative one.
+    ///
+    /// `SyncService::new`'s 3-arg signature is unchanged; this is a builder
+    /// method so existing construction sites need no modification.
+    #[must_use]
+    pub fn with_durable_index(
+        mut self,
+        index: Arc<dyn DurableMerkleIndex + Send + Sync>,
+        store: Arc<dyn MapDataStore>,
+    ) -> Self {
+        self.durable_index = Some(index);
+        self.durable_store = Some(store);
+        self
+    }
+
+    // -----------------------------------------------------------------------
+    // Session helpers
+    // -----------------------------------------------------------------------
+
+    /// Build (or return the cached) `MerkleSession` for `map_name`.
+    ///
+    /// When called from `handle_sync_init` the caller passes `force_rebuild =
+    /// true` so a fresh session is always constructed for the start of a new
+    /// sync round. Subsequent bucket handler calls pass `force_rebuild = false`
+    /// and reuse the session built during `SYNC_INIT`, keeping the per-round
+    /// cost to one `enumerate_leaves` pass.
+    ///
+    /// `build_session` uses `tokio::task::block_in_place` internally and MUST
+    /// NOT be called from a single-threaded Tokio runtime. This service is
+    /// always driven from a multi-threaded runtime (the server binary and every
+    /// `#[tokio::test(flavor = "multi_thread")]` sim test), so `block_in_place`
+    /// is safe here.
+    fn get_or_build_session(
+        &self,
+        map_name: &str,
+        force_rebuild: bool,
+    ) -> Option<Arc<MerkleSession>> {
+        let (Some(index), Some(store)) = (&self.durable_index, &self.durable_store) else {
+            return None;
+        };
+
+        if !force_rebuild {
+            if let Some(cached) = self.session_cache.get(map_name) {
+                return Some(Arc::clone(cached.value()));
+            }
+        }
+
+        match index.build_session(map_name, store.as_ref()) {
+            Ok(session) => {
+                let arc = Arc::new(session);
+                self.session_cache
+                    .insert(map_name.to_string(), Arc::clone(&arc));
+                Some(arc)
+            }
+            Err(err) => {
+                tracing::error!(
+                    map = %map_name,
+                    error = %err,
+                    "DurableMerkleIndex::build_session failed; falling back to in-memory tree"
+                );
+                None
+            }
         }
     }
 
@@ -136,13 +239,11 @@ impl SyncService {
     /// `SyncInitMessage` is a FLAT message: `map_name` is directly on the payload struct,
     /// not nested in a `.payload` sub-field (contrast with `MerkleReqBucketMessage`).
     ///
-    /// Returns a scatter-gathered root hash: the collision-resistant combine of all
-    /// per-partition root hashes. This eliminates the Mutex bottleneck on a shared
-    /// partition 0 that previously serialized all writes under concurrent load. The
-    /// combine is order-independent (commutative + associative) so `DashMap`'s
-    /// non-deterministic iteration order does not affect the aggregate, yet resists the
-    /// compensating-pair collision that plain additive folding would reintroduce one
-    /// level above the trie.
+    /// When a durable index is wired, builds a fresh `MerkleSession` for `map_name` and
+    /// caches it so subsequent `MerkleReqBucket` calls for the same sync round can reuse
+    /// the already-materialised snapshot without a second `enumerate_leaves` pass.
+    /// Returns the combined LWW+OR-Map root from the session. Falls back to the
+    /// in-memory `MerkleSyncManager` aggregate when no durable index is configured.
     #[allow(clippy::unused_async)] // declared async for uniformity with other handlers
     async fn handle_sync_init(
         &self,
@@ -150,7 +251,18 @@ impl SyncService {
         payload: messages::SyncInitMessage,
     ) -> Result<OperationResponse, OperationError> {
         let map_name = payload.map_name;
-        let root_hash = self.merkle_manager.aggregate_lww_root_hash(&map_name);
+
+        // Build a fresh session at the start of each sync round so the snapshot
+        // reflects the current durable state. force_rebuild=true replaces any
+        // cached session from a previous round for the same map.
+        let root_hash = if let Some(session) = self.get_or_build_session(&map_name, true) {
+            // Return the LWW-only root so the client drives the LWW tree walk.
+            // The combined root would mix LWW and OR-Map hashes, changing the
+            // wire protocol that the existing client expects for SYNC_INIT.
+            session.lww_root()
+        } else {
+            self.merkle_manager.aggregate_lww_root_hash(&map_name)
+        };
 
         Ok(OperationResponse::Message(Box::new(Message::SyncRespRoot(
             SyncRespRootMessage {
@@ -169,14 +281,15 @@ impl SyncService {
     /// nested `.payload` field (i.e., `payload.payload.map_name`), unlike the flat
     /// `SyncInitMessage`.
     ///
-    /// Path encoding operates in two modes:
-    /// - **Aggregate mode** (`""` or paths without a 3-digit partition prefix): the server
-    ///   combines results from all partition trees via the order-independent,
-    ///   collision-resistant combine for hashes (not plain additive folding, which would
-    ///   reintroduce the compensating-pair collision one level above the trie).
-    /// - **Routed mode** (paths beginning with a 3-digit zero-padded partition prefix like
-    ///   `"042/abc"`): the server strips the prefix and routes to the specific partition tree.
-    #[allow(clippy::too_many_lines)] // two-mode dispatch (routed vs aggregate) with leaf collection is inherently verbose
+    /// When a durable index is wired, all paths are pure hex aggregate paths (no
+    /// partition-prefix routing needed — the durable index materialises a fully
+    /// aggregated trie). Reuses the `MerkleSession` built during `SYNC_INIT` for
+    /// the same map so this call costs zero additional `enumerate_leaves` passes.
+    ///
+    /// When no durable index is wired, falls back to the original two-mode dispatch:
+    /// - **Aggregate mode** (`""` or paths without a 3-digit partition prefix)
+    /// - **Routed mode** (paths beginning with a 3-digit zero-padded partition prefix)
+    #[allow(clippy::too_many_lines)] // durable + fallback branches with leaf collection is inherently verbose
     async fn handle_merkle_req_bucket(
         &self,
         _ctx: &crate::service::operation::OperationContext,
@@ -185,6 +298,77 @@ impl SyncService {
         let map_name = payload.payload.map_name;
         let path = payload.payload.path;
 
+        // Durable-index path: reuse the session built during SYNC_INIT
+        // (force_rebuild=false) so no second enumerate_leaves pass is needed.
+        // Paths in this branch are pure hex aggregate paths — no partition prefix.
+        if let Some(session) = self.get_or_build_session(&map_name, false) {
+            // Check for internal node (has children in the LWW trie at this path).
+            let lww_children = session.lww_nodes.get(&path).cloned().unwrap_or_default();
+            if !lww_children.is_empty() {
+                let buckets: HashMap<String, u32> = lww_children
+                    .into_iter()
+                    .map(|(c, h)| (format!("{path}{c}"), h))
+                    .collect();
+                return Ok(OperationResponse::Message(Box::new(
+                    Message::SyncRespBuckets(SyncRespBucketsMessage {
+                        payload: SyncRespBucketsPayload {
+                            map_name,
+                            path,
+                            buckets,
+                        },
+                    }),
+                )));
+            }
+
+            // No children at this path — check leaf membership.
+            let leaf_keys = session.leaf_keys(&path);
+            if !leaf_keys.is_empty() {
+                let mut records = Vec::new();
+                for key in &leaf_keys {
+                    let key_partition = hash_to_partition(key);
+                    let store = self
+                        .record_store_factory
+                        .get_or_create(&map_name, key_partition);
+                    match store.get(key, false).await {
+                        Ok(Some(record)) => {
+                            if let RecordValue::Lww { value, timestamp } = record.value {
+                                records.push(SyncLeafRecord {
+                                    key: key.clone(),
+                                    record: LWWRecord {
+                                        value: Some(value_to_rmpv(&value)),
+                                        timestamp,
+                                        ttl_ms: None,
+                                    },
+                                });
+                            }
+                        }
+                        Ok(None) => {
+                            tracing::warn!(key = %key, partition = key_partition,
+                                "Merkle leaf (durable): record not found in store");
+                        }
+                        Err(e) => {
+                            tracing::error!(key = %key, partition = key_partition, error = %e,
+                                "Merkle leaf (durable): store.get() error");
+                        }
+                    }
+                }
+                return Ok(OperationResponse::Message(Box::new(Message::SyncRespLeaf(
+                    SyncRespLeafMessage {
+                        payload: SyncRespLeafPayload {
+                            map_name,
+                            path,
+                            records,
+                        },
+                    },
+                ))));
+            }
+
+            // Path not present in the durable trie — map is empty or path is beyond
+            // the trie depth. Return empty so the client stops drilling.
+            return Ok(OperationResponse::Empty);
+        }
+
+        // Fallback: no durable index wired — use the in-memory MerkleSyncManager.
         // Parse path: routed mode uses a fixed 3-digit partition prefix (e.g. "042/abc").
         if let Some((partition_id, sub_path)) = parse_partition_prefix(&path) {
             // Routed mode: route directly to the specific partition tree.
@@ -358,8 +542,12 @@ impl SyncService {
     ///
     /// `ORMapSyncInit` is a FLAT message: `map_name` is directly on the struct.
     ///
-    /// Returns a scatter-gathered root hash across all partitions, matching the
-    /// same approach as `handle_sync_init`.
+    /// When a durable index is wired, reuses the `MerkleSession` cached during
+    /// the preceding LWW `SYNC_INIT` (if any) — one `enumerate_leaves` pass covers
+    /// both LWW and OR-Map roots. If no LWW `SYNC_INIT` has yet run for this map,
+    /// builds a fresh session now (`force_rebuild=false` with a cache miss triggers
+    /// a build). Falls back to the in-memory `MerkleSyncManager` aggregate when no
+    /// durable index is configured.
     #[allow(clippy::unused_async)] // declared async for uniformity with other handlers
     async fn handle_ormap_sync_init(
         &self,
@@ -367,7 +555,15 @@ impl SyncService {
         payload: messages::ORMapSyncInit,
     ) -> Result<OperationResponse, OperationError> {
         let map_name = payload.map_name;
-        let root_hash = self.merkle_manager.aggregate_ormap_root_hash(&map_name);
+
+        // Reuse any session already built by the LWW SYNC_INIT for this map; build
+        // one now if not yet cached. force_rebuild=false so a concurrent or prior
+        // LWW SYNC_INIT's session is shared rather than discarded.
+        let root_hash = if let Some(session) = self.get_or_build_session(&map_name, false) {
+            session.ormap_root()
+        } else {
+            self.merkle_manager.aggregate_ormap_root_hash(&map_name)
+        };
 
         Ok(OperationResponse::Message(Box::new(
             Message::ORMapSyncRespRoot(ORMapSyncRespRoot {
@@ -385,8 +581,11 @@ impl SyncService {
     /// `ORMapMerkleReqBucket` is a WRAPPED message: `map_name` and `path` live in a
     /// nested `.payload` field.
     ///
-    /// Follows the same scatter-gather and path prefix routing as `handle_merkle_req_bucket`.
-    #[allow(clippy::too_many_lines)] // two-mode dispatch (routed vs aggregate) with entry collection is inherently verbose
+    /// When a durable index is wired, reuses the cached `MerkleSession` (built during
+    /// `SYNC_INIT` or `ORMapSyncInit`) with OR-Map-specific trie nodes. Paths are pure
+    /// hex aggregate paths. Falls back to the original scatter-gather routing when no
+    /// durable index is configured.
+    #[allow(clippy::too_many_lines)] // durable + fallback branches with entry collection is inherently verbose
     async fn handle_ormap_merkle_req_bucket(
         &self,
         _ctx: &crate::service::operation::OperationContext,
@@ -395,6 +594,93 @@ impl SyncService {
         let map_name = payload.payload.map_name;
         let path = payload.payload.path;
 
+        // Durable-index path: reuse the session built during ORMapSyncInit (or SYNC_INIT).
+        // OR-Map tombstones yield no leaf in the session (parity with write path: SPEC-324 R4).
+        if let Some(session) = self.get_or_build_session(&map_name, false) {
+            // Check for OR-Map internal node at this path.
+            let ormap_children = session.ormap_nodes.get(&path).cloned().unwrap_or_default();
+            if !ormap_children.is_empty() {
+                let buckets: HashMap<String, u32> = ormap_children
+                    .into_iter()
+                    .map(|(c, h)| (format!("{path}{c}"), h))
+                    .collect();
+                return Ok(OperationResponse::Message(Box::new(
+                    Message::ORMapSyncRespBuckets(ORMapSyncRespBuckets {
+                        payload: ORMapSyncRespBucketsPayload {
+                            map_name,
+                            path,
+                            buckets,
+                        },
+                    }),
+                )));
+            }
+
+            // No children — check leaf membership in the OR-Map trie.
+            let leaf_keys = session.leaf_keys(&path);
+            // Filter to keys that actually have OR-Map values (not LWW).
+            // OrTombstones have no leaf in the session so they never appear here,
+            // preserving the write-path invariant that tombstone-only keys produce
+            // no leaf (SPEC-324 R4 parity).
+            if !leaf_keys.is_empty() {
+                let mut entries = Vec::new();
+                for key in leaf_keys {
+                    let key_partition = hash_to_partition(&key);
+                    let store = self
+                        .record_store_factory
+                        .get_or_create(&map_name, key_partition);
+                    if let Ok(Some(record)) = store.get(&key, false).await {
+                        match record.value {
+                            RecordValue::OrMap {
+                                records,
+                                tombstones,
+                            } => {
+                                let wire_records: Vec<ORMapRecord<rmpv::Value>> = records
+                                    .into_iter()
+                                    .map(|r| ORMapRecord {
+                                        value: value_to_rmpv(&r.value),
+                                        timestamp: r.timestamp,
+                                        tag: r.tag,
+                                        ttl_ms: None,
+                                    })
+                                    .collect();
+                                // Carry tombstones so remove-wins suppression and
+                                // add-wins survival both replicate to the peer.
+                                entries.push(ORMapEntry {
+                                    key,
+                                    records: wire_records,
+                                    tombstones,
+                                });
+                            }
+                            RecordValue::OrTombstones { tags } => {
+                                // Tombstone-only key: propagate tombstones, no live records.
+                                entries.push(ORMapEntry {
+                                    key,
+                                    records: Vec::new(),
+                                    tombstones: tags,
+                                });
+                            }
+                            RecordValue::Lww { .. } => {
+                                // LWW value under an OR-Map leaf path: skip, wrong CRDT type.
+                            }
+                        }
+                    }
+                }
+                return Ok(OperationResponse::Message(Box::new(
+                    Message::ORMapSyncRespLeaf(ORMapSyncRespLeaf {
+                        payload: ORMapSyncRespLeafPayload {
+                            map_name,
+                            path,
+                            entries,
+                        },
+                    }),
+                )));
+            }
+
+            // Path absent from the OR-Map trie — return empty.
+            return Ok(OperationResponse::Empty);
+        }
+
+        // Fallback: no durable index wired — use the in-memory MerkleSyncManager.
         if let Some((partition_id, sub_path)) = parse_partition_prefix(&path) {
             // Routed mode: route directly to the specific OR-Map partition tree.
             let node_data = self
@@ -1814,5 +2100,230 @@ mod tests {
             }
             other => panic!("expected Message response, got {other:?}"),
         }
+    }
+
+    // =========================================================================
+    // AC9 — Durable-index SYNC handlers: no-panic on multi-thread runtime
+    //
+    // Uses `#[tokio::test(flavor = "multi_thread")]` because `build_session`
+    // calls `tokio::task::block_in_place` internally. Single-thread runtimes
+    // (the default `#[tokio::test]`) would panic on that call site. Multi-thread
+    // is the non-negotiable requirement for the production server binary and for
+    // every test that exercises the durable-index code path.
+    // =========================================================================
+
+    /// AC9 — `SyncInit` through the durable index does not panic on a
+    /// multi-threaded Tokio runtime.
+    ///
+    /// Fault scenario: a simulated "peer node" is killed (its backing store is
+    /// dropped) while the local node independently builds a Merkle session and
+    /// resolves the LWW root. The local session build must succeed regardless of
+    /// whether the peer is alive, because `build_session` reads only from the
+    /// local durable store — inter-node unavailability cannot affect it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ac9_sync_init_via_durable_index_no_panic_multi_thread() {
+        use crate::storage::datastores::RedbDataStore;
+        use crate::storage::durable_merkle::DurableMerkle;
+        use tower::ServiceExt;
+
+        // Build a real redb store and seed two LWW records so the root is non-zero.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ac9_test.redb");
+        let store = Arc::new(RedbDataStore::new(&path).expect("redb open"));
+
+        let key_a = "ac9-key-a";
+        let key_b = "ac9-key-b";
+        let ts_a = topgun_core::hlc::Timestamp {
+            millis: 100,
+            counter: 0,
+            node_id: "node-a".to_string(),
+        };
+        let ts_b = topgun_core::hlc::Timestamp {
+            millis: 200,
+            counter: 0,
+            node_id: "node-b".to_string(),
+        };
+        store
+            .add(
+                "syncmap",
+                key_a,
+                &RecordValue::Lww {
+                    value: Value::String("val-a".to_string()),
+                    timestamp: ts_a,
+                },
+                0,
+                1,
+            )
+            .await
+            .expect("seed key-a");
+        store
+            .add(
+                "syncmap",
+                key_b,
+                &RecordValue::Lww {
+                    value: Value::String("val-b".to_string()),
+                    timestamp: ts_b,
+                },
+                0,
+                2,
+            )
+            .await
+            .expect("seed key-b");
+
+        // Wire the durable index into the SyncService.
+        let durable_index: Arc<
+            dyn crate::storage::map_data_store::DurableMerkleIndex + Send + Sync,
+        > = Arc::new(DurableMerkle);
+        let durable_store: Arc<dyn crate::storage::map_data_store::MapDataStore> =
+            Arc::clone(&store) as Arc<dyn crate::storage::map_data_store::MapDataStore>;
+
+        let merkle_manager = Arc::new(MerkleSyncManager::default());
+        let record_store_factory = make_factory();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        let svc = Arc::new(
+            SyncService::new(merkle_manager, record_store_factory, connection_registry)
+                .with_durable_index(durable_index, durable_store),
+        );
+
+        // Fault scenario: simulate peer-node failure by dropping the peer's store
+        // reference before the local SYNC_INIT runs. The local node's build_session
+        // must still succeed because it reads from its own local store only.
+        let peer_store =
+            Arc::new(RedbDataStore::new(dir.path().join("ac9_peer.redb")).expect("peer redb open"));
+        // Kill the peer: drop its store (simulating node failure / partition).
+        drop(peer_store);
+
+        // Dispatch SyncInit through the operation router — this exercises
+        // `build_session` on the multi-threaded runtime. Must NOT panic.
+        let op = Operation::SyncInit {
+            ctx: make_ctx(service_names::SYNC),
+            payload: topgun_core::messages::SyncInitMessage {
+                map_name: "syncmap".to_string(),
+                last_sync_timestamp: None,
+            },
+        };
+
+        let resp = svc.oneshot(op).await.expect("SyncInit must not fail");
+
+        match resp {
+            OperationResponse::Message(msg) => {
+                if let topgun_core::messages::Message::SyncRespRoot(m) = *msg {
+                    assert_eq!(m.payload.map_name, "syncmap");
+                    assert_ne!(
+                        m.payload.root_hash, 0,
+                        "durable index over 2 seeded records must produce non-zero root"
+                    );
+                } else {
+                    panic!("expected SyncRespRoot, got different Message variant");
+                }
+            }
+            other => panic!("expected Message response, got {other:?}"),
+        }
+    }
+
+    /// AC9 — `MerkleReqBucket` via durable index reuses the session cached by
+    /// `SyncInit` (no second `enumerate_leaves` pass) and does not panic.
+    ///
+    /// Fault scenario: network partition simulated by running the bucket drill-down
+    /// after the backing store for a second "partition peer" has been dropped. The
+    /// local service must still answer from its session cache.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ac9_merkle_req_bucket_via_durable_index_reuses_session_no_panic() {
+        use crate::storage::datastores::RedbDataStore;
+        use crate::storage::durable_merkle::DurableMerkle;
+        use tower::ServiceExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store =
+            Arc::new(RedbDataStore::new(dir.path().join("ac9_bucket.redb")).expect("redb open"));
+
+        // Seed enough records to create at least one internal node at depth > 0.
+        for i in 0..20u32 {
+            let key = format!("bucket-key-{i:04}");
+            store
+                .add(
+                    "bmap",
+                    &key,
+                    &RecordValue::Lww {
+                        value: Value::Int(i64::from(i)),
+                        timestamp: topgun_core::hlc::Timestamp {
+                            millis: u64::from(i) + 1,
+                            counter: i,
+                            node_id: "n1".to_string(),
+                        },
+                    },
+                    0,
+                    1,
+                )
+                .await
+                .expect("seed");
+        }
+
+        let durable_index: Arc<
+            dyn crate::storage::map_data_store::DurableMerkleIndex + Send + Sync,
+        > = Arc::new(DurableMerkle);
+        let durable_store: Arc<dyn crate::storage::map_data_store::MapDataStore> =
+            Arc::clone(&store) as Arc<dyn crate::storage::map_data_store::MapDataStore>;
+
+        let svc = Arc::new(
+            SyncService::new(
+                Arc::new(MerkleSyncManager::default()),
+                make_factory(),
+                Arc::new(ConnectionRegistry::new()),
+            )
+            .with_durable_index(durable_index, durable_store),
+        );
+
+        // 1. SYNC_INIT — builds and caches the session.
+        let init_op = Operation::SyncInit {
+            ctx: make_ctx(service_names::SYNC),
+            payload: topgun_core::messages::SyncInitMessage {
+                map_name: "bmap".to_string(),
+                last_sync_timestamp: None,
+            },
+        };
+        let init_resp = Arc::clone(&svc)
+            .oneshot(init_op)
+            .await
+            .expect("SyncInit must succeed");
+        let _root_hash = match init_resp {
+            OperationResponse::Message(msg) => {
+                if let topgun_core::messages::Message::SyncRespRoot(m) = *msg {
+                    m.payload.root_hash
+                } else {
+                    panic!("expected SyncRespRoot");
+                }
+            }
+            other => panic!("expected Message, got {other:?}"),
+        };
+
+        // 2. Fault: simulate partition by dropping the secondary peer store reference.
+        //    The session was already built; the local service answers from cache.
+        drop(store);
+
+        // 3. MerkleReqBucket at root — reuses the cached session (no second
+        //    enumerate_leaves even though the store was dropped).
+        let bucket_op = Operation::MerkleReqBucket {
+            ctx: make_ctx(service_names::SYNC),
+            payload: topgun_core::messages::MerkleReqBucketMessage {
+                payload: topgun_core::messages::MerkleReqBucketPayload {
+                    map_name: "bmap".to_string(),
+                    path: String::new(),
+                },
+            },
+        };
+        let bucket_resp = Arc::clone(&svc)
+            .oneshot(bucket_op)
+            .await
+            .expect("MerkleReqBucket must not fail even after store drop");
+
+        // The session has data so we expect buckets or a leaf response.
+        assert!(
+            matches!(
+                bucket_resp,
+                OperationResponse::Message(_) | OperationResponse::Empty
+            ),
+            "expected Message or Empty response after session-cached bucket request"
+        );
     }
 }

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -197,18 +197,29 @@ impl SyncService {
     /// always driven from a multi-threaded runtime (the server binary and every
     /// `#[tokio::test(flavor = "multi_thread")]` sim test), so `block_in_place`
     /// is safe here.
+    ///
+    /// Returns `Ok(None)` only when no durable index is configured — the caller
+    /// then serves the round from the in-memory accelerator (the pre-durable
+    /// behaviour, correct for tests and null-store deployments). When a durable
+    /// index IS configured but the snapshot build fails, returns `Err`: we must
+    /// NOT silently fall back to the in-memory tree, because that tree only sees
+    /// resident keys and would hand the reconnecting client a root that omits
+    /// persisted-but-evicted records — the exact residency coupling this path
+    /// exists to eliminate. Surfacing the error lets the client retry against
+    /// durable truth (mirrors `DurableMerkleIndex::build_session`'s
+    /// "propagate, never degrade to wrong leaves" contract).
     fn get_or_build_session(
         &self,
         map_name: &str,
         force_rebuild: bool,
-    ) -> Option<Arc<MerkleSession>> {
+    ) -> Result<Option<Arc<MerkleSession>>, OperationError> {
         let (Some(index), Some(store)) = (&self.durable_index, &self.durable_store) else {
-            return None;
+            return Ok(None);
         };
 
         if !force_rebuild {
             if let Some(cached) = self.session_cache.get(map_name) {
-                return Some(Arc::clone(cached.value()));
+                return Ok(Some(Arc::clone(cached.value())));
             }
         }
 
@@ -217,15 +228,17 @@ impl SyncService {
                 let arc = Arc::new(session);
                 self.session_cache
                     .insert(map_name.to_string(), Arc::clone(&arc));
-                Some(arc)
+                Ok(Some(arc))
             }
             Err(err) => {
                 tracing::error!(
                     map = %map_name,
                     error = %err,
-                    "DurableMerkleIndex::build_session failed; falling back to in-memory tree"
+                    "DurableMerkleIndex::build_session failed; rejecting sync round (no silent in-memory fallback)"
                 );
-                None
+                Err(OperationError::Internal(anyhow::anyhow!(
+                    "durable Merkle session build failed for map {map_name}: {err}"
+                )))
             }
         }
     }
@@ -255,7 +268,7 @@ impl SyncService {
         // Build a fresh session at the start of each sync round so the snapshot
         // reflects the current durable state. force_rebuild=true replaces any
         // cached session from a previous round for the same map.
-        let root_hash = if let Some(session) = self.get_or_build_session(&map_name, true) {
+        let root_hash = if let Some(session) = self.get_or_build_session(&map_name, true)? {
             // Return the LWW-only root so the client drives the LWW tree walk.
             // The combined root would mix LWW and OR-Map hashes, changing the
             // wire protocol that the existing client expects for SYNC_INIT.
@@ -301,7 +314,7 @@ impl SyncService {
         // Durable-index path: reuse the session built during SYNC_INIT
         // (force_rebuild=false) so no second enumerate_leaves pass is needed.
         // Paths in this branch are pure hex aggregate paths — no partition prefix.
-        if let Some(session) = self.get_or_build_session(&map_name, false) {
+        if let Some(session) = self.get_or_build_session(&map_name, false)? {
             // Check for internal node (has children in the LWW trie at this path).
             let lww_children = session.lww_nodes.get(&path).cloned().unwrap_or_default();
             if !lww_children.is_empty() {
@@ -563,7 +576,7 @@ impl SyncService {
         // Reuse any session already built by the LWW SYNC_INIT for this map; build
         // one now if not yet cached. force_rebuild=false so a concurrent or prior
         // LWW SYNC_INIT's session is shared rather than discarded.
-        let root_hash = if let Some(session) = self.get_or_build_session(&map_name, false) {
+        let root_hash = if let Some(session) = self.get_or_build_session(&map_name, false)? {
             session.ormap_root()
         } else {
             self.merkle_manager.aggregate_ormap_root_hash(&map_name)
@@ -600,7 +613,7 @@ impl SyncService {
 
         // Durable-index path: reuse the session built during ORMapSyncInit (or SYNC_INIT).
         // OR-Map tombstones yield no leaf in the session (parity with write path: SPEC-324 R4).
-        if let Some(session) = self.get_or_build_session(&map_name, false) {
+        if let Some(session) = self.get_or_build_session(&map_name, false)? {
             // Check for OR-Map internal node at this path.
             let ormap_children = session.ormap_nodes.get(&path).cloned().unwrap_or_default();
             if !ormap_children.is_empty() {
@@ -2463,6 +2476,82 @@ mod tests {
         assert_eq!(
             found, expected,
             "durable tree-walk must recover every seeded key/value"
+        );
+    }
+
+    // When a durable index IS wired but build_session fails (transient store /
+    // enumerate fault), the SYNC handlers must REJECT the round rather than
+    // silently serving the in-memory accelerator — that tree only sees resident
+    // keys, so a fallback would hand the reconnecting client a residency-coupled
+    // root that omits persisted-but-evicted records (the exact TODO-530 defect
+    // this path eliminates). Proves the fail-closed contract behaviorally.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn durable_session_build_error_rejects_round_no_inmem_fallback() {
+        use crate::storage::datastores::RedbDataStore;
+        use tower::ServiceExt;
+
+        struct FailingIndex;
+        impl crate::storage::map_data_store::DurableMerkleIndex for FailingIndex {
+            fn build_session(
+                &self,
+                _map: &str,
+                _store: &dyn crate::storage::map_data_store::MapDataStore,
+            ) -> anyhow::Result<MerkleSession> {
+                anyhow::bail!("simulated durable session build fault")
+            }
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(RedbDataStore::new(dir.path().join("fault.redb")).expect("redb open"));
+        let factory = Arc::new(RecordStoreFactory::new(
+            StorageConfig::default(),
+            Arc::clone(&store) as Arc<dyn crate::storage::map_data_store::MapDataStore>,
+            Vec::new(),
+        ));
+        let durable_index: Arc<
+            dyn crate::storage::map_data_store::DurableMerkleIndex + Send + Sync,
+        > = Arc::new(FailingIndex);
+        let durable_store: Arc<dyn crate::storage::map_data_store::MapDataStore> =
+            Arc::clone(&store) as Arc<dyn crate::storage::map_data_store::MapDataStore>;
+        let svc = Arc::new(
+            SyncService::new(
+                Arc::new(MerkleSyncManager::default()),
+                factory,
+                Arc::new(ConnectionRegistry::new()),
+            )
+            .with_durable_index(durable_index, durable_store),
+        );
+
+        // SYNC_INIT must error, not fall back to the in-memory aggregate root.
+        let init = Arc::clone(&svc)
+            .oneshot(Operation::SyncInit {
+                ctx: make_ctx(service_names::SYNC),
+                payload: topgun_core::messages::SyncInitMessage {
+                    map_name: "fault-map".to_string(),
+                    last_sync_timestamp: None,
+                },
+            })
+            .await;
+        assert!(
+            init.is_err(),
+            "durable build failure must reject SYNC_INIT, not silently serve the in-memory tree"
+        );
+
+        // MerkleReqBucket must reject too.
+        let bucket = Arc::clone(&svc)
+            .oneshot(Operation::MerkleReqBucket {
+                ctx: make_ctx(service_names::SYNC),
+                payload: topgun_core::messages::MerkleReqBucketMessage {
+                    payload: topgun_core::messages::MerkleReqBucketPayload {
+                        map_name: "fault-map".to_string(),
+                        path: String::new(),
+                    },
+                },
+            })
+            .await;
+        assert!(
+            bucket.is_err(),
+            "durable build failure must reject MerkleReqBucket, not silently serve the in-memory tree"
         );
     }
 }

--- a/tests/integration-rust/queries.test.ts
+++ b/tests/integration-rust/queries.test.ts
@@ -4,6 +4,7 @@ import {
   createLWWRecord,
   waitForSync,
   waitUntil,
+  completeMerkleSync,
   TestClient,
 } from './helpers';
 
@@ -1236,105 +1237,160 @@ describe('Integration: Queries (Rust Server)', () => {
   });
 
   // ========================================
-  // Merkle Delta Reconnect (SPEC-144)
+  // Merkle Delta Reconnect — map-level tree-walk SYNC path
   //
-  // SKIPPED: per-query Merkle is retired on the full-scan path (SPEC-322c SYNC/QUERY
-  // separation). Reconnect now falls back to a full snapshot (correct, less efficient)
-  // until the map-level Merkle tree-walk SYNC lands (SYNC-treewalk track). The client
-  // degrades gracefully: merkleRootHash undefined → defaults to 0 → full snapshot.
-  // Re-enable (rewritten against the tree-walk protocol) when SYNC-treewalk ships.
+  // Rewritten from per-query Merkle (retired in SYNC/QUERY separation) to the
+  // durable map-level tree-walk SYNC path (SYNC_INIT → SYNC_RESP_ROOT →
+  // MERKLE_REQ_BUCKET → SYNC_RESP_BUCKETS | SYNC_RESP_LEAF). The server SYNC
+  // path reads from the DurableMerkleIndex so results survive restart and are
+  // not coupled to in-memory residency.
   // ========================================
-  describe.skip('QUERY_SYNC_INIT Merkle delta reconnect', () => {
-    test('reconnect with stored Merkle hash sends QUERY_SYNC_INIT', async () => {
-      const mapName = `merkle-reconnect-${Date.now()}`;
+  describe('Merkle delta reconnect via tree-walk SYNC path', () => {
+    test('reconnecting client gets non-zero root hash and full records via SYNC_INIT', async () => {
+      const mapName = `merkle-treewalk-${Date.now()}`;
 
-      // First connection: establish query with fields, receive QUERY_RESP with merkleRootHash
+      // First connection: write two records and confirm the server persists them
       const client1 = await createRustTestClient(port, {
-        nodeId: 'merkle-rc-client-1',
-        userId: 'merkle-rc-user-1',
+        nodeId: 'merkle-tw-client-1',
+        userId: 'merkle-tw-user-1',
         roles: ['ADMIN'],
       });
       await client1.waitForMessage('AUTH_ACK');
 
-      // Write initial data
+      const writes = [
+        { id: 'mtw-put-1', key: 'mtw-item-1', value: { name: 'Alice', status: 'active' } },
+        { id: 'mtw-put-2', key: 'mtw-item-2', value: { name: 'Bob', status: 'inactive' } },
+      ];
+
+      for (const w of writes) {
+        client1.messages.length = 0;
+        client1.send({
+          type: 'CLIENT_OP',
+          payload: {
+            id: w.id,
+            mapName,
+            opType: 'PUT',
+            key: w.key,
+            record: createLWWRecord(w.value),
+          },
+        });
+        await client1.waitForMessage('OP_ACK');
+      }
+
+      await waitForSync(300);
+
+      // First SYNC_INIT: confirm server root hash is non-zero (tree is built)
       client1.messages.length = 0;
-      client1.send({
-        type: 'CLIENT_OP',
-        payload: {
-          id: 'mrc-put-1',
-          mapName,
-          opType: 'PUT',
-          key: 'mrc-item-1',
-          record: createLWWRecord({ name: 'Initial', status: 'active' }),
-        },
-      });
-      await client1.waitForMessage('OP_ACK');
-      await waitForSync(200);
-
-      // Subscribe with field projection
-      const queryId = 'mrc-q-1';
-      client1.messages.length = 0;
-      client1.send({
-        type: 'QUERY_SUB',
-        payload: {
-          queryId,
-          mapName,
-          query: {},
-          fields: ['name', 'status'],
-        },
-      });
-
-      const initialResp = await client1.waitForMessage('QUERY_RESP');
-      expect(initialResp.payload.queryId).toBe(queryId);
-      expect(initialResp.payload.results.length).toBe(1);
-
-      // Server should return a merkleRootHash for field-projected queries
-      const storedHash = initialResp.payload.merkleRootHash;
-      expect(storedHash).toBeDefined();
-      expect(typeof storedHash).toBe('number');
-      expect(storedHash).not.toBe(0);
+      client1.send({ type: 'SYNC_INIT', mapName });
+      const rootResp = await client1.waitForMessage('SYNC_RESP_ROOT', 8000);
+      expect(rootResp.payload.mapName).toBe(mapName);
+      const storedRootHash = rootResp.payload.rootHash;
+      expect(storedRootHash).not.toBe(0);
 
       client1.close();
       await waitForSync(200);
 
-      // Second connection: simulate reconnect by opening a new client
-      // and sending QUERY_SYNC_INIT with the stored hash
+      // Simulated reconnect: open a fresh client and run the full tree-walk SYNC.
+      // This mirrors what the SyncEngine does on reconnect — it sends SYNC_INIT
+      // and walks the Merkle tree to discover divergent buckets.
       const client2 = await createRustTestClient(port, {
-        nodeId: 'merkle-rc-client-2',
-        userId: 'merkle-rc-user-2',
+        nodeId: 'merkle-tw-client-2',
+        userId: 'merkle-tw-user-2',
         roles: ['ADMIN'],
       });
       await client2.waitForMessage('AUTH_ACK');
-
-      // Send QUERY_SUB first (as QueryManager.resubscribeAll does)
       client2.messages.length = 0;
-      client2.send({
-        type: 'QUERY_SUB',
-        payload: {
-          queryId: 'mrc-q-reconnect',
-          mapName,
-          query: {},
-          fields: ['name', 'status'],
-        },
-      });
 
-      // Then send QUERY_SYNC_INIT with the stored Merkle hash
-      client2.send({
-        type: 'QUERY_SYNC_INIT',
-        payload: {
-          queryId: 'mrc-q-reconnect',
-          rootHash: storedHash,
-        },
-      });
+      const syncedRecords = await completeMerkleSync(client2, mapName);
 
-      // Server should respond — either QUERY_RESP (full snapshot if hash mismatch)
-      // or no response if state is identical. In test, we expect at least QUERY_RESP
-      // from the initial QUERY_SUB to confirm the server accepted both messages.
-      const reconnectResp = await client2.waitForMessage('QUERY_RESP');
-      expect(reconnectResp).toBeDefined();
-      expect(reconnectResp.payload.queryId).toBe('mrc-q-reconnect');
+      // All written records must be delivered through the tree-walk path
+      expect(syncedRecords.size).toBe(2);
+      expect(syncedRecords.has('mtw-item-1')).toBe(true);
+      expect(syncedRecords.get('mtw-item-1')!.value).toEqual({ name: 'Alice', status: 'active' });
+      expect(syncedRecords.has('mtw-item-2')).toBe(true);
+      expect(syncedRecords.get('mtw-item-2')!.value).toEqual({ name: 'Bob', status: 'inactive' });
+
+      // The root hash returned on reconnect must match the hash seen before disconnect,
+      // proving the durable index is consistent across connections.
+      client2.messages.length = 0;
+      client2.send({ type: 'SYNC_INIT', mapName });
+      const reconnectRootResp = await client2.waitForMessage('SYNC_RESP_ROOT', 8000);
+      expect(reconnectRootResp.payload.rootHash).toBe(storedRootHash);
 
       client2.close();
+    });
+
+    test('root hash advances when new records are written between syncs', async () => {
+      const mapName = `merkle-tw-delta-${Date.now()}`;
+
+      const writer = await createRustTestClient(port, {
+        nodeId: 'merkle-tw-writer',
+        userId: 'merkle-tw-wuser',
+        roles: ['ADMIN'],
+      });
+      await writer.waitForMessage('AUTH_ACK');
+
+      // Write first record
+      writer.messages.length = 0;
+      writer.send({
+        type: 'CLIENT_OP',
+        payload: {
+          id: 'mtwd-put-1',
+          mapName,
+          opType: 'PUT',
+          key: 'item-1',
+          record: createLWWRecord({ v: 1 }),
+        },
+      });
+      await writer.waitForMessage('OP_ACK');
+      await waitForSync(300);
+
+      // Capture root hash after first write
+      writer.messages.length = 0;
+      writer.send({ type: 'SYNC_INIT', mapName });
+      const rootResp1 = await writer.waitForMessage('SYNC_RESP_ROOT', 8000);
+      const hash1 = rootResp1.payload.rootHash;
+      expect(hash1).not.toBe(0);
+
+      // Write a second record — the tree must change
+      writer.messages.length = 0;
+      writer.send({
+        type: 'CLIENT_OP',
+        payload: {
+          id: 'mtwd-put-2',
+          mapName,
+          opType: 'PUT',
+          key: 'item-2',
+          record: createLWWRecord({ v: 2 }),
+        },
+      });
+      await writer.waitForMessage('OP_ACK');
+      await waitForSync(300);
+
+      // Root hash must differ from the pre-write snapshot
+      writer.messages.length = 0;
+      writer.send({ type: 'SYNC_INIT', mapName });
+      const rootResp2 = await writer.waitForMessage('SYNC_RESP_ROOT', 8000);
+      const hash2 = rootResp2.payload.rootHash;
+      expect(hash2).not.toBe(0);
+      expect(hash2).not.toBe(hash1);
+
+      // A client that missed the second write can discover all records via tree-walk
+      const lateJoiner = await createRustTestClient(port, {
+        nodeId: 'merkle-tw-late',
+        userId: 'merkle-tw-luser',
+        roles: ['ADMIN'],
+      });
+      await lateJoiner.waitForMessage('AUTH_ACK');
+      lateJoiner.messages.length = 0;
+
+      const synced = await completeMerkleSync(lateJoiner, mapName);
+      expect(synced.size).toBe(2);
+      expect(synced.get('item-1')!.value).toEqual({ v: 1 });
+      expect(synced.get('item-2')!.value).toEqual({ v: 2 });
+
+      writer.close();
+      lateJoiner.close();
     });
   });
 


### PR DESCRIPTION
## SPEC-325b — Tree-walk delta SYNC on the durable Merkle index

Rewires the four `SyncService` SYNC handlers onto SPEC-325a's residency-independent
`DurableMerkleIndex` so reconnecting clients converge against **durable truth regardless of
in-memory eviction** — closing the TODO-530 / TODO-539 residency-coupling defect on the SYNC
path. Builds on SPEC-325a (merged, PR #89).

### What changed
- **`sync.rs`** — 4 SYNC handlers (`SyncInit`, `MerkleReqBucket`, `ORMapSyncInit`,
  `ORMapMerkleReqBucket`) resolve root/buckets/leaf-keys from the durable index via the
  additive `with_durable_index` builder (no `::new` 19-site cascade). Per-round session cache
  (one `enumerate_leaves` pass per round per map, AC10 budget). Single-char aggregate bucket
  keys (full-path keys double-prefix the reconnecting-client DFS at depth ≥ 1).
- **`bin/topgun_server.rs`** — wire a datastore-backed `DurableMerkle` into `SyncService`,
  null-guarded (NullDataStore → in-memory fallback).
- **`soak_harness/main.rs`** — 5 `[TODO-530]` pending gates promoted to **hard**.
- **`queries.test.ts`** — Merkle delta-reconnect test re-enabled, adapted to the tree-walk
  SYNC protocol.

### Correctness hardening (cross-vendor xreview)
- **Fail-closed on durable build error** (`9f08d233`): when a durable index is configured but
  `build_session` fails, handlers **reject the round** (client retries) instead of silently
  serving the eviction-coupled in-memory tree — extends SPEC-325a's "propagate, never degrade
  to wrong leaves" contract into the SYNC layer. Behavioral test included.

### Verification
- fmt 0 · clippy `--all-targets --all-features -D warnings` 0 · lib **1508/0**
- sim 11/0 · load-harness 9550 ops/sec, p99 3807µs
- `durable_tree_walk_recovers_all_seeded_keys` — 64 keys over real redb, drives the exact
  reconnecting-client DFS, panics on `Empty`, asserts full recovery.
- **Soak SMOKE under crash-loop + ACTIVE eviction (`TOPGUN_MAX_RAM_MB=16`)** reproduced PASS
  (steady + recovery checkpoints converged); neg-controls red.

### AC1 closing gate (reviewer/merger: do not skip)
The full **G4b soak `passed:true` under crash-loop + ACTIVE eviction** is the closing gate
(TODO-484 / TODO-539). Blocking CI **Soak Harness Smoke G4b** must be green; a bounded
real soak (crash + active eviction) gates the merge, with the full 72h run tracked
post-merge via TODO-484.

### Follow-ups filed (non-blocking)
- **TODO-544** — per-connection/per-round SYNC session keying (concurrent `SYNC_INIT` swaps
  another client's in-progress snapshot; self-heals, no regression).
- **TODO-545** — SYNC session-cache lifecycle (clear-after-round / TTL / bound).
