### PR TITLE
fix(sf-333b): OR-Map soak acked-add loss — harness comparator defect, not durability bug

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -455,7 +455,7 @@ jobs:
         run: |
           ${{ steps.soak.outputs.bin }} \
             --duration 25 --crash-interval 0 --steady-interval 6 \
-            --churn-clients 6 --keyspace 48 --quiesce 3 \
+            --churn-clients 6 --keyspace 48 --or-keyspace 48 --quiesce 3 \
             --json-output soak-smoke.json
           jq -e '.passed == true' soak-smoke.json >/dev/null \
             || { echo "FAIL: no-crash soak did not pass"; cat soak-smoke.json; exit 1; }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -474,8 +474,22 @@ jobs:
           OUT=$(${{ steps.soak.outputs.bin }} \
             --duration 30 --crash-interval 9 --or-churn true --or-every 3)
           echo "$OUT"
+          # Real OR durability loss.
           if echo "$OUT" | grep -q "OR-Map acked add(s) LOST across recovery"; then
             echo "FAIL: acked OR-Map add(s) lost across crash recovery"
+            exit 1
+          fi
+          # The OR check errored (post-recovery read failed) — a real loss could
+          # hide behind it (it could even be the cause), so do not treat as green.
+          if echo "$OUT" | grep -q "OR-Map no-loss check could not complete"; then
+            echo "FAIL: OR-Map no-loss check could not complete"
+            exit 1
+          fi
+          # Positive assertion that the OR check actually RAN. Without it, a crash or
+          # early exit before the recovery check prints neither failure string, and
+          # grepping for absence-of-loss alone would be vacuously green.
+          if ! echo "$OUT" | grep -q "OR-Map no-loss check: PASS"; then
+            echo "FAIL: OR-Map no-loss check did not run (no PASS marker — crash/early-exit?)"
             exit 1
           fi
           echo "OK: no OR-Map acked-add loss across recovery"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -461,6 +461,25 @@ jobs:
             || { echo "FAIL: no-crash soak did not pass"; cat soak-smoke.json; exit 1; }
           echo "OK: no-crash soak passed"
 
+      - name: OR-churn crash soak — acked OR adds must NOT be lost across recovery
+        run: |
+          # Gate the OR-Map directional no-loss invariant under kill -9 + OR churn.
+          # We assert ONLY the absence of the OR loss signature, not the full
+          # `passed == true`: a loaded with-crash soak can still RED on the open LWW
+          # ack-before-durable window (TODO-546), which is a separate known-open
+          # critical, not an OR regression. Coupling this step to `passed == true`
+          # would just re-report TODO-546 and flap. The OR no-loss line is the
+          # regression signal owned here.
+          set +e
+          OUT=$(${{ steps.soak.outputs.bin }} \
+            --duration 30 --crash-interval 9 --or-churn true --or-every 3)
+          echo "$OUT"
+          if echo "$OUT" | grep -q "OR-Map acked add(s) LOST across recovery"; then
+            echo "FAIL: acked OR-Map add(s) lost across crash recovery"
+            exit 1
+          fi
+          echo "OK: no OR-Map acked-add loss across recovery"
+
       - name: Upload soak smoke report
         if: always()
         uses: actions/upload-artifact@v4

--- a/packages/server-rust/benches/soak_harness/client.rs
+++ b/packages/server-rust/benches/soak_harness/client.rs
@@ -32,7 +32,7 @@ use topgun_core::messages::{
     SyncInitMessage, WriteConcern,
 };
 
-use crate::or_noloss::observed_tags;
+use crate::or_noloss::observed_values;
 
 type Ws = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 
