### PR TITLE
fix(sf-333a): OR-Map WAL durability — non-LWW encode/replay survives kill -9

### DIFF
--- a/packages/server-rust/src/storage/crash_safety_proptest.rs
+++ b/packages/server-rust/src/storage/crash_safety_proptest.rs
@@ -1430,7 +1430,7 @@ async fn ac4_legacy_null_value_wal_frame_replays_as_zero_epoch_lww() {
     drop(dir);
 }
 
-/// The cardinal rule names OrMap **and** OrTombstones. New code never emits
+/// The cardinal rule names `OrMap` **and** `OrTombstones`. New code never emits
 /// `OrTombstones` through the write path, but the WAL format must still carry it
 /// losslessly so any in-flight or legacy `Record(OrTombstones)` frame survives a
 /// crash. Appends the frame through the real WAL and asserts the exact variant

--- a/packages/server-rust/src/storage/crash_safety_proptest.rs
+++ b/packages/server-rust/src/storage/crash_safety_proptest.rs
@@ -34,9 +34,11 @@ use tokio::task::block_in_place;
 use topgun_core::hlc::Timestamp;
 use topgun_core::types::Value;
 
-use crate::storage::datastores::{WalBootstrap, WriteBehindConfig, WriteBehindDataStore};
+use crate::storage::datastores::{
+    RedbDataStore, WalBootstrap, WriteBehindConfig, WriteBehindDataStore,
+};
 use crate::storage::map_data_store::{LeafSink, MapDataStore, ScanBatch, ScanCursor};
-use crate::storage::record::RecordValue;
+use crate::storage::record::{OrMapEntry, RecordValue};
 use crate::storage::wal::{Wal, WalFsyncPolicy, WalRecovery, WalWriter};
 
 // ---------------------------------------------------------------------------
