### PR TITLE
test(sf-329): non-blocking loaded G4b soak CI variant + classify crash-window write_errors (TODO-547)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -524,19 +524,27 @@ jobs:
 
       - name: Loaded no-crash convergence soak must be GREEN
         run: |
-          # Loaded params build a real write-behind backlog (vs the tiny smoke).
+          # Loaded params build a real write-behind backlog (vs the tiny smoke) — the
+          # with-crash variant at these exact params loses acked-but-unflushed writes
+          # on kill -9 (TODO-546), direct proof the backlog is real and non-trivial;
+          # this no-crash run exercises convergence under that same write pressure.
           # Memory: the slope threshold stays at the honest default (50 MB/h) but the
-          # min-growth guard is raised to 500MB so the slope arm acts only as a
-          # GROSS-leak tripwire — a 150s OR-churn burst's slope extrapolation is not a
-          # valid slow-leak signal (that is the 72h run's job); the 1200MB ceiling is
-          # the real OOM guard. This job gates on CONVERGENCE-under-backlog.
+          # min-growth guard makes the slope arm fire only as a GROSS-leak tripwire — a
+          # 150s OR-churn burst's slope extrapolation is not a valid slow-leak signal
+          # (that is the 72h run's job); the ceiling is the real OOM guard. Observed
+          # legitimate peak growth at this load is ~190MB, so 300MB min-growth clears
+          # it with margin while still tripping on a runaway leak, and a 900MB ceiling
+          # catches a runaway sooner. This job gates on CONVERGENCE-under-backlog.
           ${{ steps.soak.outputs.bin }} \
             --duration 150 --crash-interval 0 --steady-interval 15 \
             --churn-clients 16 --keyspace 200 --quiesce 3 \
-            --mem-min-growth-mb 500 --mem-ceiling-mb 1200 \
+            --mem-min-growth-mb 300 --mem-ceiling-mb 900 \
             --json-output soak-loaded.json
-          jq -e '.passed == true' soak-loaded.json >/dev/null \
-            || { echo "FAIL: loaded no-crash soak did not pass"; cat soak-loaded.json; exit 1; }
+          # Assert the load actually ran (totalWrites floor the tiny smoke cannot reach,
+          # guarding against a silent mis-edit that shrinks params back to smoke scale)
+          # AND convergence/memory/panic passed.
+          jq -e '.passed == true and .totalWrites > 20000' soak-loaded.json >/dev/null \
+            || { echo "FAIL: loaded no-crash soak did not pass or did not build load"; cat soak-loaded.json; exit 1; }
           echo "OK: loaded no-crash convergence soak passed"
 
       - name: Upload loaded soak report

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -401,9 +401,10 @@ jobs:
     # detection must keep working. We run the two negative controls (which MUST
     # go RED) plus a short no-crash convergence/churn/memory soak (which MUST be
     # green). The full 72h crash-loop soak runs on a Hetzner scratch box, not in
-    # CI. The crash-loop path is also currently RED by design against TODO-530
-    # (post-restart rehydration gap), so CI deliberately exercises the no-crash
-    # mode here — see packages/server-rust/benches/soak_harness/README.md.
+    # CI. The crash-loop path is still RED at load — now due to TODO-546
+    # (ack-before-durable), not the closed TODO-530 — so CI exercises the no-crash
+    # mode here; the loaded no-crash variant is the separate non-blocking
+    # soak-loaded job below. See packages/server-rust/benches/soak_harness/README.md.
     steps:
       - uses: actions/checkout@v4
 
@@ -466,6 +467,84 @@ jobs:
         with:
           name: soak-smoke-${{ github.run_id }}
           path: soak-smoke.json
