### PR TITLE
feat(sf-339/sf-340): OR-Map tombstone bound decision + direct tombstone-bytes soak gauge

### DIFF
--- a/packages/core-rust/src/lib.rs
+++ b/packages/core-rust/src/lib.rs
@@ -21,6 +21,7 @@ pub mod messages;
 pub mod or_map;
 pub mod partition;
 pub mod schema;
+pub mod tombstone_frontier;
 pub mod traits;
 pub mod types;
 pub mod vector;

--- a/packages/core-rust/src/tombstone_frontier.rs
+++ b/packages/core-rust/src/tombstone_frontier.rs
@@ -1,0 +1,167 @@
+//! Prune-safety contract for bounding OR-Map tombstone growth (traits/types only).
+//!
+//! This module is the **design contract** produced by the SPEC-339 mechanism-selection
+//! decision. It carries NO implementation body, NO write-path wiring, and NO prune logic —
+//! those land in the downstream implementation spec. It exists so 565 (tombstone-bytes counter
+//! placement) and 563 (harness-trust threshold) can depend on a fixed representation, and so the
+//! downstream implementer fills in these signatures against a doc-contract that cannot be
+//! misread.
+//!
+//! # Selected mechanism (SPEC-339)
+//!
+//! **M4 — epoch/generation GC.** The single-node authority rotates a server-authoritative epoch
+//! counter unilaterally. Each tombstone is associated with the server epoch current **at the
+//! moment the server applies its `OR_REMOVE`** (server-side metadata; the wire tombstone shape is
+//! unchanged). An entire epoch's tombstone set is dropped wholesale once every tracked client has
+//! advanced past that epoch. Rejected alternatives: M2 (ORSWOT/dot-store — does not bound growth;
+//! version-vector compression is unsound over HLC-reset gapped counters), M3 (spill-to-disk —
+//! bounds RAM only, unbounded disk). The epoch is stamped server-side at remove-apply time, NOT
+//! derived from the client-supplied tag `millis`, because the tag's `millis` is the *add* time
+//! (not the remove-delivery time) and is client-verbatim on the push-diff path — deriving the
+//! epoch from it would mis-bucket under clock skew and admit resurrection.
+//!
+//! # The ONE invariant this contract protects
+//!
+//! No resurrection of a removed value for a **known, monotone** client (monotone = local replica
+//! only moves forward, never rolled back — assumption A6; backup-restore regression is out of
+//! scope). A resurrection is fleet-wide silent CRDT corruption: a re-admitted record broadcasts
+//! to every connected client and CRDT merge has no quarantine.
+//!
+//! # Prune-side safety condition (HARD — all tracked clients, never per-client)
+//!
+//! A tombstone / epoch is prune-eligible **ONLY** once the *low-water-mark* — the **minimum**
+//! per-client high-water-mark taken across **ALL tracked (non-forgotten) clients** — has advanced
+//! past it. This is distinct from the per-client *advancement*-safety condition (which governs
+//! WHEN one client's cursor moves): the prune-safety condition governs WHOSE confirmation licenses
+//! reclamation. It is **NEVER** a per-creating-client or single-client frontier — a single tracked
+//! client whose cursor is behind an epoch pins that epoch for the whole fleet. See
+//! [`PruneSafety::is_epoch_prune_eligible`].
+
+/// Server-authoritative monotonic epoch / generation counter.
+///
+/// Owned by the single-node authority and stamped onto a tombstone at the moment the server
+/// applies the `OR_REMOVE` that created it. Never derived from a client-supplied tag `millis`.
+pub type Epoch = u64;
+
+/// A tracked client's identity for frontier bookkeeping.
+///
+/// This is the **server-authenticated connection identity** (JWT principal / connection
+/// registry) — NOT a tag-embedded, client-asserted nodeId. Keying the frontier and the reconnect
+/// gate off a spoofable, client-asserted identity would let a forgotten client re-present as a
+/// known-non-forgotten client and defeat the safety condition (see the module invariant and
+/// assumption A6's adjacent authentication precondition).
+pub type ClientId = String;
+
+/// A per-client high-water-mark: the highest [`Epoch`] a client has **confirmed
+/// receive-and-apply** of.
+///
+/// See [`CausalFrontier::confirm_apply`] for the advancement contract.
+pub type EpochCursor = Epoch;
+
+/// An OR-Map tombstone tag, the verbatim `"millis:counter:nodeId"` string used as the
+/// observed-remove identity. Carried unchanged on the wire; the epoch association is server-side
+/// metadata alongside it.
+pub type TombstoneTag = String;
+
+/// Max-retention policy for the forgotten-client sacrifice.
+///
+/// Retention is expressed in **cursor lag (epoch count)**, NOT a fixed wall-clock duration: lag is
+/// what actually pins tombstones, it decouples from the epoch width, and it lets RAM pressure act
+/// as a real lever (a fixed wall-clock `R` gives RAM pressure no counterweight and would lock out
+/// a cursor-current-but-idle client for no benefit).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaxRetention {
+    /// Forget a tracked client once its cursor lags more than this many epochs behind the current
+    /// server epoch. RAM pressure MAY dynamically tighten this (forget laggier clients sooner)
+    /// when un-pruned tombstone cost approaches `TOPGUN_MAX_RAM_MB`.
+    pub max_lag_epochs: u32,
+    /// Optional wall-clock ceiling (ms of silence) as a secondary bound against a client that
+    /// never advances at all. `None` = no secondary ceiling.
+    pub wall_clock_ceiling_ms: Option<u64>,
+}
+
+/// Opaque token proving a reconnect payload passed the pre-apply gate's not-forgotten check at
+/// gate time.
+///
+/// Handed from the gate to the merge-commit so the merge can re-assert that the gate-time decision
+/// still holds (see [`PruneSafety::gate_decision_holds_at_commit`]). The downstream implementation
+/// defines its representation; this contract only fixes that such a token flows gate → commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GateToken {
+    /// The client whose not-forgotten status the gate certified.
+    pub client: ClientId,
+    /// The current epoch observed at gate time; the merge-commit re-checks that no prune sweep has
+    /// since advanced the low-water-mark past a tombstone this payload still needs.
+    pub epoch_at_gate: Epoch,
+}
+
+/// Per-client causal frontier: the tracked cursors whose minimum licenses pruning.
+///
+/// Implemented downstream over the per-client high-water-marks. The doc-contract on each method is
+/// the load-bearing part — an implementer MUST honour it.
+pub trait CausalFrontier {
+    /// Record that `client` has **confirmed receive-AND-apply** up to `epoch`.
+    ///
+    /// # Contract
+    /// - Advances **only** on confirmed receive-**and-apply** of the covered tombstone/epoch state
+    ///   — **never** on sync-initiation and **never** on mere receive/delivery (an apply-lagging
+    ///   client that confirmed on receive could still push a pre-apply diff and resurrect).
+    /// - Monotone: a cursor never moves backward. A replayed or reordered confirmation carrying a
+    ///   cursor `<=` the current one is a no-op (the ACK protocol is a cumulative monotonic cursor,
+    ///   not per-tombstone ACKs, precisely so replay/reorder cannot drive a premature advance).
+    /// - The confirmation MUST be bound to the server-authenticated [`ClientId`]; a client cannot
+    ///   advance another client's cursor.
+    fn confirm_apply(&mut self, client: &ClientId, epoch: Epoch);
+
+    /// The low-water-mark: the **minimum** [`EpochCursor`] across **all tracked** clients.
+    ///
+    /// This — not any single client's cursor — is what licenses pruning. If there are no tracked
+    /// clients the implementation defines the vacuous case downstream (e.g. the current epoch);
+    /// the safety-relevant case is that any tracked-and-behind client holds the LWM down.
+    fn low_water_mark(&self) -> Epoch;
+
+    /// Whether `client` is currently tracked (known and not forgotten). Unknown clients are treated
+    /// as forgotten for gating purposes (the "new clients start empty" claim is server-unverifiable).
+    fn is_tracked(&self, client: &ClientId) -> bool;
+
+    /// Forget a client whose cursor lags past [`MaxRetention`]. Forgetting is the explicit
+    /// availability-vs-correctness sacrifice: a forgotten client returning CAN resurrect (a
+    /// fleet-wide event) unless the pre-apply gate blocks its reconnect push.
+    fn forget_client(&mut self, client: &ClientId);
+}
+
+/// Prune-safety predicate + the reconnect/merge ordering precondition.
+///
+/// The two methods encode, respectively, the PRUNE side (which epochs may be reclaimed) and the
+/// RE-ADMISSION side (that a gate-time not-forgotten decision still holds at merge-commit). Both
+/// are required for the module invariant to hold; a design that satisfies only one still admits
+/// fleet-wide resurrection.
+pub trait PruneSafety {
+    /// Returns `true` **iff** `epoch` is prune-eligible.
+    ///
+    /// # Contract (HARD)
+    /// Eligible **only** once the low-water-mark across **ALL tracked clients**
+    /// ([`CausalFrontier::low_water_mark`]) has advanced past `epoch`. **NEVER** license pruning
+    /// from a single client's cursor or the creating client's frontier — a single tracked client
+    /// behind `epoch` MUST keep it un-prunable for the whole fleet. Reading [`CausalFrontier`]'s
+    /// per-client advancement condition in isolation, as if one client's confirmation sufficed,
+    /// would violate the module invariant.
+    fn is_epoch_prune_eligible(&self, epoch: Epoch) -> bool;
+
+    /// Returns `true` **iff** the not-forgotten decision certified by `token` at gate time still
+    /// holds now, at merge-commit time.
+    ///
+    /// # Contract (gate-validity-to-merge-commit ordering, D2 (iv))
+    /// The pre-apply gate and the remove-wins merge are separated by `.await` yield points, so a
+    /// timer-driven prune sweep can interleave: a client passes the gate, crosses the forget
+    /// threshold mid-handler, its covered epochs are pruned, and the resumed handler would re-admit
+    /// a stale record against the post-prune set. The downstream implementation MUST guarantee that
+    /// a client's not-forgotten status (and the presence of the tombstones its payload is checked
+    /// against) established at gate time still holds when the merge commits — e.g. by serializing
+    /// the prune sweep against in-flight gated pushes under a **per-key** single-writer (the same
+    /// primitive that closes the SPEC-333b `OR_ADD` unlocked-RMW race — a joint fix). Per-key, not
+    /// per-partition: serializing unrelated keys in a partition would collapse fleet write
+    /// concurrency on a hot key. This MUST also preserve tombstone-set monotonicity (no pruned
+    /// tombstone flickering back in during the window).
+    fn gate_decision_holds_at_commit(&self, token: &GateToken) -> bool;
+}

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -563,10 +563,10 @@ async fn run_soak(config: &Config) -> i32 {
         config.mem_ceiling_mb,
     );
 
