### PR TITLE
fix(sf-336): per-write identity token for mark_stored — close ms-tie false-clean window

### DIFF
--- a/packages/server-rust/src/storage/engine.rs
+++ b/packages/server-rust/src/storage/engine.rs
@@ -62,27 +62,23 @@ pub trait StorageEngine: Send + Sync + 'static {
     /// `put()`, and the value is never re-put, so a concurrent same-key write
     /// can be neither clobbered nor lost.
     ///
-    /// The mark is applied only when `last_update_time <= now`. This is a
-    /// best-effort, timestamp-based guard — NOT a per-write identity check. It
-    /// reliably leaves a *strictly newer* write (`last_update_time > now`)
-    /// dirty, but it does not distinguish the caller's own write from a
-    /// concurrent same-key write carrying an equal-millisecond timestamp. Under
-    /// two concurrent puts to the same key in the same millisecond, this can
-    /// transiently mark the *other* writer's not-yet-durable record clean (hence
-    /// evictable) before that writer's own persist completes.
+    /// The mark is applied only when the resident record's `write_token` equals
+    /// the caller's `token` — a per-write identity check. This guarantees the
+    /// mark applies only when the resident record is the exact write the caller
+    /// just persisted. A concurrent same-key write (any timestamp, equal or
+    /// newer) carries a different token and is left dirty until its own persist
+    /// completes. Two concurrent puts to the same key in the same millisecond
+    /// therefore never prematurely mark each other clean.
     ///
-    /// That window is bounded and self-healing: the other writer's persist runs
-    /// to completion independently of any eviction (eviction only drops the
-    /// in-memory copy, it does not cancel an in-flight write), and
-    /// `RecordStore::put` acks only after its own persist returns — so no
-    /// acked-durable write is ever lost. It is the same class as the engine's
-    /// existing last-writer-wins blind clobber on concurrent same-key writes.
-    /// True per-write identity marking (`mark_stored(key, now, token)`) is left
-    /// to a tracked follow-up.
+    /// `now` is retained: on a successful match, `on_store(now)` stamps
+    /// `last_stored_time = now` for `is_dirty()` bookkeeping. The token
+    /// identifies the write just persisted, whether a direct `put()` or a
+    /// deferred flush of the current resident.
     ///
     /// Returns `true` if a record was found and the mark applied; `false` if
-    /// the key is absent or a strictly-newer write superseded it.
-    fn mark_stored(&self, key: &str, now: i64) -> bool;
+    /// the key is absent or the resident record is a different write (token
+    /// mismatch — a newer write owns the slot).
+    fn mark_stored(&self, key: &str, now: i64, token: u64) -> bool;
 
     /// Remove a record by key, returning the removed record.
     fn remove(&self, key: &str) -> Option<Record>;

