### PR TITLE
fix(sf-330): close acked!=durable window on kill -9 — perop→silent-Batched WAL downgrade (TODO-546)

### DIFF
--- a/packages/server-rust/benches/soak_harness/README.md
+++ b/packages/server-rust/benches/soak_harness/README.md
@@ -150,11 +150,21 @@ silently degrade durability). Under correctly-applied `PerOp` every WAL frame is
 
 The acked == durable assertion does **NOT** depend on the pre-kill quiesce drain. By default the
 recovery checkpoint sleeps `quiesce` to let the write-behind buffer flush before the kill (which
-scopes the assertion to durable-state recovery). With `--no-pre-kill-drain` the checkpoint kills
-the server **without** that flush, so recovery must rebuild every acked write from the WAL alone —
-the honest acked == durable test. The storage-layer behavioral proof of this lives in
-`crash_safety_proptest.rs` (`acked_equals_durable_from_env_string_perop`, which derives the policy
-from the `perop` env string and is red-on-revert of the parser fix).
+scopes the assertion to durable-state recovery). With `--no-pre-kill-drain` the checkpoint settles
+only the in-flight ACK pipeline (~250ms, far under the flush interval) and kills the server
+**without** flushing the buffer, so recovery must rebuild every acked write from the WAL alone —
+the honest acked == durable test (LWW convergence + delta-sync + full-scan read-backs stay HARD;
+the OR-Map strict pre==post root equality is relaxed under no-drain because add/remove churn leaves
+acked-but-unsettled tags that recovery legitimately surfaces post-restart — recovered-more, not
+loss).
+
+The no-drain validator must run the **production** write-behind flush cadence
+(`TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS=1000`); the harness default fast flush (100ms) would drain
+the buffer inside the ack-settle and mask the WAL path. The Hetzner runner pins this automatically
+when `NO_PRE_KILL_DRAIN=1`. The storage-layer behavioral proof is independent of the soak and lives
+in `crash_safety_proptest.rs` (`acked_equals_durable_from_env_string_perop`, which derives the
+policy from the `perop` env string with a never-flush config and is red-on-revert of the parser
+fix).
 
 Production context: `per_op` maximizes durability at a per-write fsync cost. The server default is
 `Batched` (CLAUDE.md production-defaults), a throughput/durability balance; the soak deliberately

--- a/packages/server-rust/benches/soak_harness/README.md
+++ b/packages/server-rust/benches/soak_harness/README.md
@@ -75,7 +75,8 @@ a multi-hour default soak.
 | `--churn-clients <n>` | 16 | Concurrent churn clients (each owns a disjoint key slice) |
 | `--keyspace <n>` | 200 | Distinct keys (bounded → legitimate memory is bounded) |
 | `--quiesce <secs>` | 3 | Pause+settle before a checkpoint reads or kills (≥ write-behind flush window) |
-| `--wal-fsync <policy>` | perop | `perop` \| `batched` \| `none`; `perop` makes recovery assertions crisp |
+| `--wal-fsync <policy>` | per_op | `per_op` (also `perop`/`per-op`, case-insensitive) \| `batched` \| `none`; `per_op` fdatasyncs each WAL frame before the ingress write acks, so acked == durable on `kill -9` |
+| `--no-pre-kill-drain` | off | Skip the pre-`kill -9` quiesce flush in the recovery checkpoint so post-restart recovery relies on the WAL alone; the acked == durable assertion that must NOT depend on a pre-kill drain |
 | `--or-churn <bool>` | true | Drive OR-Map add/remove to grow tombstones (memory watch) |
 | `--mem-threshold-mb-per-hour <f>` | 50 | Fail if RSS slope exceeds this (with `--mem-min-growth-mb` guard, default 150) |
 | `--mem-ceiling-mb <f>` | 1800 | Fail if peak RSS exceeds this |
@@ -121,31 +122,43 @@ Two CI jobs run this harness (`.github/workflows/rust.yml`):
   `--mem-ceiling-mb 900` ceiling is the real OOM guard that catches a runaway sooner. The
   job gates on **convergence-under-backlog**, not on the memory slope.
 
-## Known finding surfaced by this harness
+## Findings surfaced by this harness
 
-### Crash-recovery at load is RED — now due to TODO-546, not TODO-530
+### TODO-530 — empty-map after restart (CLOSED)
 
 The first version of this harness found **TODO-530** (HIGH): after `kill -9` + restart the
 redb-backed server served an **empty** map (Merkle root `0`) although the data was durably
 on disk — the query full-scan and Merkle-sync paths read only the in-memory `StorageEngine`
 and persisted records were not rehydrated on restart. **TODO-530 is now CLOSED** (SPEC-325a/b):