@@ -130,11 +130,12 @@ impl SoakClient {
         map: &str,
         key: &str,
         tag: &str,
+        value: i64,
         millis: u64,
         counter: u32,
     ) -> Result<()> {
         let or_record = ORMapRecord {
-            value: rmpv::Value::from(counter),
+            value: rmpv::Value::from(value),
             timestamp: Timestamp {
                 millis,
                 counter,
@@ -287,16 +288,22 @@ impl SoakClient {
         Ok(out)
     }
 
-    /// Reconstruct every OR-Map key's **observed tag set** (active record tags
-    /// minus tombstone tags) for `map` by walking the server's OR-Map Merkle tree
-    /// the way a reconnecting OR-Map sync client does: `ORMAP_SYNC_INIT` root →
-    /// `ORMAP_MERKLE_REQ_BUCKET` aggregate-mode drill-down → `ORMAP_SYNC_RESP_LEAF`.
-    /// This is the OR-Map analogue of `delta_sync_all`: it proves the durable
-    /// OR-Map content can be pulled back after a crash, not merely that a root
-    /// hash matched. Reuses the existing OR-Map sync protocol — no new wire type.
+    /// Reconstruct every OR-Map key's **observed value set** (the rendered value
+    /// of each active, non-tombstoned record) for `map` by walking the server's
+    /// OR-Map Merkle tree the way a reconnecting OR-Map sync client does:
+    /// `ORMAP_SYNC_INIT` root → `ORMAP_MERKLE_REQ_BUCKET` aggregate-mode drill-down
+    /// → `ORMAP_SYNC_RESP_LEAF`. This is the OR-Map analogue of `delta_sync_all`:
+    /// it proves the durable OR-Map content can be pulled back after a crash, not
+    /// merely that a root hash matched. Reuses the existing OR-Map sync protocol —
+    /// no new wire type.
+    ///
+    /// The set is keyed on record VALUE rather than tag because the server
+    /// re-stamps every OR add's HLC and regenerates the tag from it, so the client
+    /// tag is never the persisted identity; the value is stored verbatim and is the
+    /// identity that survives sanitization and crash recovery (see `observed_values`).
     ///
     /// Keys whose observed set is empty (e.g. a fully-tombstoned churn key) are
-    /// omitted; only keys with at least one observed tag appear in the result.
+    /// omitted; only keys with at least one observed value appear in the result.
     pub async fn ormap_read_all(&mut self, map: &str) -> Result<HashMap<String, HashSet<String>>> {
         let mut out: HashMap<String, HashSet<String>> = HashMap::new();
 
@@ -347,7 +354,11 @@ impl SoakClient {
                 }
                 Message::ORMapSyncRespLeaf(l) => {
                     for entry in l.payload.entries {
-                        let observed = observed_tags(&entry);
+                        // Key the recovered set on record VALUE, not tag: the server
+                        // re-stamps each OR add's HLC and regenerates the tag from it,
+                        // so the client tag is never the persisted identity. The value
+                        // is stored verbatim and is what the no-loss ledger reconciles.
+                        let observed = observed_values(&entry);
                         if !observed.is_empty() {
                             out.entry(entry.key).or_default().extend(observed);
                         }

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -223,6 +223,25 @@ async fn run_soak(config: &Config) -> i32 {
         config.or_churn,
     );
 
+    // Single-writer-per-persist-key invariant. The persistent OR keyspace maps
+    // slot `i` to `ork-persist-{i % or_keyspace}` and slot `i` is owned solely by
+    // churn client `i % churn_clients`. Two distinct clients share a persist
+    // bucket only if some owned slots collide under `% or_keyspace` without
+    // colliding under `% churn_clients` — impossible exactly when
+    // `churn_clients | or_keyspace`. A config that breaks this (e.g.
+    // `--churn-clients 16 --or-keyspace 24`) would make the persist keyspace
+    // multi-writer and invalidate the no-loss check's single-writer premise, so
+    // fail loudly rather than silently degrade the gate.
+    if config.or_churn {
+        assert!(
+            config.or_keyspace.is_multiple_of(config.churn_clients),
+            "or_keyspace ({}) must be a multiple of churn_clients ({}) to keep the \
+             persistent OR keyspace single-writer-per-key",
+            config.or_keyspace,
+            config.churn_clients,
+        );
+    }
+
     let binary = resolve_server_binary();
 
     // Persistent on-disk data dir. A caller-supplied dir survives the run for
@@ -966,7 +985,14 @@ async fn run_churn_client(idx: usize, ctx: ChurnCtx) {
             if ctx.or_churn && write_count.is_multiple_of(ctx.or_every) {
                 let or_key = format!("ork-{}", slot % ctx.or_keyspace.max(1));
                 let tag = format!("{ms}:{ctr}:{idx}");
-                if client.or_add(OR_MAP, &or_key, &tag, ms, ctr).await.is_ok() {
+                // Churn value is irrelevant — this stream is add-then-remove and is
+                // excluded from the no-loss ledger; only its tombstone growth matters.
+                let churn_value = i64::from(ctr);
+                if client
+                    .or_add(OR_MAP, &or_key, &tag, churn_value, ms, ctr)
+                    .await
+                    .is_ok()
+                {
                     if client.or_remove(OR_MAP, &or_key, &tag).await.is_err() {
                         session_alive = false;
                         break;
@@ -984,16 +1010,25 @@ async fn run_churn_client(idx: usize, ctx: ChurnCtx) {
                 // bound over a long soak.
                 let persist_key = format!("ork-persist-{}", slot % ctx.or_keyspace.max(1));
                 let persist_tag = format!("pt-{idx}-{slot}");
+                // The no-loss ledger keys on the record VALUE, not the tag: the
+                // server re-stamps every OR add's HLC and regenerates the tag from
+                // it, so the client tag is never the persisted identity. The value
+                // is stored verbatim, so a stable unique value per (idx, slot)
+                // gives an identity that survives sanitization and crash recovery.
+                // `idx`<churn_clients and `slot`<keyspace, so this is collision-free
+                // across clients and slots and stable across re-adds of the slot.
+                let persist_value = (idx as i64) * 1_000_000 + slot as i64;
                 let (pms, pctr) = next_stamp();
                 if client
-                    .or_add(OR_MAP, &persist_key, &persist_tag, pms, pctr)
+                    .or_add(OR_MAP, &persist_key, &persist_tag, persist_value, pms, pctr)
                     .await
                     .is_ok()
                 {
                     // Ledger updated ONLY on ack: an add whose ack never returned
                     // is never recorded, so a kill-window drop of an unacked add is
                     // not miscounted as loss.
-                    ctx.or_ledger.record_add(&persist_key, &persist_tag);
+                    ctx.or_ledger
+                        .record_add(&persist_key, &persist_value.to_string());
                 } else {
                     session_alive = false;
                     break;

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -233,6 +233,14 @@ async fn run_soak(config: &Config) -> i32 {
     // multi-writer and invalidate the no-loss check's single-writer premise, so
     // fail loudly rather than silently degrade the gate.
     if config.or_churn {
+        // `or_keyspace == 0` would make `is_multiple_of` vacuously true while every
+        // `slot % or_keyspace.max(1)` collapses to a single multi-writer persist key,
+        // defeating the single-writer premise the assert exists to protect. Require a
+        // positive keyspace explicitly.
+        assert!(
+            config.or_keyspace > 0,
+            "or_keyspace must be > 0 when or_churn is enabled"
+        );
         assert!(
             config.or_keyspace.is_multiple_of(config.churn_clients),
             "or_keyspace ({}) must be a multiple of churn_clients ({}) to keep the \
@@ -856,7 +864,18 @@ async fn recovery_checkpoint(
         match v.ormap_read_all(OR_MAP).await {
             Ok(post_observed) => {
                 let missing = missing_acked_adds(&acked, &post_observed);
-                if !missing.is_empty() {
+                if missing.is_empty() {
+                    // Positive completion marker. A CI gate that only greps for the
+                    // LOST signature is false-green if the check never reaches this
+                    // point (crash, early exit, or the read-failed HARD below): the
+                    // absence of a failure string is indistinguishable from "did not
+                    // run". Emit a PASS line the gate can positively assert ran.
+                    let acked_count: usize =
+                        acked.values().map(std::collections::HashSet::len).sum();
+                    println!(
+                        "OR-Map no-loss check: PASS — {acked_count} acked add(s) verified across recovery"
+                    );
+                } else {
                     out.hard.push(format!(
                         "OR-Map acked add(s) LOST across recovery: {} (key,tag) pair(s) (e.g. {})",
                         missing.len(),

--- a/packages/server-rust/benches/soak_harness/or_noloss.rs
+++ b/packages/server-rust/benches/soak_harness/or_noloss.rs
@@ -96,8 +96,19 @@ impl OrLedger {
 /// The persistent keyspace therefore writes a stable unique value per owned slot
 /// and the ledger reconciles on that value.
 ///
-/// A tombstoned tag's value is excluded — a removed record is no longer observed,
-/// mirroring [`observed_tags`].
+/// A tombstoned tag's value is excluded — a removed record is no longer observed.
+///
+/// ## Coverage limit: per-value, not per-add
+///
+/// The server dedups OR records by tag and stamps a fresh tag on every add, so N
+/// re-adds of the same `(key, value)` are stored as N distinct records. This set
+/// collapses them to one element, and the ledger likewise records the value once.
+/// The check therefore verifies that each acked VALUE survives recovery, not that
+/// each individual acked ADD does: losing M of N re-adds of the same value while
+/// at least one survives is not detected. The persistent keyspace writes one stable
+/// unique value per owned slot, so per-slot durability IS covered; closing the
+/// per-add gap needs the server-regenerated tag surfaced to the client (tracked in
+/// TODO-558), which is out of scope here.
 pub fn observed_values(entry: &ORMapEntry) -> HashSet<String> {
     let tombstones: HashSet<&str> = entry.tombstones.iter().map(String::as_str).collect();
     entry
@@ -112,10 +123,19 @@ pub fn observed_values(entry: &ORMapEntry) -> HashSet<String> {
 /// Integer values (the soak's persistent-keyspace shape) render to their decimal
 /// form; any other shape falls back to its debug rendering so the check still has
 /// a deterministic, comparable identity.
+///
+/// Both `as_i64` and `as_u64` are tried so a positive integer that msgpack
+/// round-trips as an unsigned variant still renders to the same decimal string the
+/// ledger recorded — otherwise the debug fallback (`UInt(42)` vs `42`) would make
+/// the check falsely RED (fail-closed, but flaky).
 pub fn render_value(value: &rmpv::Value) -> String {
-    value
-        .as_i64()
-        .map_or_else(|| format!("{value:?}"), |n| n.to_string())
+    if let Some(n) = value.as_i64() {
+        return n.to_string();
+    }
+    if let Some(n) = value.as_u64() {
+        return n.to_string();
+    }
+    format!("{value:?}")
 }
 
 /// Directional OR-Map no-loss diff: every acked (net-present) OR add tag must

--- a/packages/server-rust/benches/soak_harness/or_noloss.rs
+++ b/packages/server-rust/benches/soak_harness/or_noloss.rs
@@ -80,18 +80,42 @@ impl OrLedger {
     }
 }
 
-/// The observed tag set for one OR-Map sync leaf entry: active record tags MINUS
-/// tombstone tags. This is the user-visible OR-Map content for the key — a tag
-/// that has been tombstoned is no longer observed.
-pub fn observed_tags(entry: &ORMapEntry) -> HashSet<String> {
+/// The observed **value** set for one OR-Map sync leaf entry: the rendered
+/// `value` of every non-tombstoned active record.
+///
+/// ## Why the no-loss ledger must key on value, not tag
+///
+/// The server re-stamps every OR add's HLC (security: a forged client HLC must
+/// not win a future conflict) and, because the OR tag is derived from that HLC
+/// (`{millis}:{counter}:{node_id}`), it regenerates the tag as well. So the tag
+/// the *client* chose for an add is never the tag the server persists — keying a
+/// directional no-loss check on the client tag makes it vacuously red (the
+/// client tag is structurally absent from every recovered record). The record
+/// `value`, by contrast, is client-supplied and the server stores it verbatim,
+/// so it is the identity that actually survives sanitization and crash recovery.
+/// The persistent keyspace therefore writes a stable unique value per owned slot
+/// and the ledger reconciles on that value.
+///
+/// A tombstoned tag's value is excluded — a removed record is no longer observed,
+/// mirroring [`observed_tags`].
+pub fn observed_values(entry: &ORMapEntry) -> HashSet<String> {
     let tombstones: HashSet<&str> = entry.tombstones.iter().map(String::as_str).collect();
     entry
         .records
         .iter()
-        .map(|r| r.tag.as_str())
-        .filter(|tag| !tombstones.contains(tag))
-        .map(ToString::to_string)
+        .filter(|r| !tombstones.contains(r.tag.as_str()))
+        .map(|r| render_value(&r.value))
         .collect()
+}
+
+/// Render an OR record `value` to the stable string identity the ledger keys on.
+/// Integer values (the soak's persistent-keyspace shape) render to their decimal
+/// form; any other shape falls back to its debug rendering so the check still has
+/// a deterministic, comparable identity.
+pub fn render_value(value: &rmpv::Value) -> String {
+    value
+        .as_i64()
+        .map_or_else(|| format!("{value:?}"), |n| n.to_string())
 }
 
 /// Directional OR-Map no-loss diff: every acked (net-present) OR add tag must

--- a/packages/server-rust/tests/soak_or_noloss.rs
+++ b/packages/server-rust/tests/soak_or_noloss.rs
@@ -99,10 +99,13 @@ async fn observed_values_is_active_minus_tombstones() {
 // soak's 136-pair "loss"). Keying on the record VALUE, which the server stores
 // verbatim, makes the check honest: the acked value is present, so ZERO loss.
 //
-// RED-ON-REVERT: reverting `ormap_read_all` to key the observed set on tag (the
-// pre-fix behaviour) makes `observed` carry server-stamped tag strings that share
-// no element with the value-keyed ledger, so this assertion fails (reports the
-// acked values as missing).
+// RED-ON-REVERT: this test drives `observed_values` directly (not `ormap_read_all`),
+// so it guards the comparator's value-keying semantics independent of the call site.
+// Reverting `observed_values` to return record tags makes `observed` carry
+// server-stamped tag strings that share no element with the value-keyed ledger, so
+// the first assertion below fails. The explicit `observed_by_tag` comparison at the
+// end separately encodes the 100% false-loss the pre-fix tag-keyed call site produced
+// (`false_loss.len() == 3`), pinning the defect regardless of which surface reverts.
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]

--- a/packages/server-rust/tests/soak_or_noloss.rs
+++ b/packages/server-rust/tests/soak_or_noloss.rs
@@ -7,12 +7,21 @@
 //! comparator reddens here), this integration test pulls that module in directly
 //! via `#[path]` and tests the real functions.
 //!
-//! The load-bearing property: `missing_acked_adds` is a directional subset check
-//! (`acked ⊆ observed`). A dropped acked add must be reported (RED); a
-//! "recovered-more" observed set (extra tags/keys/tombstones not in the ledger)
-//! must NOT be reported (GREEN). Reverting the comparator to equality — or
-//! flipping the subset direction — turns the recovered-more case RED, which is
-//! precisely the regression these tests guard.
+//! Two load-bearing properties:
+//!
+//! 1. **Directional subset.** `missing_acked_adds` is `acked ⊆ observed`. A
+//!    dropped acked add must be reported (RED); a "recovered-more" observed set
+//!    (extra identities/keys not in the ledger) must NOT be reported (GREEN).
+//!    Reverting the comparator to equality — or flipping the subset direction —
+//!    turns the recovered-more case RED.
+//!
+//! 2. **Value-keyed identity (not tag).** The server re-stamps every OR add's HLC
+//!    and regenerates the tag from it, so the client tag is never the persisted
+//!    identity; the record VALUE is stored verbatim. `observed_values` therefore
+//!    keys the recovered set on value, and the ledger records the value. Reverting
+//!    that to a tag-keyed observed set makes every server-re-stamped record's tag
+//!    structurally absent from the ledger — i.e. a vacuous 100% false loss — which
+//!    `value_identity_survives_server_tag_rewrite` below catches.
 
 #[path = "../benches/soak_harness/or_noloss.rs"]
 mod or_noloss;
@@ -20,13 +29,16 @@ mod or_noloss;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use or_noloss::{missing_acked_adds, observed_tags, OrLedger};
+use or_noloss::{missing_acked_adds, observed_values, render_value, OrLedger};
 use topgun_core::hlc::{ORMapRecord, Timestamp};
 use topgun_core::messages::ORMapEntry;
 
-fn record(tag: &str) -> ORMapRecord<rmpv::Value> {
+/// Build an OR record carrying an explicit integer `value` and `tag`. The soak's
+/// persistent keyspace stores a stable unique integer value per slot; the tag is
+/// whatever the server re-stamped it to.
+fn record_v(tag: &str, value: i64) -> ORMapRecord<rmpv::Value> {
     ORMapRecord {
-        value: rmpv::Value::from(1),
+        value: rmpv::Value::from(value),
         timestamp: Timestamp {
             millis: 1,
             counter: 1,
@@ -37,88 +49,160 @@ fn record(tag: &str) -> ORMapRecord<rmpv::Value> {
     }
 }
 
-fn entry(key: &str, active: &[&str], tombstones: &[&str]) -> ORMapEntry {
+/// An OR-Map leaf entry from `(tag, value)` active records and tombstone tags.
+fn entry_v(key: &str, active: &[(&str, i64)], tombstones: &[&str]) -> ORMapEntry {
     ORMapEntry {
         key: key.to_string(),
-        records: active.iter().map(|t| record(t)).collect(),
+        records: active.iter().map(|(t, v)| record_v(t, *v)).collect(),
         tombstones: tombstones.iter().map(ToString::to_string).collect(),
     }
 }
 
-fn set(tags: &[&str]) -> HashSet<String> {
-    tags.iter().map(ToString::to_string).collect()
+fn set(items: &[&str]) -> HashSet<String> {
+    items.iter().map(ToString::to_string).collect()
 }
 
 // ---------------------------------------------------------------------------
-// AC2 — observed-set parse: active record tags MINUS tombstone tags.
+// observed_values: active record values MINUS tombstoned ones.
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]
-async fn observed_tags_is_active_minus_tombstones() {
-    // Add-only (persistent keyspace shape): all active tags observed.
+async fn observed_values_is_active_minus_tombstones() {
+    // Add-only (persistent keyspace shape): all active values observed, keyed on
+    // VALUE regardless of what tag the server stamped.
     assert_eq!(
-        observed_tags(&entry("k", &["a", "b"], &[])),
-        set(&["a", "b"])
+        observed_values(&entry_v("k", &[("srv-tag-a", 10), ("srv-tag-b", 20)], &[])),
+        set(&["10", "20"])
     );
-    // Mixed: a tombstoned tag is suppressed; the rest remain observed.
+    // Mixed: the record whose TAG is tombstoned is suppressed; its value drops.
     assert_eq!(
-        observed_tags(&entry("k", &["a", "b", "c"], &["b"])),
-        set(&["a", "c"])
+        observed_values(&entry_v(
+            "k",
+            &[("ta", 10), ("tb", 20), ("tc", 30)],
+            &["tb"]
+        )),
+        set(&["10", "30"])
     );
     // Fully tombstoned (churn keyspace end-state): observed set is empty.
-    assert!(observed_tags(&entry("k", &["a"], &["a"])).is_empty());
+    assert!(observed_values(&entry_v("k", &[("ta", 10)], &["ta"])).is_empty());
     // Tombstone for a tag with no active record: still empty, no panic.
-    assert!(observed_tags(&entry("k", &[], &["ghost"])).is_empty());
+    assert!(observed_values(&entry_v("k", &[], &["ghost"])).is_empty());
 }
 
 // ---------------------------------------------------------------------------
-// AC3 — directional no-loss comparator, red-on-revert.
+// AC2 — the real defect: value identity survives the server's OR tag rewrite.
+//
+// The server re-stamps every OR add's HLC and regenerates the tag as
+// `{millis}:{counter}:{node_id}`, discarding the client tag. A no-loss check
+// keyed on the CLIENT tag therefore reports every acked persist add as lost even
+// though the record is durably present — a vacuous 100% false loss (the original
+// soak's 136-pair "loss"). Keying on the record VALUE, which the server stores
+// verbatim, makes the check honest: the acked value is present, so ZERO loss.
+//
+// RED-ON-REVERT: reverting `ormap_read_all` to key the observed set on tag (the
+// pre-fix behaviour) makes `observed` carry server-stamped tag strings that share
+// no element with the value-keyed ledger, so this assertion fails (reports the
+// acked values as missing).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn value_identity_survives_server_tag_rewrite() {
+    // Ledger keys on the client-chosen stable value per slot.
+    let acked: HashMap<String, HashSet<String>> =
+        HashMap::from([("ork-persist-0".to_string(), set(&["0", "32", "64"]))]);
+
+    // Server-recovered leaf: the records carry SERVER-REGENERATED tags
+    // (`{ms}:{ctr}:node`), nothing like the client `pt-*` tags — but their VALUES
+    // are exactly the client-supplied stable values, stored verbatim. There are
+    // also EXTRA records (re-adds re-stamped under fresh tags) — recovered-more.
+    let leaf = entry_v(
+        "ork-persist-0",
+        &[
+            ("1782824961438:0:topgun-server-node", 0),
+            ("1782824962944:1:topgun-server-node", 32),
+            ("1782824965074:2:topgun-server-node", 64),
+            // recovered-more: a re-add of slot 0 under a fresh server tag.
+            ("1782824969094:3:topgun-server-node", 0),
+        ],
+        &[],
+    );
+    let observed: HashMap<String, HashSet<String>> =
+        HashMap::from([("ork-persist-0".to_string(), observed_values(&leaf))]);
+
+    // The value-keyed observed set contains every acked value — ZERO loss.
+    let missing = missing_acked_adds(&acked, &observed);
+    assert!(
+        missing.is_empty(),
+        "value-keyed no-loss must see every acked value despite the server tag \
+         rewrite, got {missing:?}"
+    );
+
+    // Sanity: a TAG-keyed observed set (the reverted behaviour) shares nothing
+    // with the value ledger, so the same comparator would falsely report loss.
+    let tag_keyed: HashSet<String> = leaf.records.iter().map(|r| r.tag.clone()).collect();
+    let observed_by_tag: HashMap<String, HashSet<String>> =
+        HashMap::from([("ork-persist-0".to_string(), tag_keyed)]);
+    let false_loss = missing_acked_adds(&acked, &observed_by_tag);
+    assert_eq!(
+        false_loss.len(),
+        3,
+        "the reverted tag-keyed check would falsely report every acked value lost"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn render_value_is_stable_decimal_for_integers() {
+    assert_eq!(render_value(&rmpv::Value::from(0)), "0");
+    assert_eq!(render_value(&rmpv::Value::from(1_000_000_i64)), "1000000");
+    assert_eq!(render_value(&rmpv::Value::from(-5_i64)), "-5");
+}
+
+// ---------------------------------------------------------------------------
+// Directional no-loss comparator, red-on-revert (preserved from SPEC-332).
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]
 async fn dropped_acked_add_is_reported_as_loss() {
-    // Ledger required tag `t1` under key `k`; recovery observed nothing for `k`.
-    let acked: HashMap<String, HashSet<String>> = HashMap::from([("k".to_string(), set(&["t1"]))]);
+    // Ledger required value `10` under key `k`; recovery observed nothing for `k`.
+    let acked: HashMap<String, HashSet<String>> = HashMap::from([("k".to_string(), set(&["10"]))]);
     let observed: HashMap<String, HashSet<String>> = HashMap::new();
 
     let missing = missing_acked_adds(&acked, &observed);
-    assert_eq!(missing, vec![("k".to_string(), "t1".to_string())]);
+    assert_eq!(missing, vec![("k".to_string(), "10".to_string())]);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn partial_drop_reports_only_the_missing_tag() {
+async fn partial_drop_reports_only_the_missing_value() {
     let acked: HashMap<String, HashSet<String>> =
-        HashMap::from([("k".to_string(), set(&["t1", "t2"]))]);
-    // `t1` survived; `t2` was lost.
+        HashMap::from([("k".to_string(), set(&["10", "20"]))]);
+    // `10` survived; `20` was lost.
     let observed: HashMap<String, HashSet<String>> =
-        HashMap::from([("k".to_string(), set(&["t1"]))]);
+        HashMap::from([("k".to_string(), set(&["10"]))]);
 
     let missing = missing_acked_adds(&acked, &observed);
-    assert_eq!(missing, vec![("k".to_string(), "t2".to_string())]);
+    assert_eq!(missing, vec![("k".to_string(), "20".to_string())]);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn recovered_more_does_not_redden() {
     // The benign WAL-replay asymmetry: every acked add survived, AND recovery
-    // surfaced EXTRA tags/keys not in the ledger (the churn keyspace's replayed
-    // intermediate tags). A directional superset check must treat this as no loss.
+    // surfaced EXTRA values/keys not in the ledger (the churn keyspace's replayed
+    // intermediate records). A directional superset check must treat this as no
+    // loss.
     //
     // This is the red-on-revert guard: reverting `missing_acked_adds` to equality
     // (also reporting `observed`'s extras) — or flipping the subset direction —
     // makes this assertion fail.
     let acked: HashMap<String, HashSet<String>> = HashMap::from([
-        ("persist-0".to_string(), set(&["pa", "pb"])),
-        ("persist-1".to_string(), set(&["pc"])),
+        ("persist-0".to_string(), set(&["10", "20"])),
+        ("persist-1".to_string(), set(&["30"])),
     ]);
     let observed: HashMap<String, HashSet<String>> = HashMap::from([
-        // Same ledgered tags PLUS an extra recovered tag on the same key.
-        (
-            "persist-0".to_string(),
-            set(&["pa", "pb", "extra-replayed"]),
-        ),
-        ("persist-1".to_string(), set(&["pc"])),
+        // Same ledgered values PLUS an extra recovered value on the same key.
+        ("persist-0".to_string(), set(&["10", "20", "999"])),
+        ("persist-1".to_string(), set(&["30"])),
         // An entirely extra key the ledger never tracked (churn-keyspace replay).
-        ("ork-7".to_string(), set(&["churn-tag"])),
+        ("ork-7".to_string(), set(&["7777"])),
     ]);
 
     let missing = missing_acked_adds(&acked, &observed);
@@ -132,7 +216,7 @@ async fn recovered_more_does_not_redden() {
 async fn empty_ledger_never_reports_loss() {
     let acked: HashMap<String, HashSet<String>> = HashMap::new();
     let observed: HashMap<String, HashSet<String>> =
-        HashMap::from([("anything".to_string(), set(&["x"]))]);
+        HashMap::from([("anything".to_string(), set(&["1"]))]);
     assert!(missing_acked_adds(&acked, &observed).is_empty());
 }
 
@@ -145,18 +229,15 @@ async fn ledger_records_only_what_was_added_and_is_concurrency_safe() {
     let ledger = Arc::new(OrLedger::new());
     assert!(ledger.is_empty());
 
-    // Concurrent churn clients recording acked adds on shared + distinct keys.
+    // Concurrent churn clients recording acked adds (by stable value) on shared +
+    // distinct keys — the persistent-keyspace shape.
     let mut handles = Vec::new();
     for client in 0..8u32 {
         let ledger = Arc::clone(&ledger);
         handles.push(tokio::spawn(async move {
             for slot in 0..16u32 {
-                // Shared key across clients (different tags), distinct tag per
-                // (client, slot) — the persistent-keyspace shape.
-                ledger.record_add(
-                    &format!("persist-{}", slot % 4),
-                    &format!("pt-{client}-{slot}"),
-                );
+                let value = i64::from(client) * 1_000_000 + i64::from(slot);
+                ledger.record_add(&format!("persist-{}", slot % 4), &value.to_string());
             }
         }));
     }
@@ -166,10 +247,10 @@ async fn ledger_records_only_what_was_added_and_is_concurrency_safe() {
 
     let snap = ledger.snapshot();
     assert!(!ledger.is_empty());
-    // 4 persistent keys; every (client, slot) tag landed exactly once.
+    // 4 persistent keys; every (client, slot) value landed exactly once.
     assert_eq!(snap.len(), 4);
-    let total_tags: usize = snap.values().map(HashSet::len).sum();
-    assert_eq!(total_tags, 8 * 16);
+    let total_values: usize = snap.values().map(HashSet::len).sum();
+    assert_eq!(total_values, 8 * 16);
 
     // And the directional check passes when observed exactly mirrors the ledger.
     assert!(missing_acked_adds(&snap, &snap).is_empty());


### PR DESCRIPTION
## What

SPEC-333b — closes the last TODO-557 gate (OR-Map crash-recovery). Part 2 of 2 (333a merged in #99).

**Key finding:** the "136-pair OR-Map acked-add LOST" soak signal was a **harness comparator defect**, NOT a server durability bug. The no-loss check keyed on the client-chosen OR tag (`pt-{idx}-{slot}`), which the server structurally replaces via HLC sanitization at `service/domain/crdt.rs:454` (anti-forgery since `sf-071`). So the recovered server tags (`{ms}:{ctr}:node`) shared zero elements with the ledger ⇒ vacuous 100% false loss. The OR records were durably stored and faithfully recovered the whole time.

**There is no OR-Map crash-recovery data-loss.** The refuted concurrent-RMW-race framing is recorded as refuted; no per-key lock added.

## Changes (harness / test / CI only — no server source)

- `benches/soak_harness/or_noloss.rs` — value-keyed identity (`observed_values`/`render_value`) replacing server-rewritten-tag keying.
- `benches/soak_harness/client.rs` — `or_add` takes explicit `value`; `ormap_read_all` reconciles on `observed_values`.
- `benches/soak_harness/main.rs` — value ledger per `(idx,slot)`; `or_keyspace % churn_clients == 0` + `or_keyspace > 0` single-writer-invariant asserts.
- `tests/soak_or_noloss.rs` — value-keyed comparator + AC2 `value_identity_survives_server_tag_rewrite` red-on-revert.
- `.github/workflows/rust.yml` — blocking OR-churn-crash no-loss gate with a three-signal check (fail on LOST, on "could not complete", on absence of positive `PASS` marker — closes the vacuous-green hole).

Rust-file footprint = 4 ≤ 5 (Language Profile).

## Verification

- `soak_or_noloss` 8/8 green debug + release; build + clippy (`--benches --tests --all-features`) + fmt clean.
- Drained soak: 12 consecutive runs, ZERO OR loss. No-drain soak: 5/5, ZERO OR loss.
- 1527 lib tests green (release); OR-Map algebra untouched.
- Fresh-context impl-reviewer: APPROVED (0 critical / 0 major / 0 minor), independent gate re-run.
- Cross-vendor: `/xask` + `/xreview` (glm-5.2) — HIGH vacuous-green CI finding fixed; all findings adjudicated.

## Follow-up

TODO-558 — server re-stamps OR tags, so a client can't reference its own just-added tag for a targeted `or_remove` without learning the server tag from the OR_ADD broadcast. DX/API-contract question, not a durability bug. Not addressed here.

## Merge policy

Ships ALONE. Merge ONLY on green blocking CI (full pnpm gate + Rust `Check & Lint` DEBUG `--all-targets` + `integration-rust`).