+          retention-days: 30
+
+  soak-loaded:
+    name: Soak Harness Loaded (G4b, non-blocking)
+    needs: [check]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # NON-BLOCKING (continue-on-error) loaded convergence soak. The fast soak-smoke
+    # gate above runs a tiny no-crash soak (churn 6 / keyspace 48 / 25s) that is too
+    # small to build a write-behind backlog, so backlog-dependent durability/
+    # convergence regressions cannot surface there — exactly the gap that masked
+    # SPEC-325b AC1 (which only failed at keyspace ~200 / churn ~16). This job drives
+    # a real backlog (churn 16 / keyspace 200 / 150s, no-crash) so those regressions
+    # fail at PR/CI time instead of only at the 72h Hetzner run or in production.
+    #
+    # Why NO-CRASH at load: a loaded WITH-crash soak is currently RED purely due to
+    # the open ack-before-durable gap (TODO-546) — acked-but-unflushed writes are lost
+    # on kill -9 at load. That is a known-open critical, not a fresh regression, so a
+    # with-crash gate here would just re-report TODO-546. The with-crash loaded
+    # reproducer stays local/Hetzner as the TODO-546 validator; once TODO-546 is fixed
+    # it should be promoted into CI as a blocking crash-recovery-at-load gate.
+    #
+    # Why non-blocking for now: this GREEN result is established on local debug/macOS;
+    # it is not yet validated on ubuntu CI. Promote to BLOCKING after >=10 consecutive
+    # green runs on main (owner: stabilization-program G4b gate). Until then it is
+    # advisory so a CI-platform flake never blocks merges.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-soak-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-soak-
+            ${{ runner.os }}-cargo-
+
+      - name: Build server binary + soak bench
+        run: cargo build --bin topgun-server --bench soak_harness
+
+      - name: Locate soak bench binary
+        id: soak
+        run: |
+          BIN=$(ls -t target/debug/deps/soak_harness-* | grep -vE '\.(d|o|rcgu)' | head -1)
+          test -x "$BIN" || { echo "soak bench binary not found"; exit 1; }
+          echo "bin=$BIN" >> "$GITHUB_OUTPUT"
+
+      - name: Loaded no-crash convergence soak must be GREEN
+        run: |
+          # Loaded params build a real write-behind backlog (vs the tiny smoke).
+          # Memory: the slope threshold stays at the honest default (50 MB/h) but the
+          # min-growth guard is raised to 500MB so the slope arm acts only as a
+          # GROSS-leak tripwire — a 150s OR-churn burst's slope extrapolation is not a
+          # valid slow-leak signal (that is the 72h run's job); the 1200MB ceiling is
+          # the real OOM guard. This job gates on CONVERGENCE-under-backlog.
+          ${{ steps.soak.outputs.bin }} \
+            --duration 150 --crash-interval 0 --steady-interval 15 \
+            --churn-clients 16 --keyspace 200 --quiesce 3 \
+            --mem-min-growth-mb 500 --mem-ceiling-mb 1200 \
+            --json-output soak-loaded.json
+          jq -e '.passed == true' soak-loaded.json >/dev/null \
+            || { echo "FAIL: loaded no-crash soak did not pass"; cat soak-loaded.json; exit 1; }
+          echo "OK: loaded no-crash convergence soak passed"
+
+      - name: Upload loaded soak report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: soak-loaded-${{ github.run_id }}
+          path: soak-loaded.json
           retention-days: 30
 
   audit:

--- a/packages/server-rust/benches/soak_harness/README.md
+++ b/packages/server-rust/benches/soak_harness/README.md
@@ -93,21 +93,33 @@ Two CI jobs run this harness (`.github/workflows/rust.yml`):
 - **`soak-smoke` (blocking).** The two negative controls (must go RED) + a tiny
   no-crash soak (`--duration 25 --churn-clients 6 --keyspace 48 --crash-interval 0`).
   It guards that the harness compiles and its fault detection still works, on every PR.