@@ -1225,6 +1227,186 @@ async fn crash_on_partial_active_segment_recovers_intact_prefix() {
         recovered.contains(TEST_MAP, &keys[0]).await,
         "the earliest acked write (deep in a sealed segment) must survive a torn \
          active-segment tail"
+    );
+
+    drop(dir);
+}
+
+// ---------------------------------------------------------------------------
+// OR-Map durability across recovery (SPEC-333)
+// ---------------------------------------------------------------------------
+
+/// Build an HLC timestamp for the OR-Map durability tests.
+fn or_ts(millis: u64) -> Timestamp {
+    Timestamp {
+        millis,
+        counter: 0,
+        node_id: "sf333".to_string(),
+    }
+}
+
+/// A populated OR-Map record with two live adds and a tombstone, exercising the
+/// `records` + `tombstones` shape the WAL must carry losslessly.
+fn or_record() -> RecordValue {
+    RecordValue::OrMap {
+        records: vec![
+            OrMapEntry {
+                value: Value::String("alpha".to_string()),
+                tag: "tag-a".to_string(),
+                timestamp: or_ts(1),
+            },
+            OrMapEntry {
+                value: Value::Int(42),
+                tag: "tag-b".to_string(),
+                timestamp: or_ts(2),
+            },
+        ],
+        tombstones: vec!["gone-tag".to_string()],
+    }
+}
+
+/// AC2 — an acked OR-Map add that survives only on the WAL (never flushed to the
+/// inner store before the crash) must replay as its exact OR content, not as a
+/// `Value::Null`/LWW placeholder.
+///
+/// Red on revert of the full-`RecordValue` WAL encode/replay: the pre-fix code
+/// encoded every non-LWW value as `Value::Null` and replayed every `Store` as
+/// `RecordValue::Lww`, so the recovered value would be `Lww(Null)`, not the OR
+/// record — this assertion would fail.
+#[tokio::test]
+async fn ac2_wal_only_recovery_preserves_ormap_adds() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wal_dir = dir.path().to_path_buf();
+
+    // never_flush_config ⇒ the OR add never reaches the inner store before the
+    // crash; its only durable record is the WAL frame.
+    let pre_crash_inner: Arc<dyn MapDataStore> = Arc::new(RetainingStore::default());
+    let wal = WalWriter::new(wal_dir.clone(), WalFsyncPolicy::PerOp).expect("WalWriter::new");
+    let wal_dyn: Arc<dyn Wal> = Arc::clone(&wal) as Arc<dyn Wal>;
+    let store = WriteBehindDataStore::new_with_wal(
+        pre_crash_inner,
+        never_flush_config(),
+        Some(WalBootstrap {
+            wal: wal_dyn,
+            sequence_start: 1,
+        }),
+    );
+
+    let or_value = or_record();
+    store
+        .add(TEST_MAP, "ork-1", &or_value, 0, 1000)
+        .await
+        .expect("OR add must ack");
+
+    // Crash: drop the write-behind store; only the on-disk WAL survives.
+    drop(store);
+
+    let recovered = Arc::new(RetainingStore::default());
+    let recovery = WalRecovery::new(Arc::clone(&wal), Vec::new());
+    recovery
+        .run(Arc::clone(&recovered) as Arc<dyn MapDataStore>)
+        .await
+        .expect("recovery must succeed on an intact WAL");
+
+    let got = recovered
+        .load(TEST_MAP, "ork-1")
+        .await
+        .unwrap()
+        .expect("acked OR add must survive WAL recovery (lost as Value::Null pre-fix)");
+    assert_eq!(
+        got, or_value,
+        "recovered OR content must equal the acked OR record exactly"
+    );
+
+    drop(dir);
+}
+
+/// AC4 — a legacy bare-`Value` WAL frame (the shape older servers wrote) must
+/// still decode and replay as LWW; the server must never refuse to start on an
+/// old WAL.
+///
+/// `WalStorePayload::Legacy(v)` serializes (untagged) to the exact bare-`Value`
+/// wire shape an older server emitted for `WalOp::Store { value: Value }`, so
+/// appending it reproduces a pre-existing on-disk frame. Red on revert of the
+/// untagged backward-compat decode: a tag-renamed variant would fail to decode
+/// the `"store"`-tagged legacy frame and recovery would treat it as corruption.
+#[tokio::test]
+async fn ac4_legacy_bare_value_wal_frame_replays_as_lww() {
+    use crate::storage::wal::{WalEntry, WalOp, WalStorePayload};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wal_dir = dir.path().to_path_buf();
+    let wal = WalWriter::new(wal_dir.clone(), WalFsyncPolicy::PerOp).expect("WalWriter::new");
+
+    let legacy_entry = WalEntry {
+        map: TEST_MAP.to_string(),
+        key: "legacy-k".to_string(),
+        op: WalOp::Store {
+            value: WalStorePayload::Legacy(Value::String("legacy-val".to_string())),
+            expiration_time: None,
+        },
+        timestamp: Some(or_ts(5)),
+        sequence: 1,
+    };
+    wal.append(0, &legacy_entry)
+        .await
+        .expect("append legacy frame");
+
+    let recovered = Arc::new(RetainingStore::default());
+    let recovery = WalRecovery::new(Arc::clone(&wal), Vec::new());
+    recovery
+        .run(Arc::clone(&recovered) as Arc<dyn MapDataStore>)
+        .await
+        .expect("server must not refuse to start on a legacy WAL");
+
+    let got = recovered
+        .load(TEST_MAP, "legacy-k")
+        .await
+        .unwrap()
+        .expect("legacy frame must replay");
+    match got {
+        RecordValue::Lww { value, .. } => {
+            assert_eq!(value, Value::String("legacy-val".to_string()));
+        }
+        other => panic!("legacy frame must replay as LWW, got {other:?}"),
+    }
+
+    drop(dir);
+}
+
+/// AC3 — acked OR adds flushed through the real write-behind→redb drain survive a
+/// process restart: re-opening redb with no in-memory residency still yields the
+/// full OR content. Confirms the durable OR path (Cause-2 collapse guard) and
+/// catches any regression that drops OR structure on the redb persist/reload path.
+#[tokio::test(flavor = "multi_thread")]
+async fn ac3_drained_redb_path_preserves_ormap_adds() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("redb_or.db");
+    let or_value = or_record();
+
+    {
+        let redb: Arc<dyn MapDataStore> =
+            Arc::new(RedbDataStore::new(&db_path).expect("redb new"));
+        let store = WriteBehindDataStore::new(redb, never_flush_config());
+        store
+            .add(TEST_MAP, "ork-persist-1", &or_value, 0, 1000)
+            .await
+            .expect("OR add must ack");
+        // Drain the buffer into redb, then drop all in-memory write-behind state.
+        store.hard_flush().await.expect("hard_flush drains to redb");
+        drop(store);
+    }
+
+    // Fresh redb open — no write-behind overlay, no in-memory residency.
+    let reopened = RedbDataStore::new(&db_path).expect("redb reopen");
+    let got = reopened
+        .load(TEST_MAP, "ork-persist-1")
+        .await
+        .unwrap()
+        .expect("drained OR add must persist durably in redb");
+    assert_eq!(
+        got, or_value,
+        "redb-reloaded OR content must equal the acked OR record exactly"
     );
 
     drop(dir);

