### PR TITLE
fix(sf-326): WAL segment rotation — close TODO-469 Option B + TODO-456

### DIFF
--- a/packages/server-rust/src/storage/crash_safety_proptest.rs
+++ b/packages/server-rust/src/storage/crash_safety_proptest.rs
@@ -819,7 +819,7 @@ async fn max_observed_sequence_reads_watermark_of_compacted_empty_partition() {
 //
 // The other crash scenarios drive the write path single-threaded-sequentially:
 // every op is appended, then the store is dropped. That schedule can never see
-// the F1 compaction race (compact_log rewriting the active log while an append
+// the seal/rotate race (mark_applied sealing the active segment while an append
 // interleaves) — it slipped past the suite and `kill -9` cannot see it either
 // (the page cache survives a process kill, and steady-state entries usually also
 // reached the inner store before the kill).
@@ -828,18 +828,18 @@ async fn max_observed_sequence_reads_watermark_of_compacted_empty_partition() {
 // production WriteBehindDataStore write path, then models the crash (drop), and
 // asserts against a FRESH durable inner store recovered from the on-disk WAL —
 // NOT against the OS-cached WAL file. With never-flush config every acked write
-// lives only in the WAL until the crash, so a compaction that drops a
+// lives only in the WAL until the crash, so a seal/rotate that drops a
 // concurrently-appended frame is a lost acked write that recovery cannot find.
 //
 // `mark_applied(partition, 0)` is the fault injection: it retains every entry
-// (watermark 0) yet still performs compact_log's read->rewrite->rename on the
-// active file, exactly as the real flush loop's mark_applied does while clients
-// keep writing the same partition. Driving it directly (rather than via the
-// flush loop) is what makes the race deterministic instead of timing-dependent.
+// (watermark 0) yet still seals the active segment and rotates a fresh one in,
+// exactly as the real flush loop's mark_applied does while clients keep writing
+// the same partition. Driving it directly (rather than via the flush loop) is
+// what makes the race deterministic instead of timing-dependent.
 //
-// Negative control: reverting compact_log to acquire the files lock late (the
-// pre-PR#50 shape — read/rewrite/rename without the lock) makes this test drop a
-// large fraction of acked writes and fail.
+// Negative control: reverting mark_applied to the pre-PR#50 unlocked
+// read/rewrite/rename shape (or sealing without freezing the active frames first)
+// makes this test drop a large fraction of acked writes and fail.
 // ---------------------------------------------------------------------------
 
 /// Generates `count` distinct keys that all map to `partition` under
@@ -942,4 +942,204 @@ async fn concurrent_compaction_loses_no_acked_write_across_crash() {
         missing.len(),
         &missing[..missing.len().min(10)]
     );
+}
+
+// ---------------------------------------------------------------------------
+// Crash on a PARTIAL FINAL (active) segment under concurrent same-partition
+// load (G3 / AC6).
+//
+// A SIGKILL can land mid-append: the active segment ends with a half-written
+// frame whose bytes reached the page cache but whose final frame was never
+// completed. Under segment rotation this is the ONLY place a torn tail may
+// legitimately appear — sealed segments are fsynced whole before they join the
+// sealed set, so a torn tail on a non-last segment is fatal corruption.
+//
+// This test drives concurrent appends + seal/rotate on ONE partition (so the
+// partition ends with several sealed segments plus a populated active segment),
+// models the crash by dropping the store, then PHYSICALLY TRUNCATES the active
+// (highest-first_seq) segment's tail to model the half-written final frame.
+// Recovery into a FRESH durable inner store must:
+//   - succeed (the truncated tail on the active segment is tolerated, WARN + Ok);
+//   - replay every acked write whose frame is in the intact prefix (the sealed
+//     segments + the active segment up to the torn byte) — no acked op below the
+//     torn frame is lost.
+//
+// The oracle is conservative on the boundary: only the single key whose frame was
+// torn off may be absent. We assert the prefix is fully recovered by checking
+// that recovery is Ok and that the overwhelming majority (all but at most the
+// torn tail's key) survive — and crucially that a key written EARLY (deep in a
+// sealed segment) is always present.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[allow(clippy::too_many_lines)]
+async fn crash_on_partial_active_segment_recovers_intact_prefix() {
+    use crate::storage::wal::segment::parse_segment_filename;
+
+    let dir = tempfile::tempdir().unwrap();
+    let wal_dir = dir.path().to_path_buf();
+
+    let total = 1000usize;
+    let partition = partition_of(TEST_MAP, "anchor");
+    let keys = keys_for_partition(TEST_MAP, partition, total);
+
+    // Production write path; never-flush so acked writes live ONLY in the WAL
+    // until the crash. PerOp fsync so each frame is fully on disk at ack time —
+    // we then synthesize the torn FINAL frame by truncating, not by relying on a
+    // partial OS flush.
+    let pre_crash_inner: Arc<dyn MapDataStore> = Arc::new(RetainingStore::default());
+    let wal = WalWriter::new(wal_dir.clone(), WalFsyncPolicy::PerOp).expect("WalWriter::new");
+    let store = WriteBehindDataStore::new_with_wal(
+        pre_crash_inner,
+        never_flush_config(),
+        Some(WalBootstrap {
+            wal: Arc::clone(&wal) as Arc<dyn Wal>,
+            sequence_start: 1,
+        }),
+    );
+
+    // Appender: each add returns Ok ⇒ its WAL frame is durable.
+    let appender = {
+        let store = Arc::clone(&store);
+        let keys = keys.clone();
+        tokio::spawn(async move {
+            for (i, key) in keys.iter().enumerate() {
+                let tag = u64::try_from(i).unwrap() + 1;
+                store
+                    .add(TEST_MAP, key, &lww_value(tag, tag), 0, 1000)
+                    .await
+                    .expect("add must ack");
+            }
+        })
+    };
+
+    // Compactor: seal/rotate the same partition repeatedly so the partition ends
+    // with several SEALED segments plus a populated ACTIVE segment — the layout
+    // where "torn final segment" is meaningfully distinct from "torn whole log".
+    let compactor = {
+        let wal = Arc::clone(&wal);
+        tokio::spawn(async move {
+            for _ in 0..total {
+                wal.mark_applied(partition, 0).await.expect("mark_applied");
+                tokio::task::yield_now().await;
+            }
+        })
+    };
+
+    appender.await.unwrap();
+    // Stop the compactor BEFORE the final tail batch so no rotation can run
+    // between those appends and the truncation — the seal/rotate race already ran
+    // for the bulk of the load above; the tail batch deterministically populates
+    // the active segment so a torn final frame is guaranteed to exist there
+    // (a last-moment seal would otherwise leave the active segment empty, which is
+    // a legitimate state but not the "torn active segment" this test targets).
+    compactor.await.unwrap();
+
+    // Final deterministic tail batch through the real write path, landing in the
+    // current active segment with no concurrent rotation. The last of these is the
+    // frame the truncation tears off.
+    let tail_keys = keys_for_partition(TEST_MAP, partition, total + 8)
+        .split_off(total)
+        .into_iter()
+        .collect::<Vec<_>>();
+    for (i, key) in tail_keys.iter().enumerate() {
+        let tag = u64::try_from(total + i).unwrap() + 1;
+        store
+            .add(TEST_MAP, key, &lww_value(tag, tag), 0, 1000)
+            .await
+            .expect("tail add must ack");
+    }
+
+    // Crash: in-memory staging gone; on-disk segments survive.
+    drop(store);
+    // Drop the WAL handle so its open active-segment file descriptor is closed
+    // before we truncate on disk (avoids racing an in-flight fsync timer).
+    drop(wal);
+
+    // Identify the ACTIVE (highest-first_seq) segment of the partition and lop off
+    // its last few bytes to model a half-written final frame at SIGKILL time.
+    let mut segments: Vec<(u64, std::path::PathBuf)> = std::fs::read_dir(&wal_dir)
+        .unwrap()
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            parse_segment_filename(&name)
+                .and_then(|(p, first_seq)| (p == partition).then(|| (first_seq, e.path())))
+        })
+        .collect();
+    segments.sort_by_key(|(first_seq, _)| *first_seq);
+    assert!(
+        segments.len() >= 2,
+        "test must produce a multi-segment partition (sealed + active); got {}",
+        segments.len()
+    );
+    let (_active_first_seq, active_path) = segments.last().cloned().unwrap();
+
+    let active_bytes = std::fs::read(&active_path).unwrap();
+    assert!(
+        active_bytes.len() > 4,
+        "active segment must hold the tail batch's frames to truncate a torn tail"
+    );
+    // Truncate the last 3 bytes so the active segment's final frame is incomplete
+    // on disk — the classic torn-tail SIGKILL signature.
+    std::fs::write(&active_path, &active_bytes[..active_bytes.len() - 3]).unwrap();
+
+    // Recover into a FRESH durable inner store via the real recovery path. A torn
+    // tail on the ACTIVE (last) segment must be tolerated (Ok), not fatal.
+    let recovered: Arc<RetainingStore> = Arc::new(RetainingStore::default());
+    let wal2 = WalWriter::new(wal_dir.clone(), WalFsyncPolicy::PerOp).unwrap();
+    let recovery = WalRecovery::new(Arc::clone(&wal2), Vec::new());
+    let result = recovery
+        .run(Arc::clone(&recovered) as Arc<dyn MapDataStore>)
+        .await;
+    assert!(
+        result.is_ok(),
+        "a torn tail on the active segment must be tolerated, not fatal: {result:?}"
+    );
+
+    // Every bulk-phase acked write lives in a sealed segment or in the active
+    // segment's intact prefix below the torn frame — so ALL must survive. Only the
+    // single torn final frame (the last tail-batch key) may be absent.
+    let mut missing_bulk = Vec::new();
+    for key in &keys {
+        if !recovered.contains(TEST_MAP, key).await {
+            missing_bulk.push(key.clone());
+        }
+    }
+    assert!(
+        missing_bulk.is_empty(),
+        "torn active-segment tail lost {} bulk-phase acked writes that should be in \
+         sealed segments or the intact active prefix (first few: {:?})",
+        missing_bulk.len(),
+        &missing_bulk[..missing_bulk.len().min(10)]
+    );
+
+    // The tail batch landed in the active segment; only its torn final frame may
+    // be missing. Every tail key except the last must be recovered from the intact
+    // active prefix.
+    let mut missing_tail = Vec::new();
+    for key in &tail_keys {
+        if !recovered.contains(TEST_MAP, key).await {
+            missing_tail.push(key.clone());
+        }
+    }
+    assert!(
+        missing_tail.len() <= 1,
+        "torn active-segment tail lost {} acked writes beyond the single torn final \
+         frame (first few: {:?})",
+        missing_tail.len(),
+        &missing_tail[..missing_tail.len().min(10)]
+    );
+
+    // An EARLY key (frame deep in a sealed segment, far from the torn tail) must
+    // always survive — proves recovery replayed across all sealed segments, not
+    // just the active one.
+    assert!(
+        recovered.contains(TEST_MAP, &keys[0]).await,
+        "the earliest acked write (deep in a sealed segment) must survive a torn \
+         active-segment tail"
+    );
+
+    drop(dir);
 }

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex as AsyncMutex;
 use topgun_core::hlc::Timestamp;
 use topgun_core::types::Value;
