### PR TITLE
test(sf-338): honest soak-gate for unbounded OR-Map tombstone growth (accept-unbounded + monitor calibration)

### DIFF
--- a/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
+++ b/packages/server-rust/benches/soak_harness/hetzner-soak-runner.sh
@@ -40,7 +40,12 @@ NO_PRE_KILL_DRAIN="${NO_PRE_KILL_DRAIN:-0}"
 if [ "${NO_PRE_KILL_DRAIN}" = "1" ]; then
   export TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS="${TOPGUN_WRITEBEHIND_FLUSH_INTERVAL_MS:-1000}"
 fi
-MEM_THRESHOLD="${MEM_THRESHOLD:-25}"      # MB/hour slope ceiling over a 72h run
+# Calibrated slope ceiling for the 72h run. The OR tombstone leak the soak drives
+# is ~3-5 MB/h; the former 25 MB/h sat above it and false-GREENed a real leak.
+# 2 MB/h sits below the leak band and above a genuine in-place plateau (~0 MB/h);
+# the harness min-growth guard (80 MB, in-code default) keeps short runs green.
+# Mirrors monitor::DEFAULT_MEM_THRESHOLD_MB_PER_HOUR.
+MEM_THRESHOLD="${MEM_THRESHOLD:-2}"       # MB/hour slope ceiling over a 72h run
 MEM_CEILING="${MEM_CEILING:-2048}"
 OUT_ROOT="${OUT_ROOT:-/var/soak}"
 

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -129,8 +129,12 @@ impl Default for Config {
             quiesce: Duration::from_secs(3),
             ready_timeout: Duration::from_secs(40),
             mem_sample_interval: Duration::from_secs(5),
-            mem_threshold_mb_per_hour: 50.0,
-            mem_min_growth_mb: 150.0,
+            // Calibrated to catch the OR-Map tombstone leak (~3-5 MB/h) rather
+            // than mask it: the old 50 MB/h slope sat far above the leak rate and
+            // false-GREENed it. See monitor.rs for the calibration rationale and
+            // the executable proof (tests::calibration_*).
+            mem_threshold_mb_per_hour: monitor::DEFAULT_MEM_THRESHOLD_MB_PER_HOUR,
+            mem_min_growth_mb: monitor::DEFAULT_MEM_MIN_GROWTH_MB,
             mem_ceiling_mb: 1800.0,
             server_port: 0,
             data_dir: None,

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -32,6 +32,20 @@
 //! only a run that grows past [`DEFAULT_MEM_MIN_GROWTH_MB`] at more than
 //! [`DEFAULT_MEM_THRESHOLD_MB_PER_HOUR`] — i.e. the 72h tombstone leak — fails.
 //! See `tests::calibration_*` for the executable proof of both directions.
+//!
+//! ## Detection floor — a short green soak is not a bounded-memory guarantee
+//!
+//! This is a *sustained-leak* detector, not an instantaneous one. Because the
+//! min-growth guard suppresses the slope clause until total growth clears
+//! [`DEFAULT_MEM_MIN_GROWTH_MB`], a leak is only caught once the run is long
+//! enough to accumulate that much: ~16h at 5 MB/h, ~27h at 3 MB/h. That is
+//! deliberate, not a gap — over a few hours a 3-5 MB/h leak's absolute growth is
+//! within RSS noise (allocator retention, cache warmup, GC), so failing on slope
+//! alone would false-FAIL healthy short soaks. The 72h run is therefore the gate
+//! that actually asserts bounded tombstone memory; the minutes-scale smoke and
+//! bounded soaks exercise crash/convergence, and their green memory verdict means
+//! "no leak large enough to clear the noise floor in this window", NOT "bounded
+//! memory proven". Do not read a short green soak as the latter.
 
 use std::process::Command;
 
@@ -235,6 +249,23 @@ mod tests {
             2048.0,
         );
         assert!(!a.passed, "3 MB/h leak must fail; reason={:?}", a.reason);
+    }
+
+    /// Pin the lower edge of the leak band: a 2.5 MB/h series (180 MB over 72h)
+    /// must FAIL at the 2.0 MB/h threshold. Without this, a future loosening of
+    /// the threshold toward the estimated leak band (e.g. to 2.5) would still
+    /// pass the 3.0/4.0 tests yet silently false-GREEN a 2.3 MB/h leak — this
+    /// test fails the moment the threshold creeps up to meet the band.
+    #[test]
+    fn calibration_pins_low_band_edge() {
+        let samples = linear_72h(220.0, 2.5);
+        let a = assess(
+            &samples,
+            DEFAULT_MEM_THRESHOLD_MB_PER_HOUR,
+            DEFAULT_MEM_MIN_GROWTH_MB,
+            2048.0,
+        );
+        assert!(!a.passed, "2.5 MB/h leak must fail; reason={:?}", a.reason);
     }
 
     /// A genuine in-place-overwrite plateau (slope ~0, tiny bounded jitter) MUST

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -2,16 +2,53 @@
 //!
 //! The soak runs a fixed keyspace overwritten in place, so the server's
 //! resident set should plateau. A sustained upward trend implicates a leak —
