### PR TITLE
fix(sf-327): depth-check inner-batch decode — defense-in-depth hardening (TODO-506)

### DIFF
--- a/packages/server-rust/src/network/handlers/decode.rs
+++ b/packages/server-rust/src/network/handlers/decode.rs
@@ -27,6 +27,16 @@
 //! input to well-formed, shallow frames. The pinning regression test
 //! `rmp_serde_own_depth_limit_is_present` fails loudly if a future bump removes the
 //! dependency's safety net, re-escalating the residual risk.
+//!
+//! Caveat on that safety net: `rmp_serde`'s 1024 cap only returns gracefully when
+//! the thread has enough stack left to actually descend ~1024 recursive frames and
+//! reach the guard. In unoptimized (debug) builds each frame is large enough that
+//! ~1024 of them can overflow a default ~2 MB thread stack *before* the guard
+//! fires; release builds shrink the frames enough to fit. This is one more reason
+//! the codec ceiling is only a backstop — the [`MAX_DECODE_DEPTH`] pre-scan, which
+//! never recurses, is the actual guarantee. (The pinning test runs its deliberately
+//! over-deep decode on a large stack so it observes the guard's return rather than
+//! the overflow.)
 
 use rmp::Marker;
 use serde::de::DeserializeOwned;
@@ -312,6 +322,26 @@ mod tests {
         buf
     }
 
+    /// Runs a deliberately deep raw `rmp_serde` decode on a thread with a
+    /// generous stack, so the recursion can descend far enough to hit the
+    /// codec's own 1024 depth guard and RETURN `DepthLimitExceeded` — rather
+    /// than overflowing the test thread's default ~2 MB stack first. In debug
+    /// builds the per-frame stack cost of ~1024 recursive `rmpv::Value` frames
+    /// exceeds 2 MB before the guard fires (release builds optimize the frames
+    /// small enough to fit); the big stack makes the assertion deterministic
+    /// across both profiles. Only the tests that feed an over-deep frame to RAW
+    /// `rmp_serde` (bypassing the pre-scan) need this — production never does.
+    fn decode_on_big_stack<T: serde::de::DeserializeOwned + Send + 'static>(
+        bytes: Vec<u8>,
+    ) -> Result<T, rmp_serde::decode::Error> {
+        std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(move || rmp_serde::from_slice::<T>(&bytes))
+            .expect("spawn big-stack decode thread")
+            .join()
+            .expect("big-stack decode thread panicked")
+    }
+
     #[test]
     fn shallow_nesting_passes_depth_check() {
         // Negative control: 64-deep is valid `MsgPack` and within the limit.
@@ -429,7 +459,10 @@ mod tests {
             ),
             "pre-scan must reject {depth}-deep (> MAX_DECODE_DEPTH={MAX_DECODE_DEPTH})"
         );