-- **`soak-loaded` (non-blocking, advisory).** A **loaded** no-crash convergence soak
-  (`--duration 150 --churn-clients 16 --keyspace 200`, `--crash-interval 0`) that builds
-  a real write-behind backlog. The smoke gate is too small to accumulate a backlog, so a
-  backlog-dependent durability/convergence regression cannot surface there — exactly the
-  gap that masked **SPEC-325b AC1**, which only failed at keyspace ~200 / churn ~16. This
-  job shifts that coverage left to PR/CI time. It is `continue-on-error: true` for now
-  because the GREEN result is established on local debug/macOS and not yet validated on
+- **`soak-loaded` (non-blocking, advisory).** A **loaded** no-crash convergence soak. The
+  full invocation is:
+
+  ```bash
+  soak_harness --duration 150 --crash-interval 0 --steady-interval 15 \
+    --churn-clients 16 --keyspace 200 --quiesce 3 \
+    --mem-min-growth-mb 300 --mem-ceiling-mb 900 --json-output soak-loaded.json
+  # gate: jq -e '.passed == true and .totalWrites > 20000'
+  ```
+
+  It builds a real write-behind backlog. The smoke gate is too small to accumulate a
+  backlog, so a backlog-dependent durability/convergence regression cannot surface there —
+  exactly the gap that masked **SPEC-325b AC1**, which only failed at keyspace ~200 / churn
+  ~16. This job shifts that coverage left to PR/CI time. The `.totalWrites > 20000` floor
+  asserts the load actually ran (the tiny smoke cannot reach it), guarding against a silent
+  mis-edit that shrinks the params back to smoke scale. It is `continue-on-error: true` for
+  now because the GREEN result is established on local debug/macOS and not yet validated on
   ubuntu CI; **promote it to blocking after ≥10 consecutive green runs on `main`** (owner:
   the stabilization-program G4b gate).
 
   Memory on the loaded job: the slope threshold stays at the honest default (50 MB/h) but
-  `--mem-min-growth-mb 500` makes the slope arm fire only as a **gross-leak tripwire** — a
+  `--mem-min-growth-mb 300` makes the slope arm fire only as a **gross-leak tripwire** — a
   150s OR-churn burst's slope extrapolated to MB/hour is not a valid slow-leak signal (that
-  is the 72h run's job); the `--mem-ceiling-mb 1200` ceiling is the real OOM guard. The job
-  gates on **convergence-under-backlog**, not on the memory slope.
+  is the 72h run's job); observed legitimate peak growth at this load is ~190 MB, so the
+  300 MB min-growth clears it with margin while still tripping on a runaway leak, and the
+  `--mem-ceiling-mb 900` ceiling is the real OOM guard that catches a runaway sooner. The
+  job gates on **convergence-under-backlog**, not on the memory slope.
 
 ## Known finding surfaced by this harness
 

--- a/packages/server-rust/benches/soak_harness/README.md
+++ b/packages/server-rust/benches/soak_harness/README.md
@@ -86,16 +86,81 @@ a multi-hour default soak.
 Exit code: `0` pass, `1` an assertion failed (convergence/recovery/memory/panic),
 `2` setup error, `3` a negative control failed to detect its injected fault.
 
+## CI coverage: a fast smoke gate + a loaded convergence gate
+
+Two CI jobs run this harness (`.github/workflows/rust.yml`):
+
+- **`soak-smoke` (blocking).** The two negative controls (must go RED) + a tiny
+  no-crash soak (`--duration 25 --churn-clients 6 --keyspace 48 --crash-interval 0`).
+  It guards that the harness compiles and its fault detection still works, on every PR.
+- **`soak-loaded` (non-blocking, advisory).** A **loaded** no-crash convergence soak
+  (`--duration 150 --churn-clients 16 --keyspace 200`, `--crash-interval 0`) that builds
+  a real write-behind backlog. The smoke gate is too small to accumulate a backlog, so a
+  backlog-dependent durability/convergence regression cannot surface there — exactly the
+  gap that masked **SPEC-325b AC1**, which only failed at keyspace ~200 / churn ~16. This
+  job shifts that coverage left to PR/CI time. It is `continue-on-error: true` for now
+  because the GREEN result is established on local debug/macOS and not yet validated on
+  ubuntu CI; **promote it to blocking after ≥10 consecutive green runs on `main`** (owner:
+  the stabilization-program G4b gate).
+
+  Memory on the loaded job: the slope threshold stays at the honest default (50 MB/h) but
+  `--mem-min-growth-mb 500` makes the slope arm fire only as a **gross-leak tripwire** — a
+  150s OR-churn burst's slope extrapolated to MB/hour is not a valid slow-leak signal (that
+  is the 72h run's job); the `--mem-ceiling-mb 1200` ceiling is the real OOM guard. The job
+  gates on **convergence-under-backlog**, not on the memory slope.
+
 ## Known finding surfaced by this harness
 