-the `DurableMerkleIndex` and `FullScanPager` read from the datastore, the recovery checkpoint
+the `DurableMerkleIndex` and `FullScanPager` read from the datastore, and the recovery checkpoint
 gates were promoted to **HARD** (`main.rs` `recovery_checkpoint`, "must survive a kill -9 +
-restart unchanged"), and the checkpoint quiesce (`main.rs`, `paused` + `sleep(quiesce)`) drains
-the write-behind buffer before the kill. The empty-map failure no longer reproduces.
+restart unchanged"). The empty-map failure no longer reproduces.
 
-A **loaded with-crash** soak is, however, **still RED** — but for a different reason. At
-churn 16 / keyspace 200, a `kill -9` recovery checkpoint shows keys a few increments **behind**
-post-restart with a **non-zero** Merkle root (i.e. partial, not empty). That is **TODO-546**
-(ack-before-durable): the write-behind buffer acks writes ~1s before they are persisted, and at
-load the 3s quiesce does not fully drain the backlog, so acked-but-unflushed writes are lost on
-the unclean kill. This is a **known-open critical** (MUST-FIX before public launch), not a fresh
-regression. CI therefore runs the loaded variant **no-crash** (above); the **with-crash** loaded
-run stays local and on the Hetzner 72h runner as the **TODO-546 reproducer/validator** (TODO-546
-`depends_on` this loaded soak). Once TODO-546 is fixed, promote a with-crash loaded variant into
-CI as a blocking crash-recovery-at-load gate — otherwise crash recovery at load is never
-CI-gated, the same gap class as SPEC-325b. (Issue states drift: re-check the live TODO-530/546
-status before trusting this note.)
+### TODO-546 — acked != durable one-behind loss at load (CLOSED)
+
+A **loaded with-crash** soak then showed a different failure: at churn 16 / keyspace 200, a
+`kill -9` recovery checkpoint showed keys exactly one increment **behind** post-restart with a
+**non-zero** Merkle root (partial, not empty). Root cause: the harness passed
+`TOPGUN_WAL_FSYNC_POLICY=perop`, which the parser rejected (it only accepted `per_op`) and
+**silently downgraded to `Batched`**, whose ~10ms fsync window let a `kill -9` drop the last
+appended-but-not-fsynced acked frame.
+
+The parser now normalizes case + separator so `perop`/`per_op`/`per-op` all resolve to `PerOp`,
+and an *unknown* policy value is now **fatal at startup** (the server refuses to start rather than
+silently degrade durability). Under correctly-applied `PerOp` every WAL frame is fdatasync'd
+**before** the ingress write acks, so acked == durable.
+
+The acked == durable assertion does **NOT** depend on the pre-kill quiesce drain. By default the
+recovery checkpoint sleeps `quiesce` to let the write-behind buffer flush before the kill (which
+scopes the assertion to durable-state recovery). With `--no-pre-kill-drain` the checkpoint kills
+the server **without** that flush, so recovery must rebuild every acked write from the WAL alone —
+the honest acked == durable test. The storage-layer behavioral proof of this lives in
+`crash_safety_proptest.rs` (`acked_equals_durable_from_env_string_perop`, which derives the policy
+from the `perop` env string and is red-on-revert of the parser fix).
+
+Production context: `per_op` maximizes durability at a per-write fsync cost. The server default is
+`Batched` (CLAUDE.md production-defaults), a throughput/durability balance; the soak deliberately
+selects `per_op` because its assertion is acked == durable on an unclean kill.
 
 ### Crash-window `write_errors` are transient connection drops, not a write-path defect
 

--- a/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
+++ b/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
@@ -32,6 +32,14 @@ WAL_FSYNC="${WAL_FSYNC:-per_op}"
 # so recovery must rebuild every acked write from the WAL alone — the honest
 # acked == durable assertion (does not depend on a pre-kill drain).
 NO_PRE_KILL_DRAIN="${NO_PRE_KILL_DRAIN:-0}"
+# The no-drain validator must run the PRODUCTION write-behind flush cadence
+# (1000ms): the harness's default fast flush (100ms) would drain the buffer to
+# redb inside the brief pre-snapshot ack-settle and mask the WAL durability path,
+# making acked == durable trivially true for the wrong reason. Pin production
+# cadence here so the WAL is genuinely on the critical recovery path.
+if [ "${NO_PRE_KILL_DRAIN}" = "1" ]; then
+  export TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS="${TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS:-1000}"
+fi
 MEM_THRESHOLD="${MEM_THRESHOLD:-25}"      # MB/hour slope ceiling over a 72h run
 MEM_CEILING="${MEM_CEILING:-2048}"
 OUT_ROOT="${OUT_ROOT:-/var/soak}"

--- a/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
+++ b/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
@@ -25,7 +25,13 @@ STEADY_INTERVAL="${STEADY_INTERVAL:-120}" # steady convergence check every 2 min
 CHURN_CLIENTS="${CHURN_CLIENTS:-32}"
 KEYSPACE="${KEYSPACE:-500}"
 QUIESCE="${QUIESCE:-4}"
-WAL_FSYNC="${WAL_FSYNC:-perop}"
+# per_op fdatasyncs each WAL frame before the ingress write acks, so acked == durable
+# on an unclean kill (perop/per-op are accepted aliases; per_op is canonical).
+WAL_FSYNC="${WAL_FSYNC:-per_op}"
+# Set NO_PRE_KILL_DRAIN=1 to kill -9 WITHOUT first flushing the write-behind buffer,
+# so recovery must rebuild every acked write from the WAL alone — the honest
+# acked == durable assertion (does not depend on a pre-kill drain).
+NO_PRE_KILL_DRAIN="${NO_PRE_KILL_DRAIN:-0}"
 MEM_THRESHOLD="${MEM_THRESHOLD:-25}"      # MB/hour slope ceiling over a 72h run
 MEM_CEILING="${MEM_CEILING:-2048}"
 OUT_ROOT="${OUT_ROOT:-/var/soak}"
@@ -86,6 +92,11 @@ echo "  log:      ${LOG}"
 echo "  progress: ${PROGRESS}"
 echo "  report:   ${REPORT}"
 
+DRAIN_FLAG=()
+if [ "${NO_PRE_KILL_DRAIN}" = "1" ]; then
+  DRAIN_FLAG=(--no-pre-kill-drain)
+fi
+
 nohup "${SOAK_BIN}" \
   --duration "${DURATION}" \
   --crash-interval "${CRASH_INTERVAL}" \
@@ -94,6 +105,7 @@ nohup "${SOAK_BIN}" \
   --keyspace "${KEYSPACE}" \
   --quiesce "${QUIESCE}" \
   --wal-fsync "${WAL_FSYNC}" \
+  "${DRAIN_FLAG[@]}" \
   --mem-threshold-mb-per-hour "${MEM_THRESHOLD}" \
   --mem-ceiling-mb "${MEM_CEILING}" \
   --data-dir "${DATA_DIR}" \

--- a/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
+++ b/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
@@ -113,7 +113,7 @@ nohup "${SOAK_BIN}" \
   --keyspace "${KEYSPACE}" \
   --quiesce "${QUIESCE}" \
   --wal-fsync "${WAL_FSYNC}" \
-  "${DRAIN_FLAG[@]:-}" \
+  "${DRAIN_FLAG[@]+"${DRAIN_FLAG[@]}"}" \
   --mem-threshold-mb-per-hour "${MEM_THRESHOLD}" \
   --mem-ceiling-mb "${MEM_CEILING}" \
   --data-dir "${DATA_DIR}" \

--- a/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
+++ b/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
@@ -113,7 +113,7 @@ nohup "${SOAK_BIN}" \
   --keyspace "${KEYSPACE}" \
   --quiesce "${QUIESCE}" \
   --wal-fsync "${WAL_FSYNC}" \
-  "${DRAIN_FLAG[@]}" \
+  "${DRAIN_FLAG[@]:-}" \
   --mem-threshold-mb-per-hour "${MEM_THRESHOLD}" \
   --mem-ceiling-mb "${MEM_CEILING}" \
   --data-dir "${DATA_DIR}" \

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -100,6 +100,12 @@ struct Config {
     progress_output: Option<PathBuf>,
     inject_divergence: bool,
     inject_panic: bool,
+    /// Skip the pre-`kill -9` quiesce drain in the recovery checkpoint. When set,
+    /// the checkpoint kills the server WITHOUT first letting the write-behind
+    /// buffer flush to redb, so post-restart recovery must rely on the WAL alone.
+    /// This is the assertion mode that proves acked == durable on `kill -9` under
+    /// load: it does NOT depend on a pre-kill flush masking a durability gap.
+    no_pre_kill_drain: bool,
     /// True once any soak-controlling flag is parsed. A bare invocation (or one
     /// carrying only foreign libtest args, as `cargo test --all-targets` passes)
     /// leaves this false so the harness prints usage and exits 0 instead of
@@ -126,7 +132,11 @@ impl Default for Config {
             mem_ceiling_mb: 1800.0,
             server_port: 0,
             data_dir: None,
-            wal_fsync: "perop".to_string(),
+            // Durability under the soak comes from PerOp: every WAL frame is
+            // fdatasync'd before the ingress write acks, so acked == durable on a
+            // `kill -9`. The parser normalizes case/separator, so per_op/perop are
+            // equivalent; this canonical spelling matches the production default.
+            wal_fsync: "per_op".to_string(),
             or_churn: true,
             or_keyspace: 32,
             or_every: 5,
@@ -134,6 +144,7 @@ impl Default for Config {
             progress_output: None,
             inject_divergence: false,
             inject_panic: false,
+            no_pre_kill_drain: false,
             mode_requested: false,
         }
     }
@@ -664,8 +675,23 @@ async fn recovery_checkpoint(
     paused: &Arc<AtomicBool>,
 ) -> Result<RecoveryOutcome> {
     paused.store(true, Ordering::SeqCst);
-    // Let in-flight acks settle and the write-behind buffer flush to redb+WAL.
-    tokio::time::sleep(config.quiesce).await;
+    // Pause new client writes, then choose the pre-kill behavior:
+    //
+    // - default (drain): sleep `quiesce` so in-flight acks settle and the
+    //   write-behind buffer flushes to redb+WAL before the kill. This scopes the
+    //   assertion to durable-state recovery (the Merkle/SYNC read path).
+    // - `--no-pre-kill-drain`: skip the flush entirely and kill immediately, so
+    //   the only thing standing between an acked write and a `kill -9` is the WAL.
+    //   This is the acked == durable assertion: it must NOT depend on a pre-kill
+    //   flush. Under correctly-applied PerOp the WAL frame is fsynced before the
+    //   ack returns, so recovery replays every acked write with zero one-behind
+    //   loss even though the buffer never drained.
+    if config.no_pre_kill_drain {
+        // No sleep: leave acked-but-unflushed writes in the buffer so recovery is
+        // forced to rebuild them from the WAL alone.
+    } else {
+        tokio::time::sleep(config.quiesce).await;
+    }
 
     let mut out = RecoveryOutcome::default();
 
@@ -1112,6 +1138,7 @@ const KNOWN_FLAGS: &[&str] = &[
     "--progress-output",
     "--inject-divergence",
     "--inject-panic",
+    "--no-pre-kill-drain",
     "--smoke",
 ];
 
@@ -1256,6 +1283,10 @@ fn parse_args() -> Config {
             }
             "--inject-panic" => {
                 c.inject_panic = true;
+                i += 1;
+            }
+            "--no-pre-kill-drain" => {
+                c.no_pre_kill_drain = true;
                 i += 1;
             }
             "--smoke" => {

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -687,8 +687,20 @@ async fn recovery_checkpoint(
     //   ack returns, so recovery replays every acked write with zero one-behind
     //   loss even though the buffer never drained.
     if config.no_pre_kill_drain {
-        // No sleep: leave acked-but-unflushed writes in the buffer so recovery is
-        // forced to rebuild them from the WAL alone.
+        // Settle only the in-flight ACK pipeline (a few network RTTs), NOT the
+        // write-behind buffer. This stops new acks so the pre-crash snapshot is
+        // a stable acked set, while staying well under the production write-behind
+        // flush interval (1000ms) so acked writes remain unflushed in the buffer —
+        // recovery is then forced to rebuild them from the WAL alone. This is what
+        // makes the acked == durable assertion NOT depend on a pre-kill flush.
+        //
+        // NOTE: this assertion is only honest when the server runs the production
+        // flush cadence (TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS=1000); the harness's
+        // default fast flush would drain the buffer inside this settle and mask the
+        // WAL durability path. The runner sets the production cadence for the
+        // no-drain validator.
+        const ACK_SETTLE: Duration = Duration::from_millis(250);
+        tokio::time::sleep(ACK_SETTLE).await;
     } else {
         tokio::time::sleep(config.quiesce).await;
     }
@@ -760,7 +772,16 @@ async fn recovery_checkpoint(
             "LWW merkle root changed across recovery: pre={pre_root} post={post_root}"
         ));
     }
-    if pre_or_root != post_or_root {
+    // The OR-Map strict pre==post root check assumes a quiesced pre-crash state.
+    // Under --no-pre-kill-drain the OR churn's add-then-remove pairs can leave
+    // acked-but-unsettled tag state at kill time: the verifier's pre-crash root
+    // reads the net-empty observed set (root 0), while WAL recovery faithfully
+    // replays the durable intermediate tags and surfaces a non-zero root post-
+    // restart. That is recovered-MORE (durability working), not loss — the
+    // acked == durable invariant this mode validates is carried by the LWW checks
+    // above/below (the SPEC-330 one-behind target). So the strict OR-root equality
+    // is only enforced in the drained mode where the pre-crash state is quiesced.
+    if !config.no_pre_kill_drain && pre_or_root != post_or_root {
         out.hard.push(format!(
             "OR-Map merkle root changed across recovery: pre={pre_or_root:?} post={post_or_root:?}"
         ));

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -772,16 +772,13 @@ async fn recovery_checkpoint(
             "LWW merkle root changed across recovery: pre={pre_root} post={post_root}"
         ));
     }
-    // The OR-Map strict pre==post root check assumes a quiesced pre-crash state.
-    // Under --no-pre-kill-drain the OR churn's add-then-remove pairs can leave
-    // acked-but-unsettled tag state at kill time: the verifier's pre-crash root
-    // reads the net-empty observed set (root 0), while WAL recovery faithfully
-    // replays the durable intermediate tags and surfaces a non-zero root post-
-    // restart. That is recovered-MORE (durability working), not loss — the
-    // acked == durable invariant this mode validates is carried by the LWW checks
-    // above/below (the SPEC-330 one-behind target). So the strict OR-root equality
-    // is only enforced in the drained mode where the pre-crash state is quiesced.
-    if !config.no_pre_kill_drain && pre_or_root != post_or_root {
+    // HARD (unconditional): the OR-Map merkle root must survive recovery unchanged.
+    // This is the OR-Map's only durability assertion, so it must never be skipped —
+    // a blanket skip would let an acked OR-Map write lost on kill -9 pass silently.
+    // Under --no-pre-kill-drain OR churn is disabled (see parse_args), so both roots
+    // are absent and this holds honestly; OR-Map crash-recovery under load is still
+    // covered by the drained mode (its WAL-only behavior is a tracked follow-up).
+    if pre_or_root != post_or_root {
         out.hard.push(format!(
             "OR-Map merkle root changed across recovery: pre={pre_or_root:?} post={post_or_root:?}"
         ));
@@ -1326,6 +1323,16 @@ fn parse_args() -> Config {
                 i += 1;
             }
         }
+    }
+    // The no-drain validator scopes strictly to the SPEC-330 LWW acked==durable
+    // target. OR-Map WAL-only crash-recovery semantics — the live net-compacted
+    // observed set vs the WAL-replayed intermediate tags — is a distinct question
+    // that needs its own audit. Rather than run OR churn and relax its assertion
+    // (which would let a genuine OR-Map acked-write loss pass silently), we simply
+    // do not generate OR writes in this mode, so the OR-root equality check stays
+    // unconditionally HARD and holds honestly (both roots absent).
+    if c.no_pre_kill_drain {
+        c.or_churn = false;
     }
     c
 }

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -1324,7 +1324,7 @@ fn parse_args() -> Config {
             }
         }
     }
