### PR TITLE
fix(sf-332): OR-Map directional crash-recovery no-loss check (soak harness)

### DIFF
--- a/packages/server-rust/benches/soak_harness/client.rs
+++ b/packages/server-rust/benches/soak_harness/client.rs
@@ -13,7 +13,7 @@
 //! connection that is opened and dropped repeatedly by the churn driver, so the
 //! type is deliberately small and cheap to construct.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -26,10 +26,13 @@ use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use topgun_core::hlc::{LWWRecord, ORMapRecord, Timestamp};
 use topgun_core::messages::{
-    AuthMessage, ClientOp, MerkleReqBucketMessage, MerkleReqBucketPayload, Message, OpBatchMessage,
+    AuthMessage, ClientOp, MerkleReqBucketMessage, MerkleReqBucketPayload, Message,
+    ORMapMerkleReqBucket, ORMapMerkleReqBucketPayload, ORMapSyncInit, OpBatchMessage,
     OpBatchPayload, Query, QuerySubMessage, QuerySubPayload, QueryUnsubMessage, QueryUnsubPayload,
     SyncInitMessage, WriteConcern,
 };
+
+use crate::or_noloss::observed_tags;
 
 type Ws = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 
@@ -279,6 +282,81 @@ impl SoakClient {
                 other => {
                     bail!("delta-sync: expected SYNC_RESP_BUCKETS or SYNC_RESP_LEAF, got {other:?}")
                 }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Reconstruct every OR-Map key's **observed tag set** (active record tags
+    /// minus tombstone tags) for `map` by walking the server's OR-Map Merkle tree
+    /// the way a reconnecting OR-Map sync client does: `ORMAP_SYNC_INIT` root →
+    /// `ORMAP_MERKLE_REQ_BUCKET` aggregate-mode drill-down → `ORMAP_SYNC_RESP_LEAF`.
+    /// This is the OR-Map analogue of `delta_sync_all`: it proves the durable
+    /// OR-Map content can be pulled back after a crash, not merely that a root
+    /// hash matched. Reuses the existing OR-Map sync protocol — no new wire type.
+    ///
+    /// Keys whose observed set is empty (e.g. a fully-tombstoned churn key) are
+    /// omitted; only keys with at least one observed tag appear in the result.
+    pub async fn ormap_read_all(&mut self, map: &str) -> Result<HashMap<String, HashSet<String>>> {
+        let mut out: HashMap<String, HashSet<String>> = HashMap::new();
+
+        // `ORMAP_SYNC_INIT` builds (or reuses) this connection's Merkle session
+        // and returns the OR-Map root. Root 0 ⇒ empty OR-Map: the bucket walk
+        // would wedge on the empty-path response, so return early (parity with
+        // `delta_sync_all`'s root==0 guard). The client root/bucket fields are
+        // ignored by the server, which answers from its own state.
+        let init = Message::ORMapSyncInit(ORMapSyncInit {
+            map_name: map.to_string(),
+            root_hash: 0,
+            bucket_hashes: HashMap::new(),
+            last_sync_timestamp: None,
+        });
+        send_encoded(&mut self.ws, &init).await?;
+        let root = match recv_decoded(&mut self.ws, "ORMAP_SYNC_RESP_ROOT").await? {
+            Message::ORMapSyncRespRoot(r) => r.payload.root_hash,
+            other => bail!("expected ORMAP_SYNC_RESP_ROOT, got {other:?}"),
+        };
+        if root == 0 {
+            return Ok(out);
+        }
+
+        // Aggregate-mode DFS over single-char trie children, identical in shape
+        // to `delta_sync_all`: we only descend into children the server reported,
+        // so a pushed path always answers with buckets or a leaf, never the
+        // hang-inducing empty response.
+        let mut stack = vec![String::new()];
+        let mut visited = 0usize;
+        while let Some(path) = stack.pop() {
+            visited += 1;
+            if visited > 100_000 {
+                bail!("ormap-read walk for '{map}' exceeded 100k nodes — aborting");
+            }
+            let req = Message::ORMapMerkleReqBucket(ORMapMerkleReqBucket {
+                payload: ORMapMerkleReqBucketPayload {
+                    map_name: map.to_string(),
+                    path: path.clone(),
+                },
+            });
+            send_encoded(&mut self.ws, &req).await?;
+            match recv_decoded(&mut self.ws, "ORMAP_SYNC_RESP_BUCKETS|ORMAP_SYNC_RESP_LEAF").await?
+            {
+                Message::ORMapSyncRespBuckets(b) => {
+                    for child in b.payload.buckets.keys() {
+                        stack.push(format!("{path}{child}"));
+                    }
+                }
+                Message::ORMapSyncRespLeaf(l) => {
+                    for entry in l.payload.entries {
+                        let observed = observed_tags(&entry);
+                        if !observed.is_empty() {
+                            out.entry(entry.key).or_default().extend(observed);
+                        }
+                    }
+                }
+                other => bail!(
+                    "ormap-read: expected ORMAP_SYNC_RESP_BUCKETS or ORMAP_SYNC_RESP_LEAF, got \
+                     {other:?}"
+                ),
             }
         }
         Ok(out)

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -825,23 +825,37 @@ async fn recovery_checkpoint(
     // last and on its own connection: it is a different map from the LWW reads, so
     // it cannot warm the LWW store the cold full-scan query above depends on.
     if config.or_churn && !or_ledger.is_empty() {
-        let post_observed = {
-            let mut v = SoakClient::connect(supervisor.addr(), VERIFIER_IDX, jwt).await?;
-            v.ormap_read_all(OR_MAP).await?
-        };
+        // Snapshot the ledger BEFORE reading the server. Any acked add recorded
+        // after this point (e.g. a late-delivered ack on a fresh post-restart
+        // reconnect, or a kernel-buffered pre-kill ack processed late) is simply
+        // absent from `acked` and never checked, so it cannot manufacture a false
+        // loss. Every tag in `acked` was recorded on an ack that returned before
+        // the read below, so the server had applied it before the read — keeping
+        // this a true directional superset check, never a read/snapshot race.
         let acked = or_ledger.snapshot();
-        let missing = missing_acked_adds(&acked, &post_observed);
-        if !missing.is_empty() {
-            out.hard.push(format!(
-                "OR-Map acked add(s) LOST across recovery: {} (key,tag) pair(s) (e.g. {})",
-                missing.len(),
-                missing
-                    .iter()
-                    .take(5)
-                    .map(|(k, t)| format!("{k}/{t}"))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ));
+        let mut v = SoakClient::connect(supervisor.addr(), VERIFIER_IDX, jwt).await?;
+        match v.ormap_read_all(OR_MAP).await {
+            Ok(post_observed) => {
+                let missing = missing_acked_adds(&acked, &post_observed);
+                if !missing.is_empty() {
+                    out.hard.push(format!(
+                        "OR-Map acked add(s) LOST across recovery: {} (key,tag) pair(s) (e.g. {})",
+                        missing.len(),
+                        missing
+                            .iter()
+                            .take(5)
+                            .map(|(k, t)| format!("{k}/{t}"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
+                }
+            }
+            // A read failure must NOT silently skip the no-loss check — that would
+            // let a real loss hide behind a generic harness error (a loss could
+            // even be the cause of the read failure). Surface it as a HARD failure.
+            Err(e) => out.hard.push(format!(
+                "OR-Map no-loss check could not complete (post-recovery read failed): {e}"
+            )),
         }
     }
 
@@ -962,6 +976,12 @@ async fn run_churn_client(idx: usize, ctx: ChurnCtx) {
                     break;
                 }
 
+                // `slot` cycles over this client's FIXED owned-slot set
+                // (`owned[rr % owned.len()]`), so `pt-{idx}-{slot}` ranges over a
+                // bounded set of distinct tags — one stable tag per owned slot.
+                // Re-visiting a slot re-adds the same tag (idempotent), so neither
+                // the ledger nor the server's persistent OR keyspace grows without
+                // bound over a long soak.
                 let persist_key = format!("ork-persist-{}", slot % ctx.or_keyspace.max(1));
                 let persist_tag = format!("pt-{idx}-{slot}");
                 let (pms, pctr) = next_stamp();

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -46,6 +46,7 @@
 mod client;
 mod model;
 mod monitor;
+mod or_noloss;
 mod process;
 mod report;
 
@@ -62,6 +63,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use client::SoakClient;
 use model::{compare, next_stamp, Model};
 use monitor::{assess, sample_rss_mb, MemSample};
+use or_noloss::{missing_acked_adds, OrLedger};
 use process::{resolve_server_binary, ServerConfig, ServerSupervisor};
 use report::{
     append_progress, utc_timestamp_now, write_report, MemoryReport, ProgressSnapshot, SoakReport,
@@ -163,6 +165,10 @@ struct SoakMetrics {
 struct ChurnCtx {
     supervisor: Arc<ServerSupervisor>,
     model: Arc<Model>,
+    /// Acked persistent-OR-add ledger: the set of adds that must survive a
+    /// `kill -9`. Updated only on an `or_add` ACK for the add-only persistent
+    /// keyspace; read by `recovery_checkpoint` for the directional no-loss check.
+    or_ledger: Arc<OrLedger>,
     metrics: Arc<SoakMetrics>,
     paused: Arc<AtomicBool>,
     stop: Arc<AtomicBool>,
@@ -270,6 +276,7 @@ async fn run_soak(config: &Config) -> i32 {
     let panic_watch = supervisor.panic_watch();
 
     let model = Arc::new(Model::new(config.keyspace, config.churn_clients));
+    let or_ledger = Arc::new(OrLedger::new());
     let metrics = Arc::new(SoakMetrics::default());
     let paused = Arc::new(AtomicBool::new(false));
     let stop = Arc::new(AtomicBool::new(false));
@@ -280,6 +287,7 @@ async fn run_soak(config: &Config) -> i32 {
         let ctx = ChurnCtx {
             supervisor: Arc::clone(&supervisor),
             model: Arc::clone(&model),
+            or_ledger: Arc::clone(&or_ledger),
             metrics: Arc::clone(&metrics),
             paused: Arc::clone(&paused),
             stop: Arc::clone(&stop),
@@ -367,7 +375,16 @@ async fn run_soak(config: &Config) -> i32 {
         let phase;
         if now >= next_crash {
             phase = "recovery";
-            match recovery_checkpoint(&supervisor, &model, &jwt_secret, config, &paused).await {
+            match recovery_checkpoint(
+                &supervisor,
+                &model,
+                &or_ledger,
+                &jwt_secret,
+                config,
+                &paused,
+            )
+            .await
+            {
                 Ok(outcome) => {
                     recovery_checkpoints += 1;
                     crashes += 1;
@@ -670,6 +687,7 @@ struct RecoveryOutcome {
 async fn recovery_checkpoint(
     supervisor: &Arc<ServerSupervisor>,
     model: &Arc<Model>,
+    or_ledger: &Arc<OrLedger>,
     jwt: &str,
     config: &Config,
     paused: &Arc<AtomicBool>,
@@ -707,17 +725,14 @@ async fn recovery_checkpoint(
 
     let mut out = RecoveryOutcome::default();
 
-    // Pre-crash snapshot (also a steady convergence check).
-    let (pre_lww, pre_root, pre_or_root) = {
+    // Pre-crash snapshot (also a steady convergence check). The OR-Map no-loss
+    // check is directional against the acked-add ledger, not a pre/post root
+    // comparison, so no pre-crash OR root is captured here.
+    let (pre_lww, pre_root) = {
         let mut v = SoakClient::connect(supervisor.addr(), VERIFIER_IDX, jwt).await?;
         let lww = v.read_all(LWW_MAP).await?;
         let root = v.merkle_root(LWW_MAP).await?;
-        let or_root = if config.or_churn {
-            Some(v.merkle_root(OR_MAP).await?)
-        } else {
-            None
-        };
-        (lww, root, or_root)
+        (lww, root)
     };
     let expected = model.snapshot();
     let pre_diffs = compare(&expected, &pre_lww);
@@ -752,17 +767,12 @@ async fn recovery_checkpoint(
     // first it would warm the store and the subsequent full-scan query would
     // observe the now-resident records — a false "322b recovered" signal. Reading
     // the query path before anything touches the store measures the genuine gap.
-    let (post_query, post_delta, post_root, post_or_root) = {
+    let (post_query, post_delta, post_root) = {
         let mut v = SoakClient::connect(supervisor.addr(), VERIFIER_IDX, jwt).await?;
         let query = v.read_all(LWW_MAP).await?;
         let delta = v.delta_sync_all(LWW_MAP).await?;
         let root = v.merkle_root(LWW_MAP).await?;
-        let or_root = if config.or_churn {
-            Some(v.merkle_root(OR_MAP).await?)
-        } else {
-            None
-        };
-        (query, delta, root, or_root)
+        (query, delta, root)
     };
 
     // HARD: DurableMerkleIndex (SPEC-325b) builds from the datastore, not the
@@ -772,18 +782,6 @@ async fn recovery_checkpoint(
             "LWW merkle root changed across recovery: pre={pre_root} post={post_root}"
         ));
     }
-    // HARD (unconditional): the OR-Map merkle root must survive recovery unchanged.
-    // This is the OR-Map's only durability assertion, so it must never be skipped —
-    // a blanket skip would let an acked OR-Map write lost on kill -9 pass silently.
-    // Under --no-pre-kill-drain OR churn is disabled (see parse_args), so both roots
-    // are absent and this holds honestly; OR-Map crash-recovery under load is still
-    // covered by the drained mode (its WAL-only behavior is a tracked follow-up).
-    if pre_or_root != post_or_root {
-        out.hard.push(format!(
-            "OR-Map merkle root changed across recovery: pre={pre_or_root:?} post={post_or_root:?}"
-        ));
-    }
-
     // HARD: the delta-sync leaf-fetch path drills the DurableMerkleIndex, which
     // now reads from the datastore. Post-restart the index is rebuilt from durable
     // storage, so every leaf must be reachable regardless of residency.
@@ -816,6 +814,35 @@ async fn recovery_checkpoint(
                 .collect::<Vec<_>>()
                 .join(", ")
         ));
+    }
+
+    // HARD: OR-Map directional no-loss. Every acked add in the add-only persistent
+    // keyspace MUST still be observed after recovery; a missing one is a lost acked
+    // write. This replaces the old OR-root equality, which false-redded on the
+    // benign "recovered-more" asymmetry (WAL replay reconstructs intermediate churn
+    // add/remove tags the live tree had compacted). Recovered-more is a SUPERSET of
+    // the ledger, so it never reddens here — only a true loss does. The OR read runs
+    // last and on its own connection: it is a different map from the LWW reads, so
+    // it cannot warm the LWW store the cold full-scan query above depends on.
+    if config.or_churn && !or_ledger.is_empty() {
+        let post_observed = {
+            let mut v = SoakClient::connect(supervisor.addr(), VERIFIER_IDX, jwt).await?;
+            v.ormap_read_all(OR_MAP).await?
+        };
+        let acked = or_ledger.snapshot();
+        let missing = missing_acked_adds(&acked, &post_observed);
+        if !missing.is_empty() {
+            out.hard.push(format!(
+                "OR-Map acked add(s) LOST across recovery: {} (key,tag) pair(s) (e.g. {})",
+                missing.len(),
+                missing
+                    .iter()
+                    .take(5)
+                    .map(|(k, t)| format!("{k}/{t}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
     }
 
     paused.store(false, Ordering::SeqCst);
@@ -908,7 +935,19 @@ async fn run_churn_client(idx: usize, ctx: ChurnCtx) {
                 break;
             }
 
-            // OR-Map add/remove to drive tombstone growth (memory watch).
+            // OR-Map churn. Two independent streams on the same map:
+            //
+            //  - `ork-*` add-then-immediately-remove: drives tombstone growth, the
+            //    unbounded-memory candidate the soak watches (TODO-479/480). This
+            //    keyspace is EXCLUDED from the no-loss check (its net observed set
+            //    is empty by construction; under the WAL-only window its replayed
+            //    intermediate tags are the benign "recovered-more").
+            //  - `ork-persist-*` add-only: a stable `(key, tag)` per owned slot,
+            //    never removed, recorded into the acked-add ledger ON ACK. Because
+            //    it is never tombstoned, the post-recovery observed set must always
+            //    contain it — that is the directional no-loss invariant. Re-adding
+            //    the same tag is idempotent and keeps the persistent keyspace
+            //    bounded, so it does not itself look like a memory leak.
             write_count += 1;
             if ctx.or_churn && write_count.is_multiple_of(ctx.or_every) {
                 let or_key = format!("ork-{}", slot % ctx.or_keyspace.max(1));
@@ -918,6 +957,23 @@ async fn run_churn_client(idx: usize, ctx: ChurnCtx) {
                         session_alive = false;
                         break;
                     }
+                } else {
+                    session_alive = false;
+                    break;
+                }
+
+                let persist_key = format!("ork-persist-{}", slot % ctx.or_keyspace.max(1));
+                let persist_tag = format!("pt-{idx}-{slot}");
+                let (pms, pctr) = next_stamp();
+                if client
+                    .or_add(OR_MAP, &persist_key, &persist_tag, pms, pctr)
+                    .await
+                    .is_ok()
+                {
+                    // Ledger updated ONLY on ack: an add whose ack never returned
+                    // is never recorded, so a kill-window drop of an unacked add is
+                    // not miscounted as loss.
+                    ctx.or_ledger.record_add(&persist_key, &persist_tag);
                 } else {
                     session_alive = false;
                     break;
@@ -1324,16 +1380,16 @@ fn parse_args() -> Config {
             }
         }
     }
-    // The no-drain validator scopes strictly to the LWW acked==durable
-    // target. OR-Map WAL-only crash-recovery semantics — the live net-compacted
-    // observed set vs the WAL-replayed intermediate tags — is a distinct question
-    // that needs its own audit. Rather than run OR churn and relax its assertion
-    // (which would let a genuine OR-Map acked-write loss pass silently), we simply
-    // do not generate OR writes in this mode, so the OR-root equality check stays
-    // unconditionally HARD and holds honestly (both roots absent).
-    if c.no_pre_kill_drain {
-        c.or_churn = false;
-    }
+    // OR-Map churn now runs under --no-pre-kill-drain too. The old root-equality
+    // check false-redded here on the benign "recovered-more" asymmetry (the live
+    // tree compacts an add+remove pair while WAL replay reconstructs both tags),
+    // so OR churn used to be suppressed in this mode. The check is now a
+    // DIRECTIONAL no-loss assertion instead: a separate add-only persistent OR
+    // keyspace (`ork-persist-*`) seeds an acked-add ledger, and recovery asserts
+    // the post-restart observed set is a SUPERSET of those acked adds. Recovered-
+    // more is a superset and never reddens; only a missing acked add fails. There
+    // is therefore no longer any reason to shed OR writes in no-drain mode — doing
+    // so is exactly what this spec re-enables to make WAL-only OR recovery honest.
     c
 }
 

--- a/packages/server-rust/benches/soak_harness/or_noloss.rs
+++ b/packages/server-rust/benches/soak_harness/or_noloss.rs
@@ -1,0 +1,121 @@
+//! OR-Map crash-recovery directional no-loss check.
+//!
+//! The soak proves LWW "acked == durable" across a `kill -9`. This module adds
+//! the OR-Map analogue: an acked OR-Map add must never be lost across crash
+//! recovery, while the benign WAL-replay "recovered-more" asymmetry must never
+//! produce a false failure.
+//!
+//! ## Why a directional superset, not equality
+//!
+//! The OR-Map merkle root legitimately DIVERGES pre-kill vs post-recovery under
+//! the WAL-only window: the live in-memory tree net-compacts/GCs an
+//! add-then-remove pair, while WAL replay reconstructs the intermediate add tag
+//! and its tombstone. So post-recovery can hold MORE tags/tombstones than the
+//! live tree ("recovered-more") even though no observed value was lost. A root
+//! equality check would false-red on that. The honest invariant is directional:
+//!
+//! > every acked OR add must still be observed after recovery; extra recovered
+//! > tags are benign.
+//!
+//! ## Why an add-only persistent keyspace
+//!
+//! Tracking removes in the ledger opens a kill-window false-loss race: an add is
+//! acked (in the ledger) and its remove is durably applied (tombstone fsynced)
+//! but the remove-ack never reaches the client before the `kill -9`. The ledger
+//! still holds the tag; the post-recovery observed set (active minus tombstones)
+//! correctly lacks it — a FALSE loss. The fix is to seed the ledger from a
+//! separate keyspace that is ONLY ever added to, never removed. With no
+//! tombstones in the persistent keyspace, WAL replay of its ops can only add
+//! active tags, never suppress one, so the post-recovery observed set is provably
+//! a strict superset of the ledger. The remove-driven tombstone-growth churn
+//! lives in a different keyspace that is excluded from the loss check.
+
+use std::collections::{HashMap, HashSet};
+
+use dashmap::DashMap;
+use topgun_core::messages::ORMapEntry;
+
+/// Thread-safe ledger of acked **persistent** OR-Map adds: persistent key → set
+/// of acked add tags that MUST survive crash recovery.
+///
+/// Updated only on an `or_add` ACK (an add whose ack never returned is never
+/// inserted, so a genuine kill-window drop of an *unacked* add is not miscounted
+/// as loss). The persistent keyspace is never removed from, so the ledger needs
+/// no tombstone reconciliation.
+#[derive(Default)]
+pub struct OrLedger {
+    adds: DashMap<String, HashSet<String>>,
+}
+
+impl OrLedger {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record an acked persistent OR add. Safe under concurrent churn clients
+    /// (`DashMap` entry holds a per-shard write lock across the insert).
+    pub fn record_add(&self, key: &str, tag: &str) {
+        self.adds
+            .entry(key.to_string())
+            .or_default()
+            .insert(tag.to_string());
+    }
+
+    /// Point-in-time snapshot of the acked-add set per key. Taken while churn is
+    /// quiesced at a checkpoint, so it is a consistent view.
+    pub fn snapshot(&self) -> HashMap<String, HashSet<String>> {
+        self.adds
+            .iter()
+            .map(|e| (e.key().clone(), e.value().clone()))
+            .collect()
+    }
+
+    /// True when no persistent add has been acked yet.
+    pub fn is_empty(&self) -> bool {
+        self.adds.is_empty()
+    }
+}
+
+/// The observed tag set for one OR-Map sync leaf entry: active record tags MINUS
+/// tombstone tags. This is the user-visible OR-Map content for the key — a tag
+/// that has been tombstoned is no longer observed.
+pub fn observed_tags(entry: &ORMapEntry) -> HashSet<String> {
+    let tombstones: HashSet<&str> = entry.tombstones.iter().map(String::as_str).collect();
+    entry
+        .records
+        .iter()
+        .map(|r| r.tag.as_str())
+        .filter(|tag| !tombstones.contains(tag))
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// Directional OR-Map no-loss diff: every acked (net-present) OR add tag must
+/// appear in the post-recovery observed set.
+///
+/// Returns the `(key, tag)` pairs that are MISSING from `observed` — each one a
+/// HARD loss of an acked add. An empty result means no loss.
+///
+/// The comparison is **`acked ⊆ observed`** and ONLY that direction.
+/// "Recovered-more" — `observed` holding extra keys or tags not present in
+/// `acked` — is benign and is NEVER reported. Flipping this to equality (also
+/// reporting `observed`'s extras) or to the reverse subset would re-introduce the
+/// false-positive "recovered-more" failure this check exists to avoid, and could
+/// mask a real loss. This direction is load-bearing.
+pub fn missing_acked_adds(
+    acked: &HashMap<String, HashSet<String>>,
+    observed: &HashMap<String, HashSet<String>>,
+) -> Vec<(String, String)> {
+    let mut missing = Vec::new();
+    for (key, tags) in acked {
+        let obs = observed.get(key);
+        for tag in tags {
+            let present = obs.is_some_and(|set| set.contains(tag));
+            if !present {
+                missing.push((key.clone(), tag.clone()));
+            }
+        }
+    }
+    missing.sort();
+    missing
+}

--- a/packages/server-rust/benches/soak_harness/or_noloss.rs
+++ b/packages/server-rust/benches/soak_harness/or_noloss.rs
@@ -61,8 +61,12 @@ impl OrLedger {
             .insert(tag.to_string());
     }
 
-    /// Point-in-time snapshot of the acked-add set per key. Taken while churn is
-    /// quiesced at a checkpoint, so it is a consistent view.
+    /// Snapshot of the acked-add set per key. `DashMap::iter` locks shards one at
+    /// a time rather than globally, so this is not a single atomic instant; that
+    /// is fine because the caller snapshots while churn is paused AND before the
+    /// post-recovery read, so any concurrent `record_add` is either already
+    /// applied on the server before that read or simply absent from the snapshot —
+    /// never a tag that is in `acked` but legitimately not yet on the server.
     pub fn snapshot(&self) -> HashMap<String, HashSet<String>> {
         self.adds
             .iter()

--- a/packages/server-rust/tests/soak_or_noloss.rs
+++ b/packages/server-rust/tests/soak_or_noloss.rs
@@ -1,0 +1,176 @@
+//! Behavioral red-on-revert tests for the soak harness OR-Map directional
+//! no-loss check.
+//!
+//! The no-loss logic lives in `benches/soak_harness/or_noloss.rs`. The soak bench
+//! is declared `harness = false`, so `cargo test` cannot run `#[test]` functions
+//! inside it. To exercise the EXACT bench source (so a regression in the
+//! comparator reddens here), this integration test pulls that module in directly
+//! via `#[path]` and tests the real functions.
+//!
+//! The load-bearing property: `missing_acked_adds` is a directional subset check
+//! (`acked ⊆ observed`). A dropped acked add must be reported (RED); a
+//! "recovered-more" observed set (extra tags/keys/tombstones not in the ledger)
+//! must NOT be reported (GREEN). Reverting the comparator to equality — or
+//! flipping the subset direction — turns the recovered-more case RED, which is
+//! precisely the regression these tests guard.
+
+#[path = "../benches/soak_harness/or_noloss.rs"]
+mod or_noloss;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use or_noloss::{missing_acked_adds, observed_tags, OrLedger};
+use topgun_core::hlc::{ORMapRecord, Timestamp};
+use topgun_core::messages::ORMapEntry;
+
+fn record(tag: &str) -> ORMapRecord<rmpv::Value> {
+    ORMapRecord {
+        value: rmpv::Value::from(1),
+        timestamp: Timestamp {
+            millis: 1,
+            counter: 1,
+            node_id: "test".to_string(),
+        },
+        tag: tag.to_string(),
+        ttl_ms: None,
+    }
+}
+
+fn entry(key: &str, active: &[&str], tombstones: &[&str]) -> ORMapEntry {
+    ORMapEntry {
+        key: key.to_string(),
+        records: active.iter().map(|t| record(t)).collect(),
+        tombstones: tombstones.iter().map(ToString::to_string).collect(),
+    }
+}
+
+fn set(tags: &[&str]) -> HashSet<String> {
+    tags.iter().map(ToString::to_string).collect()
+}
+
+// ---------------------------------------------------------------------------
+// AC2 — observed-set parse: active record tags MINUS tombstone tags.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn observed_tags_is_active_minus_tombstones() {
+    // Add-only (persistent keyspace shape): all active tags observed.
+    assert_eq!(
+        observed_tags(&entry("k", &["a", "b"], &[])),
+        set(&["a", "b"])
+    );
+    // Mixed: a tombstoned tag is suppressed; the rest remain observed.
+    assert_eq!(
+        observed_tags(&entry("k", &["a", "b", "c"], &["b"])),
+        set(&["a", "c"])
+    );
+    // Fully tombstoned (churn keyspace end-state): observed set is empty.
+    assert!(observed_tags(&entry("k", &["a"], &["a"])).is_empty());
+    // Tombstone for a tag with no active record: still empty, no panic.
+    assert!(observed_tags(&entry("k", &[], &["ghost"])).is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// AC3 — directional no-loss comparator, red-on-revert.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dropped_acked_add_is_reported_as_loss() {
+    // Ledger required tag `t1` under key `k`; recovery observed nothing for `k`.
+    let acked: HashMap<String, HashSet<String>> = HashMap::from([("k".to_string(), set(&["t1"]))]);
+    let observed: HashMap<String, HashSet<String>> = HashMap::new();
+
+    let missing = missing_acked_adds(&acked, &observed);
+    assert_eq!(missing, vec![("k".to_string(), "t1".to_string())]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn partial_drop_reports_only_the_missing_tag() {
+    let acked: HashMap<String, HashSet<String>> =
+        HashMap::from([("k".to_string(), set(&["t1", "t2"]))]);
+    // `t1` survived; `t2` was lost.
+    let observed: HashMap<String, HashSet<String>> =
+        HashMap::from([("k".to_string(), set(&["t1"]))]);
+
+    let missing = missing_acked_adds(&acked, &observed);
+    assert_eq!(missing, vec![("k".to_string(), "t2".to_string())]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recovered_more_does_not_redden() {
+    // The benign WAL-replay asymmetry: every acked add survived, AND recovery
+    // surfaced EXTRA tags/keys not in the ledger (the churn keyspace's replayed
+    // intermediate tags). A directional superset check must treat this as no loss.
+    //
+    // This is the red-on-revert guard: reverting `missing_acked_adds` to equality
+    // (also reporting `observed`'s extras) — or flipping the subset direction —
+    // makes this assertion fail.
+    let acked: HashMap<String, HashSet<String>> = HashMap::from([
+        ("persist-0".to_string(), set(&["pa", "pb"])),
+        ("persist-1".to_string(), set(&["pc"])),
+    ]);
+    let observed: HashMap<String, HashSet<String>> = HashMap::from([
+        // Same ledgered tags PLUS an extra recovered tag on the same key.
+        (
+            "persist-0".to_string(),
+            set(&["pa", "pb", "extra-replayed"]),
+        ),
+        ("persist-1".to_string(), set(&["pc"])),
+        // An entirely extra key the ledger never tracked (churn-keyspace replay).
+        ("ork-7".to_string(), set(&["churn-tag"])),
+    ]);
+
+    let missing = missing_acked_adds(&acked, &observed);
+    assert!(
+        missing.is_empty(),
+        "recovered-more must never redden, got {missing:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_ledger_never_reports_loss() {
+    let acked: HashMap<String, HashSet<String>> = HashMap::new();
+    let observed: HashMap<String, HashSet<String>> =
+        HashMap::from([("anything".to_string(), set(&["x"]))]);
+    assert!(missing_acked_adds(&acked, &observed).is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Ledger: acked-only recording + concurrency safety.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ledger_records_only_what_was_added_and_is_concurrency_safe() {
+    let ledger = Arc::new(OrLedger::new());
+    assert!(ledger.is_empty());
+
+    // Concurrent churn clients recording acked adds on shared + distinct keys.
+    let mut handles = Vec::new();
+    for client in 0..8u32 {
+        let ledger = Arc::clone(&ledger);
+        handles.push(tokio::spawn(async move {
+            for slot in 0..16u32 {
+                // Shared key across clients (different tags), distinct tag per
+                // (client, slot) — the persistent-keyspace shape.
+                ledger.record_add(
+                    &format!("persist-{}", slot % 4),
+                    &format!("pt-{client}-{slot}"),
+                );
+            }
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    let snap = ledger.snapshot();
+    assert!(!ledger.is_empty());
+    // 4 persistent keys; every (client, slot) tag landed exactly once.
+    assert_eq!(snap.len(), 4);
+    let total_tags: usize = snap.values().map(HashSet::len).sum();
+    assert_eq!(total_tags, 8 * 16);
+
+    // And the directional check passes when observed exactly mirrors the ledger.
+    assert!(missing_acked_adds(&snap, &snap).is_empty());
+}


### PR DESCRIPTION
## What

Adds a **directional OR-Map crash-recovery no-loss check** to the soak harness. Under load with a `kill -9` in the WAL-only window (`--no-pre-kill-drain`), the post-recovery OR observed set is now proven to be a **superset of every acked `or_add`** in the persistent (`ork-persist-*`) keyspace.

This replaces an OR-root equality assertion that was **vacuous** (`merkle_root(OR_MAP)` on the soak map returned `0` pre and post → `0 == 0`), so OR-Map crash recovery under load was never actually verified.

Soak-harness only — **zero `core-rust`/`server-rust` lib, wire, schema, or TS change**.

## How

- `client.rs` — `ormap_read_all` walks the **existing** OR-Map merkle sync protocol (`ORMapSyncInit` → `ORMapMerkleReqBucket` → `ORMapSyncRespLeaf`), a structural mirror of the proven LWW `delta_sync_all`. Returns observed set per key (active records − tombstones). No new wire type.
- `or_noloss.rs` (new) — `OrLedger` (records **acked** adds only), `observed_tags`, and the load-bearing comparator `missing_acked_adds` (`acked ⊆ observed`; never equality, never reversed).
- `main.rs` — seeds the acked-add ledger, runs the directional superset check in `recovery_checkpoint`, re-enables OR churn under `--no-pre-kill-drain`.
- `tests/soak_or_noloss.rs` (new) — red-on-revert behavioral test (dropped-acked-add → RED, recovered-more → GREEN; reverting the comparator to equality flips it). `#[tokio::test(flavor = "multi_thread")]`, passes debug + release (6/6 each).

Footprint: **4 Rust files (≤5 cap)**.

## ⚠️ This check found a real bug → TODO-557 (high)

Doing its job, the check exposed a **genuine server-side OR-Map durability loss**: acked OR adds are **not observable after `kill -9` + restart** (deterministic, both drained and no-drain; read path proven correct pre-crash @ 64 keys / 626 tags). OR-Map appears to lack the SPEC-325 datastore-backed durable rehydration that LWW received.

Consequently the loaded soak (AC4) is **intentionally not green** — and the check was **not weakened** to force it (the exact discipline SPEC-330 established). Tracked as **TODO-557**, server-side, out of scope for this harness-only PR.

The benign "recovered-more" WAL-replay asymmetry is **separately proven benign** (add-only persistent keyspace ⇒ no tombstones ⇒ replay strictly additive; unit-proven) and is distinct from the real loss above.

## Cross-vendor review

- `/xask` @ design fork (glm-5.2) chose the add-only persistent keyspace to close a durable-but-unacked-remove false-loss race.
- `/xreview` on the diff (glm-5.2): cardinal rule verified intact (7/7 invariants); HIGH-1/HIGH-2 fixed (snapshot ledger before read; read failure = HARD). A re-run on the final `main...HEAD` confirmed **0 real findings** (5 advisory all rejected diff-grounded).

## CI / merge

Ships **alone**. Merge **only on green CI**: full pnpm gate + Rust `Check & Lint` (DEBUG) full suite + `integration-rust`. The new HARD check runs only inside `recovery_checkpoint` (crash runs); per-PR CI soak smoke is `--crash-interval 0` (no crash), so **this change reddens no existing CI gate**.

Closes TODO-553.