-//! most plausibly unbounded OR-Map tombstone accumulation (TODO-479/480), which
-//! the soak deliberately drives via add/remove churn on an OR-Map.
+//! most plausibly unbounded OR-Map tombstone accumulation, which the soak
+//! deliberately drives via add/remove churn on an OR-Map with a distinct tag
+//! per iteration.
 //!
 //! RSS is sampled by shelling out to `ps -o rss= -p <pid>` (KiB on both macOS
 //! and Linux), avoiding a platform-specific dependency. The assessment fits a
 //! least-squares line to `(elapsed_hours, rss_mb)` and fails if either the
 //! slope exceeds a per-hour threshold (with a minimum absolute growth guard to
 //! ignore short-run noise) or the peak exceeds a hard ceiling.
+//!
+//! ## Slope threshold is calibrated to catch the tombstone leak, not mask it
+//!
+//! The OR-Map tombstone set on the server write path is intentionally unbounded
+//! (there is no causal-stability tracking that would let the server prune a
+//! tombstone without risking resurrection on a lagging client — pruning is a
+//! correctness hazard, not a memory optimization). The soak's OR churn stream
+//! therefore grows tombstones linearly, estimated at ~3-5 MB/h RSS over a 72h
+//! run. The earlier default slope threshold (50 MB/h in-process, 25 MB/h on the
+//! Hetzner 72h runner) sat 5-10x ABOVE that rate, so a real linear leak fitted a
+//! ~3-5 MB/h line that passed both clauses — a false GREEN masking an eventual
+//! out-of-memory.
+//!
+//! [`DEFAULT_MEM_THRESHOLD_MB_PER_HOUR`] and [`DEFAULT_MEM_MIN_GROWTH_MB`] are
+//! set so a sustained ~3-5 MB/h linear series FAILS while a genuine in-place
+//! plateau (slope near zero, total growth below the min-growth guard) PASSES.
+//! The min-growth guard is what keeps short bounded soaks (10-60 min) green: a
+//! plateau never accumulates enough absolute growth to trip the slope clause, so
+//! only a run that grows past [`DEFAULT_MEM_MIN_GROWTH_MB`] at more than
+//! [`DEFAULT_MEM_THRESHOLD_MB_PER_HOUR`] — i.e. the 72h tombstone leak — fails.
+//! See `tests::calibration_*` for the executable proof of both directions.
 
 use std::process::Command;
+
+/// Calibrated slope ceiling (MB/hour) for the 72h soak's memory assertion.
+///
+/// Below the ~3-5 MB/h the OR tombstone leak produces, above the ~0 MB/h a real
+/// in-place-overwrite plateau produces — so it distinguishes leak from plateau
+/// at the rate the soak actually drives. Callers (soak `main.rs` defaults, the
+/// Hetzner runner env default) should feed this value so the 72h run cannot
+/// false-GREEN the accepted-but-real tombstone growth.
+pub const DEFAULT_MEM_THRESHOLD_MB_PER_HOUR: f64 = 2.0;
+
+/// Calibrated absolute-growth guard (MB): below this total growth the slope
+/// clause is ignored as short-run noise. Sized so a genuine plateau (and any
+/// bounded short soak) stays green, while the 72h tombstone leak — which
+/// accumulates hundreds of MB — clears the guard and is judged on slope.
+pub const DEFAULT_MEM_MIN_GROWTH_MB: f64 = 80.0;
 
 /// One resident-set sample.
 #[derive(Debug, Clone, Copy)]