-    // The no-drain validator scopes strictly to the SPEC-330 LWW acked==durable
+    // The no-drain validator scopes strictly to the LWW acked==durable
     // target. OR-Map WAL-only crash-recovery semantics — the live net-compacted
     // observed set vs the WAL-replayed intermediate tags — is a distinct question
     // that needs its own audit. Rather than run OR churn and relax its assertion

--- a/packages/server-rust/benches/soak_harness/process.rs
+++ b/packages/server-rust/benches/soak_harness/process.rs
@@ -51,7 +51,9 @@ pub struct ServerConfig {
     pub port: u16,
     /// JWT signing secret shared with `SoakClient`.
     pub jwt_secret: String,
-    /// WAL fsync policy (`perop` | `batched` | `none`).
+    /// WAL fsync policy forwarded to `TOPGUN_WAL_FSYNC_POLICY`. Accepted spellings:
+    /// `per_op` (also `perop`, `per-op`, case-insensitive) | `batched` | `none`.
+    /// The soak relies on `per_op` for acked == durable on `kill -9`.
     pub wal_fsync_policy: String,
 }
 

--- a/packages/server-rust/src/storage/crash_safety_proptest.rs
+++ b/packages/server-rust/src/storage/crash_safety_proptest.rs
@@ -429,6 +429,85 @@ proptest! {
 }
 
 // ---------------------------------------------------------------------------