-On its first crash-recovery checkpoint, the soak found **TODO-530** (HIGH):
-after `kill -9` + restart the redb-backed server serves an **empty** map
-(Merkle root `0`) although the data is durably on disk — the query full-scan and
-Merkle-sync paths read only the in-memory `StorageEngine` and persisted records
-are not rehydrated on restart (also latent under eviction). Until TODO-530 is
-fixed the **crash-loop path is RED by design**. CI therefore runs the no-crash
-convergence/churn/memory mode + both negative controls (all green); the crash
-loop is run locally and on the Hetzner 72h runner as the TODO-530 reproducer.
+### Crash-recovery at load is RED — now due to TODO-546, not TODO-530
+
+The first version of this harness found **TODO-530** (HIGH): after `kill -9` + restart the
+redb-backed server served an **empty** map (Merkle root `0`) although the data was durably
+on disk — the query full-scan and Merkle-sync paths read only the in-memory `StorageEngine`
+and persisted records were not rehydrated on restart. **TODO-530 is now CLOSED** (SPEC-325a/b):
+the `DurableMerkleIndex` and `FullScanPager` read from the datastore, the recovery checkpoint
+gates were promoted to **HARD** (`main.rs` `recovery_checkpoint`, "must survive a kill -9 +
+restart unchanged"), and the checkpoint quiesce (`main.rs`, `paused` + `sleep(quiesce)`) drains
+the write-behind buffer before the kill. The empty-map failure no longer reproduces.
+
+A **loaded with-crash** soak is, however, **still RED** — but for a different reason. At
+churn 16 / keyspace 200, a `kill -9` recovery checkpoint shows keys a few increments **behind**
+post-restart with a **non-zero** Merkle root (i.e. partial, not empty). That is **TODO-546**
+(ack-before-durable): the write-behind buffer acks writes ~1s before they are persisted, and at
+load the 3s quiesce does not fully drain the backlog, so acked-but-unflushed writes are lost on
+the unclean kill. This is a **known-open critical** (MUST-FIX before public launch), not a fresh
+regression. CI therefore runs the loaded variant **no-crash** (above); the **with-crash** loaded
+run stays local and on the Hetzner 72h runner as the **TODO-546 reproducer/validator** (TODO-546
+`depends_on` this loaded soak). Once TODO-546 is fixed, promote a with-crash loaded variant into
+CI as a blocking crash-recovery-at-load gate — otherwise crash recovery at load is never
+CI-gated, the same gap class as SPEC-325b. (Issue states drift: re-check the live TODO-530/546
+status before trusting this note.)
+
+### Crash-window `write_errors` are transient connection drops, not a write-path defect
+
+The `write_errors` counter increments **only** when an active-burst `write_lww` fails at the
+socket (`run_churn_client`: on `write_lww(...).is_err()` it bumps `write_errors`, sets
+`session_alive = false`, breaks, and the outer loop reconnects via `connect_with_retry`, bumping
+`reconnects`; the next session's replay phase resends every owned key under LWW, bumping
+`resends`). A failed write therefore means *the connection died mid-write* — which during a
+`kill -9` window is expected — and is immediately self-healing: reconnect + idempotent
+higher-HLC resend restores any value lost to the kill window.
+
+Evidence this is transient, not a flush/write-path defect:
+
+- **No-crash runs are clean.** Every no-crash soak (smoke and loaded, 60k+ writes) reports
+  `write_errors = 0` — the steady-state write path produces no errors.
+- **In this harness the counter is 0 even with crashes**, because `kill -9` happens during the
+  recovery-checkpoint quiesce while churn is **paused** (clients hold, no in-flight burst write),
+  so no write straddles the kill window.
+- The historically observed **~13 / 20k** crash-window `write_errors` (≈0.065%) came from a
+  config where crashes overlapped **active** churn: those ~13 are exactly the in-flight burst
+  writes whose socket died during the kill, each followed by a `reconnects` increment and a
+  `resends` replay. They track reconnects 1:1 and leave no missing data once the client replays.
+
+**Conclusion:** the crash-window `write_errors` are expected transient kill-window connection
+drops, self-healed by reconnect + LWW resend — **not** a flush-induced write-path defect. (Data
+loss at the crash boundary at load is a *separate* property, owned by the crash-recovery
+assertion above = TODO-546, and is not measured by `write_errors`.) No follow-up TODO is filed.
 
 ## 72h run on Hetzner
 

--- a/packages/server-rust/benches/soak_harness/SOAK_RUNNER.md
+++ b/packages/server-rust/benches/soak_harness/SOAK_RUNNER.md
@@ -118,11 +118,16 @@ Interpretation:
   capture the `run-dir` (it holds the log, progress stream, and the on-disk
   redb + WAL for forensics) and file it.
 
-## 6. Known caveat for the current build (TODO-530)
+## 6. Known caveat for the current build (TODO-546)
 
-On the current build the crash-loop path is **RED by design** because of
-TODO-530 (after `kill -9` + restart the server serves an empty map although the
-data is durably on disk — query/Merkle read only the in-memory layer, which is
-not rehydrated on restart). Run the full crash-loop 72h soak only **after**
-TODO-530 lands. To exercise everything *except* recovery in the meantime, set
-`CRASH_INTERVAL=0` (churn + steady convergence + memory + panic watch).
+**TODO-530 is now CLOSED** (SPEC-325a/b): the empty-map-on-restart failure no longer
+reproduces — query/Merkle now read from the datastore and the recovery gates are HARD.
+But the crash-loop path is **still RED at load**, now because of **TODO-546**
+(ack-before-durable): the write-behind buffer acks writes ~1s before they are persisted,
+so at a real backlog a `kill -9` loses acked-but-unflushed writes and post-restart keys
+are a few increments **behind** (partial, non-zero Merkle root — not empty). Run the full
+crash-loop 72h soak as the TODO-546 reproducer/validator. To exercise everything *except*
+recovery in the meantime, set `CRASH_INTERVAL=0` (churn + steady convergence + memory +
+panic watch) — this is also what the non-blocking `soak-loaded` CI job runs at scale.
+(See the "Known finding" section in [`README.md`](./README.md); re-check live TODO-546
+status, issue states drift.)


### PR DESCRIPTION
## What

Adds a **loaded** G4b soak variant to CI so the write-behind backlog is actually built up under realistic load — the existing per-PR blocking `soak-smoke` gate is too small (`--churn-clients 6 --keyspace 48 --crash-interval 0`) to surface load-dependent durability bugs (the class that masked SPEC-325b AC1 / SPEC-322c).

- New `soak-loaded` job (`--churn-clients 16 --keyspace 200 --duration 150`), **non-blocking** (`continue-on-error: true`) until ≥10 green main runs trip the documented promotion gate; floor gate `jq -e '.passed==true and .totalWrites>20000'`.
- `soak-smoke` job params / `needs` / blocking status **byte-identical to main** (only a stale `TODO-530`→`TODO-546` comment swapped).
- `write_errors` (~transient kill-window drops) classified as expected reconnect behavior, not a defect — documented in README + SOAK_RUNNER.

## Scope

CI-YAML + harness README/docs only — **no Rust/TS source changed**. 3 files. Ships ALONE (SpecFlow SPEC-329, archived).

## Cross-vendor

- G1 `/xask` (design fork: placement × crash-mode) resolved empirically before impl.
- `/xreview` on diff: 1 HIGH + 2 MED fixed, 2 LOW rejected diff-grounded.

## Validators / follow-up

Unblocks **TODO-546** (SPEC-330, stacked next) — the local with-crash loaded reproducer is its validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)