@@ -185,30 +184,59 @@ pub trait Wal: Send + Sync {
 // WalWriter — production file-backed implementation
 // ===========================================================================
 
-/// Per-partition file handle managed by `WalWriter`.
-struct PartitionFile {
-    file: tokio::fs::File,
-    /// How many frames have been written since the last fsync (for batched policy).
-    unfsynced_count: u32,
+use crate::storage::wal::segment::Segment;
+
+/// All segments of one partition, with the active segment and the sealed set
+/// guarded by **separate** locks.
+///
+/// Split-locking is the structural guard for the lock-discipline invariant:
+/// `append` takes only `active`, GC takes only `sealed`, so deletion of a sealed
+/// segment never blocks an in-flight append to the active segment. Rotation is
+/// the only operation that briefly holds both (active for the fsync-old →
+/// create-new → fsync-dir → swap, sealed only for the push of the frozen segment).
+struct PartitionHandle {
+    /// The append-target segment. Appends mutate only this, under this lock.
+    active: AsyncMutex<Segment>,
+    /// Sealed, immutable segments in ascending `first_seq` order (oldest at the
+    /// front). GC reclaims a watermark-covered prefix from the front.
+    sealed: AsyncMutex<Vec<Segment>>,
 }
 
 /// Production append-only WAL writer.
 ///
-/// Maintains one file per partition under `wal_dir` named
-/// `partition-{id:03}.log`. Applied-sequence tracking uses a sidecar file
-/// `partition-{id:03}.applied` that stores the highest applied sequence number
-/// as a big-endian u64 so recovery can skip already-durable entries.
+/// Each partition's log is split into a sequence of segment files named
+/// `partition-{id:03}-{first_seq:020}.log` (see `segment`): appends always target
+/// the single active segment, and `mark_applied` seals the active segment, rotates
+/// a fresh one in, then GC-deletes sealed segments fully covered by the applied
+/// watermark. Applied-sequence tracking uses a sidecar file
+/// `partition-{id:03}.applied` that stores the highest applied sequence number as
+/// a big-endian u64 so recovery can skip already-durable entries — and so GC and
+/// the post-restart sequence seed have a crash-durable watermark.
 ///
-/// Thread safety: each partition file is guarded by its own `AsyncMutex` so
-/// concurrent appends to different partitions do not block each other.
+/// Thread safety: each partition is guarded by its own `PartitionHandle` (split
+/// active/sealed locks) so concurrent appends to different partitions do not block
+/// each other and GC never serializes against appends.
 pub struct WalWriter {
     wal_dir: PathBuf,
     policy: WalFsyncPolicy,
-    /// Per-partition file handles, lazily opened on first append.
-    files: AsyncMutex<HashMap<u32, PartitionFile>>,
+    /// Per-partition segment handles, lazily opened on first append/discovery.
+    partitions: AsyncMutex<HashMap<u32, Arc<PartitionHandle>>>,
     /// Batched-commit group-commit timer: shared notifier woken every ~10 ms.
     /// When `policy == Batched`, the writer also fsyncs after every 100 ops.
     batch_flush_tx: tokio::sync::watch::Sender<()>,
+}
+
+/// fsyncs a directory so a just-created (or just-renamed/unlinked) entry within it
+/// is durable. On most filesystems the parent-dir fsync is what makes a new file's
+/// directory entry survive a crash; without it, a freshly-created segment that has
+/// been written and acked can vanish on power loss.
+fn fsync_dir(dir: &Path) -> anyhow::Result<()> {
+    let handle = std::fs::File::open(dir)
+        .map_err(|e| anyhow::anyhow!("Cannot open WAL dir {} for fsync: {e}", dir.display()))?;
+    handle
+        .sync_all()
+        .map_err(|e| anyhow::anyhow!("Cannot fsync WAL dir {}: {e}", dir.display()))?;
+    Ok(())
 }
 
 impl WalWriter {
@@ -235,12 +263,14 @@ impl WalWriter {
         let writer = Arc::new(Self {
             wal_dir,
             policy,
-            files: AsyncMutex::new(HashMap::new()),
+            partitions: AsyncMutex::new(HashMap::new()),
             batch_flush_tx,
         });
 
-        // For the Batched policy, spawn a background task that fsyncs all open
-        // partition files every ~10 ms so group-commit amortises fsync cost.
+        // For the Batched policy, spawn a background task that fsyncs every open
+        // active segment every ~10 ms so group-commit amortises fsync cost. Only
+        // the active segment is ever appended to, so only it can have un-fsynced
+        // frames; sealed segments were already fsynced at seal time.
         if policy == WalFsyncPolicy::Batched {
             let writer_weak = Arc::downgrade(&writer);
             tokio::spawn(async move {
@@ -258,11 +288,15 @@ impl WalWriter {
                     let Some(w) = writer_weak.upgrade() else {
                         return;
                     };
-                    let mut guard = w.files.lock().await;
-                    for pf in guard.values_mut() {
-                        if pf.unfsynced_count > 0 {
-                            let _ = pf.file.sync_data().await;
-                            pf.unfsynced_count = 0;
+                    // Snapshot the handle list under the map lock, then fsync each
+                    // active segment under its own lock so the timer never blocks
+                    // appends to other partitions.
+                    let handles: Vec<Arc<PartitionHandle>> =
+                        { w.partitions.lock().await.values().cloned().collect() };
+                    for handle in handles {
+                        let mut active = handle.active.lock().await;
+                        if active.unfsynced_count() > 0 {
+                            let _ = active.sync_data().await;
                         }
                     }
                 }
@@ -272,9 +306,10 @@ impl WalWriter {
         Ok(writer)
     }
 
-    /// Path of the append log for a partition.
-    fn log_path(&self, partition: u32) -> PathBuf {
-        self.wal_dir.join(format!("partition-{partition:03}.log"))
+    /// Path of the active segment for a fresh partition (seeded at `first_seq`).
+    fn first_segment_path(&self, partition: u32) -> PathBuf {
+        self.wal_dir
+            .join(segment::format_segment_filename(partition, 0))
     }
 
     /// Path of the sidecar file that records the highest applied sequence.
@@ -292,13 +327,192 @@ impl WalWriter {
         }
     }
 
-    /// Writes the highest applied sequence to the sidecar file atomically
-    /// (write to `.tmp` then rename).
+    /// Writes the highest applied sequence to the sidecar file atomically and
+    /// crash-durably (write `.tmp`, fsync it, rename, fsync the parent dir).
+    ///
+    /// The rename is atomic but not crash-durable on its own. This watermark is now
+    /// load-bearing twice over: it is the GC gate (sealed segments at or below it
+    /// are unlinked) and the restart seed for `max_observed_sequence`. If it were
+    /// lost on a crash, a fully-compacted partition would under-seed the sequence
+    /// counter and reuse a number the recovery filter then silently drops. fsyncing
+    /// the data and the directory entry closes that hole.
     fn write_applied_sequence(path: &Path, seq: u64) -> anyhow::Result<()> {
+        use std::io::Write as _;
         let tmp = path.with_extension("applied.tmp");
-        std::fs::write(&tmp, seq.to_be_bytes())?;
+        {
+            let mut file = std::fs::File::create(&tmp)
+                .map_err(|e| anyhow::anyhow!("Cannot create applied tmp {}: {e}", tmp.display()))?;
+            file.write_all(&seq.to_be_bytes())
+                .map_err(|e| anyhow::anyhow!("Cannot write applied tmp {}: {e}", tmp.display()))?;
+            file.sync_all()
+                .map_err(|e| anyhow::anyhow!("Cannot fsync applied tmp {}: {e}", tmp.display()))?;
+        }
         std::fs::rename(&tmp, path)?;
+        if let Some(parent) = path.parent() {
+            fsync_dir(parent)?;
+        }
         Ok(())
+    }
+
+    /// Discovers a single partition's segment files on disk, returning their
+    /// `(first_seq, path)` pairs sorted ascending by `first_seq`.
+    ///
+    /// Recovery and lazy handle-open both rely on the filename convention to order
+    /// segments without opening them.
+    fn discover_partition_segments(
+        wal_dir: &Path,
+        partition: u32,
+    ) -> anyhow::Result<Vec<(u64, PathBuf)>> {
+        let mut found: Vec<(u64, PathBuf)> = Vec::new();
+        let read_dir = std::fs::read_dir(wal_dir)
+            .map_err(|e| anyhow::anyhow!("Cannot read WAL dir {}: {e}", wal_dir.display()))?;
+        for entry in read_dir.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if let Some((p, first_seq)) = segment::parse_segment_filename(&name_str) {
+                if p == partition {
+                    found.push((first_seq, entry.path()));
+                }
+            }
+        }
+        found.sort_by_key(|(first_seq, _)| *first_seq);
+        Ok(found)
+    }
+
+    /// Returns the live `PartitionHandle`, opening it from disk on first use.
+    ///
+    /// On open, the partition's existing segment files are discovered by filename
+    /// (ascending `first_seq`). The highest-`first_seq` segment becomes the active
+    /// append target (reopened in append mode, its `max_seq` decoded from its
+    /// frames); the rest are recorded as sealed with their decoded `max_seq`. A
+    /// partition with no segment files starts with a single empty active segment at
+    /// `first_seq = 0`.
+    async fn handle(&self, partition: u32) -> anyhow::Result<Arc<PartitionHandle>> {
+        {
+            let map = self.partitions.lock().await;
+            if let Some(h) = map.get(&partition) {
+                return Ok(Arc::clone(h));
+            }
+        }
+
+        let mut segments = Self::discover_partition_segments(&self.wal_dir, partition)?;
+
+        let mut sealed: Vec<Segment> = Vec::new();
+        let active: Segment = if let Some((active_first_seq, active_path)) = segments.pop() {
+            // The highest-`first_seq` segment is the active append target; the
+            // remainder are sealed (decoded for their authoritative `max_seq`).
+            for (first_seq, path) in segments {
+                let max_seq = Self::decode_segment_max_seq(&path).await?;
+                sealed.push(Segment::sealed_existing(path, first_seq, max_seq));
+            }
+            let max_seq = Self::decode_segment_max_seq(&active_path).await?;
+            let file = tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&active_path)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("Cannot open WAL segment {}: {e}", active_path.display())
+                })?;
+            let mut seg = Segment::new_active(active_path, active_first_seq, file);
+            seg.set_recovered_max_seq(max_seq);
+            seg
+        } else {
+            let path = self.first_segment_path(partition);
+            let file = tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .await
+                .map_err(|e| anyhow::anyhow!("Cannot open WAL segment {}: {e}", path.display()))?;
+            // A freshly-created segment's dir entry must be durable before any
+            // append to it is acked.
+            fsync_dir(&self.wal_dir)?;
+            Segment::new_active(path, 0, file)
+        };
+
+        let mut map = self.partitions.lock().await;
+        // Another task may have opened the handle while we were doing I/O without
+        // the map lock; honour the first one installed.
+        if let Some(h) = map.get(&partition) {
+            return Ok(Arc::clone(h));
+        }
+        let handle = Arc::new(PartitionHandle {
+            active: AsyncMutex::new(active),
+            sealed: AsyncMutex::new(sealed),
+        });
+        map.insert(partition, Arc::clone(&handle));
+        Ok(handle)
+    }
+
+    /// Decodes the highest sequence number present in a segment file, tolerating a
+    /// truncated tail on the file (returns the intact prefix's max) and refusing on
+    /// mid-file corruption. Returns the file's `first_seq` floor when it is empty —
+    /// the caller distinguishes empty from a genuine single-frame segment via the
+    /// frame count, not this value.
+    async fn decode_segment_max_seq(path: &Path) -> anyhow::Result<u64> {
+        let data = tokio::fs::read(path)
+            .await
+            .map_err(|e| anyhow::anyhow!("Cannot read WAL segment {}: {e}", path.display()))?;
+        let entries = Self::decode_segment_or_refuse(path, &data, true)?;
+        Ok(entries.iter().map(|e| e.sequence).max().unwrap_or(0))
+    }
+
+    /// Decodes every frame in one segment's bytes, applying the shared corruption
+    /// taxonomy. `tolerate_truncated_tail` controls whether a truncated tail is a
+    /// recoverable WARN (active / last segment) or a fatal refusal (a sealed,
+    /// non-last segment must never be torn).
+    fn decode_segment_or_refuse(
+        path: &Path,
+        data: &[u8],
+        tolerate_truncated_tail: bool,
+    ) -> anyhow::Result<Vec<WalEntry>> {
+        match format::decode_all(data) {
+            format::FrameDecodeResult::Complete(entries) => Ok(entries),
+            format::FrameDecodeResult::CleanEof => Ok(Vec::new()),
+            format::FrameDecodeResult::TruncatedTail { complete } => {
+                if tolerate_truncated_tail {
+                    tracing::warn!(
+                        path = ?path,
+                        "WAL tail truncated (crash mid-write); replaying intact prefix"
+                    );
+                    Ok(complete)
+                } else {
+                    let path_display = path.display();
+                    anyhow::bail!(
+                        "WAL segment {path_display} has a truncated tail but is not the active \
+                         segment; a torn non-last segment is corruption — refusing to start"
+                    );
+                }
+            }
+            format::FrameDecodeResult::BadMagic { offset } => {
+                let path_display = path.display();
+                anyhow::bail!(
+                    "WAL file {path_display} has wrong magic at offset {offset}; \
+                     refusing to start to avoid replaying corrupt data"
+                );
+            }
+            format::FrameDecodeResult::UnknownVersion { found, offset } => {
+                let path_display = path.display();
+                anyhow::bail!(
+                    "WAL file {path_display} has unknown format version {found} at offset {offset}; \
+                     refusing to start"
+                );
+            }
+            format::FrameDecodeResult::Corruption {
+                offset,
+                stored_crc,
+                computed_crc,
+            } => {
+                let path_display = path.display();
+                anyhow::bail!(
+                    "WAL corruption in {path_display} at offset {offset}: \
+                     stored CRC={stored_crc:#010x} computed CRC={computed_crc:#010x}; \
+                     refusing to start to avoid replaying corrupt data. \
+                     Delete or repair the WAL file to allow startup."
+                );
+            }
+        }
     }
 }
 
@@ -307,59 +521,24 @@ impl Wal for WalWriter {
     async fn append(&self, partition: u32, entry: &WalEntry) -> anyhow::Result<()> {
         let frame = format::encode(entry)?;
 
-        let mut files = self.files.lock().await;
-        let pf = if let Some(pf) = files.get_mut(&partition) {
-            pf
-        } else {
-            let path = self.log_path(partition);
-            let file = tokio::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&path)
-                .await
-                .map_err(|e| anyhow::anyhow!("Cannot open WAL file {}: {e}", path.display()))?;
-            files.insert(
-                partition,
-                PartitionFile {
-                    file,
-                    unfsynced_count: 0,
-                },
-            );
-            files.get_mut(&partition).unwrap()
-        };
+        let handle = self.handle(partition).await?;
+        // Take ONLY the active-append lock. GC of sealed segments runs under a
+        // distinct lock and never blocks this path; rotation briefly takes this
+        // same lock, which is correct — an append and a rotate on the same
+        // partition must serialize so a seal never freezes a half-written frame.
+        let mut active = handle.active.lock().await;
 
-        pf.file
-            .write_all(&frame)
-            .await
-            .map_err(|e| anyhow::anyhow!("WAL write failed for partition {partition}: {e}"))?;
-
-        // Push tokio's internal write buffer out to the OS so a subsequent fresh
-        // read of this partition file (unapplied/recovery/compaction all reopen
-        // the path) observes the entry. This is visibility, not durability:
-        // flush() does not fsync. Durability is governed separately by the policy
-        // match below. Without this, the None policy never leaves tokio's buffer
-        // and a concurrent reader can miss a just-appended entry.
-        pf.file
-            .flush()
-            .await
-            .map_err(|e| anyhow::anyhow!("WAL flush failed for partition {partition}: {e}"))?;
+        let count = active.append_frame(&frame, entry.sequence).await?;
 
         match self.policy {
             WalFsyncPolicy::PerOp => {
-                pf.file.sync_data().await.map_err(|e| {
-                    anyhow::anyhow!("WAL fsync failed for partition {partition}: {e}")
-                })?;
-                pf.unfsynced_count = 0;
+                active.sync_data().await?;
             }
             WalFsyncPolicy::Batched => {
-                pf.unfsynced_count += 1;
                 // Flush immediately when the batch threshold is reached so
                 // high-throughput bursts don't wait for the timer task.
-                if pf.unfsynced_count >= 100 {
-                    pf.file.sync_data().await.map_err(|e| {
-                        anyhow::anyhow!("WAL batch fsync failed for partition {partition}: {e}")
-                    })?;
-                    pf.unfsynced_count = 0;
+                if count >= 100 {
+                    active.sync_data().await?;
                     // Notify the background timer that we just fsynced so it
                     // resets its internal cooldown.
                     let _ = self.batch_flush_tx.send(());
@@ -374,155 +553,126 @@ impl Wal for WalWriter {
     }
 
     async fn mark_applied(&self, partition: u32, sequence: u64) -> anyhow::Result<()> {
-        let path = self.applied_path(partition);
-        // Read the current max and only advance it, never regress it.
-        let current = Self::read_applied_sequence(&path);
-        if sequence > current {
-            Self::write_applied_sequence(&path, sequence).map_err(|e| {
-                anyhow::anyhow!("Cannot write applied sidecar {}: {e}", path.display())
+        let applied_path = self.applied_path(partition);
+        // Advance the watermark monotonically; never regress it.
+        let current = Self::read_applied_sequence(&applied_path);
+        let watermark = sequence.max(current);
+        if watermark > current {
+            // Durably advance the watermark BEFORE any sealed segment is unlinked:
+            // a crash after an unlink but before the watermark fsync would
+            // under-seed max_observed_sequence on restart and reuse a sequence the
+            // recovery filter then silently drops. The fsync (data + parent dir)
+            // closes that hole.
+            Self::write_applied_sequence(&applied_path, watermark).map_err(|e| {
+                anyhow::anyhow!(
+                    "Cannot write applied sidecar {}: {e}",
+                    applied_path.display()
+                )
             })?;
         }
 
-        // After marking applied, compact the WAL log: rebuild it with only
-        // entries whose sequence is above the new applied watermark.
-        self.compact_log(partition, sequence).await
-    }
+        let handle = self.handle(partition).await?;
 
-    async fn unapplied(&self, partition: u32) -> anyhow::Result<Vec<WalEntry>> {
-        let log_path = self.log_path(partition);
-        if !log_path.exists() {
-            return Ok(Vec::new());
+        // --- Seal + rotate (RULE-ordered, under the active-append lock) ---
+        // Only rotate when the active segment actually holds frames. Sealing an
+        // empty active segment would leave a zero-length sealed file the next
+        // append could never reach and GC would have to special-case.
+        {
+            let mut active = handle.active.lock().await;
+            if active.has_frames() {
+                let next_first_seq = active.max_seq().saturating_add(1);
+                let new_path = self
+                    .wal_dir
+                    .join(segment::format_segment_filename(partition, next_first_seq));
+                let new_file = tokio::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&new_path)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!("Cannot open WAL segment {}: {e}", new_path.display())
+                    })?;
+                // (c) fsync the parent dir so the new active file's dir entry is
+                // durable BEFORE any append is acked to it (before this lock is
+                // released).
+                fsync_dir(&self.wal_dir)?;
+
+                // Swap in the fresh active, take the old one out to seal it. The
+                // old segment's data is fsynced inside `seal()` BEFORE it joins the
+                // sealed set, because a torn tail on a non-last segment is fatal.
+                let new_active = Segment::new_active(new_path, next_first_seq, new_file);
+                let old_active = std::mem::replace(&mut *active, new_active);
+                let frozen = old_active.seal().await?;
+                // The sealed-set lock is taken only for the push, never held across
+                // the append-lock release, so appenders are not serialized by GC.
+                handle.sealed.lock().await.push(frozen);
+                // Active-append lock released here.
+            }
         }
 
-        let applied_seq = Self::read_applied_sequence(&self.applied_path(partition));
-
-        let data = tokio::fs::read(&log_path)
-            .await
-            .map_err(|e| anyhow::anyhow!("Cannot read WAL file {}: {e}", log_path.display()))?;
-
-        let entries = match format::decode_all(&data) {
-            format::FrameDecodeResult::Complete(entries) => entries,
-            format::FrameDecodeResult::CleanEof => Vec::new(),
-            format::FrameDecodeResult::TruncatedTail { complete } => {
-                tracing::warn!(
-                    partition = partition,
-                    path = ?log_path,
-                    "WAL tail truncated (crash mid-write); replaying intact prefix"
-                );
-                complete
-            }
-            format::FrameDecodeResult::BadMagic { offset } => {
-                let path_display = log_path.display();
-                anyhow::bail!(
-                    "WAL file {path_display} has wrong magic at offset {offset}; \
-                     refusing to start to avoid replaying corrupt data"
-                );
-            }
-            format::FrameDecodeResult::UnknownVersion { found, offset } => {
-                let path_display = log_path.display();
-                anyhow::bail!(
-                    "WAL file {path_display} has unknown format version {found} at offset {offset}; \
-                     refusing to start"
-                );
-            }
-            format::FrameDecodeResult::Corruption {
-                offset,
-                stored_crc,
-                computed_crc,
-            } => {
-                let path_display = log_path.display();
-                anyhow::bail!(
-                    "WAL corruption in {path_display} at offset {offset}: \
-                     stored CRC={stored_crc:#010x} computed CRC={computed_crc:#010x}; \
-                     refusing to start to avoid replaying corrupt data. \
-                     Delete or repair the WAL file to allow startup."
-                );
-            }
+        // --- GC sealed segments fully covered by the watermark ---
+        // Takes ONLY the sealed-set lock; never the active-append lock. Appends in
+        // flight to the active segment are not blocked by this deletion.
+        let reclaimed: Vec<PathBuf> = {
+            let mut sealed = handle.sealed.lock().await;
+            // Reclaimable sealed segments are a prefix of the ascending-ordered set
+            // (oldest first), valid because sequences are monotonic and gap-free.
+            let reclaim = sealed
+                .iter()
+                .take_while(|s| s.max_seq() <= watermark)
+                .count();
+            sealed
+                .drain(..reclaim)
+                .map(|s| s.path().to_path_buf())
+                .collect()
         };
 
-        // Return only entries that have not yet been applied.
-        let unapplied: Vec<WalEntry> = entries
-            .into_iter()
-            .filter(|e| e.sequence > applied_seq)
-            .collect();
-
-        Ok(unapplied)
-    }
-}
-
-impl WalWriter {
-    /// Rewrites the partition log retaining only entries above `applied_through`.
-    ///
-    /// Writes to a `.tmp` file first and atomically renames it over the original
-    /// so a crash mid-compaction does not corrupt the WAL.
-    async fn compact_log(&self, partition: u32, applied_through: u64) -> anyhow::Result<()> {
-        let log_path = self.log_path(partition);
-
-        // Hold the per-writer file lock across the ENTIRE compaction
-        // (snapshot read → rewrite → rename → handle swap). append() takes the
-        // same lock, so without holding it here an append that interleaves
-        // between the snapshot read and the rename writes to the old inode,
-        // which the rename then unlinks — silently dropping an already-acked
-        // write and defeating append-before-ack. Serializing append against
-        // compaction is the correctness guarantee; the O(n) rewrite cost under
-        // the lock is tracked separately (segment rotation).
-        let mut guard = self.files.lock().await;
-
-        if !log_path.exists() {
-            return Ok(());
+        for path in &reclaimed {
+            tokio::fs::remove_file(path).await.map_err(|e| {
+                anyhow::anyhow!("Cannot unlink sealed WAL segment {}: {e}", path.display())
+            })?;
         }
-
-        // Flush the cached handle before the fresh read so the snapshot includes
-        // every byte appended so far (append() flushes too, but this is robust
-        // against any future buffered-write path).
-        if let Some(pf) = guard.get_mut(&partition) {
-            pf.file
-                .flush()
-                .await
-                .map_err(|e| anyhow::anyhow!("WAL flush before compaction failed: {e}"))?;
+        // A single parent-dir fsync after the unlink batch makes the reclamation
+        // durable. Per-unlink dir fsync is unnecessary: GC is resumable and replay
+        // is idempotent under the watermark filter, so a crash between unlinks is
+        // safe.
+        if !reclaimed.is_empty() {
+            fsync_dir(&self.wal_dir)?;
         }
-
-        let data = tokio::fs::read(&log_path).await?;
-        let all_entries = match format::decode_all(&data) {
-            format::FrameDecodeResult::Complete(e) => e,
-            format::FrameDecodeResult::CleanEof => Vec::new(),
-            format::FrameDecodeResult::TruncatedTail { complete } => complete,
-            _ => return Ok(()), // corrupt log — leave it for recovery to handle
-        };
-
-        let remaining: Vec<&WalEntry> = all_entries
-            .iter()
-            .filter(|e| e.sequence > applied_through)
-            .collect();
-
-        // Build the compacted log
-        let mut compacted = Vec::new();
-        for entry in &remaining {
-            compacted.extend_from_slice(&format::encode(entry)?);
-        }
-
-        let tmp_path = log_path.with_extension("log.tmp");
-        tokio::fs::write(&tmp_path, &compacted).await?;
-        tokio::fs::rename(&tmp_path, &log_path).await?;
-
-        // Swap the in-memory file handle (still under the lock) so subsequent
-        // appends go to the freshly-rewritten file.
-        let new_file = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&log_path)
-            .await?;
-        guard.insert(
-            partition,
-            PartitionFile {
-                file: new_file,
-                unfsynced_count: 0,
-            },
-        );
 
         Ok(())
     }
 
+    async fn unapplied(&self, partition: u32) -> anyhow::Result<Vec<WalEntry>> {
+        let applied_seq = Self::read_applied_sequence(&self.applied_path(partition));
+        let segments = Self::discover_partition_segments(&self.wal_dir, partition)?;
+        if segments.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let last_idx = segments.len() - 1;
+        let mut all: Vec<WalEntry> = Vec::new();
+        for (idx, (_first_seq, path)) in segments.into_iter().enumerate() {
+            let data = tokio::fs::read(&path)
+                .await
+                .map_err(|e| anyhow::anyhow!("Cannot read WAL segment {}: {e}", path.display()))?;
+            // A truncated tail is tolerated ONLY on the active (last) segment; a
+            // torn tail on a sealed, non-last segment is corruption.
+            let tolerate_tail = idx == last_idx;
+            let entries = Self::decode_segment_or_refuse(&path, &data, tolerate_tail)?;
+            all.extend(entries);
+        }
+
+        // Frames are written in ascending sequence order within and across
+        // segments, but sort defensively so the ordering contract holds even if a
+        // future path interleaves.
+        all.sort_by_key(|e| e.sequence);
+        all.retain(|e| e.sequence > applied_seq);
+        Ok(all)
+    }
+}
+
+impl WalWriter {
     /// Highest sequence this WAL has ever durably observed across **all**
     /// partitions: the max over every `.applied` sidecar watermark AND every
     /// log's max sequence.
@@ -544,21 +694,22 @@ impl WalWriter {
     pub async fn max_observed_sequence(&self) -> anyhow::Result<u64> {
         let mut global = 0u64;
         for partition in Self::discover_all_partitions(&self.wal_dir)? {
-            // The sidecar watermark survives compaction even when the log was
-            // rewritten to empty, so it must be read for every partition.
+            // The sidecar watermark survives GC even when every segment was
+            // reclaimed (compacted-to-empty partition), so it must be read for
+            // every partition.
             global = global.max(Self::read_applied_sequence(&self.applied_path(partition)));
             global = global.max(self.max_log_sequence(partition).await?);
         }
         Ok(global)
     }
 
-    /// Discovers partition IDs by scanning `wal_dir` for **both**
-    /// `partition-*.log` and `partition-*.applied`, taking the union.
+    /// Discovers partition IDs by scanning `wal_dir` for **both** segment files
+    /// (`partition-NNN-SSS.log`) and `.applied` sidecars, taking the union.
     ///
-    /// A compacted-empty partition (log rewritten to empty by `compact_log`)
-    /// still carries a live `.applied` watermark, so discovery keyed on `.log`
-    /// alone would skip it and the seed would land below that watermark —
-    /// reproducing the durability defect. The union defends against that.
+    /// A compacted-to-empty partition (all segments GC'd) still carries a live
+    /// `.applied` watermark, so discovery keyed on segment files alone would skip
+    /// it and the seed would land below that watermark — reproducing the durability
+    /// defect. The union defends against that.
     fn discover_all_partitions(wal_dir: &Path) -> anyhow::Result<Vec<u32>> {
         let mut ids: HashSet<u32> = HashSet::new();
         let read_dir = std::fs::read_dir(wal_dir)
@@ -566,19 +717,16 @@ impl WalWriter {
         for entry in read_dir.flatten() {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
-            if !name_str.starts_with("partition-") {
+            if let Some((partition, _first_seq)) = segment::parse_segment_filename(&name_str) {
+                ids.insert(partition);
                 continue;
             }
-            let inner = if let Some(rest) = name_str.strip_suffix(".log") {
-                rest
-            } else if let Some(rest) = name_str.strip_suffix(".applied") {
-                rest
-            } else {
-                continue;
-            };
-            let inner = &inner["partition-".len()..];
-            if let Ok(id) = inner.parse::<u32>() {
-                ids.insert(id);
+            if let Some(rest) = name_str.strip_prefix("partition-") {
+                if let Some(inner) = rest.strip_suffix(".applied") {
+                    if let Ok(id) = inner.parse::<u32>() {
+                        ids.insert(id);
+                    }
+                }
             }
         }
         let mut ids: Vec<u32> = ids.into_iter().collect();
@@ -586,55 +734,29 @@ impl WalWriter {
         Ok(ids)
     }
 
-    /// Returns the maximum `WalEntry.sequence` still present in a partition's
-    /// log, or `0` if the log is absent/empty.
+    /// Returns the maximum `WalEntry.sequence` still present across **all** of a
+    /// partition's segment files, or `0` if it has none.
     ///
-    /// Tolerates a truncated tail (uses the intact prefix) using the same
-    /// `format::decode_all` classification as `unapplied`; refuses (returns
-    /// `Err`) on mid-file corruption, bad magic, or an unknown version.
+    /// Tolerates a truncated tail (uses the intact prefix) ONLY on the active
+    /// (last) segment, and refuses on mid-file corruption / bad magic / unknown
+    /// version in any segment — the same taxonomy `unapplied` uses.
     async fn max_log_sequence(&self, partition: u32) -> anyhow::Result<u64> {
-        let log_path = self.log_path(partition);
-        if !log_path.exists() {
+        let segments = Self::discover_partition_segments(&self.wal_dir, partition)?;
+        if segments.is_empty() {
             return Ok(0);
         }
-
-        let data = tokio::fs::read(&log_path)
-            .await
-            .map_err(|e| anyhow::anyhow!("Cannot read WAL file {}: {e}", log_path.display()))?;
-
-        let entries = match format::decode_all(&data) {
-            format::FrameDecodeResult::Complete(entries) => entries,
-            format::FrameDecodeResult::CleanEof => Vec::new(),
-            format::FrameDecodeResult::TruncatedTail { complete } => complete,
-            format::FrameDecodeResult::BadMagic { offset } => {
-                let path_display = log_path.display();
-                anyhow::bail!(
-                    "WAL file {path_display} has wrong magic at offset {offset}; \
-                     refusing to compute max sequence on corrupt data"
-                );
+        let last_idx = segments.len() - 1;
+        let mut global = 0u64;
+        for (idx, (_first_seq, path)) in segments.into_iter().enumerate() {
+            let data = tokio::fs::read(&path)
+                .await
+                .map_err(|e| anyhow::anyhow!("Cannot read WAL segment {}: {e}", path.display()))?;
+            let entries = Self::decode_segment_or_refuse(&path, &data, idx == last_idx)?;
+            if let Some(m) = entries.iter().map(|e| e.sequence).max() {
+                global = global.max(m);
             }
-            format::FrameDecodeResult::UnknownVersion { found, offset } => {
-                let path_display = log_path.display();
-                anyhow::bail!(
-                    "WAL file {path_display} has unknown format version {found} at offset {offset}; \
-                     refusing to compute max sequence"
-                );
-            }
-            format::FrameDecodeResult::Corruption {
-                offset,
-                stored_crc,
-                computed_crc,
-            } => {
-                let path_display = log_path.display();
-                anyhow::bail!(
-                    "WAL corruption in {path_display} at offset {offset}: \
-                     stored CRC={stored_crc:#010x} computed CRC={computed_crc:#010x}; \
-                     refusing to compute max sequence on corrupt data"
-                );
-            }
-        };
-
-        Ok(entries.iter().map(|e| e.sequence).max().unwrap_or(0))
+        }
+        Ok(global)
     }
 }
 
@@ -662,23 +784,20 @@ impl WalRecovery {
         Self { wal, partitions }
     }
 
-    /// Discovers partition IDs by scanning `wal_dir` for `partition-*.log` files.
+    /// Discovers partition IDs by scanning `wal_dir` for segment files
+    /// (`partition-NNN-SSS.log`).
     fn discover_partitions(wal_dir: &Path) -> anyhow::Result<Vec<u32>> {
-        let mut ids = Vec::new();
+        let mut ids: HashSet<u32> = HashSet::new();
         let read_dir = std::fs::read_dir(wal_dir)
             .map_err(|e| anyhow::anyhow!("Cannot read WAL dir {}: {e}", wal_dir.display()))?;
         for entry in read_dir.flatten() {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
-            // Extract the partition id from the filename pattern partition-NNN.log
-            if let Some(rest) = name_str.strip_prefix("partition-") {
-                if let Some(inner) = rest.strip_suffix(".log") {
-                    if let Ok(id) = inner.parse::<u32>() {
-                        ids.push(id);
-                    }
-                }
+            if let Some((partition, _first_seq)) = segment::parse_segment_filename(&name_str) {
+                ids.insert(partition);
             }
         }
+        let mut ids: Vec<u32> = ids.into_iter().collect();
         ids.sort_unstable();
         Ok(ids)
     }
@@ -976,12 +1095,11 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Concurrency regression: compaction must not drop appends that interleave
-    // with it. mark_applied(0) triggers compact_log while an appender races on
-    // the same partition; before the fix (compaction did not hold the files
-    // lock across read→rename) acked appends written during compaction were
-    // silently dropped (~1864/2000 reproduced). applied_through stays 0 so every
-    // appended seq must survive in unapplied.
+    // Concurrency regression: seal/rotate must not drop appends that interleave
+    // with it. mark_applied(0) seals + rotates the active segment while an
+    // appender races on the same partition. The watermark stays 0 so GC reclaims
+    // nothing and every appended seq must survive in unapplied — proving the
+    // RULE: no acked frame is lost when a rotation lands between two appends.
     // -----------------------------------------------------------------------
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1064,7 +1182,7 @@ mod tests {
         let frame2 = format::encode(&entry2).unwrap();
         data.extend_from_slice(&frame2[..frame2.len() / 2]);
 
-        let log_path = dir.path().join("partition-000.log");
+        let log_path = dir.path().join(segment::format_segment_filename(0, 1));
         tokio::fs::write(&log_path, &data).await.unwrap();
 
         let wal = WalWriter::new(dir.path().to_path_buf(), WalFsyncPolicy::None).unwrap();
@@ -1096,7 +1214,7 @@ mod tests {
         let mut data = frame1;
         data.extend_from_slice(&frame2);
 
-        let log_path = dir.path().join("partition-000.log");
+        let log_path = dir.path().join(segment::format_segment_filename(0, 1));
         tokio::fs::write(&log_path, &data).await.unwrap();
 
         let wal = WalWriter::new(dir.path().to_path_buf(), WalFsyncPolicy::None).unwrap();

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -1143,6 +1143,231 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // RULE stress regression (promoted from the G9 depth-audit scratch suite):
+    // no acked WAL frame may be dropped by seal/rotate/GC under concurrent
+    // same-partition append. Two variants:
+    //
+    //   Variant A — watermark pinned at 0: GC reclaims nothing, so EVERY acked
+    //     sequence must survive in `unapplied`. This isolates the seal/rotate
+    //     interleave from GC (a rotation landing between two appends must not
+    //     orphan an acked frame).
+    //
+    //   Variant B — a non-zero, advancing watermark that lags the appender: this
+    //     actually exercises seal → rotate → unlink. The invariant is the RULE:
+    //     every acked sequence `s` must be either present in `unapplied` (it is
+    //     above the final watermark) OR provably applied (`s <= final watermark`,
+    //     so a correct `unapplied` filter excludes it). Zero acked sequences may
+    //     be silently dropped — i.e. absent from `unapplied` while also above the
+    //     watermark.
+    // -----------------------------------------------------------------------
+
+    /// Variant A — pinned watermark 0: every acked sequence survives in
+    /// `unapplied` because GC reclaims nothing while seal/rotate keeps racing the
+    /// appender. This is the segment-rotation analogue of the audit's original
+    /// `stress_compact_races_append_loses_acked_writes` repro.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn stress_compact_races_append_loses_acked_writes() {
+        const N: u64 = 2000;
+
+        let dir = tempfile::tempdir().unwrap();
+        let wal = WalWriter::new(dir.path().to_path_buf(), WalFsyncPolicy::None).unwrap();
+
+        let appender = {
+            let wal = Arc::clone(&wal);
+            tokio::spawn(async move {
+                let mut acked = HashSet::new();
+                for seq in 1..=N {
+                    wal.append(0, &make_wal_entry(seq)).await.unwrap();
+                    acked.insert(seq);
+                }
+                acked
+            })
+        };
+
+        let compactor = {
+            let wal = Arc::clone(&wal);
+            tokio::spawn(async move {
+                // watermark == 0 ⇒ GC retains every entry, but seal/rotate still
+                // freezes the active segment under the appender's feet on every
+                // call — the window the RULE forbids from dropping a frame.
+                for _ in 0..4000 {
+                    wal.mark_applied(0, 0).await.unwrap();
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+
+        let acked = appender.await.unwrap();
+        compactor.await.unwrap();
+
+        // Watermark is still 0, so `unapplied` must return every acked frame.
+        let present: HashSet<u64> = wal
+            .unapplied(0)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.sequence)
+            .collect();
+
+        let lost: Vec<u64> = acked.difference(&present).copied().collect();
+        assert!(
+            lost.is_empty(),
+            "{} acked sequences silently dropped by seal/rotate race (e.g. {:?})",
+            lost.len(),
+            &lost.iter().take(10).collect::<Vec<_>>()
+        );
+    }
+
+    /// Variant B — an advancing, appender-lagging watermark drives real
+    /// seal/rotate/GC (sealed segments below the watermark are unlinked). The
+    /// RULE: no acked sequence may be both absent from `unapplied` and above the
+    /// final watermark.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn stress_advancing_watermark_drops_no_acked_write() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        const N: u64 = 4000;
+        // The GC task advances the watermark to this many sequences behind the
+        // appender's latest ack, so a band of recent sequences always stays above
+        // the watermark (in live segments) while older ones are genuinely GC'd.
+        const LAG: u64 = 64;
+
+        let dir = tempfile::tempdir().unwrap();
+        let wal = WalWriter::new(dir.path().to_path_buf(), WalFsyncPolicy::None).unwrap();
+
+        // Highest sequence the appender has acked so far; the GC task reads it to
+        // pick a watermark that lags behind the live frontier.
+        let acked_frontier = Arc::new(AtomicU64::new(0));
+
+        let appender = {
+            let wal = Arc::clone(&wal);
+            let frontier = Arc::clone(&acked_frontier);
+            tokio::spawn(async move {
+                for seq in 1..=N {
+                    wal.append(0, &make_wal_entry(seq)).await.unwrap();
+                    // Publish the ack only AFTER append returns Ok, so the GC task
+                    // can never advance the watermark past a not-yet-acked frame.
+                    frontier.store(seq, Ordering::Release);
+                }
+            })
+        };
+
+        let compactor = {
+            let wal = Arc::clone(&wal);
+            let frontier = Arc::clone(&acked_frontier);
+            tokio::spawn(async move {
+                loop {
+                    let acked = frontier.load(Ordering::Acquire);
+                    // Lag the watermark behind the live frontier so seal/rotate +
+                    // unlink run continuously without the watermark ever reaching
+                    // an unacked sequence.
+                    let watermark = acked.saturating_sub(LAG);
+                    wal.mark_applied(0, watermark).await.unwrap();
+                    tokio::task::yield_now().await;
+                    if acked >= N {
+                        break;
+                    }
+                }
+            })
+        };
+
+        appender.await.unwrap();
+        compactor.await.unwrap();
+
+        // Final watermark observed on disk: every acked sequence at or below it is
+        // provably applied and a correct `unapplied` filter excludes it.
+        let final_watermark = WalWriter::read_applied_sequence(&wal.applied_path(0));
+        let present: HashSet<u64> = wal
+            .unapplied(0)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.sequence)
+            .collect();
+
+        // The RULE: every acked sequence is either still live (in `unapplied`) or
+        // below the watermark (provably applied). A sequence that is BOTH absent
+        // from `unapplied` AND above the watermark was silently dropped.
+        let dropped: Vec<u64> = (1..=N)
+            .filter(|s| !present.contains(s) && *s > final_watermark)
+            .collect();
+        assert!(
+            dropped.is_empty(),
+            "{} acked sequences dropped above the final watermark {} (e.g. {:?})",
+            dropped.len(),
+            final_watermark,
+            &dropped[..dropped.len().min(10)]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC3 — lock discipline (structural): GC of sealed segments must NEVER block
+    // an in-flight append to the active segment. The two paths take DISTINCT
+    // locks (`PartitionHandle::active` vs `PartitionHandle::sealed`), so GC can
+    // run to completion while the active-append lock is held by someone else.
+    //
+    // We assert this by reproducing `mark_applied`'s exact GC body (drain the
+    // watermark-covered prefix of the sealed set + unlink) while HOLDING the
+    // active-append lock the whole time. If GC took the active lock, this would
+    // deadlock; the test completing proves the locks are separate and that an
+    // append in flight (which would hold `active`) does not serialize against GC.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn gc_does_not_block_inflight_append() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal = WalWriter::new(dir.path().to_path_buf(), WalFsyncPolicy::None).unwrap();
+
+        // Build a partition with several sealed segments below a watermark by
+        // appending and sealing repeatedly. Each mark_applied seals the active
+        // segment and rotates a fresh one; watermark 0 keeps them sealed (not yet
+        // GC'd) so the sealed set is populated for the GC-under-lock assertion.
+        for seq in 1..=8u64 {
+            wal.append(0, &make_wal_entry(seq)).await.unwrap();
+            wal.mark_applied(0, 0).await.unwrap();
+        }
+
+        let handle = wal.handle(0).await.unwrap();
+
+        // Hold the active-append lock for the entire GC run. An in-flight append
+        // holds exactly this lock; if GC needed it, this would deadlock.
+        let active_guard = handle.active.lock().await;
+
+        // Reproduce mark_applied's GC body verbatim: it takes ONLY the sealed-set
+        // lock, drains the watermark-covered prefix, and unlinks — never touching
+        // the active lock we are holding above.
+        let watermark = u64::MAX; // reclaim every sealed segment
+        let reclaimed: Vec<PathBuf> = {
+            let mut sealed = handle.sealed.lock().await;
+            let reclaim = sealed
+                .iter()
+                .take_while(|s| s.max_seq() <= watermark)
+                .count();
+            assert!(
+                reclaim > 0,
+                "test setup must leave at least one sealed segment to GC"
+            );
+            sealed
+                .drain(..reclaim)
+                .map(|s| s.path().to_path_buf())
+                .collect()
+        };
+        for path in &reclaimed {
+            tokio::fs::remove_file(path).await.unwrap();
+        }
+
+        // Reaching here while still holding the active lock proves GC made full
+        // progress without the active-append lock — the AC3 lock-discipline
+        // guarantee. Drop the guard explicitly to document the held duration.
+        drop(active_guard);
+
+        // Sanity: the sealed set is now empty (everything GC'd) and the active
+        // segment is untouched and still appendable.
+        assert!(handle.sealed.lock().await.is_empty());
+        wal.append(0, &make_wal_entry(9)).await.unwrap();
+    }
+
+    // -----------------------------------------------------------------------
     // AC2: mark_applied removes entry from unapplied set (clean restart is no-op)
     // -----------------------------------------------------------------------
 

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -8,6 +8,7 @@
 //! replays un-applied entries through the inner store on startup.
 
 pub mod format;
+pub mod segment;
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -296,7 +296,17 @@ impl WalWriter {
                     for handle in handles {
                         let mut active = handle.active.lock().await;
                         if active.unfsynced_count() > 0 {
-                            let _ = active.sync_data().await;
+                            // Surface batch-fsync failures: swallowing the error
+                            // would leave acked frames non-durable under Batched
+                            // with no operator signal that durability is
+                            // compromised.
+                            if let Err(e) = active.sync_data().await {
+                                tracing::error!(
+                                    segment = ?active.path(),
+                                    error = %e,
+                                    "WAL batch fsync failed; acked frames may not be durable"
+                                );
+                            }
                         }
                     }
                 }
@@ -405,7 +415,55 @@ impl WalWriter {
                 let max_seq = Self::decode_segment_max_seq(&path).await?;
                 sealed.push(Segment::sealed_existing(path, first_seq, max_seq));
             }
-            let max_seq = Self::decode_segment_max_seq(&active_path).await?;
+            // Decode the active segment's intact prefix (tolerating a torn tail
+            // from a crash mid-append; mid-file corruption stays fatal). If the
+            // intact prefix is shorter than the file on disk, the tail was torn:
+            // truncate it durably BEFORE opening the append handle. Left in place,
+            // the torn bytes would sit between the intact prefix and the new
+            // appends; once this segment is later sealed (becomes non-last), the
+            // torn region becomes fatal mid-file corruption that refuses recovery.
+            let data = tokio::fs::read(&active_path).await.map_err(|e| {
+                anyhow::anyhow!("Cannot read WAL segment {}: {e}", active_path.display())
+            })?;
+            let entries = Self::decode_segment_or_refuse(&active_path, &data, true)?;
+            // Exact byte length of the intact prefix: re-encode each intact entry
+            // (the codec is deterministic) and sum the frame lengths.
+            let mut intact_len: u64 = 0;
+            for e in &entries {
+                intact_len = intact_len.saturating_add(format::encode(e)?.len() as u64);
+            }
+            if intact_len < data.len() as u64 {
+                tracing::warn!(
+                    path = ?active_path,
+                    file_len = data.len(),
+                    intact_len,
+                    "WAL active segment has a torn tail; truncating to intact prefix \
+                     before reopening for append"
+                );
+                let truncate_file = tokio::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&active_path)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Cannot open WAL segment {} for truncation: {e}",
+                            active_path.display()
+                        )
+                    })?;
+                truncate_file.set_len(intact_len).await.map_err(|e| {
+                    anyhow::anyhow!(
+                        "Cannot truncate torn WAL segment {}: {e}",
+                        active_path.display()
+                    )
+                })?;
+                truncate_file.sync_all().await.map_err(|e| {
+                    anyhow::anyhow!(
+                        "Cannot fsync truncated WAL segment {}: {e}",
+                        active_path.display()
+                    )
+                })?;
+            }
+            let max_seq = entries.iter().map(|e| e.sequence).max().unwrap_or(0);
             let file = tokio::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
@@ -580,6 +638,16 @@ impl Wal for WalWriter {
         {
             let mut active = handle.active.lock().await;
             if active.has_frames() {
+                // Durably fsync the current active's data FIRST, before any swap or
+                // new-file creation. A sealed segment is non-last in the live
+                // ordering, and a torn tail on a non-last segment is fatal during
+                // recovery — so its data must be synced before it is frozen. Doing
+                // the only fallible fsync here (while the old active is still
+                // installed and no new file exists yet) means a failure leaves no
+                // orphan: returning early keeps the old active in place with no
+                // dangling new segment.
+                active.sync_data().await?;
+
                 let next_first_seq = active.max_seq().saturating_add(1);
                 let new_path = self
                     .wal_dir
@@ -597,12 +665,14 @@ impl Wal for WalWriter {
                 // released).
                 fsync_dir(&self.wal_dir)?;
 
-                // Swap in the fresh active, take the old one out to seal it. The
-                // old segment's data is fsynced inside `seal()` BEFORE it joins the
-                // sealed set, because a torn tail on a non-last segment is fatal.
+                // Swap in the fresh active, take the old one out to freeze it. The
+                // old segment's data was already fsynced above, so the freeze is
+                // the infallible `into_sealed` — no fallible fsync runs AFTER the
+                // swap, which guarantees the old active can never be dropped
+                // (orphaned) by a failing fsync after it has been replaced.
                 let new_active = Segment::new_active(new_path, next_first_seq, new_file);
                 let old_active = std::mem::replace(&mut *active, new_active);
-                let frozen = old_active.seal().await?;
+                let frozen = old_active.into_sealed();
                 // The sealed-set lock is taken only for the push, never held across
                 // the append-lock release, so appenders are not serialized by GC.
                 handle.sealed.lock().await.push(frozen);
@@ -653,9 +723,21 @@ impl Wal for WalWriter {
         let last_idx = segments.len() - 1;
         let mut all: Vec<WalEntry> = Vec::new();
         for (idx, (_first_seq, path)) in segments.into_iter().enumerate() {
-            let data = tokio::fs::read(&path)
-                .await
-                .map_err(|e| anyhow::anyhow!("Cannot read WAL segment {}: {e}", path.display()))?;
+            let data = match tokio::fs::read(&path).await {
+                Ok(data) => data,
+                // A concurrent GC can unlink a sealed segment between the directory
+                // scan above and this read. A GC'd segment is `<= watermark` by
+                // construction, so its frames are already applied and the later
+                // `retain(|e| e.sequence > applied_seq)` would drop them anyway —
+                // skipping the vanished file is correct, not a lost frame.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "Cannot read WAL segment {}: {e}",
+                        path.display()
+                    ));
+                }
+            };
             // A truncated tail is tolerated ONLY on the active (last) segment; a
             // torn tail on a sealed, non-last segment is corruption.
             let tolerate_tail = idx == last_idx;
@@ -1365,6 +1447,87 @@ mod tests {
         // segment is untouched and still appendable.
         assert!(handle.sealed.lock().await.is_empty());
         wal.append(0, &make_wal_entry(9)).await.unwrap();
+    }
+
+    // -----------------------------------------------------------------------
+    // HIGH-1 regression: a crash-torn tail on the ACTIVE segment must be
+    // truncated on reopen, BEFORE further appends and BEFORE the segment is later
+    // sealed. Without truncation the torn bytes stay between the pre-crash prefix
+    // and the post-reopen appends; once the segment seals (becomes non-last) the
+    // torn region is fatal mid-file corruption and recovery refuses to start,
+    // losing every frame written after the tear.
+    //
+    // Repro: append frames to the active segment, simulate a torn tail by
+    // appending garbage bytes to the segment file on disk, reopen the writer,
+    // append MORE frames, then mark_applied(0) to seal+rotate the (truncated-then-
+    // extended) segment. Reopen once more and assert recovery is Ok and every
+    // acked frame before AND after the tear is recovered (the torn partial frame
+    // may be absent). Fails without Fix 1 (seal hits mid-file corruption → Err);
+    // passes with it.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn torn_active_tail_truncated_on_reopen_survives_seal() {
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+
+        // Phase 1: write frames 1..=3 to the active segment, then drop the writer.
+        {
+            let wal = WalWriter::new(dir_path.clone(), WalFsyncPolicy::None).unwrap();
+            for seq in 1..=3u64 {
+                wal.append(0, &make_wal_entry(seq)).await.unwrap();
+            }
+        }
+
+        // Simulate a crash mid-append: append a few garbage / partial bytes to the
+        // active segment file so its tail is torn (not a clean frame boundary).
+        let active_path = dir_path.join(segment::format_segment_filename(0, 0));
+        {
+            use tokio::io::AsyncWriteExt as _;
+            let mut f = tokio::fs::OpenOptions::new()
+                .append(true)
+                .open(&active_path)
+                .await
+                .unwrap();
+            // Start a frame (valid magic+version) but truncate it — a classic torn
+            // mid-append tail.
+            f.write_all(&format::FRAME_MAGIC.to_be_bytes())
+                .await
+                .unwrap();
+            f.write_all(&[format::FRAME_VERSION, 0xAB, 0xCD])
+                .await
+                .unwrap();
+            f.flush().await.unwrap();
+        }
+
+        // Phase 2: reopen the writer (Fix 1 truncates the torn tail on handle open),
+        // append frames 4..=6, then seal+rotate via mark_applied. Watermark 0 keeps
+        // nothing GC'd so every frame must remain recoverable.
+        {
+            let wal = WalWriter::new(dir_path.clone(), WalFsyncPolicy::None).unwrap();
+            for seq in 4..=6u64 {
+                wal.append(0, &make_wal_entry(seq)).await.unwrap();
+            }
+            // Seals the (now-truncated-then-extended) segment and rotates a fresh
+            // one. Without Fix 1 the sealed segment carries the torn region as a
+            // mid-file gap.
+            wal.mark_applied(0, 0).await.unwrap();
+        }
+
+        // Phase 3: fresh writer over the same dir — recovery must succeed and
+        // return every acked frame (1..=6). Without Fix 1, the sealed segment's
+        // torn region is fatal mid-file corruption → Err here.
+        let wal = WalWriter::new(dir_path.clone(), WalFsyncPolicy::None).unwrap();
+        let unapplied = wal
+            .unapplied(0)
+            .await
+            .expect("recovery must succeed: a sealed segment must not carry a torn tail");
+        let seen: HashSet<u64> = unapplied.iter().map(|e| e.sequence).collect();
+        let missing: Vec<u64> = (1..=6u64).filter(|s| !seen.contains(s)).collect();
+        assert!(
+            missing.is_empty(),
+            "acked frames lost across the torn-tail truncate+seal: {missing:?} (seen: {seen:?})"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/packages/server-rust/src/storage/wal/segment.rs
+++ b/packages/server-rust/src/storage/wal/segment.rs
@@ -20,6 +20,8 @@
 
 use std::path::{Path, PathBuf};
 
+use tokio::io::AsyncWriteExt;
+
 // ---------------------------------------------------------------------------
 // Filename convention
 // ---------------------------------------------------------------------------
@@ -127,10 +129,14 @@ pub struct Segment {
     /// in the filename so coverage is known without opening the file.
     first_seq: u64,
     /// Highest sequence number written to this segment so far. Advances on append
-    /// to the active segment; frozen at seal time. Equals `first_seq.wrapping_sub`
-    /// semantics are avoided — a freshly created empty segment reports its
-    /// `max_seq` as its `first_seq` floor (see `max_seq`).
+    /// to the active segment; frozen at seal time. A freshly created empty segment
+    /// seeds this to `first_seq` as a floor — `max_seq_explicit` distinguishes that
+    /// seed from a genuine single-frame segment whose only frame is `first_seq`.
     max_seq: u64,
+    /// Whether `max_seq` reflects a frame that was actually appended (or decoded),
+    /// rather than the `first_seq` floor seeded into an empty active segment. Guards
+    /// the empty-segment +1 overcount from leaking into watermark / GC decisions.
+    max_seq_explicit: bool,
 }
 
 impl Segment {
@@ -150,6 +156,7 @@ impl Segment {
             },
             first_seq,
             max_seq: first_seq,
+            max_seq_explicit: false,
         }
     }
 
@@ -167,6 +174,9 @@ impl Segment {
             state: SegmentState::Sealed,
             first_seq,
             max_seq,
+            // A sealed segment discovered on disk covers real decoded frames; its
+            // max_seq is authoritative even when it equals first_seq.
+            max_seq_explicit: true,
         }
     }
 
@@ -198,6 +208,133 @@ impl Segment {
     #[must_use]
     pub fn is_sealed(&self) -> bool {
         matches!(self.state, SegmentState::Sealed)
+    }
+
+    /// Whether this segment has actually had any frame appended to it.
+    ///
+    /// A freshly-created active segment seeds `max_seq = first_seq`, which would
+    /// otherwise overstate its coverage by one phantom sequence. Callers use this
+    /// to treat an empty segment as covering no frames (so its seeded `max_seq`
+    /// never leaks into a watermark / GC decision).
+    #[must_use]
+    pub fn has_frames(&self) -> bool {
+        self.max_seq > self.first_seq || self.max_seq_explicit
+    }
+
+    /// Appends an already-encoded frame to the active segment, advancing
+    /// `max_seq` to `sequence` and bumping the un-fsynced frame counter.
+    ///
+    /// Performs the OS-visibility flush (not an fsync) so a concurrent fresh
+    /// reader observes the bytes; durability is governed by the caller's fsync
+    /// policy. Returns the new un-fsynced count so the caller can apply its
+    /// batched-fsync threshold.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the segment is sealed (a programming bug) or if the
+    /// underlying write/flush fails.
+    pub async fn append_frame(&mut self, frame: &[u8], sequence: u64) -> anyhow::Result<u32> {
+        let path = self.path.clone();
+        let SegmentState::Active {
+            file,
+            unfsynced_count,
+        } = &mut self.state
+        else {
+            anyhow::bail!("append to sealed WAL segment {}", path.display());
+        };
+        file.write_all(frame)
+            .await
+            .map_err(|e| anyhow::anyhow!("WAL write failed for {}: {e}", path.display()))?;
+        // Push tokio's buffer to the OS so a concurrent fresh read of this
+        // segment observes the frame. This is visibility, not durability.
+        file.flush()
+            .await
+            .map_err(|e| anyhow::anyhow!("WAL flush failed for {}: {e}", path.display()))?;
+        *unfsynced_count = unfsynced_count.saturating_add(1);
+        let count = *unfsynced_count;
+        // A frame was written; coverage now genuinely reaches `sequence`.
+        self.max_seq = sequence;
+        self.max_seq_explicit = true;
+        Ok(count)
+    }
+
+    /// fsyncs the active segment's data and resets the un-fsynced counter.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the segment is sealed or the fsync fails.
+    pub async fn sync_data(&mut self) -> anyhow::Result<()> {
+        let path = self.path.clone();
+        let SegmentState::Active {
+            file,
+            unfsynced_count,
+        } = &mut self.state
+        else {
+            anyhow::bail!("fsync of sealed WAL segment {}", path.display());
+        };
+        file.sync_data()
+            .await
+            .map_err(|e| anyhow::anyhow!("WAL fsync failed for {}: {e}", path.display()))?;
+        *unfsynced_count = 0;
+        Ok(())
+    }
+
+    /// fsyncs the active segment's data, then freezes it into a sealed segment.
+    ///
+    /// The data fsync happens **before** the segment is frozen because a sealed
+    /// segment is non-last in the live ordering, and a torn tail on a non-last
+    /// segment is fatal during recovery (truncated-tail tolerance is active-only).
+    /// Consumes the open file handle (dropping it closes the descriptor).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the segment is already sealed or the fsync fails.
+    pub async fn seal(self) -> anyhow::Result<Self> {
+        let Segment {
+            path,
+            state,
+            first_seq,
+            max_seq,
+            max_seq_explicit,
+        } = self;
+        let SegmentState::Active { file, .. } = state else {
+            anyhow::bail!("seal of already-sealed WAL segment {}", path.display());
+        };
+        file.sync_data()
+            .await
+            .map_err(|e| anyhow::anyhow!("WAL seal fsync failed for {}: {e}", path.display()))?;
+        drop(file);
+        Ok(Self {
+            path,
+            state: SegmentState::Sealed,
+            first_seq,
+            max_seq,
+            max_seq_explicit,
+        })
+    }
+
+    /// Seeds an active segment reopened during recovery with the `max_seq` decoded
+    /// from its existing frames, marking the coverage as explicit (real frames).
+    ///
+    /// `max_seq` is only raised, never lowered — a recovered file already holds
+    /// those frames, so its coverage cannot retreat. A value at or below
+    /// `first_seq` means the file held no frames, leaving the empty floor intact.
+    pub fn set_recovered_max_seq(&mut self, max_seq: u64) {
+        if max_seq > self.first_seq {
+            self.max_seq = max_seq;
+            self.max_seq_explicit = true;
+        }
+    }
+
+    /// Number of frames written since the last fsync (0 for a sealed segment).
+    #[must_use]
+    pub fn unfsynced_count(&self) -> u32 {
+        match &self.state {
+            SegmentState::Active {
+                unfsynced_count, ..
+            } => *unfsynced_count,
+            SegmentState::Sealed => 0,
+        }
     }
 }
 

--- a/packages/server-rust/src/storage/wal/segment.rs
+++ b/packages/server-rust/src/storage/wal/segment.rs
@@ -1,0 +1,350 @@
+//! Per-partition WAL segment abstraction (active-vs-sealed boundary).
+//!
+//! A partition's Write-Ahead Log is split into a sequence of fixed-lineage
+//! **segment** files instead of one ever-growing file. Appends always target the
+//! single **active** segment; compaction **seals** the active segment, starts a
+//! fresh active segment, and **deletes** sealed segments whose entire sequence
+//! range is at or below the applied watermark. This replaces the O(n) full-file
+//! read→re-encode→rename compaction with a single `unlink` per reclaimed segment,
+//! and lets appenders run without contending on the sealed set.
+//!
+//! Segment metadata lives entirely in the **filename** (`partition-{id:03}-
+//! {first_seq:020}.log`), so recovery can discover and order a partition's
+//! segments — and GC can read a sealed segment's coverage — without opening the
+//! file or parsing an in-file header. The frame codec in `format.rs` is unchanged:
+//! each segment file is a plain stream of the same frames a single-file WAL wrote.
+//!
+//! This module is the type/trait surface the `WalWriter` rewrite builds on. The
+//! method bodies that the writer owns (the actual seal/rotate/GC I/O) are stubbed
+//! here so the surface can be reviewed before the implementation lands.
+
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Filename convention
+// ---------------------------------------------------------------------------
+
+/// Filename prefix shared by every segment of every partition.
+///
+/// Mirrors the single-file WAL naming (`partition-{id:03}.log`) so a reader can
+/// still tell a WAL file apart from the `.applied` sidecar at a glance.
+pub const SEGMENT_FILE_PREFIX: &str = "partition-";
+
+/// Filename suffix for a segment file.
+///
+/// Kept identical to the single-file WAL's `.log` extension so the corruption
+/// taxonomy, tooling, and operator expectations carry over unchanged; the
+/// segment distinction is encoded in the embedded `first_seq`, not the extension.
+pub const SEGMENT_FILE_SUFFIX: &str = ".log";
+
+/// Zero-padding width for the partition id in a segment filename.
+///
+/// Matches the existing `partition-{id:03}` convention so segment files sort
+/// next to the legacy single-file layout in a directory listing.
+pub const SEGMENT_PARTITION_PAD: usize = 3;
+
+/// Zero-padding width for the `first_seq` component of a segment filename.
+///
+/// `u64::MAX` is 20 decimal digits, so padding to 20 makes a partition's segments
+/// sort lexicographically in ascending `first_seq` order — recovery can therefore
+/// order segments by filename alone, without opening any of them.
+pub const SEGMENT_SEQ_PAD: usize = 20;
+
+/// Formats the on-disk filename for a segment.
+///
+/// The returned name encodes both the owning partition and the segment's
+/// `first_seq` (its lowest covered sequence), e.g. `partition-005-
+/// 00000000000000000042.log`. Recovery and GC parse this with
+/// [`parse_segment_filename`]; neither needs to open the file to learn its
+/// partition or coverage start.
+#[must_use]
+pub fn format_segment_filename(partition: u32, first_seq: u64) -> String {
+    let pad_p = SEGMENT_PARTITION_PAD;
+    let pad_s = SEGMENT_SEQ_PAD;
+    format!("{SEGMENT_FILE_PREFIX}{partition:0pad_p$}-{first_seq:0pad_s$}{SEGMENT_FILE_SUFFIX}")
+}
+
+/// Parses a segment filename back into its `(partition, first_seq)` components.
+///
+/// Returns `None` for any name that is not a segment file (wrong prefix/suffix,
+/// missing separator, or non-numeric components) so callers can skip sidecar and
+/// unrelated files during directory discovery without erroring.
+#[must_use]
+pub fn parse_segment_filename(name: &str) -> Option<(u32, u64)> {
+    let inner = name
+        .strip_prefix(SEGMENT_FILE_PREFIX)?
+        .strip_suffix(SEGMENT_FILE_SUFFIX)?;
+    // The first '-' separates the partition id from the first_seq. first_seq is
+    // pure digits, so splitting on the first '-' is unambiguous.
+    let (partition_str, first_seq_str) = inner.split_once('-')?;
+    let partition = partition_str.parse::<u32>().ok()?;
+    let first_seq = first_seq_str.parse::<u64>().ok()?;
+    Some((partition, first_seq))
+}
+
+// ---------------------------------------------------------------------------
+// SegmentState — active vs sealed
+// ---------------------------------------------------------------------------
+
+/// Whether a [`Segment`] is still being appended to or has been frozen.
+///
+/// The active segment owns an open append file handle; a sealed segment is
+/// immutable and may carry no handle (it is reopened read-only on demand). GC
+/// only ever deletes sealed segments — the variant is the structural guard that
+/// the active segment is never reclaimed.
+pub enum SegmentState {
+    /// The single segment appends currently target. Holds the open append handle
+    /// and the live batched-fsync accounting.
+    Active {
+        /// Open append handle for the active segment file.
+        file: tokio::fs::File,
+        /// Frames written to this handle since the last fsync, carried over from
+        /// the single-file batched-fsync accounting (`u32`, a non-negative count).
+        unfsynced_count: u32,
+    },
+    /// A frozen segment. No further frames are appended; it is reopened read-only
+    /// for recovery/`unapplied` and dropped by GC with a single `unlink`.
+    Sealed,
+}
+
+// ---------------------------------------------------------------------------
+// Segment — one on-disk segment file
+// ---------------------------------------------------------------------------
+
+/// One on-disk WAL segment file for a single partition.
+///
+/// A segment covers a contiguous-by-arrival range of sequence numbers
+/// `[first_seq, max_seq]`. `first_seq` is fixed at creation (and encoded in the
+/// filename); `max_seq` advances as frames are appended to the active segment and
+/// is frozen when the segment is sealed. Sequences are `u64`; the fsync counter is
+/// `u32` — no `f64` (per the project type-mapping rules).
+pub struct Segment {
+    /// Absolute path to this segment's file on disk.
+    path: PathBuf,
+    /// Active (open handle + fsync accounting) or sealed (immutable) state.
+    state: SegmentState,
+    /// Lowest sequence number this segment covers. Fixed at creation and mirrored
+    /// in the filename so coverage is known without opening the file.
+    first_seq: u64,
+    /// Highest sequence number written to this segment so far. Advances on append
+    /// to the active segment; frozen at seal time. Equals `first_seq.wrapping_sub`
+    /// semantics are avoided — a freshly created empty segment reports its
+    /// `max_seq` as its `first_seq` floor (see `max_seq`).
+    max_seq: u64,
+}
+
+impl Segment {
+    /// Creates an active segment rooted at `path` covering sequences from
+    /// `first_seq`, taking ownership of an already-open append `file` handle.
+    ///
+    /// The caller (the writer) is responsible for having opened `path` in
+    /// create+append mode; this constructor only wires the bookkeeping. `max_seq`
+    /// is seeded to `first_seq` and advances as frames are appended.
+    #[must_use]
+    pub fn new_active(path: PathBuf, first_seq: u64, file: tokio::fs::File) -> Self {
+        Self {
+            path,
+            state: SegmentState::Active {
+                file,
+                unfsynced_count: 0,
+            },
+            first_seq,
+            max_seq: first_seq,
+        }
+    }
+
+    /// Constructs a sealed-segment handle for an already-existing on-disk file
+    /// discovered during recovery, with its known sequence coverage.
+    ///
+    /// `first_seq` comes from the filename; `max_seq` is the highest sequence the
+    /// caller decoded from the file (or computed from the filename of the next
+    /// segment). No file handle is held — sealed segments are reopened read-only
+    /// on demand.
+    #[must_use]
+    pub fn sealed_existing(path: PathBuf, first_seq: u64, max_seq: u64) -> Self {
+        Self {
+            path,
+            state: SegmentState::Sealed,
+            first_seq,
+            max_seq,
+        }
+    }
+
+    /// Path to this segment's file.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Lowest sequence number this segment covers (fixed at creation).
+    #[must_use]
+    pub fn first_seq(&self) -> u64 {
+        self.first_seq
+    }
+
+    /// Highest sequence number written to this segment so far.
+    #[must_use]
+    pub fn max_seq(&self) -> u64 {
+        self.max_seq
+    }
+
+    /// Whether this segment is the active (append-target) segment.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        matches!(self.state, SegmentState::Active { .. })
+    }
+
+    /// Whether this segment is sealed (immutable, GC-eligible).
+    #[must_use]
+    pub fn is_sealed(&self) -> bool {
+        matches!(self.state, SegmentState::Sealed)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SegmentSet — per-partition active + sealed segments
+// ---------------------------------------------------------------------------
+
+/// All segments of a single partition: one active segment plus an ordered list of
+/// sealed segments.
+///
+/// Invariants the writer must uphold (enforced by the methods below in G2):
+/// - exactly one active segment exists at any time;
+/// - sealed segments are ordered by ascending `first_seq` (so recovery and
+///   `unapplied` can read them in sequence order without re-sorting);
+/// - every sealed segment's range is strictly below the active segment's
+///   `first_seq` (sealing freezes the boundary before a fresh active starts);
+/// - GC only ever removes from `sealed` — the active segment is structurally
+///   unreachable from `gc_below_watermark`.
+pub struct SegmentSet {
+    /// The partition this set belongs to (mirrored in every segment filename).
+    partition: u32,
+    /// Sealed, immutable segments in ascending `first_seq` order. The front is the
+    /// oldest; GC reclaims from the front up to the watermark.
+    sealed: Vec<Segment>,
+    /// The single segment that appends currently target.
+    active: Segment,
+}
+
+impl SegmentSet {
+    /// Creates a `SegmentSet` for `partition` with `active` as its sole segment
+    /// and no sealed segments (a fresh partition).
+    #[must_use]
+    pub fn new(partition: u32, active: Segment) -> Self {
+        Self {
+            partition,
+            sealed: Vec::new(),
+            active,
+        }
+    }
+
+    /// Reconstructs a `SegmentSet` from segments discovered on disk during
+    /// recovery: the already-ordered `sealed` segments plus the `active` segment.
+    ///
+    /// `sealed` MUST be in ascending `first_seq` order and all below
+    /// `active.first_seq` — recovery builds it that way from the filename ordering.
+    #[must_use]
+    pub fn from_recovered(partition: u32, sealed: Vec<Segment>, active: Segment) -> Self {
+        Self {
+            partition,
+            sealed,
+            active,
+        }
+    }
+
+    /// The partition this set serves.
+    #[must_use]
+    pub fn partition(&self) -> u32 {
+        self.partition
+    }
+
+    /// The active segment — the append target.
+    ///
+    /// `append` writes here; this is the only segment a writer mutates outside of
+    /// seal/rotate. Returned mutably so the writer can advance `max_seq` and the
+    /// fsync accounting on append.
+    pub fn append_target(&mut self) -> &mut Segment {
+        &mut self.active
+    }
+
+    /// Seals the current active segment and rotates a fresh active segment in.
+    ///
+    /// Ordering is correctness-critical (the RULE): the current active segment is
+    /// frozen into the sealed set *before* the new active is wired in, so no window
+    /// exists in which an already-acked frame is neither in a sealed segment nor in
+    /// the active segment. `next_first_seq` is the `first_seq` of the new active
+    /// segment (`current active.max_seq + 1`), and `new_active_file` is its
+    /// already-opened append handle.
+    ///
+    /// The body (the file open + handle swap + sealed push) is owned by the writer
+    /// and lands with the G2 implementation; this G1 stub freezes `max_seq` and
+    /// installs the new active segment so the type compiles and the surface is
+    /// reviewable, but the full crash-ordered I/O path is G2's.
+    pub fn seal_active_and_rotate(
+        &mut self,
+        next_first_seq: u64,
+        new_active_file: tokio::fs::File,
+    ) {
+        let sealed_path = self.active.path().to_path_buf();
+        let sealed_first = self.active.first_seq();
+        let sealed_max = self.active.max_seq();
+        let new_path = self
+            .active
+            .path()
+            .with_file_name(format_segment_filename(self.partition, next_first_seq));
+
+        let frozen = Segment::sealed_existing(sealed_path, sealed_first, sealed_max);
+        // Freeze the current active into the sealed set BEFORE wiring the fresh
+        // active in, so no window exists where an acked frame belongs to neither.
+        self.sealed.push(frozen);
+        self.active = Segment::new_active(new_path, next_first_seq, new_active_file);
+    }
+
+    /// Selects and deletes sealed segments fully covered by the applied watermark.
+    ///
+    /// A sealed segment is reclaimable iff `max_seq <= applied_through` — every
+    /// frame it holds has been durably applied to the inner store, so dropping the
+    /// file loses nothing. The active segment is NEVER considered, regardless of
+    /// its `max_seq`: appenders may still be writing to it, so it stays until a
+    /// future seal moves its frames into the sealed set. Reclaimed segments are
+    /// removed from the front of `sealed` (oldest first) and `unlink`ed.
+    ///
+    /// Returns the paths that were deleted so the caller can log/account for them.
+    /// The actual `unlink` I/O is owned by the writer and lands with G2; this G1
+    /// stub performs the watermark **selection** (never touching `active`) so the
+    /// surface and the active-segment-exclusion invariant are reviewable, and
+    /// drains the selected handles from the sealed set.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a sealed segment file cannot be unlinked (G2).
+    pub fn gc_below_watermark(&mut self, applied_through: u64) -> anyhow::Result<Vec<PathBuf>> {
+        // Reclaimable sealed segments are a prefix of the ascending-ordered set
+        // (oldest first). The active segment is intentionally not in `sealed`, so
+        // it can never be selected here regardless of its `max_seq`.
+        let reclaim = self
+            .sealed
+            .iter()
+            .take_while(|s| s.max_seq() <= applied_through)
+            .count();
+        let drained: Vec<PathBuf> = self
+            .sealed
+            .drain(..reclaim)
+            .map(|s| s.path().to_path_buf())
+            .collect();
+        Ok(drained)
+    }
+
+    /// Every live segment in ascending sequence order: sealed segments (oldest
+    /// first) followed by the active segment last.
+    ///
+    /// Recovery and `unapplied` iterate this to decode frames across the whole
+    /// partition; the active segment is last so a `TruncatedTail` is only ever
+    /// tolerated on it (a mid-stream truncation in a sealed segment is corruption).
+    #[must_use]
+    pub fn all_segments_in_seq_order(&self) -> Vec<&Segment> {
+        let mut out: Vec<&Segment> = self.sealed.iter().collect();
+        out.push(&self.active);
+        out
+    }
+}

--- a/packages/server-rust/src/storage/wal/segment.rs
+++ b/packages/server-rust/src/storage/wal/segment.rs
@@ -292,38 +292,36 @@ impl Segment {
         Ok(())
     }
 
-    /// fsyncs the active segment's data, then freezes it into a sealed segment.
+    /// Freezes an active segment into a sealed one **without** fsyncing, dropping
+    /// the open file handle.
     ///
-    /// The data fsync happens **before** the segment is frozen because a sealed
-    /// segment is non-last in the live ordering, and a torn tail on a non-last
-    /// segment is fatal during recovery (truncated-tail tolerance is active-only).
-    /// Consumes the open file handle (dropping it closes the descriptor).
+    /// Unlike [`seal`](Self::seal), this is infallible: it performs no I/O. The
+    /// caller MUST have already durably synced the segment's data (e.g. via
+    /// [`sync_data`](Self::sync_data)) before calling this, because a sealed
+    /// segment becomes non-last in the live ordering and a torn tail on a non-last
+    /// segment is fatal during recovery. Doing the (fallible) fsync first and the
+    /// (infallible) state transition second guarantees no fsync can fail *after*
+    /// the segment has been swapped out — which would otherwise orphan a non-last
+    /// segment that was dropped without being unlinked.
     ///
-    /// # Errors
-    ///
-    /// Returns an error if the segment is already sealed or the fsync fails.
-    pub async fn seal(self) -> anyhow::Result<Self> {
+    /// `first_seq` / `max_seq` / `max_seq_explicit` are preserved unchanged.
+    #[must_use]
+    pub fn into_sealed(self) -> Self {
         let Segment {
             path,
-            state,
+            state: _,
             first_seq,
             max_seq,
             max_seq_explicit,
         } = self;
-        let SegmentState::Active { file, .. } = state else {
-            anyhow::bail!("seal of already-sealed WAL segment {}", path.display());
-        };
-        file.sync_data()
-            .await
-            .map_err(|e| anyhow::anyhow!("WAL seal fsync failed for {}: {e}", path.display()))?;
-        drop(file);
-        Ok(Self {
+        // Dropping `state` (the Active file handle, if any) closes the descriptor.
+        Self {
             path,
             state: SegmentState::Sealed,
             first_seq,
             max_seq,
             max_seq_explicit,
-        })
+        }
     }
 
     /// Seeds an active segment reopened during recovery with the `max_seq` decoded

--- a/packages/server-rust/src/storage/wal/segment.rs
+++ b/packages/server-rust/src/storage/wal/segment.rs
@@ -68,9 +68,15 @@ pub fn format_segment_filename(partition: u32, first_seq: u64) -> String {
 
 /// Parses a segment filename back into its `(partition, first_seq)` components.
 ///
-/// Returns `None` for any name that is not a segment file (wrong prefix/suffix,
-/// missing separator, or non-numeric components) so callers can skip sidecar and
-/// unrelated files during directory discovery without erroring.
+/// Returns `None` for any name that is not a segment file (wrong prefix/suffix
+/// or non-numeric components) so callers can skip sidecar and unrelated files
+/// during directory discovery without erroring.
+///
+/// A legacy single-file WAL name (`partition-NNN.log`, with no `first_seq`
+/// component) is auto-migrated: it is treated as the partition's oldest segment
+/// (`first_seq = 0`). Without this, a pre-rotation WAL file would be silently
+/// skipped on upgrade and its un-applied frames lost. Discovery sorts by numeric
+/// `first_seq`, so a legacy file (`first_seq = 0`) orders first.
 #[must_use]
 pub fn parse_segment_filename(name: &str) -> Option<(u32, u64)> {
     let inner = name
@@ -78,10 +84,17 @@ pub fn parse_segment_filename(name: &str) -> Option<(u32, u64)> {
         .strip_suffix(SEGMENT_FILE_SUFFIX)?;
     // The first '-' separates the partition id from the first_seq. first_seq is
     // pure digits, so splitting on the first '-' is unambiguous.
-    let (partition_str, first_seq_str) = inner.split_once('-')?;
-    let partition = partition_str.parse::<u32>().ok()?;
-    let first_seq = first_seq_str.parse::<u64>().ok()?;
-    Some((partition, first_seq))
+    if let Some((partition_str, first_seq_str)) = inner.split_once('-') {
+        let partition = partition_str.parse::<u32>().ok()?;
+        let first_seq = first_seq_str.parse::<u64>().ok()?;
+        Some((partition, first_seq))
+    } else {
+        // No separator → legacy single-file layout (`partition-NNN.log`). Treat
+        // the whole inner string as the partition id at first_seq 0 so the file
+        // is discovered and replayed instead of silently skipped on upgrade.
+        let partition = inner.parse::<u32>().ok()?;
+        Some((partition, 0))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -483,5 +496,43 @@ impl SegmentSet {
         let mut out: Vec<&Segment> = self.sealed.iter().collect();
         out.push(&self.active);
         out
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_new_format_filename() {
+        // New rotation format: partition + first_seq components.
+        assert_eq!(
+            parse_segment_filename("partition-005-00000000000000000042.log"),
+            Some((5, 42))
+        );
+    }
+
+    #[test]
+    fn parse_legacy_single_file_filename() {
+        // Legacy pre-rotation single file (`partition-NNN.log`, no first_seq) is
+        // auto-migrated to first_seq 0 so its frames are recovered, not skipped.
+        assert_eq!(parse_segment_filename("partition-007.log"), Some((7, 0)));
+    }
+
+    #[test]
+    fn parse_rejects_non_segment_names() {
+        assert_eq!(parse_segment_filename("partition-007.applied"), None);
+        assert_eq!(parse_segment_filename("partition-abc.log"), None);
+        assert_eq!(parse_segment_filename("unrelated.log"), None);
+    }
+
+    #[test]
+    fn format_then_parse_round_trips() {
+        let name = format_segment_filename(5, 42);
+        assert_eq!(parse_segment_filename(&name), Some((5, 42)));
     }
 }


### PR DESCRIPTION
## SPEC-326 — WAL segment rotation (TODO-469 Option B)

Replaces the Option-A full-file `compact_log` rewrite (under-lock O(n²) per applied entry) with
**segment rotation**: appends go to the active segment; `mark_applied` seals the active segment,
starts a fresh one, and GC-`unlink`s sealed segments whose max-seq ≤ the `.applied` watermark.
Appenders no longer contend with GC on the active file, and the O(n²) rewrite is gone. Closes
**TODO-469 Option B** and **TODO-456**.

**RULE (invariant):** no acked WAL frame may be dropped by compaction/rotation under concurrent
same-partition append or crash.

### Cross-vendor gated (standing rule)
- **AC9 `/xask`** (design fork) — recorded design verdict + 6 fsync/ordering requirements; surfaced
  a pre-existing `write_applied_sequence` non-durability bug (fixed in scope, now load-bearing as
  the GC gate / restart seed).
- **AC10 `/xreview`** (diff) — glm returned 2 HIGH / 2 MED / 1 LOW; **all 5 verified real against
  code and fixed**: HIGH-1 torn active-tail never truncated on reopen → fatal mid-file corruption
  once sealed (fail-without/pass-with proven); HIGH-2 seal-fsync-fail-after-swap orphans old
  active; + GC-race / batch-fsync robustness; + legacy single-file WAL recovery on upgrade.

### Verification (reviewer independently re-ran on this HEAD)
- fmt 0 · clippy `--all-targets --all-features -D warnings` 0 · lib **1512/0** · sim **12/0**
- RULE seal/rotate/GC stress regression (both variants) + AC3 lock-discipline + rebuilt torn-active
  `kill -9` durability test — green, 3× non-flaky locally.
- Footprint **3 files**: `wal/segment.rs` (new) + `wal/mod.rs` + `crash_safety_proptest.rs`.
  `format.rs` codec untouched; `Wal` trait frozen.

### PR-CI-owned remainder (AC11)
- Full pre-merge gate + green CI, incl. the **≥3-CI-run stress non-flakiness gate**.
- **72h Hetzner soak (TODO-484)** — durability-track validation; see merge note for sequencing.

### Deferred (filed)
- TODO-548 — size-threshold rotation (currently rotation is per-applied-watermark).
- TODO-549 — in-file generation marker (blocked by the frozen codec).