-    // --- Assess tombstone-byte growth (primary, tight-threshold leak signal).
-    // Coexists with the RSS gate above — neither replaces the other (AC6). A
-    // run that collected zero gauge samples fails as a blind monitor, same as
-    // the RSS empty-samples branch.
+    // --- Assess tombstone-byte growth (direct residency-independent leak
+    // instrument). Coexists with the RSS gate above — neither replaces the other.
+    // The SLOPE clause is report-only today (see below); the blind-monitor clause
+    // (zero samples) hard-gates, mirroring the RSS empty-samples branch.
     let tombstone_samples_snapshot = tombstone_samples.lock().clone();
     let tombstones = assess_tombstone_bytes(
         &tombstone_samples_snapshot,
@@ -574,11 +574,26 @@ async fn run_soak(config: &Config) -> i32 {
         DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
     );
 
+    // The tombstone-byte SLOPE clause is REPORT-ONLY today, not a hard gate: the
+    // OR-Map tombstone leak it measures is deliberately unbounded until TODO-566
+    // bounds it, so any or-churn soak REDding on slope is the EXPECTED honest
+    // signal (a real, known leak), not a regression. Hard-gating on it would make
+    // every or-churn soak permanently red — including the blocking no-crash CI
+    // smoke. It is surfaced as a pending (expected-fail) gate below and flips to a
+    // hard gate once TODO-566 bounds the leak (see TODO-563 Gap 4). A process-
+    // local gauge that also resets to 0 on `kill -9`/restart is a further reason
+    // it cannot gate — its slope over a cross-restart sawtooth is untrustworthy.
+    //
+    // The blind-monitor guard, by contrast, DOES hard-gate: zero samples means
+    // the `/metrics` scrape was dead — a real harness defect independent of the
+    // leak magnitude, so a run that monitored nothing must not pass.
+    let blind_monitor = tombstones.samples == 0;
+
     let panic_report = panic_watch.report();
     let passed = convergence_failures.is_empty()
         && recovery_failures.is_empty()
         && mem.passed
-        && tombstones.passed
+        && !blind_monitor
         && panic_report.is_none();
 
     if !mem.passed {
@@ -587,11 +602,19 @@ async fn run_soak(config: &Config) -> i32 {
             mem.reason.clone().unwrap_or_default()
         );
     }
-    if !tombstones.passed {
+    if blind_monitor {
         finished_reason = format!(
-            "tombstone-byte growth assertion failed: {}",
+            "tombstone-byte monitoring blind: {}",
             tombstones.reason.clone().unwrap_or_default()
         );
+    } else if !tombstones.passed {
+        // Real, expected leak signal — record it as a pending gate (reported,
+        // did NOT fail the run) until TODO-566 makes bounded growth the norm.
+        pending_gates.push(format!(
+            "tombstone-byte slope {:.1} B/h exceeds {:.1} B/h — EXPECTED until \
+             TODO-566 bounds OR-Map tombstones (report-only, did NOT fail the run)",
+            tombstones.slope_bytes_per_hour, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR
+        ));
     }
     if let Some(pr) = &panic_report {
         if passed {
@@ -670,14 +693,19 @@ fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment) {
         r.memory.slope_mb_per_hour,
         if r.memory.passed { "ok" } else { "FAIL" }
     );
+    // The byte SLOPE is report-only until TODO-566 bounds the (currently
+    // deliberate) OR-Map tombstone leak; only the blind-monitor (zero-sample)
+    // clause hard-gates today. See the run-end verdict rationale.
+    let tombstone_role = "slope report-only until TODO-566; blind-monitor hard-gates";
     println!(
-        "tombstone_bytes:   first={} peak={} last={} slope={:.1}B/h samples={} -> {} (primary){}",
+        "tombstone_bytes:   first={} peak={} last={} slope={:.1}B/h samples={} -> {} ({}){}",
         tombstones.first_bytes,
         tombstones.peak_bytes,
         tombstones.last_bytes,
         tombstones.slope_bytes_per_hour,
         tombstones.samples,
         if tombstones.passed { "ok" } else { "FAIL" },
+        tombstone_role,
         tombstones
             .reason
             .as_ref()
@@ -733,6 +761,9 @@ async fn scrape_tombstone_bytes(http: &reqwest::Client, port: u16) -> Option<u64
 /// prefix match keeps the parser correct if one is ever added.
 fn parse_tombstone_bytes_total(body: &str) -> Option<u64> {
     const METRIC: &str = "topgun_ormap_tombstone_bytes_total";
+    // Compute the labelled-series prefix once rather than allocating a fresh
+    // `String` per scanned line in the hot scrape loop.
+    let labelled_prefix = format!("{METRIC}{{");
     for line in body.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
@@ -740,12 +771,16 @@ fn parse_tombstone_bytes_total(body: &str) -> Option<u64> {
         }
         let mut parts = line.split_whitespace();
         let name = parts.next()?;
-        if name == METRIC || name.starts_with(&format!("{METRIC}{{")) {
+        if name == METRIC || name.starts_with(&labelled_prefix) {
             let value = parts.next()?;
-            // Prometheus renders counter values as text floats (e.g. "1234" or
-            // "1234.0"); the gauge is logically u64 bytes, so parse as f64 and
-            // truncate rather than fail on the trailing ".0" rendering.
-            return value.parse::<f64>().ok().map(|f| f as u64);
+            // The gauge is logically u64 bytes. Parse as u64 first (exact for a
+            // whole-number counter); fall back to f64-then-truncate only for the
+            // trailing ".0" float rendering Prometheus may emit — avoids the f64
+            // precision loss a `u64` value above 2^53 would otherwise suffer.
+            return value
+                .parse::<u64>()
+                .ok()
+                .or_else(|| value.parse::<f64>().ok().map(|f| f as u64));
         }
     }
     None

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -16,9 +16,14 @@
 //!    is a HARD gate; the **full-scan QUERY** read-back is a tracked
 //!    *expected-fail* gate pending the datastore-backed full-scan, so the two
 //!    halves are scoped to the capability each actually delivers.
-//! 3. **Bounded memory:** with a fixed keyspace overwritten in place, the
-//!    server RSS must plateau; a sustained upward slope flags a leak (e.g.
-//!    unbounded OR-Map tombstone growth, TODO-479/480).
+//! 3. **Bounded memory:** the OR-Map tombstone-bytes gauge
+//!    (`topgun_ormap_tombstone_bytes_total`, scraped from the server's own
+//!    `GET /metrics`) is sampled every interval and its slope is asserted
+//!    against a tight per-hour threshold — a direct, residency-independent
+//!    leak signal with no allocator/cache noise floor. Server RSS is sampled
+//!    in parallel and asserted against a looser slope as a secondary/backstop
+//!    gate; neither replaces the other (e.g. unbounded OR-Map tombstone
+//!    growth, TODO-479/480).
 //! 4. **Zero panics:** any panic marker in server output, or any un-requested
 //!    exit, fails the run with the captured context.
 //!
@@ -62,7 +67,10 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 
 use client::SoakClient;
 use model::{compare, next_stamp, Model};
-use monitor::{assess, sample_rss_mb, MemSample};
+use monitor::{
+    assess, assess_tombstone_bytes, sample_rss_mb, MemSample, TombstoneAssessment, TombstoneSample,
+    DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+};
 use or_noloss::{missing_acked_adds, OrLedger};
 use process::{resolve_server_binary, ServerConfig, ServerSupervisor};
 use report::{
@@ -333,7 +341,10 @@ async fn run_soak(config: &Config) -> i32 {
         churn_handles.push(tokio::spawn(run_churn_client(idx, ctx)));
     }
 
-    // --- Spawn memory sampler ---
+    // --- Spawn memory + tombstone-bytes samplers ---
+    // Both samplers share one clock so their `elapsed_secs` axes line up exactly
+    // (required for a fair side-by-side slope comparison in the summary/report).
+    let sampler_start = Instant::now();
     let samples: Arc<Mutex<Vec<MemSample>>> = Arc::new(Mutex::new(Vec::new()));
     let peak_rss = Arc::new(Mutex::new(0.0_f64));
     {
@@ -342,7 +353,7 @@ async fn run_soak(config: &Config) -> i32 {
         let peak_rss = Arc::clone(&peak_rss);
         let stop = Arc::clone(&stop);
         let interval = config.mem_sample_interval;
-        let start = Instant::now();
+        let start = sampler_start;
         tokio::spawn(async move {
             loop {
                 if stop.load(Ordering::SeqCst) {
@@ -360,6 +371,36 @@ async fn run_soak(config: &Config) -> i32 {
                             *p = mb;
                         }
                     }
+                }
+                tokio::time::sleep(interval).await;
+            }
+        });
+    }
+
+    // Direct, residency-independent tombstone-byte gauge sampler: scrapes the
+    // real `topgun_ormap_tombstone_bytes_total` Prometheus counter off the same
+    // running server over HTTP, the production surface (KL2) rather than a
+    // test-only hook. A transient scrape failure (connection refused mid-restart,
+    // non-200, or the metric line absent) is skipped rather than recorded as a
+    // bogus point, mirroring `sample_rss_mb`'s `None`-on-gone-process contract.
+    let tombstone_samples: Arc<Mutex<Vec<TombstoneSample>>> = Arc::new(Mutex::new(Vec::new()));
+    {
+        let samples = Arc::clone(&tombstone_samples);
+        let stop = Arc::clone(&stop);
+        let interval = config.mem_sample_interval;
+        let start = sampler_start;
+        let http = reqwest::Client::new();
+        tokio::spawn(async move {
+            loop {
+                if stop.load(Ordering::SeqCst) {
+                    return;
+                }
+                if let Some(bytes) = scrape_tombstone_bytes(&http, port).await {
+                    let elapsed = start.elapsed().as_secs_f64();
+                    samples.lock().push(TombstoneSample {
+                        elapsed_secs: elapsed,
+                        bytes,
+                    });
                 }
                 tokio::time::sleep(interval).await;
             }
@@ -513,7 +554,7 @@ async fn run_soak(config: &Config) -> i32 {
     }
     supervisor.shutdown().await;
 
-    // --- Assess memory ---
+    // --- Assess memory (secondary/backstop gate) ---
     let mem_samples = samples.lock().clone();
     let mem = assess(
         &mem_samples,
@@ -522,16 +563,34 @@ async fn run_soak(config: &Config) -> i32 {
         config.mem_ceiling_mb,
     );
 
+    // --- Assess tombstone-byte growth (primary, tight-threshold leak signal).
+    // Coexists with the RSS gate above — neither replaces the other (AC6). A
+    // run that collected zero gauge samples fails as a blind monitor, same as
+    // the RSS empty-samples branch.
+    let tombstone_samples_snapshot = tombstone_samples.lock().clone();
+    let tombstones = assess_tombstone_bytes(
+        &tombstone_samples_snapshot,
+        DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+        DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+    );
+
     let panic_report = panic_watch.report();
     let passed = convergence_failures.is_empty()
         && recovery_failures.is_empty()
         && mem.passed
+        && tombstones.passed
         && panic_report.is_none();
 
     if !mem.passed {
         finished_reason = format!(
             "memory growth assertion failed: {}",
             mem.reason.clone().unwrap_or_default()
+        );
+    }
+    if !tombstones.passed {
+        finished_reason = format!(
+            "tombstone-byte growth assertion failed: {}",
+            tombstones.reason.clone().unwrap_or_default()
         );
     }
     if let Some(pr) = &panic_report {
@@ -572,16 +631,21 @@ async fn run_soak(config: &Config) -> i32 {
         timestamp: utc_timestamp_now(),
     };
 
-    print_summary(&report);
+    print_summary(&report, &tombstones);
     if let Some(path) = &config.json_output {
         write_report(path, &report);
         println!("wrote JSON report to {}", path.display());
     }
+    // NOTE: the tombstone-byte verdict is asserted into `passed`/`finished_reason`
+    // above and printed in the console summary below, but is not yet a field on
+    // `SoakReport` (report.rs) — adding it there would be a 6th touched file
+    // against this spec's 5-file cap. Tracked as a follow-up so JSON consumers
+    // (CI dashboards) gain the same visibility the console already has.
 
     i32::from(!passed)
 }
 
-fn print_summary(r: &SoakReport) {
+fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment) {
     println!("\n=== SOAK SUMMARY ===");
     println!(
         "result:            {}",
@@ -599,12 +663,25 @@ fn print_summary(r: &SoakReport) {
         r.recovery_checkpoints, r.crashes
     );
     println!(
-        "memory:            first={:.0}MB peak={:.0}MB last={:.0}MB slope={:.1}MB/h -> {}",
+        "memory:            first={:.0}MB peak={:.0}MB last={:.0}MB slope={:.1}MB/h -> {} (backstop)",
         r.memory.first_mb,
         r.memory.peak_mb,
         r.memory.last_mb,
         r.memory.slope_mb_per_hour,
         if r.memory.passed { "ok" } else { "FAIL" }
+    );
+    println!(
+        "tombstone_bytes:   first={} peak={} last={} slope={:.1}B/h samples={} -> {} (primary){}",
+        tombstones.first_bytes,
+        tombstones.peak_bytes,
+        tombstones.last_bytes,
+        tombstones.slope_bytes_per_hour,
+        tombstones.samples,
+        if tombstones.passed { "ok" } else { "FAIL" },
+        tombstones
+            .reason
+            .as_ref()
+            .map_or_else(String::new, |r| format!(" reason={r}")),
     );
     if !r.convergence_failures.is_empty() {
         println!("convergence_failures:");
@@ -627,6 +704,51 @@ fn print_summary(r: &SoakReport) {
     if let Some(pr) = &r.panic_report {
         println!("panic_report:      {pr}");
     }
+}
+
+// ---------------------------------------------------------------------------
+// Tombstone-bytes gauge sampling
+// ---------------------------------------------------------------------------
+
+/// Scrape `topgun_ormap_tombstone_bytes_total` from the real running server's
+/// `GET /metrics` (Prometheus text exposition format). Returns `None` on any
+/// transient failure — connection refused (server mid-restart), non-2xx
+/// status, an unreadable body, or the metric line simply not being present —
+/// so the caller skips the sample instead of recording a bogus point. This
+/// mirrors `sample_rss_mb`'s `None`-on-gone-process contract in `monitor.rs`.
+async fn scrape_tombstone_bytes(http: &reqwest::Client, port: u16) -> Option<u64> {
+    let url = format!("http://127.0.0.1:{port}/metrics");
+    let resp = http.get(&url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body = resp.text().await.ok()?;
+    parse_tombstone_bytes_total(&body)
+}
+
+/// Parse the `topgun_ormap_tombstone_bytes_total` sample value out of a
+/// Prometheus text exposition body, skipping `# HELP`/`# TYPE` comment lines
+/// and any blank lines. A metric line is `name value` or `name{labels} value`
+/// (space-separated); this counter carries no labels today, but the label-form
+/// prefix match keeps the parser correct if one is ever added.
+fn parse_tombstone_bytes_total(body: &str) -> Option<u64> {
+    const METRIC: &str = "topgun_ormap_tombstone_bytes_total";
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        let name = parts.next()?;
+        if name == METRIC || name.starts_with(&format!("{METRIC}{{")) {
+            let value = parts.next()?;
+            // Prometheus renders counter values as text floats (e.g. "1234" or
+            // "1234.0"); the gauge is logically u64 bytes, so parse as f64 and
+            // truncate rather than fail on the trailing ".0" rendering.
+            return value.parse::<f64>().ok().map(|f| f as u64);
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -215,13 +215,10 @@ fn least_squares_slope_per_hour(samples: &[MemSample]) -> f64 {
 /// with no RSS-style noise to absorb, any sustained per-hour growth this small
 /// is already real signal, not measurement wobble.
 ///
-/// `allow(dead_code)`: this bench target (`harness = false`) is a binary, so
-/// unused-in-`main.rs` pub items are flagged dead by design until the harness
-/// wiring lands (samples `GET /metrics` and calls [`assess_tombstone_bytes`]
-/// alongside the existing RSS `assess` call) — the calibration tests below
-/// exercise this code today via the `soak_monitor_calibration` integration
-/// target, which re-includes this module under the standard libtest harness.
-#[allow(dead_code)]
+/// Consumed by `main.rs` (the soak loop scrapes `GET /metrics` and calls
+/// [`assess_tombstone_bytes`] with this threshold alongside the RSS `assess`) and
+/// by the `soak_monitor_calibration` integration target's tests — the harness
+/// wiring has landed, so no `allow(dead_code)` is needed here.
 pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 
 /// Absolute-growth guard (bytes) for the tombstone-byte slope clause.
@@ -233,14 +230,12 @@ pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 /// RSS gate's multi-hour detection floor for no benefit. Kept just above zero
 /// so a one/two-sample run (degenerate least-squares fit) cannot trip the
 /// clause on rounding.
-#[allow(dead_code)]
 pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
 
 /// One tombstone-byte-gauge sample (`topgun_ormap_tombstone_bytes_total`,
 /// scraped over HTTP). `bytes` is `u64` — a counted byte total is a
 /// non-negative integer, never a float.
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]
 pub struct TombstoneSample {
     pub elapsed_secs: f64,
     pub bytes: u64,
@@ -249,7 +244,6 @@ pub struct TombstoneSample {
 /// Verdict of a tombstone-byte-growth assessment. Mirrors [`MemoryAssessment`]'s
 /// shape so callers (soak `main.rs`) can report both gates uniformly.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct TombstoneAssessment {
     pub samples: usize,
     pub first_bytes: u64,
@@ -266,7 +260,7 @@ pub struct TombstoneAssessment {
 /// * `min_growth_bytes` — absolute growth (peak − first) below which slope is
 ///   treated as noise. Kept minimal (see [`DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH`]
 ///   doc) rather than mirroring the RSS gate's large guard.
-#[allow(clippy::cast_precision_loss, dead_code)]
+#[allow(clippy::cast_precision_loss)]
 pub fn assess_tombstone_bytes(
     samples: &[TombstoneSample],
     threshold_bytes_per_hour: f64,
@@ -330,7 +324,7 @@ pub fn assess_tombstone_bytes(
 /// Least-squares slope of `bytes` vs. time, expressed in bytes per hour.
 /// Same fit as [`least_squares_slope_per_hour`]; kept as a separate function
 /// because the sample type differs (`u64` bytes vs. `f64` MB).
-#[allow(clippy::cast_precision_loss, dead_code)]
+#[allow(clippy::cast_precision_loss)]
 fn least_squares_slope_per_hour_bytes(samples: &[TombstoneSample]) -> f64 {
     let n = samples.len() as f64;
     if n < 2.0 {

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -46,6 +46,21 @@
 //! bounded soaks exercise crash/convergence, and their green memory verdict means
 //! "no leak large enough to clear the noise floor in this window", NOT "bounded
 //! memory proven". Do not read a short green soak as the latter.
+//!
+//! ## Tombstone-byte gate: same slope idea, no detection floor
+//!
+//! `topgun_ormap_tombstone_bytes_total` (sampled over HTTP from `GET /metrics`)
+//! is a direct, residency-independent count of tombstone bytes on the write
+//! path — unlike RSS it carries no allocator retention, no read/GC jitter, and
+//! no cache-warmup wobble. Every unit of observed growth is either a newly
+//! inserted tombstone or nothing; there is no noise floor to wait out. That is
+//! why [`assess_tombstone_bytes`] uses a much tighter per-hour threshold than
+//! the RSS gate AND does not replicate RSS's large min-growth guard (see
+//! "Detection floor" above) — the RSS guard exists solely to suppress noise
+//! until a leak's absolute growth clears it, and this gauge has no analogous
+//! noise to suppress. That is precisely what lets *short* soak runs gain real
+//! leak signal from the byte gate long before the RSS gate's multi-hour
+//! detection floor would let it see anything.
 
 use std::process::Command;
 
@@ -179,6 +194,150 @@ fn least_squares_slope_per_hour(samples: &[MemSample]) -> f64 {
     // x in hours so the slope is directly MB/hour.
     let xs: Vec<f64> = samples.iter().map(|s| s.elapsed_secs / 3600.0).collect();
     let ys: Vec<f64> = samples.iter().map(|s| s.rss_mb).collect();
+    let mean_x = xs.iter().sum::<f64>() / n;
+    let mean_y = ys.iter().sum::<f64>() / n;
+    let mut num = 0.0;
+    let mut den = 0.0;
+    for (x, y) in xs.iter().zip(ys.iter()) {
+        num += (x - mean_x) * (y - mean_y);
+        den += (x - mean_x) * (x - mean_x);
+    }
+    if den.abs() < f64::EPSILON {
+        0.0
+    } else {
+        num / den
+    }
+}
+
+/// Calibrated slope ceiling (bytes/hour) for the tombstone-byte gate.
+///
+/// ~0.5 KB/h. Tight by design — see the module-level "no detection floor" doc:
+/// with no RSS-style noise to absorb, any sustained per-hour growth this small
+/// is already real signal, not measurement wobble.
+///
+/// `allow(dead_code)`: this bench target (`harness = false`) is a binary, so
+/// unused-in-`main.rs` pub items are flagged dead by design until the harness
+/// wiring lands (samples `GET /metrics` and calls [`assess_tombstone_bytes`]
+/// alongside the existing RSS `assess` call) — the calibration tests below
+/// exercise this code today via the `soak_monitor_calibration` integration
+/// target, which re-includes this module under the standard libtest harness.
+#[allow(dead_code)]
+pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
+
+/// Absolute-growth guard (bytes) for the tombstone-byte slope clause.
+///
+/// Deliberately minimal — NOT the RSS gate's large [`DEFAULT_MEM_MIN_GROWTH_MB`]
+/// analogue. The RSS guard exists to suppress a real leak's *slope* signal
+/// until enough hours have passed for its absolute growth to clear RSS noise;
+/// this gauge has no such noise, so a large guard would only reintroduce the
+/// RSS gate's multi-hour detection floor for no benefit. Kept just above zero
+/// so a one/two-sample run (degenerate least-squares fit) cannot trip the
+/// clause on rounding.
+#[allow(dead_code)]
+pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
+
+/// One tombstone-byte-gauge sample (`topgun_ormap_tombstone_bytes_total`,
+/// scraped over HTTP). `bytes` is `u64` — a counted byte total is a
+/// non-negative integer, never a float.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub struct TombstoneSample {
+    pub elapsed_secs: f64,
+    pub bytes: u64,
+}
+
+/// Verdict of a tombstone-byte-growth assessment. Mirrors [`MemoryAssessment`]'s
+/// shape so callers (soak `main.rs`) can report both gates uniformly.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct TombstoneAssessment {
+    pub samples: usize,
+    pub first_bytes: u64,
+    pub peak_bytes: u64,
+    pub last_bytes: u64,
+    pub slope_bytes_per_hour: f64,
+    pub passed: bool,
+    pub reason: Option<String>,
+}
+
+/// Assess a series of tombstone-byte samples for bounded growth.
+///
+/// * `threshold_bytes_per_hour` — maximum tolerated growth slope.
+/// * `min_growth_bytes` — absolute growth (peak − first) below which slope is
+///   treated as noise. Kept minimal (see [`DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH`]
+///   doc) rather than mirroring the RSS gate's large guard.
+#[allow(clippy::cast_precision_loss, dead_code)]
+pub fn assess_tombstone_bytes(
+    samples: &[TombstoneSample],
+    threshold_bytes_per_hour: f64,
+    min_growth_bytes: f64,
+) -> TombstoneAssessment {
+    if samples.is_empty() {
+        // Same rationale as the RSS gate's empty-samples branch: zero samples
+        // means the monitor was BLIND (metrics scrape failed or the server was
+        // never reachable) — a leak would be invisible. Fail rather than
+        // silently pass.
+        return TombstoneAssessment {
+            samples: 0,
+            first_bytes: 0,
+            peak_bytes: 0,
+            last_bytes: 0,
+            slope_bytes_per_hour: 0.0,
+            passed: false,
+            reason: Some(
+                "no tombstone-byte samples collected — monitoring was blind (metrics scrape \
+                 failed or server never reachable); cannot assert bounded tombstone growth"
+                    .to_string(),
+            ),
+        };
+    }
+
+    let first_bytes = samples[0].bytes;
+    let last_bytes = samples[samples.len() - 1].bytes;
+    let peak_bytes = samples.iter().map(|s| s.bytes).max().unwrap_or(first_bytes);
+
+    let slope_bytes_per_hour = least_squares_slope_per_hour_bytes(samples);
+
+    #[allow(clippy::cast_precision_loss)]
+    let growth = peak_bytes.saturating_sub(first_bytes) as f64;
+    let mut reasons = Vec::new();
+
+    if growth >= min_growth_bytes && slope_bytes_per_hour > threshold_bytes_per_hour {
+        reasons.push(format!(
+            "tombstone-byte growth slope {slope_bytes_per_hour:.1} bytes/h exceeds \
+             {threshold_bytes_per_hour:.1} bytes/h (total growth {growth:.0} bytes over {} \
+             samples)",
+            samples.len()
+        ));
+    }
+
+    let passed = reasons.is_empty();
+    TombstoneAssessment {
+        samples: samples.len(),
+        first_bytes,
+        peak_bytes,
+        last_bytes,
+        slope_bytes_per_hour,
+        passed,
+        reason: if passed {
+            None
+        } else {
+            Some(reasons.join("; "))
+        },
+    }
+}
+
+/// Least-squares slope of `bytes` vs. time, expressed in bytes per hour.
+/// Same fit as [`least_squares_slope_per_hour`]; kept as a separate function
+/// because the sample type differs (`u64` bytes vs. `f64` MB).
+#[allow(clippy::cast_precision_loss, dead_code)]
+fn least_squares_slope_per_hour_bytes(samples: &[TombstoneSample]) -> f64 {
+    let n = samples.len() as f64;
+    if n < 2.0 {
+        return 0.0;
+    }
+    let xs: Vec<f64> = samples.iter().map(|s| s.elapsed_secs / 3600.0).collect();
+    let ys: Vec<f64> = samples.iter().map(|s| s.bytes as f64).collect();
     let mean_x = xs.iter().sum::<f64>() / n;
     let mean_y = ys.iter().sum::<f64>() / n;
     let mut num = 0.0;
@@ -372,5 +531,72 @@ mod tests {
             "hetzner-soak-runner.sh MEM_THRESHOLD default must match \
              monitor::DEFAULT_MEM_THRESHOLD_MB_PER_HOUR (expected {expected:?})"
         );
+    }
+
+    /// Build an hourly-sampled tombstone-byte series with a constant per-hour
+    /// growth rate, starting at `first_bytes`.
+    fn linear_bytes_series(
+        first_bytes: u64,
+        hours: u32,
+        bytes_per_hour: u64,
+    ) -> Vec<TombstoneSample> {
+        (0..=hours)
+            .map(|h| TombstoneSample {
+                elapsed_secs: f64::from(h) * 3600.0,
+                bytes: first_bytes + u64::from(h) * bytes_per_hour,
+            })
+            .collect()
+    }
+
+    /// A clearly-linear tombstone-byte-growth series — well above the tight
+    /// per-hour threshold — MUST FAIL. Mirrors the RSS gate's
+    /// `calibration_fails_linear_tombstone_leak`, but at the byte gauge's much
+    /// tighter scale: with no RSS noise floor, a sustained per-hour growth this
+    /// small is already real signal (see module docs).
+    #[test]
+    fn calibration_fails_linear_tombstone_bytes() {
+        let samples = linear_bytes_series(1_000, 24, 5_000);
+        let a = assess_tombstone_bytes(
+            &samples,
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+        );
+        assert!(
+            !a.passed,
+            "5000 bytes/h linear tombstone-byte growth must fail the tight gate; \
+             slope={:.1} reason={:?}",
+            a.slope_bytes_per_hour, a.reason
+        );
+        assert!(a.slope_bytes_per_hour > DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR);
+    }
+
+    /// A flat tombstone-byte series (churn stopped, or a future prune landed)
+    /// MUST PASS — otherwise the gate false-FAILs every healthy run.
+    #[test]
+    fn calibration_passes_flat_tombstone_bytes() {
+        let samples = linear_bytes_series(50_000, 24, 0);
+        let a = assess_tombstone_bytes(
+            &samples,
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+        );
+        assert!(
+            a.passed,
+            "flat tombstone-byte series must pass; slope={:.3} reason={:?}",
+            a.slope_bytes_per_hour, a.reason
+        );
+    }
+
+    /// Zero samples means the metrics scrape was blind — must FAIL, same
+    /// rationale as the RSS gate's empty-samples branch (AC6: a zero-sample
+    /// run must not silently report bounded growth).
+    #[test]
+    fn calibration_fails_zero_tombstone_samples() {
+        let a = assess_tombstone_bytes(
+            &[],
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+        );
+        assert!(!a.passed, "zero samples must fail as a blind monitor");
     }
 }

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -61,6 +61,18 @@
 //! noise to suppress. That is precisely what lets *short* soak runs gain real
 //! leak signal from the byte gate long before the RSS gate's multi-hour
 //! detection floor would let it see anything.
+//!
+//! Note on gating responsibility: [`assess_tombstone_bytes`] *computes* the byte
+//! verdict (including its `passed` flag), but whether that verdict gates the run
+//! is decided in `main.rs`, not here. Today the byte **slope** is report-only —
+//! the process-local counter resets to 0 on every `kill -9`, so across a
+//! crash-enabled run its series is a per-life sawtooth whose OLS slope is
+//! untrustworthy, and the OR-Map tombstone leak it measures is deliberately
+//! unbounded until TODO-566. `main.rs` therefore routes a slope breach to its
+//! `pending_gates` channel (surfaced, does NOT fail the run) and hard-gates only
+//! on the blind-monitor (zero-sample) case. So do not read this module's
+//! `passed: bool` as load-bearing everywhere — see `main.rs`'s run-end
+//! verdict-assembly for the authoritative gating decision.
 
 use std::process::Command;
 

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -332,13 +332,12 @@ impl ClusterService for ClusterStateAdapter {
 #[tokio::main]
 #[allow(clippy::too_many_lines)]
 async fn main() -> anyhow::Result<()> {
-    // Initialize tracing for debug output
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .init();
+    // Initialize tracing AND install the global Prometheus recorder in one call.
+    // Without this the `/metrics` endpoint renders an empty body (no recorder is
+    // installed), so counters like `topgun_ormap_tombstone_bytes_total` are
+    // invisible to out-of-process scrapers such as the soak harness. The handle
+    // is threaded into AppState so the `/metrics` handler can render it.
+    let observability = Arc::new(topgun_server::service::middleware::init_observability());
 
     let args = Args::parse();
     let node_id = args.node_id.clone();
@@ -937,7 +936,7 @@ async fn main() -> anyhow::Result<()> {
             ..NetworkConfig::default()
         }),
         start_time: Instant::now(),
-        observability: None,
+        observability: Some(observability),
         operation_service: Some(classify_svc),
         dispatcher: Some(Arc::new(dispatcher)),
         jwt_secret,

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -559,6 +559,10 @@ impl CrdtService {
                 // Dedup: a re-issued remove must not duplicate the tombstone.
                 if !tombstones.contains(tag) {
                     tombstones.push(tag.clone());
+                    // Feeds the residency-independent soak leak gauge: counted here
+                    // on the write path (once per genuinely-new tag) so eviction and
+                    // rehydration of the record never move this number.
+                    crate::storage::record::add_tombstone_bytes(tag.len() as u64);
                 }
                 RecordValue::OrMap {
                     records,
@@ -2706,6 +2710,96 @@ mod tests {
                 .collect(),
             _ => Vec::new(),
         }
+    }
+
+    // -- Tombstone-bytes gauge is residency-independent --
+    //
+    // Drives the REAL evict -> rehydrate path via `RecordStore::evict_lru` (the
+    // same primitive `EvictionOrchestrator` calls in production) rather than the
+    // documented read-path surrogate, since the existing store/factory test
+    // infrastructure (a real `RedbDataStore` + `evict_lru`/`get`) makes it
+    // practical here — this exercises the actual eviction blind-spot the gauge
+    // exists to defend against, not a stand-in for it.
+    #[tokio::test]
+    async fn or_remove_tombstone_gauge_survives_real_eviction_and_rehydration() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let redb_path = dir.path().join("gauge_residency.redb");
+        let data_store: Arc<dyn crate::storage::MapDataStore> = Arc::new(
+            crate::storage::datastores::RedbDataStore::new(&redb_path).expect("redb open"),
+        );
+        let factory = Arc::new(RecordStoreFactory::new(
+            StorageConfig::default(),
+            data_store,
+            Vec::new(),
+        ));
+        let registry = Arc::new(ConnectionRegistry::new());
+        let query_registry = Arc::new(QueryRegistry::new());
+        let svc = Arc::new(CrdtService::new(
+            Arc::clone(&factory),
+            registry,
+            make_validator(),
+            query_registry,
+            Arc::new(SchemaService::new()),
+        ));
+
+        let map_name = "gauge_residency_map";
+        let key = "item-1";
+        let tag = "tag-gauge-residency";
+
+        // The gauge is a process-global static shared across parallel test
+        // threads, so assert on the DELTA this test produces, never an absolute
+        // value.
+        let before_write = crate::storage::record::tombstone_bytes();
+
+        svc.clone()
+            .oneshot(or_add_op(map_name, key, "payload", tag))
+            .await
+            .expect("or_add must succeed");
+        svc.clone()
+            .oneshot(or_remove_op(map_name, key, tag))
+            .await
+            .expect("or_remove must succeed");
+
+        let after_write = crate::storage::record::tombstone_bytes();
+        assert_eq!(
+            after_write - before_write,
+            tag.len() as u64,
+            "gauge must increase by exactly the new tombstone tag's byte length"
+        );
+
+        // Force the record non-resident via the real eviction primitive. The
+        // OR_REMOVE above wrote through with `CallerProvenance::CrdtMerge` over a
+        // real (non-null) data store, which marks the record clean and therefore
+        // evictable.
+        let store = factory.get_or_create(map_name, hash_to_partition(key));
+        let evicted = store.evict_lru(u32::MAX, false);
+        assert!(evicted > 0, "the clean record must be evicted");
+        assert!(
+            !store.exists_in_memory(key),
+            "record must be non-resident after eviction"
+        );
+
+        let after_eviction = crate::storage::record::tombstone_bytes();
+        assert_eq!(
+            after_eviction, after_write,
+            "evicting a tombstone-bearing record must not drop the gauge"
+        );
+
+        // Rehydrate: `get()` transparently reloads the non-resident record from
+        // the datastore. Confirm the tombstone survived the round trip and the
+        // gauge did not move.
+        let (_, tombstones) = read_or_map(&factory, map_name, key).await;
+        assert_eq!(
+            tombstones,
+            vec![tag.to_string()],
+            "tombstone must still be present after rehydration"
+        );
+
+        let after_rehydration = crate::storage::record::tombstone_bytes();
+        assert_eq!(
+            after_rehydration, after_write,
+            "rehydrating a tombstone-bearing record must not double-count the gauge"
+        );
     }
 
     // AC1: add-wins — OR_REMOVE of one tag preserves concurrent survivors.

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -538,8 +538,8 @@ impl CrdtService {
                 let (mut records, mut tombstones) = read_or_map_state(existing.map(|r| r.value));
 
                 records.retain(|e| e.tag != *tag);
-                // The tombstone set grows unbounded by design: it is NOT pruned
-                // here. Pruning a tag is only safe once every replica that could
+                // The tombstone set grows unbounded here today: it is NOT pruned on
+                // this path. Pruning a tag is only safe once every replica that could
                 // still hold the matching add has observed this remove, and a
                 // single node with transient reconnecting clients has no
                 // causal-stability / delivery-ack tracking to know that. A
@@ -548,9 +548,14 @@ impl CrdtService {
                 // the dropped tombstone, and resurrects the removed value. A loud,
                 // bounded-memory OOM is preferable to silent CRDT corruption, so
                 // for the single-node demo tier we accept linear tombstone growth.
-                // Revisit when a causal-stability low-water-mark lands or the tier
-                // moves beyond single-node demo (see the soak memory monitor,
-                // which is calibrated to flag this growth rather than mask it).
+                // The real bound is designed: epoch/generation GC (M4) prunes an
+                // entire epoch's tombstone set wholesale once the low-water-mark
+                // across ALL tracked clients has passed it. The prune wiring, the
+                // forgotten-client pre-apply gate, and the confirmed-apply ACK
+                // protocol it depends on are the downstream implementation
+                // (TODO-566; contract in core-rust tombstone_frontier.rs). Until
+                // that lands, the soak memory monitor is calibrated to flag this
+                // growth rather than mask it.
                 // Dedup: a re-issued remove must not duplicate the tombstone.
                 if !tombstones.contains(tag) {
                     tombstones.push(tag.clone());

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -1110,7 +1110,14 @@ impl SyncService {
 
             // Union inbound tombstones (remove-wins) before applying records, so a
             // tag tombstoned anywhere suppresses its record everywhere.
-            tombstones.extend(entry.tombstones.iter().cloned());
+            // `insert` returns true only for tags not already in the local set, so
+            // the tombstone-bytes gauge counts genuinely-new inbound tombstones —
+            // idempotent re-pushes and intra-batch duplicates don't inflate it.
+            for tag in &entry.tombstones {
+                if tombstones.insert(tag.clone()) {
+                    crate::storage::record::add_tombstone_bytes(tag.len() as u64);
+                }
+            }
 
             // Drop any locally-stored record whose tag is now tombstoned.
             merged_records.retain(|r| !tombstones.contains(&r.tag));

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -19,6 +19,74 @@ use topgun_core::types::Value;
 /// synchronized by the `DashMap` shard lock at `get_mut`/put.
 static WRITE_TOKEN: AtomicU64 = AtomicU64::new(1);
 
+/// Process-global running total of OR-Map tombstone bytes (sum of removed
+/// tags' UTF-8 byte lengths currently tracked across all `OrMap.tombstones`
+/// sets).
+///
+/// This is the in-process source of truth behind [`add_tombstone_bytes`],
+/// [`sub_tombstone_bytes`], and [`tombstone_bytes`]. It exists to give the
+/// unbounded-tombstone-growth soak monitor (and the `/metrics` Prometheus
+/// surface) a cheap, lock-free signal of how much tombstone data has
+/// accumulated, without walking every resident `OrMap` record on each check.
+/// `Relaxed` ordering is sufficient: this is a monitoring counter, not a
+/// correctness-critical value guarding any invariant, so no other memory
+/// operation needs to be ordered against it.
+static OR_TOMBSTONE_BYTES: AtomicU64 = AtomicU64::new(0);
+
+/// Adds `n` bytes to the process-global OR-Map tombstone-bytes gauge and
+/// emits the same delta to the `topgun_ormap_tombstone_bytes_total`
+/// Prometheus counter (mirrors the `topgun_operations_total` emit pattern in
+/// `service/middleware/metrics.rs`).
+///
+/// Call sites pass `tag.len() as u64` — the tombstone's contribution is its
+/// removed tag's UTF-8 byte length, which is the direct measure of what grows
+/// in `OrMap.tombstones: Vec<String>`. Fixed per-entry allocator overhead is
+/// intentionally excluded: the slope, not the absolute total, is the signal
+/// this gauge exists to expose, and a constant per-entry factor only scales
+/// it without changing what it reveals.
+pub fn add_tombstone_bytes(n: u64) {
+    OR_TOMBSTONE_BYTES.fetch_add(n, Ordering::Relaxed);
+    metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(n);
+}
+
+/// Subtracts `n` bytes from the process-global OR-Map tombstone-bytes gauge.
+///
+/// This is the decrement path for the future OR-Map epoch-GC prune
+/// (TODO-566): once that prune wires in, it will call this function as it
+/// drops fully-superseded tombstone epochs. It is intentionally unused on
+/// today's additive-only write path (nothing yet prunes tombstones), so it is
+/// exercised solely by a unit test to keep it out of `-D warnings` dead-code
+/// territory until the prune lands.
+///
+/// **Prometheus divergence (forward-looking):** unlike [`add_tombstone_bytes`],
+/// this function does NOT emit to `topgun_ormap_tombstone_bytes_total` — that
+/// metric follows the `_total` *monotonic*-counter convention, so it cannot
+/// legally decrease. That is harmless today because usage is purely additive,
+/// but once TODO-566's prune starts calling this decrement path, the exported
+/// Prometheus series will diverge from (stay flat relative to) the
+/// authoritative in-process [`tombstone_bytes`] value. TODO-566 must reconcile
+/// the external surface at that point — e.g. switch the exported metric to a
+/// gauge, or have consumers (soak harness, dashboards) read the in-process
+/// accessor instead of scraping the counter.
+///
+/// Saturating-safe by construction: the future prune is only ever expected to
+/// subtract bytes it previously observed being added, so it should never
+/// underflow in practice, but `fetch_sub` wraps on underflow rather than
+/// panicking — acceptable for a monitoring counter.
+pub fn sub_tombstone_bytes(n: u64) {
+    OR_TOMBSTONE_BYTES.fetch_sub(n, Ordering::Relaxed);
+}
+
+/// Reads the current value of the process-global OR-Map tombstone-bytes gauge.
+///
+/// This is the authoritative in-process accessor referenced by the
+/// [`sub_tombstone_bytes`] Prometheus-divergence note above, and by the
+/// soak-test monitor that watches for unbounded tombstone growth.
+#[must_use]
+pub fn tombstone_bytes() -> u64 {
+    OR_TOMBSTONE_BYTES.load(Ordering::Relaxed)
+}
+
 /// Minimum elapsed milliseconds before a read access updates `last_access_time`.
 ///
 /// Coalesces recency updates to bound write amplification under read-heavy load
@@ -230,7 +298,7 @@ pub enum RecordValue {
         /// across ALL tracked clients has passed it. Migrating existing blobs to the
         /// epoch-indexed form (assigning the legacy corpus to one conservative
         /// pre-migration generation) is the downstream implementation's obligation
-        /// (TODO-566; contract in core-rust tombstone_frontier.rs).
+        /// (TODO-566; contract in core-rust `tombstone_frontier.rs`).
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         tombstones: Vec<String>,
     },
@@ -270,6 +338,92 @@ pub struct Record {
     pub value: RecordValue,
     /// Server-internal metadata (NOT sent over the wire).
     pub metadata: RecordMetadata,
+}
+
+#[cfg(test)]
+mod tombstone_bytes_gauge_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // `OR_TOMBSTONE_BYTES` is a single process-global static. No production
+    // call site exists yet (added by later task groups), so the only writers
+    // today are these three tests themselves — but the Rust test harness runs
+    // them concurrently on separate threads, and a delta-based assertion in
+    // one test can still observe an in-flight mutation from another. A
+    // test-local mutex serializes just this module's tests against each
+    // other, which is sufficient today; asserting deltas (rather than
+    // absolute values) additionally keeps these tests robust once real call
+    // sites (G2/G3) start mutating the gauge from other test modules too.
+    static TEST_SERIALIZE: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn add_tombstone_bytes_is_monotonic_and_visible_via_accessor() {
+        let _guard = TEST_SERIALIZE.lock().unwrap();
+        let baseline = tombstone_bytes();
+
+        add_tombstone_bytes(5);
+        assert_eq!(
+            tombstone_bytes(),
+            baseline + 5,
+            "add_tombstone_bytes must increase the gauge by exactly n"
+        );
+
+        add_tombstone_bytes(3);
+        assert_eq!(
+            tombstone_bytes(),
+            baseline + 8,
+            "successive adds must accumulate monotonically"
+        );
+    }
+
+    #[test]
+    fn sub_tombstone_bytes_decrements_the_gauge() {
+        let _guard = TEST_SERIALIZE.lock().unwrap();
+        // Add first so the subtraction has headroom and cannot underflow
+        // relative to this test's own contribution, independent of whatever
+        // baseline other parallel tests have left in the global counter.
+        add_tombstone_bytes(10);
+        let after_add = tombstone_bytes();
+
+        sub_tombstone_bytes(4);
+        assert_eq!(
+            tombstone_bytes(),
+            after_add - 4,
+            "sub_tombstone_bytes must decrease the gauge by exactly n"
+        );
+    }
+
+    /// Serializing/deserializing an `OrMap` `RecordValue` must not touch the
+    /// gauge — the gauge is updated only by explicit call sites at the
+    /// OR_REMOVE tombstone-push / inbound-sync-union points (later task
+    /// groups), never as a side effect of encoding.
+    #[test]
+    fn ormap_serde_round_trip_does_not_touch_gauge() {
+        let _guard = TEST_SERIALIZE.lock().unwrap();
+        let baseline = tombstone_bytes();
+
+        let value = RecordValue::OrMap {
+            records: vec![OrMapEntry {
+                value: Value::String("hello".to_string()),
+                tag: "tag-1".to_string(),
+                timestamp: Timestamp {
+                    millis: 100,
+                    counter: 0,
+                    node_id: "node-a".to_string(),
+                },
+            }],
+            tombstones: vec!["tag-removed".to_string()],
+        };
+
+        let bytes = rmp_serde::to_vec_named(&value).expect("serialize OrMap");
+        let _decoded: RecordValue = rmp_serde::from_slice(&bytes).expect("deserialize OrMap");
+
+        assert_eq!(
+            tombstone_bytes(),
+            baseline,
+            "serde round-trip must not mutate the tombstone-bytes gauge"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -219,8 +219,18 @@ pub enum RecordValue {
         /// Tags of entries that have been removed but not yet garbage-collected.
         ///
         /// Coexists with `records` so both live additions and observed-remove
-        /// tombstones are carried in the same storage slot. Empty on all paths
-        /// today; the read-modify-write `OR_REMOVE` fix populates this field.
+        /// tombstones are carried in the same storage slot. `OR_REMOVE` populates
+        /// this field (see the CRDT service write path), so it is NOT empty once
+        /// any removal has occurred for the key.
+        ///
+        /// Grows unbounded today. The designed bound is epoch/generation GC (M4):
+        /// the server associates each tombstone with a server-authoritative epoch
+        /// at remove-apply time (server-side metadata — this WIRE shape stays
+        /// `Vec<String>`) and drops an epoch's set wholesale once the low-water-mark
+        /// across ALL tracked clients has passed it. Migrating existing blobs to the
+        /// epoch-indexed form (assigning the legacy corpus to one conservative
+        /// pre-migration generation) is the downstream implementation's obligation
+        /// (TODO-566; contract in core-rust tombstone_frontier.rs).
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         tombstones: Vec<String>,
     },

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -395,7 +395,7 @@ mod tombstone_bytes_gauge_tests {
 
     /// Serializing/deserializing an `OrMap` `RecordValue` must not touch the
     /// gauge — the gauge is updated only by explicit call sites at the
-    /// OR_REMOVE tombstone-push / inbound-sync-union points (later task
+    /// `OR_REMOVE` tombstone-push / inbound-sync-union points (later task
     /// groups), never as a side effect of encoding.
     #[test]
     fn ormap_serde_round_trip_does_not_touch_gauge() {


### PR DESCRIPTION
## Summary

Delivers the OR-Map tombstone-bound **decision** (SPEC-339, design/traits-only) and the direct tombstone-bytes **measurement instrument** (SPEC-340) for the soak monitor. Rust-only diff, 8 files.

### SPEC-340 — direct OR-Map tombstone-bytes gauge (TODO-565)
- Write-path `static AtomicU64` gauge at the two tombstone-insert sites (`crdt.rs` OR_REMOVE push, `sync.rs` `handle_ormap_push_diff` new-inbound union), counting `tag.len()` bytes — **residency-independent** (never increments on read/rehydration/legacy-fold/serde round-trip), so it has no eviction blind spot.
- Exposed as the Prometheus counter `topgun_ormap_tombstone_bytes_total` on the real binary's `GET /metrics`.
- Soak harness scrapes it and runs a tight-threshold byte-slope assessment alongside the RSS gate.
- **The byte slope is report-only** (surfaced via the existing `pending_gates` channel; does **not** fail the run): the OR-Map tombstone leak it measures is deliberately unbounded until TODO-566, so hard-gating would turn every or-churn soak — including the blocking no-crash CI smoke — permanently red. The **blind-monitor** (zero-sample) clause and the **RSS** gate still hard-gate.
- **Pre-existing prod bug also fixed** (scope+1 `bin/topgun_server.rs`, user-approved): the binary never installed a Prometheus recorder, so `/metrics` rendered an empty body. Now calls `init_observability()`.

### SPEC-339 — prune-safety contract (TODO-564, design/traits-only)
- `core-rust/src/tombstone_frontier.rs`: `PruneSafety` + `CausalFrontier` traits for the selected M4 epoch/generation GC mechanism (wire `Vec<String>` representation unchanged). No runtime behavior; production prune wiring is TODO-566.

## Follow-ups (tracked, out of scope)
- **TODO-566** — M4 epoch-GC prune (the actual bound); consumes `sub_tombstone_bytes` (already present, decrement-ready).
- **TODO-563 Gap 4** — promote byte slope to a hard gate + make the gauge restart-survivable (startup reconciliation) once the leak is bounded.
- **TODO-484** — the gated 72h soak (blocked on TODO-566 + TODO-563).

## Test plan (local pre-merge gate — all green)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test -p topgun-core` — 7/7
- `cargo build --release --bin topgun-server` — OK
- `cargo test --release -p topgun-server --test soak_monitor_calibration` — 11/11
- `cargo test --release -p topgun-server --lib` — **1534 passed / 0 failed / 1 ignored**
- Reviewed via SpecFlow: SPEC-340 Review v1 → cross-vendor `/xreview` (caught + fixed a fail-open byte gate) → Fix Response v1 → Review v2 APPROVED. SPEC-339 archived APPROVED.

## Notes
- Rust-only change; no TypeScript touched.
- `.specflow/` is local-only (gitignored) and intentionally not part of this diff.