--- a/packages/server-rust/src/storage/crash_safety_proptest.rs
+++ b/packages/server-rust/src/storage/crash_safety_proptest.rs
@@ -1385,8 +1385,7 @@ async fn ac3_drained_redb_path_preserves_ormap_adds() {
     let or_value = or_record();
 
     {
-        let redb: Arc<dyn MapDataStore> =
-            Arc::new(RedbDataStore::new(&db_path).expect("redb new"));
+        let redb: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&db_path).expect("redb new"));
         let store = WriteBehindDataStore::new(redb, never_flush_config());
         store
             .add(TEST_MAP, "ork-persist-1", &or_value, 0, 1000)

--- a/packages/server-rust/src/storage/crash_safety_proptest.rs
+++ b/packages/server-rust/src/storage/crash_safety_proptest.rs
@@ -1374,6 +1374,179 @@ async fn ac4_legacy_bare_value_wal_frame_replays_as_lww() {
     drop(dir);
 }
 
+/// The realistic legacy OR-Map WAL frame: pre-fix servers hard-coded
+/// `WalOp::Store { value: Value::Null }` for every non-LWW record and wrote no
+/// HLC timestamp. `Value::Null` is a serde *unit* variant — it round-trips
+/// through a different `untagged` content path than a newtype variant like
+/// `Value::String`, so it needs explicit coverage. Recovery must decode it via
+/// the `Legacy` arm (never refusing to start) and replay it as a zero-epoch LWW
+/// value so the inner store's merge always accepts it.
+#[tokio::test]
+async fn ac4_legacy_null_value_wal_frame_replays_as_zero_epoch_lww() {
+    use crate::storage::wal::{WalEntry, WalOp, WalStorePayload};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wal_dir = dir.path().to_path_buf();
+    let wal = WalWriter::new(wal_dir.clone(), WalFsyncPolicy::PerOp).expect("WalWriter::new");
+
+    // The exact shape an older server wrote for OR-Map data: bare Value::Null, no ts.
+    let legacy_entry = WalEntry {
+        map: TEST_MAP.to_string(),
+        key: "legacy-null-k".to_string(),
+        op: WalOp::Store {
+            value: WalStorePayload::Legacy(Value::Null),
+            expiration_time: None,
+        },
+        timestamp: None,
+        sequence: 1,
+    };
+    wal.append(0, &legacy_entry)
+        .await
+        .expect("append legacy Value::Null frame");
+
+    let recovered = Arc::new(RetainingStore::default());
+    let recovery = WalRecovery::new(Arc::clone(&wal), Vec::new());
+    recovery
+        .run(Arc::clone(&recovered) as Arc<dyn MapDataStore>)
+        .await
+        .expect("server must not refuse to start on a legacy Value::Null WAL");
+
+    let got = recovered
+        .load(TEST_MAP, "legacy-null-k")
+        .await
+        .unwrap()
+        .expect("legacy Value::Null frame must replay");
+    match got {
+        RecordValue::Lww { value, timestamp } => {
+            assert_eq!(value, Value::Null, "legacy Null must replay as LWW Null");
+            assert_eq!(
+                timestamp.millis, 0,
+                "absent WAL timestamp must replay as a zero-epoch LWW timestamp"
+            );
+        }
+        other => panic!("legacy Value::Null frame must replay as LWW, got {other:?}"),
+    }
+
+    drop(dir);
+}
+
+/// The cardinal rule names OrMap **and** OrTombstones. New code never emits
+/// `OrTombstones` through the write path, but the WAL format must still carry it
+/// losslessly so any in-flight or legacy `Record(OrTombstones)` frame survives a
+/// crash. Appends the frame through the real WAL and asserts the exact variant
+/// recovers — the `Record` arm must not collapse it to LWW.
+#[tokio::test]
+async fn ac2_wal_only_recovery_preserves_ortombstones() {
+    use crate::storage::wal::{WalEntry, WalOp, WalStorePayload};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wal_dir = dir.path().to_path_buf();
+    let wal = WalWriter::new(wal_dir.clone(), WalFsyncPolicy::PerOp).expect("WalWriter::new");
+
+    let tomb = RecordValue::OrTombstones {
+        tags: vec!["t-1".to_string(), "t-2".to_string()],
+    };
+    let entry = WalEntry {
+        map: TEST_MAP.to_string(),
+        key: "ortomb-1".to_string(),
+        op: WalOp::Store {
+            value: WalStorePayload::Record(tomb.clone()),
+            expiration_time: None,
+        },
+        timestamp: None,
+        sequence: 1,
+    };
+    wal.append(0, &entry)
+        .await
+        .expect("append OrTombstones frame");
+
+    let recovered = Arc::new(RetainingStore::default());
+    let recovery = WalRecovery::new(Arc::clone(&wal), Vec::new());
+    recovery
+        .run(Arc::clone(&recovered) as Arc<dyn MapDataStore>)
+        .await
+        .expect("recovery must succeed on an OrTombstones WAL frame");
+
+    let got = recovered
+        .load(TEST_MAP, "ortomb-1")
+        .await
+        .unwrap()
+        .expect("OrTombstones frame must replay");
+    assert_eq!(
+        got, tomb,
+        "recovered OrTombstones must equal the acked record exactly (no LWW collapse)"
+    );
+
+    drop(dir);
+}
+
+/// A WAL segment written across an upgrade carries both legacy bare-`Value`
+/// frames and new `Record(RecordValue)` frames. `untagged` decoding is
+/// per-frame, so both must replay correctly from a single segment — this guards
+/// against any cross-frame decode desync between the two payload shapes.
+#[tokio::test]
+async fn ac4_mixed_legacy_and_record_frames_both_replay() {
+    use crate::storage::wal::{WalEntry, WalOp, WalStorePayload};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wal_dir = dir.path().to_path_buf();
+    let wal = WalWriter::new(wal_dir.clone(), WalFsyncPolicy::PerOp).expect("WalWriter::new");
+
+    let or_value = or_record();
+    let legacy = WalEntry {
+        map: TEST_MAP.to_string(),
+        key: "mixed-legacy".to_string(),
+        op: WalOp::Store {
+            value: WalStorePayload::Legacy(Value::Null),
+            expiration_time: None,
+        },
+        timestamp: None,
+        sequence: 1,
+    };
+    let modern = WalEntry {
+        map: TEST_MAP.to_string(),
+        key: "mixed-modern".to_string(),
+        op: WalOp::Store {
+            value: WalStorePayload::Record(or_value.clone()),
+            expiration_time: None,
+        },
+        timestamp: None,
+        sequence: 2,
+    };
+    wal.append(0, &legacy).await.expect("append legacy frame");
+    wal.append(0, &modern)
+        .await
+        .expect("append modern OR frame");
+
+    let recovered = Arc::new(RetainingStore::default());
+    let recovery = WalRecovery::new(Arc::clone(&wal), Vec::new());
+    recovery
+        .run(Arc::clone(&recovered) as Arc<dyn MapDataStore>)
+        .await
+        .expect("recovery must succeed on a mixed-format WAL");
+
+    match recovered
+        .load(TEST_MAP, "mixed-legacy")
+        .await
+        .unwrap()
+        .expect("legacy frame must replay")
+    {
+        RecordValue::Lww { value, .. } => assert_eq!(value, Value::Null),
+        other => panic!("legacy frame must replay as LWW, got {other:?}"),
+    }
+    let got_modern = recovered
+        .load(TEST_MAP, "mixed-modern")
+        .await
+        .unwrap()
+        .expect("modern OR frame must replay");
+    assert_eq!(
+        got_modern, or_value,
+        "modern OR frame must replay losslessly alongside a legacy frame"
+    );
+
+    drop(dir);
+}
+
 /// AC3 — acked OR adds flushed through the real write-behind→redb drain survive a
 /// process restart: re-opening redb with no in-memory residency still yields the
 /// full OR content. Confirms the durable OR path (Cause-2 collapse guard) and

