### PR TITLE
fix(sf-328): charge transport Batch by actual inner-item count + hard cap (TODO-552)

### DIFF
--- a/packages/server-rust/src/network/handlers/websocket.rs
+++ b/packages/server-rust/src/network/handlers/websocket.rs
@@ -457,16 +457,63 @@ fn release_session_state(state: &AppState, conn_id: ConnectionId) {
 /// individually. Non-BATCH messages are classified, have `connection_id`
 /// and `principal` set, and are routed through the pipeline. Each
 /// `OperationResponse` variant is mapped to the appropriate outbound message(s).
+/// Hard upper bound on the number of inner items a single transport `Batch`
+/// frame may carry through `unpack_and_dispatch_batch`.
+///
+/// Bounds worst-case per-frame dispatch work: the 2 MB inbound frame cap lets a
+/// `Batch.data` blob pack roughly 524K minimal 4-byte length-prefixed entries,
+/// each of which would otherwise drive a decode + classify + dispatch. Capping
+/// at `8_192` keeps per-frame dispatch cost bounded while sitting far above any
+/// legitimate batch size (tens to low thousands), so honest clients never hit it.
+const MAX_BATCH_INNER_ITEMS: usize = 8_192;
+
+/// Counts the well-formed length-prefixed inner items packed into a transport
+/// `Batch.data` blob, without decoding any inner payload.
+///
+/// This is the single source of truth for BOTH the rate-limiter charge and the
+/// hard inner-item cap, so the charged count and the dispatched count agree by
+/// construction. It mirrors `unpack_and_dispatch_batch`'s framing walk exactly:
+/// read a 4-byte big-endian length prefix, skip that many bytes, repeat. A
+/// truncated trailing prefix or payload ends the walk (the unpacker `break`s on
+/// the same condition), so only complete framed items are counted — the charge
+/// is never larger than what the unpacker would actually dispatch.
+///
+/// Pure pointer arithmetic over the already-in-memory slice: no heap allocation,
+/// no inner decode.
+fn count_batch_items(data: &[u8]) -> usize {
+    let mut offset = 0;
+    let mut count = 0;
+    while offset + 4 <= data.len() {
+        let len = u32::from_be_bytes([
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ]) as usize;
+        offset += 4;
+        if offset + len > data.len() {
+            // Truncated payload: the unpacker stops here, so do we.
+            break;
+        }
+        offset += len;
+        count += 1;
+    }
+    count
+}
+
 /// Cost, in op-rate-limiter tokens, of an inbound frame.
 ///
 /// A frame's cost is the number of individual ops it carries so a single peer
 /// cannot evade the per-connection rate limit by packing many ops into one
-/// `OpBatch`/`Batch` frame. Non-batch messages cost one token. Always at least
-/// 1 so an empty batch still consumes a token (and cannot be used to spin).
+/// `OpBatch`/`Batch` frame. For a transport `Batch` the declared `count` field
+/// is attacker-controlled and is NOT trusted: the cost is the actual number of
+/// length-prefixed inner items the unpacker would dispatch. Non-batch messages
+/// cost one token. Always at least 1 so an empty batch still consumes a token
+/// (and cannot be used to spin).
 fn inbound_op_cost(msg: &TopGunMessage) -> u32 {
     let count = match msg {
         TopGunMessage::OpBatch(b) => b.payload.ops.len(),
-        TopGunMessage::Batch(b) => b.count as usize,
+        TopGunMessage::Batch(b) => count_batch_items(&b.data),
         _ => 1,
     };
     u32::try_from(count.max(1)).unwrap_or(u32::MAX)
@@ -723,6 +770,32 @@ async fn unpack_and_dispatch_batch(
     tx: &mpsc::Sender<OutboundMessage>,
 ) {
     let data = &batch_msg.data;
+
+    // Authoritative dispatch-side bound: drop the WHOLE frame if it packs more
+    // inner items than the cap. This holds even if the cost function is later
+    // changed or this path is reached another way, and matches the existing
+    // whole-frame token-exhaustion behavior — the batch path has no per-item ack,
+    // so partial dispatch would be silent unacked loss. The client is told via an
+    // explicit error rather than a silent drop.
+    let item_count = count_batch_items(data);
+    if item_count > MAX_BATCH_INNER_ITEMS {
+        debug!(
+            "batch from {:?} exceeds max inner items ({} > {}); dropping whole frame",
+            conn_id, item_count, MAX_BATCH_INNER_ITEMS
+        );
+        let err = TopGunMessage::Error {
+            payload: ErrorPayload {
+                code: 413,
+                message: "batch exceeds maximum inner item count".to_string(),
+                details: None,
+            },
+        };
+        if let Ok(bytes) = rmp_serde::to_vec_named(&err) {
+            let _ = tx.send(OutboundMessage::Binary(bytes)).await;
+        }
+        return;
+    }
+
     let mut offset = 0;
 
     while offset < data.len() {
@@ -945,8 +1018,28 @@ mod tests {
     use topgun_core::messages::search::SearchOptions;
     use topgun_core::messages::{BatchMessage, ClientOp, OpBatchMessage, OpBatchPayload};
 
+    /// Frames `body` as one length-prefixed batch inner item (4-byte big-endian
+    /// length header + body), matching the wire framing the unpacker expects.
+    fn frame_inner_item(body: &[u8]) -> Vec<u8> {
+        let len = u32::try_from(body.len()).expect("inner item fits in u32");
+        let mut out = len.to_be_bytes().to_vec();
+        out.extend_from_slice(body);
+        out
+    }
+
+    /// Concatenates `n` minimal (empty-body) framed inner items.
+    fn pack_n_minimal_items(n: usize) -> Vec<u8> {
+        let mut data = Vec::new();
+        for _ in 0..n {
+            data.extend_from_slice(&frame_inner_item(&[]));
+        }
+        data
+    }
+
     /// The op-rate limiter charges a frame by the number of ops it carries, so a
     /// peer cannot evade the per-connection cap by packing ops into one batch.
+    /// For a transport `Batch` the declared `count` is attacker-controlled and
+    /// must NOT be the cost basis — the cost is the actual packed inner-item count.
     #[test]
     fn inbound_op_cost_counts_batch_ops() {
         // A non-batch message costs one token.
@@ -967,18 +1060,34 @@ mod tests {
         });
         assert_eq!(inbound_op_cost(&three_ops), 3);
 
-        // An empty batch still costs one token (cannot be used to spin for free).
+        // An empty OpBatch still costs one token (cannot be used to spin for free).
         let empty = TopGunMessage::OpBatch(OpBatchMessage {
             payload: OpBatchPayload::default(),
         });
         assert_eq!(inbound_op_cost(&empty), 1);
 
-        // A transport Batch costs its declared message count.
-        let batch = TopGunMessage::Batch(BatchMessage {
-            count: 5,
+        // A transport Batch declaring count=1 but packing 50 framed inner items
+        // is charged ~50, NOT 1 — the declared count is not trusted.
+        let amplified = TopGunMessage::Batch(BatchMessage {
+            count: 1,
+            data: pack_n_minimal_items(50),
+        });
+        assert_eq!(inbound_op_cost(&amplified), 50);
+
+        // An empty transport Batch (no framed items) still costs one token.
+        let empty_batch = TopGunMessage::Batch(BatchMessage {
+            count: 0,
             data: vec![],
         });
-        assert_eq!(inbound_op_cost(&batch), 5);
+        assert_eq!(inbound_op_cost(&empty_batch), 1);
+
+        // A transport Batch declaring count=99 but packing only 3 framed items
+        // is charged 3 — the cost follows the actual packed count, not the lie.
+        let over_declared = TopGunMessage::Batch(BatchMessage {
+            count: 99,
+            data: pack_n_minimal_items(3),
+        });
+        assert_eq!(inbound_op_cost(&over_declared), 3);
     }
 
     /// Disconnect cleanup must drain a connection's standing subscriptions from

--- a/packages/server-rust/src/network/handlers/websocket.rs
+++ b/packages/server-rust/src/network/handlers/websocket.rs
@@ -475,15 +475,23 @@ const MAX_BATCH_INNER_ITEMS: usize = 8_192;
 /// construction. It mirrors `unpack_and_dispatch_batch`'s framing walk exactly:
 /// read a 4-byte big-endian length prefix, skip that many bytes, repeat. A
 /// truncated trailing prefix or payload ends the walk (the unpacker `break`s on
-/// the same condition), so only complete framed items are counted — the charge
-/// is never larger than what the unpacker would actually dispatch.
+/// the same condition), so the count is exactly the number of complete framed
+/// items the unpacker iterates over — i.e. the charge is never *smaller* than
+/// what the unpacker would actually attempt to decode and dispatch, which is the
+/// property the rate limiter relies on.
+///
+/// Comparisons are written against the remaining byte count (`data.len() -
+/// offset`) rather than `offset + len` so an adversarial length prefix near
+/// `u32::MAX` cannot overflow `usize` on a 32-bit target (where it would
+/// otherwise wrap the truncation guard and spin the walk). `offset <= data.len()`
+/// holds on every iteration, so the subtraction never underflows.
 ///
 /// Pure pointer arithmetic over the already-in-memory slice: no heap allocation,
 /// no inner decode.
 fn count_batch_items(data: &[u8]) -> usize {
     let mut offset = 0;
     let mut count = 0;
-    while offset + 4 <= data.len() {
+    while data.len() - offset >= 4 {
         let len = u32::from_be_bytes([
             data[offset],
             data[offset + 1],
@@ -491,7 +499,7 @@ fn count_batch_items(data: &[u8]) -> usize {
             data[offset + 3],
         ]) as usize;
         offset += 4;
-        if offset + len > data.len() {
+        if len > data.len() - offset {
             // Truncated payload: the unpacker stops here, so do we.
             break;
         }
@@ -799,8 +807,13 @@ async fn unpack_and_dispatch_batch(
     let mut offset = 0;
 
     while offset < data.len() {
-        // Read 4-byte big-endian length prefix
-        if offset + 4 > data.len() {
+        // Read 4-byte big-endian length prefix. Comparisons use the remaining
+        // byte count (`data.len() - offset`) rather than `offset + len` so an
+        // adversarial near-`u32::MAX` length cannot overflow `usize` on a 32-bit
+        // target; `offset < data.len()` here and `offset <= data.len()` after the
+        // prefix read keep the subtraction from underflowing. This mirrors
+        // `count_batch_items` exactly so the charged and dispatched counts agree.
+        if data.len() - offset < 4 {
             debug!("truncated batch length prefix from {:?}", conn_id);
             break;
         }
@@ -812,7 +825,7 @@ async fn unpack_and_dispatch_batch(
         ]) as usize;
         offset += 4;
 
-        if offset + len > data.len() {
+        if len > data.len() - offset {
             debug!(
                 "truncated batch message (need {} bytes, {} available) from {:?}",
                 len,

--- a/tests/integration-rust/decode-dos.test.ts
+++ b/tests/integration-rust/decode-dos.test.ts
@@ -149,11 +149,30 @@ function exitTracker(server: SpawnedServer): () => boolean {
   return () => exited || server.process.exitCode !== null || server.process.signalCode !== null;
 }
 
-type InboundMessage = { type: string; payload?: { lastId?: string } };
+type InboundMessage = { type: string; payload?: { lastId?: string; code?: number } };
 
 /** True if an OP_ACK referencing `lastId` has been received. */
 function sawOpAck(messages: InboundMessage[], lastId: string): boolean {
   return messages.some((m) => m.type === 'OP_ACK' && m.payload?.lastId === lastId);
+}
+
+/** True if an ERROR frame carrying `code` has been received. */
+function sawError(messages: InboundMessage[], code: number): boolean {
+  return messages.some((m) => m.type === 'ERROR' && m.payload?.code === code);
+}
+
+/** Polls until an ERROR frame with `code` arrives; returns whether it did. */
+async function waitForError(
+  messages: InboundMessage[],
+  code: number,
+  timeout = 5_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (sawError(messages, code)) return true;
+    await waitForSync(50);
+  }
+  return sawError(messages, code);
 }
 
 /** Polls until an OP_ACK for `lastId` arrives, or throws on timeout. */
@@ -383,6 +402,69 @@ describe('Integration: MsgPack decode depth defense (Rust Server)', () => {
       // The shallow inner op is classified, dispatched, and acked — proving the
       // drops above are depth-driven, not a blanket batch drop.
       await waitForOpAck(client.messages, id);
+
+      client.close();
+    });
+  });
+
+  describe('transport Batch rate-limiter charge follows actual inner-item count', () => {
+    test('LOAD-BEARING: count=1 frames packing >40k framed items are charged their true count and trigger a 429', async () => {
+      // Each outer frame declares count=1 (encodeBatchFrame hardcodes it) but packs
+      // 40_001 well-formed zero-length framed inner items (each a 4-byte BE length of
+      // 0). The server's count_batch_items returns 40_001 per frame. The cost is
+      // clamped to the bucket capacity (40_000) at the charge site, so the FIRST such
+      // frame drains the full burst to ~0 (and succeeds); the SECOND frame, arriving a
+      // few ms later with only a sliver of refill available, cannot cover its clamped
+      // cost → try_consume fails → a 429 ERROR fires at the CHARGE SITE, before any
+      // inner item is decoded or dispatched (inner validity is irrelevant). ~160 KB
+      // per frame, well under the 2 MB inbound cap.
+      //
+      // WHY this discriminates the fix: under the pre-fix model each frame costs the
+      // declared count (1), so neither frame meaningfully drains the bucket and NO 429
+      // is produced. Revert inbound_op_cost's Batch arm to `b.count as usize` and this
+      // test goes red. (Burst is the hardcoded 40_000 in the spawned server — the
+      // over-burst approach is required; it is not env-tunable.)
+      const client = await createRustTestClient(port);
+      await client.waitForMessage('AUTH_ACK', 10_000);
+      client.messages.length = 0;
+
+      const ITEMS = 40_001;
+      // ITEMS framed len-0 entries = ITEMS * 4 zero bytes (each 4-byte BE length = 0).
+      const data = Buffer.alloc(ITEMS * 4, 0);
+      // First frame drains the burst; second finds the bucket empty → 429.
+      client.ws.send(encodeBatchFrame(data));
+      client.ws.send(encodeBatchFrame(data));
+
+      const got429 = await waitForError(client.messages, 429);
+      expect(got429).toBe(true);
+      expect(hasExited()).toBe(false);
+
+      client.close();
+    });
+
+    test('negative control: a count=1 frame packing a few valid ops is charged its true small count and processed (no 429)', async () => {
+      // A legitimate small batch: count=1 on the wire, ~5 valid shallow inner ops
+      // packed in data. Its true charge is ~5, far under the burst, so it is admitted
+      // and processed normally — no 429. Proves the >40k rejection above is the
+      // amplification guard, not a blanket batch penalty.
+      const client = await createRustTestClient(port);
+      await client.waitForMessage('AUTH_ACK', 10_000);
+      client.messages.length = 0;
+
+      const ids = Array.from({ length: 5 }, (_, i) => `batch-charge-neg-${i}-${Date.now()}`);
+      const data = Buffer.concat(
+        ids.flatMap((id) => {
+          const inner = validDeepClientOp(id, 1); // shallow, valid CLIENT_OP
+          return [lenPrefix(inner.length), Buffer.from(inner)];
+        }),
+      );
+      client.ws.send(encodeBatchFrame(data));
+
+      // Each valid inner op is dispatched and acked; the last ack confirms the whole
+      // frame was processed, and no 429 was raised for this legitimate batch.
+      await waitForOpAck(client.messages, ids[ids.length - 1]);
+      expect(sawError(client.messages, 429)).toBe(false);
+      expect(hasExited()).toBe(false);
 
       client.close();
     });


### PR DESCRIPTION
## Summary

Closes the transport-`Batch` rate-limiter **under-charge ("lying count") CPU/dispatch amplification DoS** (TODO-552). A client could send a transport `Batch` frame declaring `count: 1` while packing N length-prefixed inner messages into `data`; the limiter charged 1 token but the server did N units of decode + classify + dispatch. The attacker-controlled declared `count` is no longer trusted as the cost basis.

This is a **separate amplification class** from the depth-recursion issue closed in #93 (SPEC-327). Ships **alone** per the stabilization roadmap (security work ships in its own PR).

## What changed

- **`inbound_op_cost`** — the `Batch` arm now charges `count_batch_items(&b.data)` (actual packed inner-item count) instead of `b.count`.
- **`count_batch_items`** — a single framing-walk helper (4-byte BE length prefix, skip body, repeat) that is the **single source of truth** for both the limiter charge and the dispatch-side cap, so `charge == dispatched` by construction. Pure pointer arithmetic — no heap allocation, no inner decode.
- **`unpack_and_dispatch_batch`** — authoritative whole-frame drop with an explicit `413` when a frame packs more than `MAX_BATCH_INNER_ITEMS = 8_192` inner items (bounds worst-case per-frame work even against a maximally-packed 2 MB frame). The SPEC-327 per-item `decode_depth_checked` + `continue`-on-error loop is preserved for frames under the cap.
- Framing comparisons use remaining bytes (`data.len() - offset`) rather than `offset + len`, so an adversarial near-`u32::MAX` length prefix cannot overflow `usize` / spin the walk.

**Wire protocol unchanged** — `BatchMessage` (`core-rust`) is untouched; `data` stays `Vec<u8>`/`serde_bytes`, `count` stays on the wire (just no longer trusted for cost).

## Tests

- **Over-the-wire discriminator** (`decode-dos.test.ts`): two `count:1` frames each packing 40,001 framed items → the first drains the burst, the second hits an empty bucket → `429`. **Non-vacuous** — reverting the `inbound_op_cost` Batch arm to `b.count as usize` makes it go RED (proven).
- **Negative control**: a legitimate `count:1` frame packing 5 valid ops is charged its true small count and processed — no 429.
- Updated `inbound_op_cost_counts_batch_ops` unit test asserts the actual/cap charge model (count≠items divergence), not the old trusted-`count` bug.

## Local gate (DEBUG, per the SPEC-327 lesson that CI runs `cargo test` in debug)

- `cargo fmt --check` → 0
- `cargo clippy -p topgun-server --all-targets --all-features -- -D warnings` → 0
- `cargo test -p topgun-server --lib` (DEBUG) → 1515 passed / 0 failed
- `pnpm test:integration-rust` decode-dos → 9 passed / 9

## Review trail

- Fresh-context impl review: **APPROVED** (0 Critical / 0 Major / 0 Minor).
- Cross-vendor `/xask` (design fork) + `/xreview` (final diff, glm-5.2): 2 real findings fixed (overflow-safe framing walk + invariant-direction docs in `aeb03eba`), 3 rejected with diff-grounded reasons.

## Acceptance criteria

AC1–AC9 all met (see commit history). Footprint: 2 files, within the 5-file Rust cap.