--- a/packages/server-rust/src/storage/engines/hashmap.rs
+++ b/packages/server-rust/src/storage/engines/hashmap.rs
@@ -449,7 +449,7 @@ mod tests {
     /// AC1 behavioral test: same-millisecond two-concurrent-same-key writes.
     ///
     /// Two writes to the same key share an identical timestamp (same-ms tie).
-    /// Under the old timestamp guard (<= now), write A's mark_stored call would
+    /// Under the old timestamp guard (<= now), write A's `mark_stored` call would
     /// pass for write B's resident record, prematurely marking B clean before B
     /// persists. Under the token guard (== token), the tokens differ and the
     /// loser stays dirty until its own persist.

--- a/packages/server-rust/src/storage/engines/hashmap.rs
+++ b/packages/server-rust/src/storage/engines/hashmap.rs
@@ -63,12 +63,15 @@ impl StorageEngine for HashMapStorage {
         self.entries.get(key).map(|r| r.clone())
     }
 
-    fn mark_stored(&self, key: &str, now: i64) -> bool {
+    fn mark_stored(&self, key: &str, now: i64, token: u64) -> bool {
         // `get_mut` holds the shard's write lock for the lifetime of the guard,
-        // so the version-by-timestamp check and the mutation are atomic with
-        // respect to any other engine operation on this key.
+        // so the token check and the mutation are atomic with respect to any
+        // other engine operation on this key — no separate get()+put() window.
+        // The token uniquely identifies the exact write the caller persisted:
+        // a concurrent same-key write (any timestamp, equal or newer) carries a
+        // different token and is left dirty until its own persist completes.
         if let Some(mut entry) = self.entries.get_mut(key) {
-            if entry.metadata.last_update_time <= now {
+            if entry.metadata.write_token == token {
                 entry.metadata.on_store(now);
                 return true;
             }
@@ -395,13 +398,15 @@ mod tests {
         let storage = HashMapStorage::new();
         // make_record stamps last_update_time = 0 (RecordMetadata::new), so it
         // starts dirty (last_update 0 > last_stored 0 is false → actually clean
-        // at 0/0; bump update to force dirty).
+        // at 0/0; bump update to force dirty, which also mints a fresh token).
         let mut record = make_record(10);
         record.metadata.on_update(5);
+        let token = record.metadata.write_token;
         storage.put("a", record);
         assert!(storage.get("a").unwrap().metadata.is_dirty());
 
-        assert!(storage.mark_stored("a", 5));
+        // Matching token → mark applies.
+        assert!(storage.mark_stored("a", 5, token));
         assert!(!storage.get("a").unwrap().metadata.is_dirty());
         assert_eq!(storage.get("a").unwrap().metadata.last_stored_time, 5);
     }
@@ -409,21 +414,123 @@ mod tests {
     #[test]
     fn mark_stored_skips_newer_write() {
         let storage = HashMapStorage::new();
-        let mut record = make_record(10);
-        record.metadata.on_update(10); // resident write is newer than `now`
-        storage.put("a", record);
+        // Two records for the same key: first write (A) is placed, then a newer
+        // write (B) replaces it. Passing A's token must not mark B clean —
+        // a different token means a different logical write owns the slot.
+        let record_a = make_record(10);
+        let token_a = record_a.metadata.write_token;
+        storage.put("a", record_a);
 
-        // A stale persistence completion (now = 5) must NOT mark the newer
-        // (still-dirty) resident write clean.
-        assert!(!storage.mark_stored("a", 5));
+        // Second write — on_update mints a new token, making B's token != A's.
+        let mut record_b = make_record(10);
+        record_b.metadata.on_update(10);
+        let token_b = record_b.metadata.write_token;
+        storage.put("a", record_b);
+
+        // Tokens must differ: each logical write boundary gets a unique token.
+        assert_ne!(token_a, token_b, "each write must carry a unique token");
+
+        // A stale persist (using A's token) must NOT mark B's slot clean.
+        assert!(!storage.mark_stored("a", 5, token_a));
         assert!(storage.get("a").unwrap().metadata.is_dirty());
         assert_eq!(storage.get("a").unwrap().metadata.last_stored_time, 0);
+
+        // Matching token (B's) → mark applies.
+        assert!(storage.mark_stored("a", 10, token_b));
+        assert!(!storage.get("a").unwrap().metadata.is_dirty());
     }
 
     #[test]
     fn mark_stored_absent_key_returns_false() {
         let storage = HashMapStorage::new();
-        assert!(!storage.mark_stored("missing", 100));
+        assert!(!storage.mark_stored("missing", 100, 42));
+    }
+
+    /// AC1 behavioral test: same-millisecond two-concurrent-same-key writes.
+    ///
+    /// Two writes to the same key share an identical timestamp (same-ms tie).
+    /// Under the old timestamp guard (<= now), write A's mark_stored call would
+    /// pass for write B's resident record, prematurely marking B clean before B
+    /// persists. Under the token guard (== token), the tokens differ and the
+    /// loser stays dirty until its own persist.
+    ///
+    /// This test is RED if the token guard is reverted to the timestamp-only
+    /// `<= now` guard — the dirty-state assertion would pass for the loser
+    /// under the old guard, so the test would fail on the assert that the
+    /// loser remains dirty.
+    #[test]
+    fn ac1_same_millisecond_write_stays_dirty_until_own_persist() {
+        let storage = HashMapStorage::new();
+
+        // Both writes share the same "now" — simulating a same-millisecond tie
+        // without relying on wall-clock timing.
+        let same_now: i64 = 1_000_000;
+
+        // Write A: first to arrive, gets pushed out by Write B.
+        let record_a = Record {
+            value: RecordValue::Lww {
+                value: topgun_core::types::Value::String("value-a".to_string()),
+                timestamp: Timestamp {
+                    millis: same_now as u64,
+                    counter: 0,
+                    node_id: "node-a".to_string(),
+                },
+            },
+            metadata: RecordMetadata::new(same_now, 64),
+        };
+        let token_a = record_a.metadata.write_token;
+        storage.put("key", record_a);
+
+        // Write B: arrives after A, replaces the slot. Same timestamp as A.
+        let record_b = Record {
+            value: RecordValue::Lww {
+                value: topgun_core::types::Value::String("value-b".to_string()),
+                timestamp: Timestamp {
+                    millis: same_now as u64,
+                    counter: 0,
+                    node_id: "node-b".to_string(),
+                },
+            },
+            metadata: RecordMetadata::new(same_now, 64),
+        };
+        let token_b = record_b.metadata.write_token;
+        storage.put("key", record_b);
+
+        // AC1 KL2 proof: tokens must differ even for same-ms writes.
+        assert_ne!(
+            token_a, token_b,
+            "same-millisecond writes must carry distinct tokens (KL2)"
+        );
+
+        // Resident is now Write B. Write A's persist completes and calls
+        // mark_stored with A's token — must NOT mark B clean.
+        let marked = storage.mark_stored("key", same_now, token_a);
+        assert!(
+            !marked,
+            "mark_stored with A's token must not match B's resident slot"
+        );
+
+        // B is still dirty — its own persist has not completed.
+        let resident = storage.get("key").unwrap();
+        assert!(
+            resident.metadata.is_dirty(),
+            "loser write B must remain dirty until its own persist completes; \
+             this assertion is RED under the old timestamp-only guard"
+        );
+
+        // Token inequality is the concrete proof that KL2 holds.
+        assert_ne!(
+            token_a, resident.metadata.write_token,
+            "loser token must differ from resident token (KL2 token-inequality proof)"
+        );
+
+        // AC2: B's own persist then completes with the matching token → B is marked clean.
+        let marked_b = storage.mark_stored("key", same_now, token_b);
+        assert!(marked_b, "B's own persist must mark it clean");
+        assert!(
+            !storage.get("key").unwrap().metadata.is_dirty(),
+            "B must be clean after its own persist"
+        );
     }
 
     #[test]

--- a/packages/server-rust/src/storage/impls/default_record_store.rs
+++ b/packages/server-rust/src/storage/impls/default_record_store.rs
@@ -166,11 +166,26 @@ impl RecordStore for DefaultRecordStore {
         let cost = crate::storage::record::estimated_cost(&value) + key.len() as u64;
         let metadata = RecordMetadata::new(now, cost);
 
-        // Step 3: Create record
+        // Step 3: Create record. Capture the token from this record's metadata
+        // before it is moved — this is the exact token that identifies this write.
+        // Never re-allocate or re-read the token off the resident after put(),
+        // since a concurrent writer may have already replaced the slot.
+        let write_token = metadata.write_token;
         let record = Record { value, metadata };
 
         // Step 4: Put into engine
         self.engine.put(key, record.clone());
+
+        // Sanity check: in debug builds, verify the resident's token matches the
+        // one we just minted. A mismatch here means a concurrent same-key write
+        // landed between our put() and this check — normal under contention, but
+        // the token we captured above is still the right one to pass to mark_stored.
+        debug_assert!(
+            self.engine
+                .get(key)
+                .map_or(true, |r| r.metadata.write_token >= write_token),
+            "resident token must be >= our token (a newer write may have landed)"
+        );
 
         // Step 5: Fire observer notifications
         if let Some(ref old) = old_record {
@@ -190,25 +205,22 @@ impl RecordStore for DefaultRecordStore {
                 .add(&self.name, key, &record.value, expiration_time, now)
                 .await?;
 
-            // Mark the record clean only when the value was written to a real
-            // persistent store (not a no-op null store). The WAL append + fsync
-            // inside add() completes before returning Ok on real backends, so the
-            // value is durable and the record is safely evictable. Mark in place
-            // under the engine's per-key lock (mark_stored) rather than a
-            // get()+put(): the in-place mark never re-puts the value, so a
-            // concurrent same-key write can be neither clobbered nor lost. The
-            // timestamp guard leaves a strictly-newer write dirty, but it is
-            // best-effort, not a per-write identity check — a concurrent same-key
-            // write in the same millisecond may be transiently marked clean
-            // before its own persist completes. That window is bounded and
-            // self-healing (the concurrent persist completes independently of
-            // eviction, and put() acks only after its own persist), so no
-            // acked-durable write is lost.
-            if !self.data_store.is_null() && !self.engine.mark_stored(key, now) {
+            // Mark the record clean only if the value was written to a real
+            // persistent store (not a no-op null store) AND the token of the
+            // resident record still matches the one we persisted. The WAL append
+            // + fsync inside add() completes before returning Ok on real backends,
+            // so the value is durable when we reach here. The per-write token
+            // ensures that only the exact write just persisted is marked clean:
+            // a concurrent same-key write in the same millisecond carries a
+            // different token and stays dirty until its own persist completes.
+            // Mark in place under the engine's per-key lock (mark_stored) — the
+            // in-place mark never re-puts the value, so concurrent writes are
+            // never clobbered or lost.
+            if !self.data_store.is_null() && !self.engine.mark_stored(key, now, write_token) {
                 // Record was evicted between the engine put and this mark, or a
-                // strictly-newer write superseded it. Harmless (the value is
-                // durable via add(), or the newer write owns the slot), but worth
-                // a trace to surface write-then-immediately-evict churn.
+                // concurrent write landed and owns the slot. Harmless: the value
+                // is durable via add(), and the newer write will mark itself clean
+                // when its own persist completes.
                 tracing::trace!(
                     key,
                     "mark_stored found no eligible record after persist (evicted or superseded)"
@@ -1201,6 +1213,7 @@ mod tests {
             last_stored_time: 1, // equal to last_update_time => not dirty
             hits: 0,
             cost: 0,
+            write_token: 0, // test helper only — not used on the mark_stored path
         };
         Record {
             value: make_value("clean"),
@@ -1222,6 +1235,7 @@ mod tests {
             last_stored_time: 0, // never stored => dirty
             hits: 0,
             cost: 0,
+            write_token: 0, // test helper only — not used on the mark_stored path
         };
         Record {
             value: make_value("dirty"),

--- a/packages/server-rust/src/storage/impls/default_record_store.rs
+++ b/packages/server-rust/src/storage/impls/default_record_store.rs
@@ -173,19 +173,20 @@ impl RecordStore for DefaultRecordStore {
         let write_token = metadata.write_token;
         let record = Record { value, metadata };
 
+        // Sanity check: a live write must carry a minted token (>= 1). Token 0 is
+        // reserved for Default-constructed/hydrated metadata, which must never
+        // enter the engine dirty on this path. We assert our OWN captured token,
+        // not the resident's: a concurrent same-key write can replace the slot
+        // between our put() and any read, and tokens are minted at new() time
+        // rather than put() time, so the resident's token has no ordering
+        // relationship to ours — comparing against it would panic spuriously.
+        debug_assert_ne!(
+            write_token, 0,
+            "live write must carry a minted token (>= 1)"
+        );
+
         // Step 4: Put into engine
         self.engine.put(key, record.clone());
-
-        // Sanity check: in debug builds, verify the resident's token matches the
-        // one we just minted. A mismatch here means a concurrent same-key write
-        // landed between our put() and this check — normal under contention, but
-        // the token we captured above is still the right one to pass to mark_stored.
-        debug_assert!(
-            self.engine
-                .get(key)
-                .map_or(true, |r| r.metadata.write_token >= write_token),
-            "resident token must be >= our token (a newer write may have landed)"
-        );
 
         // Step 5: Fire observer notifications
         if let Some(ref old) = old_record {

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -16,7 +16,7 @@ use topgun_core::types::Value;
 /// never enter the engine in a dirty state. Every live write constructs its
 /// metadata via `RecordMetadata::new()`, which mints a token ≥ 1.
 /// `Relaxed` ordering is sufficient because token publication is already
-/// synchronized by the DashMap shard lock at `get_mut`/put.
+/// synchronized by the `DashMap` shard lock at `get_mut`/put.
 static WRITE_TOKEN: AtomicU64 = AtomicU64::new(1);
 
 /// Minimum elapsed milliseconds before a read access updates `last_access_time`.

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -3,9 +3,21 @@
 //! Defines the core data structures stored in [`StorageEngine`](super::StorageEngine):
 //! [`Record`], [`RecordMetadata`], [`RecordValue`], and [`OrMapEntry`].
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use serde::{Deserialize, Serialize};
 use topgun_core::hlc::Timestamp;
 use topgun_core::types::Value;
+
+/// Process-monotonic counter for minting per-write identity tokens.
+///
+/// Initialized at 1 so the first `fetch_add(1)` returns 1. Token `0` is
+/// reserved exclusively for `Default`-constructed `RecordMetadata`, which must
+/// never enter the engine in a dirty state. Every live write constructs its
+/// metadata via `RecordMetadata::new()`, which mints a token ≥ 1.
+/// `Relaxed` ordering is sufficient because token publication is already
+/// synchronized by the DashMap shard lock at `get_mut`/put.
+static WRITE_TOKEN: AtomicU64 = AtomicU64::new(1);
 
 /// Minimum elapsed milliseconds before a read access updates `last_access_time`.
 ///
@@ -21,9 +33,16 @@ pub const RECENCY_COALESCE_MS: i64 = 100;
 ///
 /// **Non-leakage invariant:** This struct intentionally has NO `Serialize` or
 /// `Deserialize` derive. Only `RecordValue` crosses the wire or reaches the
-/// persistence layer. The `cost` field in particular is a local, never-wire,
-/// never-disk heap-accounting value derived at write time and re-derived on
-/// every load — it must never be serialized.
+/// persistence layer. The `cost` and `write_token` fields in particular are
+/// local, never-wire, never-disk values — they must never be serialized.
+///
+/// **Write-token invariant:** `write_token == 0` means the record was
+/// `Default`-constructed and must never enter the engine dirty. Every live or
+/// hydrated write constructs metadata via `new()`, which mints a token ≥ 1.
+/// `mark_stored` uses the token as an exact per-write identity check: it marks a
+/// record clean only when the resident record's token matches the one the caller
+/// just persisted, so a concurrent same-key write (any timestamp, equal or newer)
+/// carrying a different token is never prematurely marked clean.
 #[derive(Debug, Clone, Default)]
 pub struct RecordMetadata {
     /// Record version, incremented on every update.
@@ -46,13 +65,35 @@ pub struct RecordMetadata {
     /// Re-derived on every load/hydrate so records entering via any path carry
     /// a real cost (eviction → reload steady state).
     pub cost: u64,
+    /// Process-monotonic per-write identity token.
+    ///
+    /// Minted once per logical write via `WRITE_TOKEN.fetch_add(1, Relaxed)`
+    /// inside `new()`. Token `0` is reserved for `Default`-constructed metadata
+    /// (which must never enter the engine dirty); every live write mints a
+    /// token ≥ 1. `mark_stored` uses this token as an exact identity check —
+    /// only the record whose token matches the one the caller persisted is
+    /// marked clean.
+    ///
+    /// LOCAL ONLY — never serialized to the wire or persisted to the datastore.
+    pub write_token: u64,
 }
 
 impl RecordMetadata {
+    /// Mints a fresh per-write identity token from the process-monotonic counter.
+    ///
+    /// Returns a value ≥ 1. Token `0` is reserved for `Default`-constructed
+    /// metadata. All minting goes through this single helper — never
+    /// `load`+`store`, which would break uniqueness under concurrent writers.
+    fn mint_token() -> u64 {
+        WRITE_TOKEN.fetch_add(1, Ordering::Relaxed)
+    }
+
     /// Creates new metadata with the given wall-clock time and estimated cost.
     ///
     /// Sets `creation_time`, `last_access_time`, and `last_update_time` to `now`.
     /// Version starts at 1, hits at 0, and `last_stored_time` at 0 (never stored).
+    /// Mints a fresh per-write identity token (≥ 1) for use as the exact-identity
+    /// key in `mark_stored`.
     #[must_use]
     pub fn new(now: i64, cost: u64) -> Self {
         Self {
@@ -63,6 +104,7 @@ impl RecordMetadata {
             last_stored_time: 0,
             hits: 0,
             cost,
+            write_token: Self::mint_token(),
         }
     }
 
@@ -79,10 +121,17 @@ impl RecordMetadata {
         }
     }
 
-    /// Records a write: increments `version` and updates `last_update_time`.
+    /// Records a write: increments `version`, updates `last_update_time`, and
+    /// mints a fresh per-write identity token.
+    ///
+    /// A fresh token is minted so that every logical write boundary has a unique
+    /// identity. Without this, an in-place update followed by `mark_stored` could
+    /// match a stale token from the original `new()` call and mark the record clean
+    /// before the updated value is persisted.
     pub fn on_update(&mut self, now: i64) {
         self.version = self.version.saturating_add(1);
         self.last_update_time = now;
+        self.write_token = Self::mint_token();
     }
 
     /// Records a persistence event: updates `last_stored_time`.


### PR DESCRIPTION
## Summary

Closes the SPEC-323 **path-(b)** same-millisecond false-clean window in `StorageEngine::mark_stored` (source TODO-537; pre-soak input on the reconciled durability roadmap).

Replaces the timestamp guard `last_update_time <= now` with a per-write **identity** guard `write_token == token`. A process-static `AtomicU64::new(1)` mints a unique `u64` token per write into the deliberately serde-free `RecordMetadata` (never wire/disk — the "Non-leakage invariant" holds). Under two concurrent same-key writes in the **same millisecond**, only the exact write the caller persisted is marked clean; the other stays dirty until its own persist completes. No acked-durable write is ever lost (SPEC-323 invariant preserved).

## Changes (4 Rust source files, ≤5 cap)

- `record.rs` — `static WRITE_TOKEN: AtomicU64 = AtomicU64::new(1)` + `mint_token()` helper; `write_token: u64` on `RecordMetadata`, minted in `new()` and `on_update()` (token `0` reserved for `Default`/hydrated records).
- `engine.rs` — `mark_stored(key, now, token: u64)` trait signature + strong per-write-identity doc.
- `engines/hashmap.rs` — `write_token == token` identity guard (was `<= now`); 3 migrated unit tests + new AC1 behavioral test `ac1_same_millisecond_write_stays_dirty_until_own_persist`.
- `impls/default_record_store.rs` — `put()` threads its own captured `write_token` into `mark_stored`; non-racy `debug_assert_ne!(write_token, 0)` counter-init guard.

## Verification

- RED-on-revert proven: reverting the guard to `<= now` fails the AC1 dirty-state assertion.
- Gates green locally: `cargo build --release`, `cargo test --release -p topgun-server --lib` (1530 pass / 0 fail / 1 ignored), `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`.
- Cross-vendor net (glm-5.2): `/xask` design + `/xreview` diff + `/xreview` review-gate ×2. Review v1 override caught a racy call-site `debug_assert!` (false mint-order==put-order invariant, debug-only panic risk); fixed in `de634bed`. Review v2 + review-gate `/xreview` both clean.

## Scope fence

Does **not** touch the pre-existing accepted LWW blind-clobber race on concurrent same-key writes (out of scope). Only the clean-MARK becomes exact.

Merge only on fully green blocking CI.