--- a/packages/server-rust/src/storage/crash_safety_proptest.rs
+++ b/packages/server-rust/src/storage/crash_safety_proptest.rs
@@ -849,7 +849,7 @@ async fn ac4_acked_writes_survive_multiple_restart_cycles() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn max_observed_sequence_reads_watermark_of_compacted_empty_partition() {
-    use crate::storage::wal::{WalEntry, WalOp};
+    use crate::storage::wal::{WalEntry, WalOp, WalStorePayload};
 
     let dir = tempfile::tempdir().unwrap();
     let wal_dir = dir.path().to_path_buf();
@@ -863,7 +863,14 @@ async fn max_observed_sequence_reads_watermark_of_compacted_empty_partition() {
         map: "m".to_string(),
         key: "k".to_string(),
         op: WalOp::Store {
-            value: Value::Int(1),
+            value: WalStorePayload::Record(RecordValue::Lww {
+                value: Value::Int(1),
+                timestamp: Timestamp {
+                    millis: 1,
+                    counter: 0,
+                    node_id: "n".to_string(),
+                },
+            }),
             expiration_time: None,
         },
         timestamp: Some(Timestamp {

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -19,7 +19,7 @@ use crate::storage::map_data_store::{
     merkle_leaf_hash, LeafSink, MapDataStore, MerkleLeaf, ScanBatch, ScanCursor,
 };
 use crate::storage::record::RecordValue;
-use crate::storage::wal::{Wal, WalEntry, WalFsyncPolicy, WalOp};
+use crate::storage::wal::{Wal, WalEntry, WalFsyncPolicy, WalOp, WalStorePayload};
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -762,37 +762,28 @@ impl MapDataStore for WriteBehindDataStore {
         // Append to WAL and satisfy the fsync policy before touching in-memory
         // state. This must happen before returning Ok(()) so a crash after ack
         // still has the write in the WAL for recovery to replay.
-        let wal_value_for_entry = if let RecordValue::Lww {
-            value: v,
-            timestamp,
-        } = value
-        {
-            let wal_op = WalOp::Store {
-                value: v.clone(),
-                expiration_time: if expiration_time == 0 {
-                    None
-                } else {
-                    Some(expiration_time)
-                },
-            };
-            (wal_op, Some(timestamp.clone()))
+        // Persist the full RecordValue so OR-Map adds and tombstones survive a
+        // kill -9 in the write-behind window — not just LWW scalars. The WAL
+        // entry timestamp is the LWW idempotency-dedup key; OR values carry their
+        // own per-entry timestamps inside the record, so it stays None for them.
+        let wal_timestamp = if let RecordValue::Lww { timestamp, .. } = value {
+            Some(timestamp.clone())
         } else {
-            // Non-LWW values (OrMap, OrTombstones) use a Store op with no timestamp.
-            let wal_op = WalOp::Store {
-                value: topgun_core::types::Value::Null,
-                expiration_time: if expiration_time == 0 {
-                    None
-                } else {
-                    Some(expiration_time)
-                },
-            };
-            (wal_op, None)
+            None
+        };
+        let wal_op = WalOp::Store {
+            value: WalStorePayload::Record(value.clone()),
+            expiration_time: if expiration_time == 0 {
+                None
+            } else {
+                Some(expiration_time)
+            },
         };
         let wal_entry = WalEntry {
             map: map.to_string(),
             key: key.to_string(),
-            op: wal_value_for_entry.0,
-            timestamp: wal_value_for_entry.1,
+            op: wal_op,
+            timestamp: wal_timestamp,
             sequence: wal_seq,
         };
         self.wal_append(partition_id, &wal_entry).await?;

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -153,7 +153,7 @@ pub fn estimated_cost(value: &RecordValue) -> u64 {
 ///
 /// Each variant corresponds to a different CRDT strategy. Serialized to
 /// `MsgPack` for persistence in the `MapDataStore` layer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum RecordValue {
     /// Last-Write-Wins value with HLC timestamp.
@@ -190,7 +190,7 @@ pub enum RecordValue {
 /// A single entry in an OR-Map record.
 ///
 /// Each entry carries a unique tag for observed-remove semantics.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrMapEntry {
     /// The actual data value.

--- a/packages/server-rust/src/storage/wal/format.rs
+++ b/packages/server-rust/src/storage/wal/format.rs
@@ -314,23 +314,28 @@ pub fn decode_all(data: &[u8]) -> FrameDecodeResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::wal::{WalEntry, WalOp};
+    use crate::storage::record::RecordValue;
+    use crate::storage::wal::{WalEntry, WalOp, WalStorePayload};
     use topgun_core::hlc::Timestamp;
     use topgun_core::types::Value;
 
     fn make_store_entry(seq: u64) -> WalEntry {
+        let timestamp = Timestamp {
+            millis: 1_700_000_000_000,
+            counter: 0,
+            node_id: "node1".to_string(),
+        };
         WalEntry {
             map: "test_map".to_string(),
             key: format!("key_{seq}"),
             op: WalOp::Store {
-                value: Value::String("hello".to_string()),
+                value: WalStorePayload::Record(RecordValue::Lww {
+                    value: Value::String("hello".to_string()),
+                    timestamp: timestamp.clone(),
+                }),
                 expiration_time: Some(1_700_000_000_000),
             },
-            timestamp: Some(Timestamp {
-                millis: 1_700_000_000_000,
-                counter: 0,
-                node_id: "node1".to_string(),
-            }),
+            timestamp: Some(timestamp),
             sequence: seq,
         }
     }

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -970,12 +970,11 @@ impl WalRecovery {
                         let record_value = match value {
                             WalStorePayload::Record(rv) => rv.clone(),
                             WalStorePayload::Legacy(v) => {
-                                let ts =
-                                    entry.timestamp.clone().unwrap_or_else(|| Timestamp {
-                                        millis: 0,
-                                        counter: 0,
-                                        node_id: String::new(),
-                                    });
+                                let ts = entry.timestamp.clone().unwrap_or_else(|| Timestamp {
+                                    millis: 0,
+                                    counter: 0,
+                                    node_id: String::new(),
+                                });
                                 RecordValue::Lww {
                                     value: v.clone(),
                                     timestamp: ts,

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -105,10 +105,13 @@ impl FromStr for WalFsyncPolicy {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum WalOp {
-    /// Upsert: the record value and its TTL expiration timestamp in milliseconds.
+    /// Upsert: the full CRDT record value and its TTL expiration timestamp in
+    /// milliseconds.
     Store {
-        /// The full CRDT value to persist.
-        value: Value,
+        /// The CRDT value to persist. Carries the full [`RecordValue`] so OR-Map
+        /// adds and tombstones survive `kill -9` recovery losslessly, while still
+        /// decoding the bare-`Value` shape written by older servers.
+        value: WalStorePayload,
         /// Wall-clock expiration time in milliseconds since epoch.
         /// Negative or zero means no expiration.
         #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -116,6 +119,28 @@ pub enum WalOp {
     },
     /// Tombstone: remove the record from the store.
     Remove,
+}
+
+/// Payload of a [`WalOp::Store`] frame.
+///
+/// Current servers write `Record(RecordValue)`, preserving the exact CRDT shape
+/// (LWW, OR-Map, or legacy OR tombstones). Older servers wrote a bare
+/// [`Value`] (and destroyed OR payloads as `Value::Null`); those frames still
+/// decode through the `Legacy` arm and replay as LWW.
+///
+/// The enum is `untagged` so the same `value` field decodes both shapes. A
+/// legacy frame's `value` holds an externally-tagged `Value` (e.g. `{"Int": …}`,
+/// or the bare string `"Null"`), whose tags are disjoint from the
+/// externally-tagged `RecordValue` tags (`lww`/`orMap`/`orTombstones`). The
+/// `Record` arm therefore rejects legacy frames and the `Legacy` arm accepts
+/// them, so the server never refuses to start on a pre-existing WAL.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WalStorePayload {
+    /// Full CRDT record value written by current servers.
+    Record(RecordValue),
+    /// Bare value written by older servers; replayed as an LWW record.
+    Legacy(Value),
 }
 
 // ---------------------------------------------------------------------------
@@ -936,18 +961,26 @@ impl WalRecovery {
                         value,
                         expiration_time,
                     } => {
-                        // Build a RecordValue from the WAL entry.  The timestamp
-                        // in the WAL entry is used when present; absent timestamps
-                        // (malformed/legacy frames) are treated as always-replay
-                        // by using a zero-epoch timestamp.
-                        let ts = entry.timestamp.clone().unwrap_or_else(|| Timestamp {
-                            millis: 0,
-                            counter: 0,
-                            node_id: String::new(),
-                        });
-                        let record_value = RecordValue::Lww {
-                            value: value.clone(),
-                            timestamp: ts,
+                        // Reconstruct the exact RecordValue. Current frames carry
+                        // the full value (LWW or OR), so OR-Map adds/tombstones
+                        // replay losslessly. Legacy frames carried a bare Value and
+                        // are replayed as LWW; an absent WAL timestamp (legacy/
+                        // malformed) becomes a zero-epoch timestamp so the inner
+                        // store treats the replay as always-merge.
+                        let record_value = match value {
+                            WalStorePayload::Record(rv) => rv.clone(),
+                            WalStorePayload::Legacy(v) => {
+                                let ts =
+                                    entry.timestamp.clone().unwrap_or_else(|| Timestamp {
+                                        millis: 0,
+                                        counter: 0,
+                                        node_id: String::new(),
+                                    });
+                                RecordValue::Lww {
+                                    value: v.clone(),
+                                    timestamp: ts,
+                                }
+                            }
                         };
                         inner_store
                             .add(
@@ -1149,18 +1182,22 @@ mod tests {
     }
 
     fn make_wal_entry(seq: u64) -> WalEntry {
+        let timestamp = Timestamp {
+            millis: seq,
+            counter: 0,
+            node_id: "n1".to_string(),
+        };
         WalEntry {
             map: "m".to_string(),
             key: format!("k{seq}"),
             op: WalOp::Store {
-                value: TgValue::String("v".to_string()),
+                value: WalStorePayload::Record(RecordValue::Lww {
+                    value: TgValue::String("v".to_string()),
+                    timestamp: timestamp.clone(),
+                }),
                 expiration_time: None,
             },
-            timestamp: Some(Timestamp {
-                millis: seq,
-                counter: 0,
-                node_id: "n1".to_string(),
-            }),
+            timestamp: Some(timestamp),
             sequence: seq,
         }
     }


### PR DESCRIPTION
## What

Repairs the write-behind WAL data flow so **acked OR-Map adds survive `kill -9`** in the WAL-only recovery window. The WAL was structurally LWW-only on both encode and replay:

- **Encode** (`write_behind.rs::add`): the non-LWW else-arm hard-coded `WalOp::Store { value: Value::Null }` — OR adds were durably recorded as `Null`.
- **Replay** (`wal/mod.rs WalRecovery::run`): every `WalOp::Store` was reconstructed unconditionally as `RecordValue::Lww`.
- **Type**: `WalOp::Store { value: Value }` (a bare scalar) was structurally unable to express an OR-Map.

⇒ On a crash in the WAL window, acked OR adds replayed as `Null`/LWW garbage — silent data loss.

## How

- `WalOp::Store.value` changes from bare `Value` to **`WalStorePayload`** — an `untagged` enum `Record(RecordValue) | Legacy(Value)`. The untagged arms have **disjoint serde tags** (camelCase `RecordValue`: `lww`/`orMap`/`orTombstones` vs PascalCase `Value`: `Null`/`Bool`/`Int`/`Map`/…), so new frames decode via `Record` and legacy bare-`Value` frames decode unambiguously via `Legacy`.
- `write_behind.rs::add` now encodes the full `RecordValue` for **all** variants.
- `WalRecovery::run` reconstructs the exact `RecordValue`; legacy frames replay as LWW with a zero-epoch timestamp when no WAL timestamp is present.
- **Backward-compat:** old WALs (bare `Value`, the pre-fix OR encoding being `Value::Null`) still decode and replay — the server never refuses to start.

## Tests

`storage/crash_safety_proptest.rs` (extends existing file — footprint stays at 5 Rust files):

- `ac2_wal_only_recovery_preserves_ormap_adds` — OR add through WriteBehind+WAL, crash (drop), `WalRecovery::run` into a fresh store, exact OR content recovers. Red-on-revert: pre-fix recovers `Lww(Null)`.
- `ac3_drained_redb_path_preserves_ormap_adds` — drained write-behind→redb path, reopen fresh redb, OR survives.
- `ac4_legacy_bare_value_wal_frame_replays_as_lww` — legacy frame, LWW replay, no refuse-to-start.
- **`ac4_legacy_null_value_wal_frame_replays_as_zero_epoch_lww`** — the *realistic* legacy OR frame (`Value::Null`, a unit variant, no timestamp) decodes through the untagged `Legacy` arm and replays zero-epoch. _(added from cross-vendor `/xreview`)_
- **`ac2_wal_only_recovery_preserves_ortombstones`** — `Record(OrTombstones)` round-trips losslessly. _(xreview)_
- **`ac4_mixed_legacy_and_record_frames_both_replay`** — legacy + new frames in one segment both replay. _(xreview)_

All 15 crash_safety tests green (debug); clippy + fmt clean. 48 CRDT merge tests green (add-wins / remove-wins / tombstone) — CRDT semantics unchanged.

## Review

- Fresh-context impl review: **APPROVED** (0 critical / 0 major / 0 minor).
- Cross-vendor `/xreview` (glm-5.2): **0 cardinal-rule violations**; 4 advisory test-coverage findings, 3 acted on (the 3 starred tests above), 1 rejected diff-grounded (NaN `PartialEq` — no test feeds `Value::Float`).

## Scope

- Ships **alone**. Server-internal WAL format only — **no** sync wire-protocol change, **no** TS/client change.
- **Out of scope:** the full soak `--or-churn` green (AC6/AC7) is held by **SPEC-333b** — a separate pre-crash concurrent-`OR_ADD` lost-update race (`crdt.rs` unlocked read-modify-write), proven independent of this WAL fix (identical 136-pair loss on `main` pre-fix and in both drain modes). 333b branches off `main` after this lands.
- Closes Cause 1 of the OR-Map crash-recovery data loss; the umbrella issue fully closes when 333b lands.