+// AC1 (RED) + AC3: acked == durable when the policy is derived FROM THE ENV
+// STRING the harness actually passes (`"perop"`), not the `WalFsyncPolicy::PerOp`
+// literal. This closes the green-bypasses-env gap: the proptest above passes the
+// enum directly, so it stays green even if `from_str` is broken. This test goes
+// RED on revert of the `from_str` normalization — a reverted parser makes
+// `"perop"` either fail to parse (panic at `.expect`) or, if a fallback is
+// reintroduced, downgrade to Batched, whose ~10ms fsync window drops the
+// last-appended-but-not-fsynced frame as a one-behind loss after the crash.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn acked_equals_durable_from_env_string_perop() {
+    // Derive the policy the way the soak harness does: from the env *string*, so
+    // the test exercises the parser, not a hand-picked enum variant. A reverted
+    // `from_str` cannot satisfy this expect for the `perop` spelling.
+    let policy: WalFsyncPolicy = "perop"
+        .parse()
+        .expect("the env-string spelling used by the soak harness must parse to a durable policy");
+    assert_eq!(
+        policy,
+        WalFsyncPolicy::PerOp,
+        "the harness env string must resolve to the durable PerOp policy, \
+         not a downgraded default"
+    );
+
+    // A load-shaped sequence: many overlapping keys each incremented several
+    // times, so a one-behind loss (actual = expected - 1) would surface as the
+    // last store of a key going missing after the crash — exactly the soak's
+    // observed signature.
+    let mut ops = Vec::new();
+    for round in 0..8u64 {
+        for k in 0..32u8 {
+            ops.push(Op::Store {
+                key: format!("k{k}"),
+                value_tag: round * 100 + u64::from(k),
+            });
+        }
+    }
+    let crash_after = ops.len();
+
+    // Crash after EVERY op is acked, with NO pre-flush drain: the scenario drops
+    // the store immediately after the last ack, so every acked write must survive
+    // on the WAL alone (never_flush_config keeps the background flush from leaking
+    // writes to the inner store before the crash).
+    let (recovered, acked) = run_crash_scenario(&ops, crash_after, policy).await;
+
+    // Zero one-behind: every acked store must be present after recovery, with its
+    // final value_tag intact.
+    let expected = expected_final_state(&ops);
+    let mut missing = Vec::new();
+    for (key, state) in &expected {
+        match state {
+            Some(_) => {
+                if !recovered.contains(TEST_MAP, key).await {
+                    missing.push(key.clone());
+                }
+            }
+            None => {
+                if recovered.contains(TEST_MAP, key).await {
+                    missing.push(format!("{key} (should be tombstoned)"));
+                }
+            }
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "acked == durable violated under env-string PerOp: {} acked writes lost \
+         after crash recovery (one-behind regression): {:?}",
+        missing.len(),
+        &missing[..missing.len().min(10)]
+    );
+    assert_eq!(
+        acked.len(),
+        expected.len(),
+        "every distinct key must have been acked before the crash"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // AC2(a): clean/strict recovery replays all acked ops (full sequence acked).
 // ---------------------------------------------------------------------------
 

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -200,21 +200,23 @@ impl WriteBehindConfig {
         }
 
         // Parse TOPGUN_WAL_FSYNC_POLICY → wal_fsync_policy (WalFsyncPolicy)
+        //
+        // An unknown value is FATAL: silently falling back to the Batched default
+        // here is exactly what masked a durability regression through a full RED
+        // soak (a misspelled durable policy quietly ran with the weaker default).
+        // Refusing to start forces the misconfiguration to surface at boot rather
+        // than as silent data loss on the next unclean shutdown.
         if let Some(raw) = get("TOPGUN_WAL_FSYNC_POLICY") {
             match raw.trim().parse::<WalFsyncPolicy>() {
                 Ok(policy) => {
                     cfg.wal_fsync_policy = policy;
                 }
                 Err(err) => {
-                    tracing::warn!(
-                        target: "topgun_server::storage::write_behind",
-                        var = "TOPGUN_WAL_FSYNC_POLICY",
-                        value = %raw,
-                        error = %err,
-                        default = ?defaults.wal_fsync_policy,
-                        "Failed to parse env var; using default"
+                    panic!(
+                        "TOPGUN_WAL_FSYNC_POLICY={raw:?} is not a valid WAL fsync policy: {err}. \
+                         Refusing to start: an unknown durability policy must not be silently \
+                         downgraded to a weaker default. Set a valid value or unset the variable."
                     );
-                    cfg.wal_fsync_policy = defaults.wal_fsync_policy;
                 }
             }
         }
@@ -2408,20 +2410,27 @@ mod tests {
             WriteBehindConfig::from_source(config_source(&[("TOPGUN_WAL_FSYNC_POLICY", "per_op")]));
         assert_eq!(cfg.wal_fsync_policy, WalFsyncPolicy::PerOp);
 
-        // TOPGUN_WAL_FSYNC_POLICY with an invalid value falls back to Batched
-        let cfg = WriteBehindConfig::from_source(config_source(&[(
-            "TOPGUN_WAL_FSYNC_POLICY",
-            "invalid_policy",
-        )]));
-        assert_eq!(
-            cfg.wal_fsync_policy,
-            WalFsyncPolicy::Batched,
-            "Invalid policy must fall back to Batched default"
-        );
+        // The harness/doc `perop` spelling must resolve to PerOp (no silent
+        // downgrade) now that the parser normalizes the separator/case.
+        let cfg =
+            WriteBehindConfig::from_source(config_source(&[("TOPGUN_WAL_FSYNC_POLICY", "perop")]));
+        assert_eq!(cfg.wal_fsync_policy, WalFsyncPolicy::PerOp);
 
         // No override → Batched default
         let cfg = WriteBehindConfig::from_source(config_source(&[]));
         assert_eq!(cfg.wal_fsync_policy, WalFsyncPolicy::Batched);
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a valid WAL fsync policy")]
+    fn from_source_unknown_fsync_policy_is_fatal() {
+        // An unknown durability policy must refuse to start rather than silently
+        // degrade to the weaker default — the silent-downgrade path is what hid a
+        // durability regression through a full RED soak.
+        let _ = WriteBehindConfig::from_source(config_source(&[(
+            "TOPGUN_WAL_FSYNC_POLICY",
+            "invalid_policy",
+        )]));
     }
 
     /// Wiring-only smoke test for the real `from_env` → `std::env` seam. The sole

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -106,6 +106,14 @@ impl WriteBehindConfig {
     /// over `std::env::var`. Tests pass a map-backed closure so they exercise the
     /// full parse logic without mutating process-global environment state —
     /// eliminating the cross-test env race that made parallel runs flaky.
+    ///
+    /// # Panics
+    ///
+    /// Panics (refuses to start) if `TOPGUN_WAL_FSYNC_POLICY` is set to a value
+    /// that does not parse to a known [`WalFsyncPolicy`]. Silently downgrading an
+    /// unknown durability policy to the weaker default is what masked a durability
+    /// regression through a full RED soak, so the misconfiguration is made fatal at
+    /// startup rather than surfacing as data loss on the next unclean shutdown.
     #[must_use]
     pub fn from_source<F: Fn(&str) -> Option<String>>(get: F) -> Self {
         let defaults = Self::default();

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -64,7 +64,8 @@ impl std::fmt::Display for ParseWalFsyncPolicyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "unknown WAL fsync policy {:?}; valid values are per_op, batched, none",
+            "unknown WAL fsync policy {:?}; valid values are per_op (also perop, per-op), \
+             batched, none (case-insensitive)",
             self.0
         )
     }
@@ -76,11 +77,18 @@ impl FromStr for WalFsyncPolicy {
     type Err = ParseWalFsyncPolicyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.trim() {
-            "per_op" => Ok(Self::PerOp),
+        // Normalize so operator/harness/doc spellings all resolve: case-insensitive
+        // and tolerant of the separator (`per_op`, `perop`, `per-op` are the same
+        // intent). The soak harness and docs historically used the unseparated
+        // `perop` spelling; rejecting it silently downgraded durability to the
+        // Batched default, which is precisely the failure mode this normalization
+        // prevents.
+        let normalized = s.trim().to_ascii_lowercase().replace(['_', '-'], "");
+        match normalized.as_str() {
+            "perop" => Ok(Self::PerOp),
             "batched" => Ok(Self::Batched),
             "none" => Ok(Self::None),
-            other => Err(ParseWalFsyncPolicyError(other.to_string())),
+            _ => Err(ParseWalFsyncPolicyError(s.trim().to_string())),
         }
     }
 }
@@ -1667,6 +1675,35 @@ mod tests {
         assert_eq!(
             "per_op".parse::<WalFsyncPolicy>().unwrap(),
             WalFsyncPolicy::PerOp
+        );
+    }
+
+    #[test]
+    fn fsync_policy_parse_perop_aliases() {
+        // The harness and docs use the unseparated `perop` spelling; it must
+        // resolve to PerOp so the durable mode is actually applied rather than
+        // silently downgraded to Batched.
+        for spelling in ["perop", "PerOp", "PER_OP", "per-op", "  perop  ", "PEROP"] {
+            assert_eq!(
+                spelling.parse::<WalFsyncPolicy>().unwrap(),
+                WalFsyncPolicy::PerOp,
+                "spelling {spelling:?} must resolve to PerOp"
+            );
+        }
+    }
+
+    #[test]
+    fn fsync_policy_parse_garbage_still_rejected() {
+        // Normalization must not turn genuinely-unknown values into a silent
+        // default — they must still surface as an error at startup.
+        let result = "garbage".parse::<WalFsyncPolicy>();
+        assert!(
+            result.is_err(),
+            "unknown policy 'garbage' must return Err, not a default"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains("garbage"),
+            "error must name the bad value"
         );
     }
 


### PR DESCRIPTION
## Problem

Under loaded `kill -9` the G4b soak lost acked writes — every key one increment behind (`actual = expected − 1`), on BOTH the SYNC delta-sync and QUERY full-scan read-backs. That two-path agreement localized the loss to the durability layer.

## Root cause

The ack-after-WAL-**of-ingress** mechanism already existed and was wired — the durable mode just wasn't in force. `WalFsyncPolicy::from_str` accepted only `per_op`, but the soak harness/docs pass `perop` (no underscore) everywhere → parse failure → `from_source` **silently downgraded to `Batched`** (~10 ms / 100-frame fsync window) → `kill -9` dropped appended-but-unfsynced acked ingress frames. The proptests stayed green because they passed the `PerOp` **enum literal** directly, never the env string — exactly the green-bypasses-env class that overturned prior claims.

## Fix

- `WalFsyncPolicy::from_str` normalizes case + separator (`perop`/`per-op`/`PER_OP` → `PerOp`); genuine unknowns still `Err`.
- `from_source` now **panics at startup** on an unknown `TOPGUN_WAL_FSYNC_POLICY` instead of silently falling back to `Batched` — kills the regression-enabler that hid this through a full RED soak.
- **No `ack_after_wal` flag** (per cross-vendor `/xask` ×2 convergent): `PerOp` already does an awaited `fdatasync` before the ack; a flag would be a no-op alias re-introducing the two-knobs footgun that caused this.
- New `--no-pre-kill-drain` soak mode (settles only the ACK pipeline, buffer left unflushed → WAL is the sole recovery path); pre-kill-drain narrative reconciled.

## Proof (real behavioral verification)

- `acked_equals_durable_from_env_string_perop` derives the policy via `"perop".parse()` (the **env-string path**, not the enum literal), crashes after every ack with a never-flush config (recovery into a fresh inner store = WAL-only), asserts zero one-behind. **Red-on-revert** (reverting `from_str` → `.expect()` panic). Green in **debug AND release** (crash_safety 9/9).
- Pre-fix RED reproduced on identical loaded no-drain params; post-fix GREEN.
- Local pre-merge gate: `pnpm -r build` + `lint` (0 errors) + `format:check` + `cargo build --release` + `cargo test --release -p topgun-server --lib` → **1519 passed, 0 failed**.

## Scope / discipline

7 files (5 Rust = at cap: 3 lib + 2 bench; + 2 non-Rust). **`rust.yml` untouched** → `soak-smoke` byte-identical to main (AC8). Ships ALONE.

## Cross-vendor

- `/xask` (G1, before impl): two convergent glm-5.2 runs → parse-only force `PerOp`, no flag, WAL format frozen.
- `/xreview` ×2 on the diff (RULE "no acked write lost on kill -9 under load"): real findings fixed (OR-root restored to HARD; `set -u` empty-array idiom), rest rejected diff-grounded.

## Follow-ups (filed)

TODO-553 (OR-Map WAL-only recovery audit), TODO-554 (prod default `Batched`→`PerOp` decision), TODO-555 (CI: promote with-crash no-drain variant + stale comment).

Closes TODO-546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)