@@ -140,5 +177,120 @@ fn least_squares_slope_per_hour(samples: &[MemSample]) -> f64 {
         0.0
     } else {
         num / den
+    }
+}
+
+// This bench target is `harness = false` (it owns `main`), so these `#[test]`
+// functions do NOT run under `cargo test --bench soak_harness` — libtest never
+// drives them. They are executed as a real CI gate by the integration target
+// `tests/soak_monitor_calibration.rs`, which re-includes this module under the
+// standard harness. `allow(dead_code)` keeps the bench's own test-mode compile
+// warning-free (the helper is unreferenced there because libtest is absent).
+#[cfg(test)]
+#[allow(dead_code)]
+mod tests {
+    use super::*;
+
+    /// Build a 72h series sampled hourly with a constant per-hour slope,
+    /// starting at `first_mb`.
+    fn linear_72h(first_mb: f64, slope_mb_per_hour: f64) -> Vec<MemSample> {
+        (0..=72)
+            .map(|h| MemSample {
+                elapsed_secs: f64::from(h) * 3600.0,
+                rss_mb: first_mb + slope_mb_per_hour * f64::from(h),
+            })
+            .collect()
+    }
+
+    /// A ~4 MB/h linear tombstone leak over 72h (≈288 MB total growth) MUST FAIL
+    /// under the calibrated defaults — this is the exact shape the soak's OR
+    /// churn drives, and the whole point of the calibration is that it can no
+    /// longer false-GREEN.
+    #[test]
+    fn calibration_fails_linear_tombstone_leak() {
+        let samples = linear_72h(220.0, 4.0);
+        let a = assess(
+            &samples,
+            DEFAULT_MEM_THRESHOLD_MB_PER_HOUR,
+            DEFAULT_MEM_MIN_GROWTH_MB,
+            2048.0,
+        );
+        assert!(
+            !a.passed,
+            "4 MB/h linear leak must fail the calibrated gate; slope={:.2} reason={:?}",
+            a.slope_mb_per_hour, a.reason
+        );
+        assert!(a.slope_mb_per_hour > DEFAULT_MEM_THRESHOLD_MB_PER_HOUR);
+    }
+
+    /// The lower edge of the estimated leak band (~3 MB/h) must also FAIL — the
+    /// gate must not have a blind spot just above plateau.
+    #[test]
+    fn calibration_fails_low_end_leak() {
+        let samples = linear_72h(220.0, 3.0);
+        let a = assess(
+            &samples,
+            DEFAULT_MEM_THRESHOLD_MB_PER_HOUR,
+            DEFAULT_MEM_MIN_GROWTH_MB,
+            2048.0,
+        );
+        assert!(!a.passed, "3 MB/h leak must fail; reason={:?}", a.reason);
+    }
+
+    /// A genuine in-place-overwrite plateau (slope ~0, tiny bounded jitter) MUST
+    /// PASS — otherwise the gate false-FAILs every healthy long run.
+    #[test]
+    fn calibration_passes_plateau() {
+        // Flat at 300 MB with ±1 MB sawtooth jitter, hourly over 72h.
+        let samples: Vec<MemSample> = (0..=72)
+            .map(|h| MemSample {
+                elapsed_secs: f64::from(h) * 3600.0,
+                rss_mb: 300.0 + if h % 2 == 0 { 1.0 } else { -1.0 },
+            })
+            .collect();
+        let a = assess(
+            &samples,
+            DEFAULT_MEM_THRESHOLD_MB_PER_HOUR,
+            DEFAULT_MEM_MIN_GROWTH_MB,
+            2048.0,
+        );
+        assert!(
+            a.passed,
+            "plateau must pass; slope={:.3} peak={:.1} reason={:?}",
+            a.slope_mb_per_hour, a.peak_mb, a.reason
+        );
+    }
+
+    /// Proof the tightening is what makes it a gate: the SAME 4 MB/h leak that
+    /// the calibrated defaults reject would have PASSED under the old loose
+    /// thresholds (25 MB/h slope, 150 MB min-growth). Guards against a future
+    /// loosening silently restoring the false-GREEN.
+    #[test]
+    fn old_loose_thresholds_would_false_green_the_leak() {
+        let samples = linear_72h(220.0, 4.0);
+        let old = assess(&samples, 25.0, 150.0, 2048.0);
+        assert!(
+            old.passed,
+            "the old 25 MB/h threshold is exactly the false-GREEN this spec closes"
+        );
+    }
+
+    /// A plateau that parks at a high-but-flat RSS (allocator retention) must
+    /// still PASS on slope — retention is not growth. Only the hard ceiling may
+    /// fail it, which it does not here.
+    #[test]
+    fn calibration_passes_high_flat_retention() {
+        let samples = linear_72h(900.0, 0.0);
+        let a = assess(
+            &samples,
+            DEFAULT_MEM_THRESHOLD_MB_PER_HOUR,
+            DEFAULT_MEM_MIN_GROWTH_MB,
+            2048.0,
+        );
+        assert!(
+            a.passed,
+            "flat-but-high retention must pass; reason={:?}",
+            a.reason
+        );
     }
 }

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -324,4 +324,53 @@ mod tests {
             a.reason
         );
     }