-        let raw: Result<rmpv::Value, _> = rmp_serde::from_slice(&bytes);
+        // Run on a big stack: 500 recursive frames can crowd a debug build's
+        // default ~2 MB test-thread stack, and we want to observe rmp_serde's
+        // ACCEPT, not an environment-dependent overflow.
+        let raw: Result<rmpv::Value, _> = decode_on_big_stack(bytes);
         assert!(
             raw.is_ok(),
             "rmp_serde itself ACCEPTS {depth}-deep (< its 1024 limit) — proving our \
@@ -445,9 +478,16 @@ mod tests {
         // guard — but any future code path that bypasses the pre-scan still leans on
         // this ceiling to avoid a stack-overflow abort. If a dependency bump removes
         // it, this fails loudly so the residual risk is caught and re-escalated.
-        let within: Result<rmpv::Value, _> = rmp_serde::from_slice(&nested_msgpack(1023));
+        //
+        // Both decodes run on a big stack: descending ~1024 recursive frames blows
+        // a debug build's default ~2 MB test-thread stack BEFORE the 1024 guard
+        // returns, so on the default stack this would SIGABRT instead of asserting.
+        // The big stack lets the guard's graceful Err be observed deterministically
+        // (and the need for it is itself why our pre-scan, not this cap, is the
+        // real guarantee — see the module docs).
+        let within: Result<rmpv::Value, _> = decode_on_big_stack(nested_msgpack(1023));
         assert!(within.is_ok(), "1023-deep is within rmp_serde's 1024 limit");
-        let over = rmp_serde::from_slice::<rmpv::Value>(&nested_msgpack(1025));
+        let over: Result<rmpv::Value, _> = decode_on_big_stack(nested_msgpack(1025));
         assert!(
             matches!(over, Err(rmp_serde::decode::Error::DepthLimitExceeded)),
             "rmp_serde must still reject >1024-deep with DepthLimitExceeded, got {over:?}"

--- a/packages/server-rust/src/network/handlers/decode.rs
+++ b/packages/server-rust/src/network/handlers/decode.rs
@@ -282,7 +282,12 @@ pub fn decode_depth_checked<T: DeserializeOwned>(data: &[u8]) -> Result<T, Decod
     let observed = check_msgpack_depth(data, MAX_DECODE_DEPTH)?;
     // Telemetry, not a guard: an accepted frame deeper than the old 128 bound is
     // unusual. Log it (without rejecting) so the real-world depth distribution is
-    // measured before MAX_DECODE_DEPTH is ever tightened on a guess.
+    // measured before MAX_DECODE_DEPTH is ever tightened on a guess. Deliberately
+    // `debug!`, not `info!`/`warn!`: this band is reachable by an UNauthenticated
+    // client (Phase 1), so a louder level would be a log-amplification vector — a
+    // flood of (128, 256]-deep frames could spam production logs. The production-
+    // grade form of this telemetry is a counter/histogram metric (follow-up), which
+    // is flood-safe; until then operators enable `debug` on this target to sample.
     if observed > WARN_DECODE_DEPTH {
         tracing::debug!(
             depth = observed,

--- a/packages/server-rust/src/network/handlers/decode.rs
+++ b/packages/server-rust/src/network/handlers/decode.rs
@@ -2,32 +2,59 @@
 //!
 //! Every inbound WebSocket frame (and the HTTP `/sync` body) is `MsgPack`, decoded
 //! with `rmp_serde` — and on `/ws` the decode happens in Phase 1, BEFORE the
-//! connection is authenticated. `rmp_serde` applies no recursion-depth limit,
-//! and the message types are internally tagged (`#[serde(tag = "type")]`, which
-//! buffers the whole frame into serde's recursive `Content` type) and embed
-//! `rmpv::Value` — itself a recursive enum. A deeply-nested frame therefore
-//! recurses one native stack frame per nesting level during deserialization, and
-//! a stack overflow in safe Rust aborts the whole process (uncatchable: no
-//! `catch_unwind`, no per-task isolation). One small unauthenticated frame would
+//! connection is authenticated. The message types are internally tagged
+//! (`#[serde(tag = "type")]`, which buffers frame content into serde's recursive
+//! `Content` type) and embed `rmpv::Value` — itself a recursive enum — so in
+//! principle a deeply-nested frame drives one native stack frame per nesting level
+//! during deserialization. An unbounded recursive decode would overflow the stack,
+//! and a stack overflow in safe Rust aborts the whole process (uncatchable: no
+//! `catch_unwind`, no per-task isolation) — one small unauthenticated frame could
 //! kill every connection on the node.
 //!
-//! [`decode_depth_checked`] closes this by scanning the raw `MsgPack` bytes
-//! iteratively — an explicit heap stack, so the scanner itself never recurses and
-//! cannot overflow — and rejecting any frame whose container nesting exceeds
-//! [`MAX_DECODE_DEPTH`] before the bytes ever reach `rmp_serde`. Paired with the
-//! inbound frame-size cap on the WebSocket upgrade, this bounds the decoder's
-//! input to well-formed, shallow frames.
+//! Note the "unbounded" is no longer literally true of the pinned codec:
+//! `rmp_serde` 1.3.1 caps its OWN recursion at 1024 levels (an internal
+//! `depth_count!` guard, default `depth: 1024`) and returns `DepthLimitExceeded`
+//! instead of overflowing. That ceiling is a safety net, but it is an unstable
+//! implementation detail — not a documented API contract — and it would not exist
+//! on a different codec we might swap to. [`decode_depth_checked`] therefore
+//! enforces our OWN bound, version-independently, by scanning the raw `MsgPack`
+//! bytes iteratively — an explicit heap stack, so the scanner itself never
+//! recurses and cannot overflow — and rejecting any frame whose container nesting
+//! exceeds [`MAX_DECODE_DEPTH`] before the bytes ever reach `rmp_serde`.
+//! [`MAX_DECODE_DEPTH`] sits well below the dependency's 1024 ceiling, so our
+//! reject fires first and predictably, independent of codec internals. Paired with
+//! the inbound frame-size cap on the WebSocket upgrade, this bounds the decoder's
+//! input to well-formed, shallow frames. The pinning regression test
+//! `rmp_serde_own_depth_limit_is_present` fails loudly if a future bump removes the
+//! dependency's safety net, re-escalating the residual risk.
 
 use rmp::Marker;
 use serde::de::DeserializeOwned;
 
 /// Maximum container-nesting depth accepted for an inbound `MsgPack` frame.
 ///
-/// Legitimate `TopGun` payloads (operation envelopes carrying `rmpv::Value`
-/// records and `where` predicates) nest only a handful of levels deep; 128 is
-/// far above any real document while still well below the thousands of levels it
-/// takes to exhaust a worker thread's stack during `rmp_serde` recursion.
-pub const MAX_DECODE_DEPTH: usize = 128;
+/// `TopGun` envelopes themselves are shallow, but the payload they carry
+/// (`rmpv::Value` records and `where` predicates) is user-controlled and may be
+/// machine-generated — nested JSON-like documents can run deeper than a typical
+/// hand-written object. Measured against representative payloads, typical
+/// envelopes nest ≤9 levels and a deliberately 40-deep machine-generated record
+/// value reaches ~43; this bound is set to 256, leaving a wide margin above any
+/// observed legitimate payload while staying well below `rmp_serde`'s own 1024
+/// ceiling (so our reject fires first, predictably) and far below anything that
+/// could exhaust a worker stack. Because production traffic depth is ultimately
+/// unknowable from fixtures, frames deeper than [`WARN_DECODE_DEPTH`] but still
+/// accepted are logged (see [`decode_depth_checked`]) so the real-world
+/// distribution can be observed before this bound is ever tightened — telemetry,
+/// not a guess.
+pub const MAX_DECODE_DEPTH: usize = 256;
+
+/// Soft telemetry threshold. An accepted frame nesting deeper than this is
+/// unusual — it would have been rejected by the original, tighter 128-level bound
+/// — but it is still well within [`MAX_DECODE_DEPTH`], so it is logged at `debug`
+/// rather than rejected. This is how the real-world depth distribution is gathered
+/// instead of guessed; if logs show legitimate traffic approaching the cap, raise
+/// [`MAX_DECODE_DEPTH`] with data, don't tighten blind.
+pub const WARN_DECODE_DEPTH: usize = 128;
 
 /// Why an inbound frame was rejected before or during decode.
 #[derive(Debug)]
@@ -92,11 +119,13 @@ fn skip(data: &[u8], pos: &mut usize, n: u64) -> Result<(), DecodeError> {
 
 /// Scans `data` as `MsgPack` iteratively, bounding container nesting to `max_depth`.
 ///
-/// Returns `Err(TooDeep)` the moment nesting would exceed `max_depth`, and
-/// `Err(Malformed)` on a truncated stream or reserved marker. The scan uses an
-/// explicit heap stack and **never recurses**, so it cannot itself overflow on
-/// adversarial input — that is the whole point: it runs before the recursive
-/// `rmp_serde` decoder and rejects frames that would overflow it.
+/// On success returns the **maximum container-nesting depth observed** (0 for a
+/// flat scalar), which the caller uses for depth telemetry. Returns `Err(TooDeep)`
+/// the moment nesting would exceed `max_depth`, and `Err(Malformed)` on a truncated
+/// stream or reserved marker. The scan uses an explicit heap stack and **never
+/// recurses**, so it cannot itself overflow on adversarial input — that is the
+/// whole point: it runs before the recursive `rmp_serde` decoder and rejects frames
+/// that would overflow it.
 ///
 /// Trailing bytes after the first complete top-level value are ignored here;
 /// `rmp_serde` rejects them downstream if it cares.
@@ -110,21 +139,23 @@ fn skip(data: &[u8], pos: &mut usize, n: u64) -> Result<(), DecodeError> {
 // splitting the function would obscure the byte-advance accounting that makes it
 // safe, so the length and a few same-bodied arms are intentional.
 #[allow(clippy::too_many_lines, clippy::match_same_arms)]
-pub fn check_msgpack_depth(data: &[u8], max_depth: usize) -> Result<(), DecodeError> {
+pub fn check_msgpack_depth(data: &[u8], max_depth: usize) -> Result<usize, DecodeError> {
     let mut pos = 0usize;
 
     // `stack[i]` = number of child values still to read at nesting level `i`.
     // `pending` is the count at the current (deepest open) level. The scanner
-    // expects exactly one top-level value.
+    // expects exactly one top-level value. `max_observed` tracks the deepest
+    // nesting reached, for the caller's telemetry.
     let mut stack: Vec<u64> = Vec::new();
     let mut pending: u64 = 1;
+    let mut max_observed: usize = 0;
 
     loop {
         // Pop levels whose child count has been fully consumed.
         while pending == 0 {
             match stack.pop() {
                 Some(parent_remaining) => pending = parent_remaining,
-                None => return Ok(()), // all values consumed
+                None => return Ok(max_observed), // all values consumed
             }
         }
         // Consume one value at the current level.
@@ -229,6 +260,7 @@ pub fn check_msgpack_depth(data: &[u8], max_depth: usize) -> Result<(), DecodeEr
             }
             stack.push(pending);
             pending = children;
+            max_observed = max_observed.max(stack.len());
         }
     }
 }
@@ -247,7 +279,17 @@ pub fn check_msgpack_depth(data: &[u8], max_depth: usize) -> Result<(), DecodeEr
 /// rejects the frame, or [`DecodeError::Decode`] if `rmp_serde` fails to
 /// deserialize a structurally-valid, in-depth frame into `T`.
 pub fn decode_depth_checked<T: DeserializeOwned>(data: &[u8]) -> Result<T, DecodeError> {
-    check_msgpack_depth(data, MAX_DECODE_DEPTH)?;
+    let observed = check_msgpack_depth(data, MAX_DECODE_DEPTH)?;
+    // Telemetry, not a guard: an accepted frame deeper than the old 128 bound is
+    // unusual. Log it (without rejecting) so the real-world depth distribution is
+    // measured before MAX_DECODE_DEPTH is ever tightened on a guess.
+    if observed > WARN_DECODE_DEPTH {
+        tracing::debug!(
+            depth = observed,
+            limit = MAX_DECODE_DEPTH,
+            "accepted unusually deeply-nested inbound MsgPack frame"
+        );
+    }
     rmp_serde::from_slice(data).map_err(DecodeError::Decode)
 }
 
@@ -282,10 +324,11 @@ mod tests {
 
     #[test]
     fn deeply_nested_frame_rejected_not_overflowed() {
-        // The DoS payload: ~512k-deep. The OLD path fed this straight to
-        // `rmp_serde::from_slice`, recursing ~512k native frames → stack overflow
-        // → SIGABRT. The pre-scan rejects it in O(MAX_DECODE_DEPTH) memory with
-        // zero recursion, so this test returns an Err instead of aborting.
+        // The DoS-shaped payload: ~512k-deep. The pre-scan rejects it in
+        // O(MAX_DECODE_DEPTH) memory with zero recursion, returning Err instead of
+        // descending. (The pinned `rmp_serde` would itself cap at 1024 and error,
+        // not overflow — but the pre-scan is the version-independent guard that does
+        // not depend on that codec internal; see `rmp_serde_own_depth_limit_is_present`.)
         let bytes = nested_msgpack(512_000);
         assert!(matches!(
             check_msgpack_depth(&bytes, MAX_DECODE_DEPTH),
@@ -362,5 +405,64 @@ mod tests {
         let bytes = rmp_serde::to_vec_named(&msg).expect("encode");
         let decoded: TopGunMessage = decode_depth_checked(&bytes).expect("decode");
         assert!(matches!(decoded, TopGunMessage::Ping(_)));
+    }
+
+    #[test]
+    fn scanner_rejects_within_rmp_serde_own_limit() {
+        // DISCRIMINATOR — proves OUR bound is active and strictly tighter than the
+        // dependency's. A frame nested deeper than MAX_DECODE_DEPTH (256) but well
+        // within `rmp_serde`'s own 1024 ceiling: the pre-scan MUST reject it, while
+        // raw `rmp_serde` decodes the very same bytes WITHOUT error. If
+        // MAX_DECODE_DEPTH were raised to/above this depth, or the pre-scan removed,
+        // this fails — so a green here is not a property of the codec, it is our fix.
+        let depth = 500; // 256 < 500 < 1024
+        let bytes = nested_msgpack(depth);
+        assert!(
+            matches!(
+                check_msgpack_depth(&bytes, MAX_DECODE_DEPTH),
+                Err(DecodeError::TooDeep)
+            ),
+            "pre-scan must reject {depth}-deep (> MAX_DECODE_DEPTH={MAX_DECODE_DEPTH})"
+        );
+        let raw: Result<rmpv::Value, _> = rmp_serde::from_slice(&bytes);
+        assert!(
+            raw.is_ok(),
+            "rmp_serde itself ACCEPTS {depth}-deep (< its 1024 limit) — proving our \
+             reject is depth-driven and tighter than the dependency, got {raw:?}"
+        );
+    }
+
+    #[test]
+    fn rmp_serde_own_depth_limit_is_present() {
+        // PINNING REGRESSION on the dependency safety net. `rmp_serde` 1.3.1 caps
+        // recursion at 1024 and returns DepthLimitExceeded rather than overflowing
+        // the stack. `decode_depth_checked` is the PRIMARY, version-independent
+        // guard — but any future code path that bypasses the pre-scan still leans on
+        // this ceiling to avoid a stack-overflow abort. If a dependency bump removes
+        // it, this fails loudly so the residual risk is caught and re-escalated.
+        let within: Result<rmpv::Value, _> = rmp_serde::from_slice(&nested_msgpack(1023));
+        assert!(within.is_ok(), "1023-deep is within rmp_serde's 1024 limit");
+        let over = rmp_serde::from_slice::<rmpv::Value>(&nested_msgpack(1025));
+        assert!(
+            matches!(over, Err(rmp_serde::decode::Error::DepthLimitExceeded)),
+            "rmp_serde must still reject >1024-deep with DepthLimitExceeded, got {over:?}"
+        );
+    }
+
+    #[test]
+    fn check_reports_observed_depth() {
+        // The scanner returns the deepest nesting it saw — this powers the WARN
+        // telemetry in `decode_depth_checked`.
+        assert_eq!(
+            check_msgpack_depth(&nested_msgpack(10), MAX_DECODE_DEPTH).unwrap(),
+            10
+        );
+        // A flat scalar is depth 0.
+        assert_eq!(check_msgpack_depth(&[0xc0], MAX_DECODE_DEPTH).unwrap(), 0);
+        // A frame at exactly the WARN threshold is reported (caller decides to log).
+        assert_eq!(
+            check_msgpack_depth(&nested_msgpack(WARN_DECODE_DEPTH + 1), MAX_DECODE_DEPTH).unwrap(),
+            WARN_DECODE_DEPTH + 1
+        );
     }
 }

--- a/packages/server-rust/src/network/handlers/websocket.rs
+++ b/packages/server-rust/src/network/handlers/websocket.rs
@@ -155,10 +155,12 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
             };
             match next {
                 Some(Ok(Message::Binary(data))) => {
-                    // Depth-checked decode BEFORE auth: a deeply-nested frame would
-                    // otherwise recurse `rmp_serde` to a stack-overflow abort,
-                    // killing every connection on the node from an unauthenticated
-                    // client. Over-deep/malformed frames are dropped, not fatal.
+                    // Depth-checked decode BEFORE auth: our version-independent
+                    // guard against an unbounded recursive decode (a deeply-nested
+                    // frame), which on a codec without an internal cap would
+                    // stack-overflow and abort the whole node from an
+                    // unauthenticated client. Over-deep/malformed frames are
+                    // dropped, not fatal.
                     let tg_msg = match decode::decode_depth_checked::<TopGunMessage>(&data) {
                         Ok(msg) => msg,
                         Err(e) => {
@@ -750,8 +752,14 @@ async fn unpack_and_dispatch_batch(
         let msg_bytes = &data[offset..offset + len];
         offset += len;
 
-        // Deserialize the inner message
-        let inner_msg = match rmp_serde::from_slice::<TopGunMessage>(msg_bytes) {
+        // Deserialize the inner message. Inner messages live inside the batch's
+        // opaque `bin` body, which the outer frame's depth pre-scan skips without
+        // descending — so each inner message gets its own depth-checked decode,
+        // consistent with the top-level Phase 1/2 sites. This is the
+        // version-independent guard against an unbounded recursive decode of a
+        // deeply-nested inner frame; the pinned rmp_serde also caps recursion at
+        // 1024, but that is an unstable codec internal we do not rely on.
+        let inner_msg = match decode::decode_depth_checked::<TopGunMessage>(msg_bytes) {
             Ok(msg) => msg,
             Err(e) => {
                 debug!(

--- a/tests/integration-rust/decode-dos.test.ts
+++ b/tests/integration-rust/decode-dos.test.ts
@@ -308,6 +308,42 @@ describe('Integration: MsgPack decode depth defense (Rust Server)', () => {
       client.close();
     });
 
+    test('batch loop continues past a dropped over-deep inner item (multi-item batch)', async () => {
+      // [over-deep inner (rejected), shallow valid inner] packed into ONE batch.
+      // The over-deep first item must be dropped with `continue` — NOT break/return
+      // — so the second item is still classified, dispatched, and acked. This fails
+      // if the inner-decode error arm ever tears down the batch loop (silent loss of
+      // every inner item after a hostile one).
+      const client = await createRustTestClient(port);
+      await client.waitForMessage('AUTH_ACK', 10_000);
+      client.messages.length = 0;
+
+      const id = `batch-multi-${Date.now()}`;
+      const deep = deepFrame(); // map-wrapped, rejected by the scanner
+      const shallow = serialize({
+        type: 'CLIENT_OP',
+        payload: {
+          id,
+          mapName: 'decode-dos-multi',
+          opType: 'PUT',
+          key: 'k',
+          record: createLWWRecord({ ok: true }),
+        },
+      });
+      const data = Buffer.concat([
+        lenPrefix(deep.length),
+        deep,
+        lenPrefix(shallow.length),
+        Buffer.from(shallow),
+      ]);
+      client.ws.send(encodeBatchFrame(data));
+
+      // The shallow second item is acked only if the loop continued past the drop.
+      await waitForOpAck(client.messages, id);
+
+      client.close();
+    });
+
     test('negative control: a shallow inner message inside an OpBatch is processed', async () => {
       const client = await createRustTestClient(port);
       await client.waitForMessage('AUTH_ACK', 10_000);

--- a/tests/integration-rust/decode-dos.test.ts
+++ b/tests/integration-rust/decode-dos.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Integration tests for the bounded-recursion MsgPack decode defense.
+ *
+ * Background — and an honesty note. A deeply-nested MsgPack frame drives one
+ * native stack frame per nesting level inside a *naive* recursive decoder; an
+ * unbounded such decode overflows the stack and aborts the WHOLE process
+ * (uncatchable in safe Rust). HOWEVER, the pinned codec `rmp_serde` 1.3.1 already
+ * caps its own recursion at 1024 levels and returns a graceful `DepthLimitExceeded`
+ * rather than overflowing. So on the current dependency a hostile deep frame is
+ * handled gracefully WITH OR WITHOUT our fix — a "the process survives" assertion
+ * alone is therefore a property of the dependency, not proof of our change.
+ *
+ * The server's own defense (`decode_depth_checked`) is a *version-independent*,
+ * strictly tighter bound (MAX_DECODE_DEPTH = 256, enforced by an iterative
+ * pre-scan that itself never recurses), so it keeps holding if the codec is ever
+ * swapped or its internal cap removed. This suite therefore has two kinds of test:
+ *
+ *  1. Behavioral coverage (graceful reject + liveness + negative controls) over
+ *     all three untrusted-inbound paths: pre-auth `/ws` (Phase 1), `/sync`, and
+ *     inner messages inside an authenticated OpBatch. These confirm the wire-level
+ *     handling is graceful; they pass on the dependency alone.
+ *
+ *  2. The LOAD-BEARING, fix-specific DISCRIMINATOR (`inner message ... within
+ *     rmp_serde's 1024 limit is dropped`): a *valid* inner op nested between our
+ *     256 bound and the codec's 1024 ceiling. Our scanner drops it; raw rmp_serde
+ *     would accept and process it. This test FAILS if the inner-batch decode is
+ *     not routed through `decode_depth_checked` — i.e. it actually exercises the
+ *     fix, not the dependency. (Its unit-level twin is
+ *     `decode::tests::scanner_rejects_within_rmp_serde_own_limit`.)
+ */
+
+import WebSocket from 'ws';
+import { serialize } from '@topgunbuild/core';
+import {
+  spawnRustServer,
+  createRustTestClient,
+  createLWWRecord,
+  waitForSync,
+} from './helpers';
+import type { SpawnedServer } from './helpers';
+
+// Deep enough that BOTH our 256 scanner bound AND rmp_serde's own 1024 ceiling
+// reject it — used for the graceful-reject/liveness coverage. ~2 KB frame, far
+// under the 2 MB inbound cap, so it reaches the decoder rather than the size gate.
+const DEEP_NESTING = 2_000;
+
+// In the (256, 1024] window: above OUR scanner bound but BELOW rmp_serde's own
+// limit. This is what discriminates the fix from the dependency.
+const MODERATE_NESTING = 500;
+
+/**
+ * Builds a `fixmap(1) { "k": <depth nested 1-element arrays> nil }` payload.
+ *
+ * The deep chain is wrapped as a MAP VALUE, not sent bare: a bare nested array is
+ * rejected *shallowly* by the internally-tagged `TopGunMessage` decoder (which
+ * needs a map to find the `type` tag) and by the `/sync` struct decoder, so it
+ * never recurses. Burying the chain under a map key forces serde to traverse it.
+ */
+function deepFrame(depth = DEEP_NESTING): Buffer {
+  const head = Buffer.from([0x81, 0xa1, 0x6b]); // fixmap(1), fixstr "k"
+  return Buffer.concat([head, Buffer.alloc(depth, 0x91), Buffer.from([0xc0])]);
+}
+
+/** A `depth`-deep nested 1-element JS array — a valid `rmpv::Value` record value. */
+function deepArray(depth: number): unknown {
+  let a: unknown = 0;
+  for (let i = 0; i < depth; i++) a = [a];
+  return a;
+}
+
+/**
+ * A structurally VALID CLIENT_OP whose `record.value` nests `depth` deep. Decodes
+ * fine through raw rmp_serde (when depth < 1024) and dispatches to an OP_ACK — so
+ * it is the right probe for whether the inner-batch site applies our tighter bound.
+ */
+function validDeepClientOp(id: string, depth: number): Uint8Array {
+  return serialize({
+    type: 'CLIENT_OP',
+    payload: {
+      id,
+      mapName: 'decode-dos-disc',
+      opType: 'PUT',
+      key: 'dk',
+      record: {
+        value: deepArray(depth),
+        timestamp: { millis: Date.now(), counter: 0, nodeId: 'decode-dos-node' },
+      },
+    },
+  });
+}
+
+/** 4-byte big-endian length prefix, as `unpack_and_dispatch_batch` expects. */
+function lenPrefix(n: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeUInt32BE(n, 0);
+  return b;
+}
+
+/** Wraps inner-message bytes as a single-entry OpBatch `data` blob. */
+function packBatchData(inner: Uint8Array): Buffer {
+  return Buffer.concat([lenPrefix(inner.length), Buffer.from(inner)]);
+}
+
+/**
+ * Hand-encodes the outer OpBatch frame: `fixmap{ type:"BATCH", count:1, data:<bin> }`.
+ *
+ * The client `serialize()` runs `stripUndefined`, which walks a binary `data`
+ * field as if its bytes were object keys and corrupts it into a huge map. The
+ * envelope is therefore encoded directly so `data` stays a MsgPack `bin` blob —
+ * exactly what the server's `serde_bytes` batch body expects, and what lets the
+ * outer depth scan skip it (the whole point of the inner-batch attack surface).
+ */
+function encodeBatchFrame(data: Uint8Array): Uint8Array {
+  const head = Buffer.from([
+    0x83, // fixmap, 3 entries
+    0xa4, 0x74, 0x79, 0x70, 0x65, // "type"
+    0xa5, 0x42, 0x41, 0x54, 0x43, 0x48, // "BATCH"
+    0xa5, 0x63, 0x6f, 0x75, 0x6e, 0x74, // "count"
+    0x01, // 1
+    0xa4, 0x64, 0x61, 0x74, 0x61, // "data"
+    0xc6, // bin32 marker; 4-byte big-endian length follows
+  ]);
+  return new Uint8Array(Buffer.concat([head, lenPrefix(data.length), Buffer.from(data)]));
+}
+
+/**
+ * Returns a predicate that reports whether the spawned server process has died.
+ * A liveness sanity check — with rmp_serde's 1024 cap a crash is not expected, but
+ * if a regression ever did abort the process this trips directly.
+ */
+function exitTracker(server: SpawnedServer): () => boolean {
+  let exited = false;
+  server.process.once('exit', () => {
+    exited = true;
+  });
+  return () =>
+    exited || server.process.exitCode !== null || server.process.signalCode !== null;
+}
+
+/** True if an OP_ACK referencing `lastId` has been received. */
+function sawOpAck(messages: any[], lastId: string): boolean {
+  return messages.some((m) => m.type === 'OP_ACK' && m.payload?.lastId === lastId);
+}
+
+/** Polls until an OP_ACK for `lastId` arrives, or throws on timeout. */
+async function waitForOpAck(messages: any[], lastId: string, timeout = 10_000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (sawOpAck(messages, lastId)) return;
+    await waitForSync(50);
+  }
+  throw new Error(`timeout waiting for OP_ACK lastId=${lastId}`);
+}
+
+describe('Integration: MsgPack decode depth defense (Rust Server)', () => {
+  let server: SpawnedServer;
+  let port: number;
+  let hasExited: () => boolean;
+
+  beforeAll(async () => {
+    server = await spawnRustServer();
+    port = server.port;
+    hasExited = exitTracker(server);
+  });
+
+  afterAll(async () => {
+    await server.cleanup();
+  });
+
+  /** Authenticates a fresh client and round-trips a shallow PUT → OP_ACK. */
+  async function assertServerStillServing(label: string): Promise<void> {
+    const probe = await createRustTestClient(port);
+    await probe.waitForMessage('AUTH_ACK', 10_000);
+    probe.messages.length = 0;
+    const id = `survive-${label}-${Date.now()}`;
+    probe.send({
+      type: 'CLIENT_OP',
+      payload: {
+        id,
+        mapName: 'decode-dos-survive',
+        opType: 'PUT',
+        key: 'k',
+        record: createLWWRecord({ ok: true }),
+      },
+    });
+    const ack = await probe.waitForMessage('OP_ACK', 10_000);
+    expect(ack.type).toBe('OP_ACK');
+    probe.close();
+  }
+
+  describe('pre-auth /ws (Phase 1)', () => {
+    test('deeply-nested frame is rejected gracefully and the server stays alive', async () => {
+      const client = await createRustTestClient(port, { autoAuth: false });
+      await client.waitForMessage('AUTH_REQUIRED', 10_000);
+
+      // Hostile frame BEFORE authenticating — the Phase 1 pre-auth decode path.
+      client.ws.send(deepFrame());
+      await waitForSync(500);
+
+      // The frame is dropped, not interpreted as an AUTH: no AUTH_ACK arrives.
+      expect(client.isAuthenticated).toBe(false);
+      expect(hasExited()).toBe(false);
+      // A fresh connection still authenticates and round-trips.
+      await assertServerStillServing('ws-preauth');
+
+      client.close();
+    });
+
+    test('negative control: a shallow frame authenticates and processes normally', async () => {
+      const client = await createRustTestClient(port);
+      await client.waitForMessage('AUTH_ACK', 10_000);
+      expect(client.ws.readyState).toBe(WebSocket.OPEN);
+      expect(client.isAuthenticated).toBe(true);
+      client.close();
+    });
+  });
+
+  describe('POST /sync', () => {
+    test('deeply-nested body returns HTTP 400 and the server stays alive', async () => {
+      const resp = await fetch(`http://127.0.0.1:${port}/sync`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/msgpack' },
+        body: new Uint8Array(deepFrame()),
+      });
+
+      expect(resp.status).toBe(400);
+      expect(hasExited()).toBe(false);
+
+      // Negative control + liveness: a valid shallow /sync returns 200.
+      const ok = await fetch(`http://127.0.0.1:${port}/sync`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/msgpack' },
+        body: new Uint8Array(
+          serialize({
+            clientId: 'decode-dos-sync',
+            clientHlc: { millis: Date.now(), counter: 0, nodeId: 'decode-dos-node' },
+          }),
+        ),
+      });
+      expect(ok.status).toBe(200);
+    });
+  });
+
+  describe('inner message inside an OpBatch (post-auth)', () => {
+    test('deeply-nested inner message is rejected gracefully and the server stays alive', async () => {
+      const client = await createRustTestClient(port);
+      await client.waitForMessage('AUTH_ACK', 10_000);
+
+      // OpBatch whose opaque `bin` data packs one deeply-nested inner message.
+      // The outer frame is shallow, so it passes the outer scan and reaches
+      // unpack_and_dispatch_batch, where the inner gets its own depth-checked decode.
+      client.ws.send(encodeBatchFrame(packBatchData(deepFrame())));
+      await waitForSync(500);
+
+      expect(hasExited()).toBe(false);
+
+      // Liveness: the same connection still round-trips a shallow op.
+      client.messages.length = 0;
+      const id = `batch-survive-${Date.now()}`;
+      client.send({
+        type: 'CLIENT_OP',
+        payload: {
+          id,
+          mapName: 'decode-dos-batch',
+          opType: 'PUT',
+          key: 'k',
+          record: createLWWRecord({ ok: true }),
+        },
+      });
+      await waitForOpAck(client.messages, id);
+
+      client.close();
+    });
+
+    test('DISCRIMINATOR: a valid inner op nested beyond our 256 bound but within rmp_serde 1024 is dropped (not processed)', async () => {
+      // This is the fix-specific assertion. The inner op is structurally VALID and
+      // nests ~500 deep — above MAX_DECODE_DEPTH (256) but below rmp_serde's 1024
+      // limit. Patched (:754 → decode_depth_checked): the scanner drops it, so NO
+      // OP_ACK for its id is ever produced. Unpatched (:754 → raw rmp_serde): the op
+      // decodes (500 < 1024), dispatches, and acks → this test FAILS. That is what
+      // makes it exercise the fix and not merely the dependency.
+      const client = await createRustTestClient(port);
+      await client.waitForMessage('AUTH_ACK', 10_000);
+      client.messages.length = 0;
+
+      const deepId = `disc-deep-${Date.now()}`;
+      const probeId = `disc-probe-${Date.now()}`;
+
+      client.ws.send(encodeBatchFrame(packBatchData(validDeepClientOp(deepId, MODERATE_NESTING))));
+      // A shallow probe op on the same in-order connection. Once it acks, the deep
+      // inner has been processed-or-dropped, so the absence of its ack is decisive.
+      client.send({
+        type: 'CLIENT_OP',
+        payload: {
+          id: probeId,
+          mapName: 'decode-dos-disc',
+          opType: 'PUT',
+          key: 'pk',
+          record: createLWWRecord({ ok: true }),
+        },
+      });
+
+      await waitForOpAck(client.messages, probeId);
+
+      expect(sawOpAck(client.messages, deepId)).toBe(false);
+      expect(hasExited()).toBe(false);
+
+      client.close();
+    });
+
+    test('negative control: a shallow inner message inside an OpBatch is processed', async () => {
+      const client = await createRustTestClient(port);
+      await client.waitForMessage('AUTH_ACK', 10_000);
+      client.messages.length = 0;
+
+      const id = `batch-inner-${Date.now()}`;
+      const inner = serialize({
+        type: 'CLIENT_OP',
+        payload: {
+          id,
+          mapName: 'decode-dos-batch-neg',
+          opType: 'PUT',
+          key: 'k',
+          record: createLWWRecord({ ok: true }),
+        },
+      });
+      client.ws.send(encodeBatchFrame(packBatchData(inner)));
+
+      // The shallow inner op is classified, dispatched, and acked — proving the
+      // drops above are depth-driven, not a blanket batch drop.
+      await waitForOpAck(client.messages, id);
+
+      client.close();
+    });
+  });
+});

--- a/tests/integration-rust/decode-dos.test.ts
+++ b/tests/integration-rust/decode-dos.test.ts
@@ -31,12 +31,7 @@
 
 import WebSocket from 'ws';
 import { serialize } from '@topgunbuild/core';
-import {
-  spawnRustServer,
-  createRustTestClient,
-  createLWWRecord,
-  waitForSync,
-} from './helpers';
+import { spawnRustServer, createRustTestClient, createLWWRecord, waitForSync } from './helpers';
 import type { SpawnedServer } from './helpers';
 
 // Deep enough that BOTH our 256 scanner bound AND rmp_serde's own 1024 ceiling
@@ -113,11 +108,29 @@ function packBatchData(inner: Uint8Array): Buffer {
 function encodeBatchFrame(data: Uint8Array): Uint8Array {
   const head = Buffer.from([
     0x83, // fixmap, 3 entries
-    0xa4, 0x74, 0x79, 0x70, 0x65, // "type"
-    0xa5, 0x42, 0x41, 0x54, 0x43, 0x48, // "BATCH"
-    0xa5, 0x63, 0x6f, 0x75, 0x6e, 0x74, // "count"
+    0xa4,
+    0x74,
+    0x79,
+    0x70,
+    0x65, // "type"
+    0xa5,
+    0x42,
+    0x41,
+    0x54,
+    0x43,
+    0x48, // "BATCH"
+    0xa5,
+    0x63,
+    0x6f,
+    0x75,
+    0x6e,
+    0x74, // "count"
     0x01, // 1
-    0xa4, 0x64, 0x61, 0x74, 0x61, // "data"
+    0xa4,
+    0x64,
+    0x61,
+    0x74,
+    0x61, // "data"
     0xc6, // bin32 marker; 4-byte big-endian length follows
   ]);
   return new Uint8Array(Buffer.concat([head, lenPrefix(data.length), Buffer.from(data)]));
@@ -133,17 +146,22 @@ function exitTracker(server: SpawnedServer): () => boolean {
   server.process.once('exit', () => {
     exited = true;
   });
-  return () =>
-    exited || server.process.exitCode !== null || server.process.signalCode !== null;
+  return () => exited || server.process.exitCode !== null || server.process.signalCode !== null;
 }
 
+type InboundMessage = { type: string; payload?: { lastId?: string } };
+
 /** True if an OP_ACK referencing `lastId` has been received. */
-function sawOpAck(messages: any[], lastId: string): boolean {
+function sawOpAck(messages: InboundMessage[], lastId: string): boolean {
   return messages.some((m) => m.type === 'OP_ACK' && m.payload?.lastId === lastId);
 }
 
 /** Polls until an OP_ACK for `lastId` arrives, or throws on timeout. */
-async function waitForOpAck(messages: any[], lastId: string, timeout = 10_000): Promise<void> {
+async function waitForOpAck(
+  messages: InboundMessage[],
+  lastId: string,
+  timeout = 10_000,
+): Promise<void> {
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
     if (sawOpAck(messages, lastId)) return;


### PR DESCRIPTION
## Summary

Routes the **inner-OpBatch** msgpack decode (`unpack_and_dispatch_batch`, `websocket.rs`) through the existing iterative depth pre-scanner `decode_depth_checked`, closing the one untrusted client-inbound decode site that bypassed it (inner messages live inside the batch's opaque `bin` body, which the outer depth scan skips). Plus scanner hardening + honest documentation + real behavioral tests.

## ⚠️ Severity correction (read this)

The originating finding (TODO-506 / `DEPTH_NETWORK_TRANSPORT.md` F1) was framed as a **live pre-auth SIGABRT DoS** ("demo crashes right now"). **That premise is false for the pinned codec.** Established empirically during this work:

- **`rmp_serde` 1.3.1 caps its own recursion at 1024 levels** (internal `depth_count!` guard) and returns a graceful `Err(DepthLimitExceeded)` — it does **not** stack-overflow / SIGABRT.
- Verified over the wire: a deeply-nested frame on the **unpatched** inner-batch path was handled gracefully (no crash) at depth 100K / 512K / 2M; `rmpv::Value` decode returns `Err` at depth ≥1024.

So **this is NOT a live crash fix** — it is **defense-in-depth**: the 1024 cap is an *unstable codec internal, not an API contract*. Our iterative pre-scan is a **tighter (256), version-independent** bound that survives a codec swap or a future bump removing that cap. **TODO-506 is re-classified P0-live-vuln → hardening.** (The earlier commit message "close residual DoS" overclaimed; corrected here and in the amended commit.)

## Changes

- **`websocket.rs`** — inner-batch decode at the OpBatch boundary → `decode_depth_checked` (over-deep inner dropped via `continue`, never aborts). Phase 1 decode comment corrected (dropped the unconditional stack-overflow claim).
- **`decode.rs`** — corrected module/const docs (rmp_serde *does* cap at 1024); `MAX_DECODE_DEPTH` 128 → **256** (measured: typical envelopes ≤9 deep, a 40-deep machine-generated record value ~43; 256 = wide margin, still ≪ 1024 — reduces false-positive rejection of legitimate user `rmpv::Value` data); `WARN_DECODE_DEPTH=128` debug telemetry (`check_msgpack_depth` now returns max observed depth).
- **Tests** —
  - `scanner_rejects_within_rmp_serde_own_limit` — **discriminator**: scanner rejects a 500-deep frame that raw `rmp_serde` *accepts* (proves our bound is active & strictly tighter).
  - `rmp_serde_own_depth_limit_is_present` — **pins** the 1024 dependency cap; fails loudly if a future bump removes it.
  - `tests/integration-rust/decode-dos.test.ts` — wire-level coverage on all three untrusted-inbound paths (pre-auth `/ws`, `/sync`, inner-batch): graceful reject + liveness + negative controls; a **fix-specific over-the-wire discriminator** (valid 500-deep inner dropped, verified to **FAIL on the pre-fix `:754`**); multi-item-batch loop-continuation test.

## Verification (local)

- `cargo fmt --check` ✓ · `cargo clippy --all-targets --all-features -D warnings` ✓ · `cargo test --release -p topgun-server --lib` → **1515/0** ✓
- `decode-dos.test.ts` → **7/7** ✓ (discriminator confirmed non-vacuous: fails on unpatched `:754`)
- prettier + eslint clean on changed test

## Cross-vendor

- `/xask` (glm-5.2) on the design fork → one-line fix correct & sufficient, no wire change.
- `/xreview` (glm-5.2) on the diff → H1 (multi-item batch test) fixed; L1 (telemetry level) documented; M1/M2/L2 verified already-covered/non-issues.

## Follow-up filed

- **TODO-552** — OpBatch rate-limiter under-charge (lying `count`): resource-amplification, separate from the depth class; out of scope here.

Ships alone (security/CI-infra rule). Blocking `integration-rust` gate runs in CI.