+
+    /// A *noisy* linear leak — a 3.5 MB/h trend with a large ±40 MB sawtooth on
+    /// top of it (allocator GC / cache warmup jitter) — must still FAIL. This
+    /// pins the robustness of the growth clause: because `assess` computes total
+    /// growth as `peak_mb - first_mb` (fold-max, not `last - first`), a low final
+    /// sample cannot drag computed growth below the min-growth guard, so endpoint
+    /// noise cannot suppress the slope clause on a real trend.
+    #[test]
+    fn calibration_fails_noisy_linear_leak() {
+        // 3.5 MB/h trend + deterministic ±40 MB oscillation, hourly over 72h.
+        let samples: Vec<MemSample> = (0..=72)
+            .map(|h| MemSample {
+                elapsed_secs: f64::from(h) * 3600.0,
+                rss_mb: 220.0 + 3.5 * f64::from(h) + 40.0 * (f64::from(h % 3) - 1.0),
+            })
+            .collect();
+        let a = assess(
+            &samples,
+            DEFAULT_MEM_THRESHOLD_MB_PER_HOUR,
+            DEFAULT_MEM_MIN_GROWTH_MB,
+            2048.0,
+        );
+        assert!(
+            !a.passed,
+            "noisy 3.5 MB/h leak must fail; slope={:.2} peak={:.1} reason={:?}",
+            a.slope_mb_per_hour, a.peak_mb, a.reason
+        );
+        assert!(a.slope_mb_per_hour > DEFAULT_MEM_THRESHOLD_MB_PER_HOUR);
+    }
+
+    /// The Hetzner 72h runner and this module are two independent sources of
+    /// truth for the same slope threshold. The runner default MUST track
+    /// [`DEFAULT_MEM_THRESHOLD_MB_PER_HOUR`] so the 72h gate cannot be silently
+    /// loosened by editing only one of them (e.g. bumping the shell default back
+    /// to 25 without failing any test — the exact false-GREEN this spec closes).
+    /// `include_str!` is resolved relative to this file, i.e. the `soak_harness` dir.
+    #[test]
+    fn hetzner_runner_default_matches_calibrated_constant() {
+        let script = include_str!("hetzner-soak-runner.sh");
+        // `{}` on an integral f64 prints without a trailing `.0` (2.0 -> "2"),
+        // matching the integer MB/h the shell default carries.
+        let expected =
+            format!("MEM_THRESHOLD=\"${{MEM_THRESHOLD:-{DEFAULT_MEM_THRESHOLD_MB_PER_HOUR}}}\"");
+        assert!(
+            script.contains(&expected),
+            "hetzner-soak-runner.sh MEM_THRESHOLD default must match \
+             monitor::DEFAULT_MEM_THRESHOLD_MB_PER_HOUR (expected {expected:?})"
+        );
+    }
 }

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -538,6 +538,19 @@ impl CrdtService {
                 let (mut records, mut tombstones) = read_or_map_state(existing.map(|r| r.value));
 
                 records.retain(|e| e.tag != *tag);
+                // The tombstone set grows unbounded by design: it is NOT pruned
+                // here. Pruning a tag is only safe once every replica that could
+                // still hold the matching add has observed this remove, and a
+                // single node with transient reconnecting clients has no
+                // causal-stability / delivery-ack tracking to know that. A
+                // time-threshold prune is unsafe for any horizon — a client
+                // offline longer than the horizon reconnects, delta-syncs without
+                // the dropped tombstone, and resurrects the removed value. A loud,
+                // bounded-memory OOM is preferable to silent CRDT corruption, so
+                // for the single-node demo tier we accept linear tombstone growth.
+                // Revisit when a causal-stability low-water-mark lands or the tier
+                // moves beyond single-node demo (see the soak memory monitor,
+                // which is calibrated to flag this growth rather than mask it).
                 // Dedup: a re-issued remove must not duplicate the tombstone.
                 if !tombstones.contains(tag) {
                     tombstones.push(tag.clone());

--- a/packages/server-rust/tests/soak_monitor_calibration.rs
+++ b/packages/server-rust/tests/soak_monitor_calibration.rs
@@ -1,0 +1,17 @@
+//! CI gate for the soak memory monitor's calibrated thresholds.
+//!
+//! The soak bench (`benches/soak_harness/`) is declared `harness = false`, so the
+//! `#[cfg(test)] mod tests` inside `monitor.rs` never runs under `cargo test
+//! --bench soak_harness` (that command runs the bench's `main`, not libtest).
+//! Re-including the module here as an integration target puts those calibration
+//! tests under the standard libtest harness, so they run as a real gate on
+//! `cargo test` / `cargo test --all-targets` (the CI test job).
+//!
+//! `monitor.rs` is self-contained (only `std`), so including it by path pulls in
+//! no other bench state. `allow(dead_code)` covers `sample_rss_mb` and any
+//! assessment fields the calibration tests don't read — they are live in the
+//! bench binary, just unreferenced from this test crate's view.
+
+#[path = "../benches/soak_harness/monitor.rs"]
+#[allow(dead_code)]
+mod monitor;


### PR DESCRIPTION
## What & why

OR-Map tombstones on the server write path grow **unbounded** by design — correct for CRDT
convergence, but a real long-run memory cost. This change (SPEC-338, TODO-479, the #1
pre-72h-soak-gate blocker) resolves the *soak-gate honesty* half of the problem:

- **Diagnose-first outcome (accept-unbounded):** there is **no** safe tombstone-prune predicate
  on a single node with transient reconnecting clients and no causal-stability / low-water-mark
  tracking. A `now − T` prune is unsafe for *any* finite `T` — a client offline past the horizon
  reconnects, delta-syncs without the dropped tombstone, and **resurrects** the removed value. A
  loud, bounded-memory OOM is strictly preferable to silent CRDT corruption, so for the
  single-node demo tier we accept linear tombstone growth and **document** it (WHY-comment at the
  OR_REMOVE site + Engineering Decision Record in the spec).
- **Calibrate the soak memory monitor so it stops false-GREENing the leak.** The old slope
  threshold (50 MB/h in-proc, 25 MB/h on the Hetzner 72h runner) sat 5–10× above the ~3–5 MB/h
  leak the soak's unique-tag OR churn drives, so a real leak passed. Lowered to **2.0 MB/h** slope
  + **80 MB** min-growth guard (`monitor::DEFAULT_MEM_*`, referenced by `main.rs` defaults and the
  Hetzner runner's `MEM_THRESHOLD`).

**Consequence (intended):** the 72h soak will now correctly **RED** on the unbounded OR churn —
the honest signal replacing the old false-GREEN. A *meaningful* green 72h now depends on the real
memory bound landing (follow-up, causal-stability GC / spill-to-disk).

## Changes

- `benches/soak_harness/monitor.rs` — calibrated constants + calibration/detection-floor doc + 8
  synthetic-series `#[test]`s.
- `tests/soak_monitor_calibration.rs` (new) — runs the bench's `harness = false` calibration
  tests under libtest as a real CI gate.
- `benches/soak_harness/main.rs` — soak `Config` defaults reference the calibrated constants.
- `benches/soak_harness/hetzner-soak-runner.sh` — `MEM_THRESHOLD` default `25 → 2`.
- `src/service/domain/crdt.rs` — **comment-only** WHY-note at the OR_REMOVE tombstone append.

## Scope fence

Comment-only in `crdt.rs`: the OR_ADD unlocked-RMW lock/merge path and all LWW paths are
**untouched**. No new prune, no records-merge / add-wins/remove-wins change.

## Cross-vendor gates (project standing rule)

- `/xask` (safe-to-prune design) → Outcome B; `/xreview` run twice on the diff (run-time +
  review-gate) — both converge on invariant-holds, 0 confirmed-real blocking findings.

## Local gates

`cargo build --release -p topgun-server`, `cargo clippy --all-targets --all-features -- -D
warnings`, `cargo fmt --check`, `cargo test --test soak_monitor_calibration` (**8/8**) — all green.

## Follow-ups (deferred by design)

- Real safe memory bound (causal-stability GC / spill-to-disk).
- Direct tombstone-bytes gauge (server instrumentation).
