### PR TITLE
feat(sf-341a): soak disk-space monitor (Gap 1, harness-only)

### DIFF
--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -68,7 +68,9 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use client::SoakClient;
 use model::{compare, next_stamp, Model};
 use monitor::{
-    assess, assess_tombstone_bytes, sample_rss_mb, MemSample, TombstoneAssessment, TombstoneSample,
+    assess, assess_disk, assess_tombstone_bytes, sample_disk_mb, sample_rss_mb, DiskAssessment,
+    DiskSample, MemSample, TombstoneAssessment, TombstoneSample, DEFAULT_DISK_CEILING_MB,
+    DEFAULT_DISK_MIN_GROWTH_MB, DEFAULT_DISK_THRESHOLD_MB_PER_HOUR,
     DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
 };
 use or_noloss::{missing_acked_adds, OrLedger};
@@ -341,9 +343,10 @@ async fn run_soak(config: &Config) -> i32 {
         churn_handles.push(tokio::spawn(run_churn_client(idx, ctx)));
     }
 
-    // --- Spawn memory + tombstone-bytes samplers ---
-    // Both samplers share one clock so their `elapsed_secs` axes line up exactly
-    // (required for a fair side-by-side slope comparison in the summary/report).
+    // --- Spawn memory + tombstone-bytes + disk samplers ---
+    // All three samplers share one clock so their `elapsed_secs` axes line up
+    // exactly (required for a fair side-by-side slope comparison in the
+    // summary/report).
     let sampler_start = Instant::now();
     let samples: Arc<Mutex<Vec<MemSample>>> = Arc::new(Mutex::new(Vec::new()));
     let peak_rss = Arc::new(Mutex::new(0.0_f64));
@@ -400,6 +403,37 @@ async fn run_soak(config: &Config) -> i32 {
                     samples.lock().push(TombstoneSample {
                         elapsed_secs: elapsed,
                         bytes,
+                    });
+                }
+                tokio::time::sleep(interval).await;
+            }
+        });
+    }
+
+    // Disk-usage sampler: shells `du -sk` over the resolved local `data_dir`
+    // binding above (the same value handed to `ServerConfig.data_dir`) — NOT
+    // the raw `config.data_dir` `Option`, which is `None` on the default/CI
+    // path (the blocking Soak Smoke G4b invocation passes no `--data-dir`) and
+    // would yield zero samples, spuriously tripping the disk blind-monitor
+    // clause below. Runs on the same `sampler_start` clock as RSS/tombstone
+    // bytes so all three `elapsed_secs` axes line up for comparison.
+    let disk_samples: Arc<Mutex<Vec<DiskSample>>> = Arc::new(Mutex::new(Vec::new()));
+    {
+        let samples = Arc::clone(&disk_samples);
+        let stop = Arc::clone(&stop);
+        let interval = config.mem_sample_interval;
+        let start = sampler_start;
+        let dir = data_dir.clone();
+        tokio::spawn(async move {
+            loop {
+                if stop.load(Ordering::SeqCst) {
+                    return;
+                }
+                if let Some(mb) = sample_disk_mb(&dir) {
+                    let elapsed = start.elapsed().as_secs_f64();
+                    samples.lock().push(DiskSample {
+                        elapsed_secs: elapsed,
+                        disk_mb: mb,
                     });
                 }
                 tokio::time::sleep(interval).await;
@@ -589,11 +623,28 @@ async fn run_soak(config: &Config) -> i32 {
     // leak magnitude, so a run that monitored nothing must not pass.
     let blind_monitor = tombstones.samples == 0;
 
+    // --- Assess disk growth (durable-dir footprint; catches leaks RSS cannot
+    // see, e.g. lazy-loaded records that never touch the in-memory cache).
+    // Mirrors the tombstone-byte gate exactly: the SLOPE is report-only (the
+    // pre-TODO-566 OR-churn leak grows the durable dir linearly by design, so
+    // hard-gating the slope would RED the blocking no-crash Soak Smoke G4b
+    // run — the same regression class SPEC-340 hit); only the blind-monitor
+    // (zero-sample) clause hard-gates.
+    let disk_samples_snapshot = disk_samples.lock().clone();
+    let disk = assess_disk(
+        &disk_samples_snapshot,
+        DEFAULT_DISK_THRESHOLD_MB_PER_HOUR,
+        DEFAULT_DISK_MIN_GROWTH_MB,
+        DEFAULT_DISK_CEILING_MB,
+    );
+    let disk_blind_monitor = disk.samples == 0;
+
     let panic_report = panic_watch.report();
     let passed = convergence_failures.is_empty()
         && recovery_failures.is_empty()
         && mem.passed
         && !blind_monitor
+        && !disk_blind_monitor
         && panic_report.is_none();
 
     if !mem.passed {
@@ -614,6 +665,22 @@ async fn run_soak(config: &Config) -> i32 {
             "tombstone-byte slope {:.1} B/h exceeds {:.1} B/h — EXPECTED until \
              TODO-566 bounds OR-Map tombstones (report-only, did NOT fail the run)",
             tombstones.slope_bytes_per_hour, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR
+        ));
+    }
+    if disk_blind_monitor {
+        finished_reason = format!(
+            "disk monitoring blind: {}",
+            disk.reason.clone().unwrap_or_default()
+        );
+    } else if !disk.passed {
+        // Report-only, same rationale as the tombstone-byte slope above: the
+        // pre-566 OR churn grows the durable dir linearly by design, so this is
+        // the EXPECTED honest signal, not a regression. Do NOT AND this into
+        // `passed`.
+        pending_gates.push(format!(
+            "disk growth slope {:.1} MB/h exceeds {:.1} MB/h — EXPECTED until \
+             TODO-566 bounds OR-Map tombstones (report-only, did NOT fail the run)",
+            disk.slope_mb_per_hour, DEFAULT_DISK_THRESHOLD_MB_PER_HOUR
         ));
     }
     if let Some(pr) = &panic_report {
@@ -654,21 +721,22 @@ async fn run_soak(config: &Config) -> i32 {
         timestamp: utc_timestamp_now(),
     };
 
-    print_summary(&report, &tombstones);
+    print_summary(&report, &tombstones, &disk);
     if let Some(path) = &config.json_output {
         write_report(path, &report);
         println!("wrote JSON report to {}", path.display());
     }
-    // NOTE: the tombstone-byte verdict is asserted into `passed`/`finished_reason`
-    // above and printed in the console summary below, but is not yet a field on
-    // `SoakReport` (report.rs) — adding it there would be a 6th touched file
-    // against this spec's 5-file cap. Tracked as a follow-up so JSON consumers
-    // (CI dashboards) gain the same visibility the console already has.
+    // NOTE: neither the tombstone-byte nor the disk verdict is a field on
+    // `SoakReport` (report.rs) — both are asserted into `passed`/`finished_reason`
+    // above and printed in the console summary below, but adding structured
+    // fields there would be a 6th touched file against this spec's 5-file cap.
+    // Tracked as a follow-up so JSON consumers (CI dashboards) gain the same
+    // visibility the console already has.
 
     i32::from(!passed)
 }
 
-fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment) {
+fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment, disk: &DiskAssessment) {
     println!("\n=== SOAK SUMMARY ===");
     println!(
         "result:            {}",
@@ -708,6 +776,23 @@ fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment) {
         tombstone_role,
         tombstones
             .reason
+            .as_ref()
+            .map_or_else(String::new, |r| format!(" reason={r}")),
+    );
+    // Same report-only stance as tombstone bytes: the disk slope is EXPECTED to
+    // breach pre-TODO-566 under default OR-churn (linear durable-dir growth by
+    // design); only the blind-monitor (zero-sample) clause hard-gates.
+    let disk_role = "slope report-only until TODO-566; blind-monitor hard-gates";
+    println!(
+        "disk_mb:           first={:.1} peak={:.1} last={:.1} slope={:.1}MB/h samples={} -> {} ({}){}",
+        disk.first_mb,
+        disk.peak_mb,
+        disk.last_mb,
+        disk.slope_mb_per_hour,
+        disk.samples,
+        if disk.passed { "ok" } else { "FAIL" },
+        disk_role,
+        disk.reason
             .as_ref()
             .map_or_else(String::new, |r| format!(" reason={r}")),
     );

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -162,7 +162,8 @@ pub fn assess(
     let last_mb = samples[samples.len() - 1].rss_mb;
     let peak_mb = samples.iter().fold(0.0_f64, |m, s| m.max(s.rss_mb));
 
-    let slope_mb_per_hour = least_squares_slope_per_hour(samples);
+    let points: Vec<(f64, f64)> = samples.iter().map(|s| (s.elapsed_secs, s.rss_mb)).collect();
+    let slope_mb_per_hour = least_squares_slope_per_hour(&points);
 
     let growth = peak_mb - first_mb;
     let mut reasons = Vec::new();
@@ -196,17 +197,22 @@ pub fn assess(
     }
 }
 
-/// Least-squares slope of `rss_mb` vs. time, expressed in MB per hour. Returns
-/// 0 when there is insufficient variance in the time axis (e.g. one sample).
+/// Least-squares slope of `value` vs. `elapsed_secs`, expressed as a per-hour
+/// rate. Returns 0 when there is insufficient variance in the time axis (e.g.
+/// one sample).
+///
+/// Shared by all three samplers (RSS MB, tombstone-bytes, disk MB) — the fit
+/// math is identical regardless of which quantity is being tracked, so it
+/// exists exactly once here rather than as a per-sampler-type copy.
 #[allow(clippy::cast_precision_loss)]
-fn least_squares_slope_per_hour(samples: &[MemSample]) -> f64 {
-    let n = samples.len() as f64;
+fn least_squares_slope_per_hour(points: &[(f64, f64)]) -> f64 {
+    let n = points.len() as f64;
     if n < 2.0 {
         return 0.0;
     }
-    // x in hours so the slope is directly MB/hour.
-    let xs: Vec<f64> = samples.iter().map(|s| s.elapsed_secs / 3600.0).collect();
-    let ys: Vec<f64> = samples.iter().map(|s| s.rss_mb).collect();
+    // x in hours so the slope is directly <unit>/hour.
+    let xs: Vec<f64> = points.iter().map(|(secs, _)| secs / 3600.0).collect();
+    let ys: Vec<f64> = points.iter().map(|(_, value)| *value).collect();
     let mean_x = xs.iter().sum::<f64>() / n;
     let mean_y = ys.iter().sum::<f64>() / n;
     let mut num = 0.0;
@@ -303,7 +309,12 @@ pub fn assess_tombstone_bytes(
     let last_bytes = samples[samples.len() - 1].bytes;
     let peak_bytes = samples.iter().map(|s| s.bytes).max().unwrap_or(first_bytes);
 
-    let slope_bytes_per_hour = least_squares_slope_per_hour_bytes(samples);
+    #[allow(clippy::cast_precision_loss)]
+    let points: Vec<(f64, f64)> = samples
+        .iter()
+        .map(|s| (s.elapsed_secs, s.bytes as f64))
+        .collect();
+    let slope_bytes_per_hour = least_squares_slope_per_hour(&points);
 
     #[allow(clippy::cast_precision_loss)]
     let growth = peak_bytes.saturating_sub(first_bytes) as f64;
@@ -331,32 +342,6 @@ pub fn assess_tombstone_bytes(
         } else {
             Some(reasons.join("; "))
         },
-    }
-}
-
-/// Least-squares slope of `bytes` vs. time, expressed in bytes per hour.
-/// Same fit as [`least_squares_slope_per_hour`]; kept as a separate function
-/// because the sample type differs (`u64` bytes vs. `f64` MB).
-#[allow(clippy::cast_precision_loss)]
-fn least_squares_slope_per_hour_bytes(samples: &[TombstoneSample]) -> f64 {
-    let n = samples.len() as f64;
-    if n < 2.0 {
-        return 0.0;
-    }
-    let xs: Vec<f64> = samples.iter().map(|s| s.elapsed_secs / 3600.0).collect();
-    let ys: Vec<f64> = samples.iter().map(|s| s.bytes as f64).collect();
-    let mean_x = xs.iter().sum::<f64>() / n;
-    let mean_y = ys.iter().sum::<f64>() / n;
-    let mut num = 0.0;
-    let mut den = 0.0;
-    for (x, y) in xs.iter().zip(ys.iter()) {
-        num += (x - mean_x) * (y - mean_y);
-        den += (x - mean_x) * (x - mean_x);
-    }
-    if den.abs() < f64::EPSILON {
-        0.0
-    } else {
-        num / den
     }
 }
 
@@ -407,7 +392,18 @@ pub struct DiskAssessment {
 /// macOS and Linux with `-k`). Returns `None` if `du` fails or its output
 /// cannot be parsed (mirrors `sample_rss_mb`'s `None`-on-failure contract).
 pub fn sample_disk_mb(dir: &Path) -> Option<f64> {
-    todo!("G2 fills in the du -sk shell-out body")
+    let out = Command::new("du")
+        .args(["-sk", dir.to_str()?])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    // `du -sk` prints "<KiB>\t<path>"; the KiB total is the first
+    // whitespace-separated field.
+    let kib: f64 = text.split_whitespace().next()?.parse().ok()?;
+    Some(kib / 1024.0)
 }
 
 /// Assess a series of on-disk data-dir samples for bounded growth. Mirrors
@@ -419,13 +415,73 @@ pub fn sample_disk_mb(dir: &Path) -> Option<f64> {
 /// * `min_growth_mb` — absolute growth (peak − first) below which slope is
 ///   treated as noise (guards tiny/short runs).
 /// * `ceiling_mb` — hard cap on peak on-disk size.
+#[allow(clippy::cast_precision_loss)]
 pub fn assess_disk(
     samples: &[DiskSample],
     threshold_mb_per_hour: f64,
     min_growth_mb: f64,
     ceiling_mb: f64,
 ) -> DiskAssessment {
-    todo!("G2 fills in the assess_disk body")
+    if samples.is_empty() {
+        // Zero samples over a real run means the monitor was BLIND (`du` failing
+        // or the data dir never resolving) — a leak would be invisible on disk
+        // exactly as an unreachable `ps`/`/metrics` would be for RSS/tombstone
+        // bytes. Fail rather than silently pass.
+        return DiskAssessment {
+            samples: 0,
+            first_mb: 0.0,
+            peak_mb: 0.0,
+            last_mb: 0.0,
+            slope_mb_per_hour: 0.0,
+            passed: false,
+            reason: Some(
+                "no disk-usage samples collected — disk monitoring was blind (du failed or \
+                 the data dir never resolved); cannot assert bounded disk growth"
+                    .to_string(),
+            ),
+        };
+    }
+
+    let first_mb = samples[0].disk_mb;
+    let last_mb = samples[samples.len() - 1].disk_mb;
+    let peak_mb = samples.iter().fold(0.0_f64, |m, s| m.max(s.disk_mb));
+
+    let points: Vec<(f64, f64)> = samples
+        .iter()
+        .map(|s| (s.elapsed_secs, s.disk_mb))
+        .collect();
+    let slope_mb_per_hour = least_squares_slope_per_hour(&points);
+
+    let growth = peak_mb - first_mb;
+    let mut reasons = Vec::new();
+
+    if peak_mb > ceiling_mb {
+        reasons.push(format!(
+            "peak disk usage {peak_mb:.1}MB exceeds ceiling {ceiling_mb:.1}MB"
+        ));
+    }
+    if growth >= min_growth_mb && slope_mb_per_hour > threshold_mb_per_hour {
+        reasons.push(format!(
+            "disk growth slope {slope_mb_per_hour:.1}MB/h exceeds {threshold_mb_per_hour:.1}MB/h \
+             (total growth {growth:.1}MB over {} samples)",
+            samples.len()
+        ));
+    }
+
+    let passed = reasons.is_empty();
+    DiskAssessment {
+        samples: samples.len(),
+        first_mb,
+        peak_mb,
+        last_mb,
+        slope_mb_per_hour,
+        passed,
+        reason: if passed {
+            None
+        } else {
+            Some(reasons.join("; "))
+        },
+    }
 }
 
 // This bench target is `harness = false` (it owns `main`), so these `#[test]`
@@ -673,5 +729,71 @@ mod tests {
             DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
         );
         assert!(!a.passed, "zero samples must fail as a blind monitor");
+    }
+
+    /// Build an hourly-sampled disk-usage series with a constant per-hour
+    /// growth rate, starting at `first_mb`.
+    fn linear_disk_series(first_mb: f64, hours: u32, mb_per_hour: f64) -> Vec<DiskSample> {
+        (0..=hours)
+            .map(|h| DiskSample {
+                elapsed_secs: f64::from(h) * 3600.0,
+                disk_mb: first_mb + mb_per_hour * f64::from(h),
+            })
+            .collect()
+    }
+
+    /// Zero disk samples means `du` never succeeded / the data dir never
+    /// resolved — the monitor was BLIND. AC2: must FAIL, same rationale as the
+    /// RSS/tombstone-byte empty-samples branches, since this is the ONE clause
+    /// that hard-gates `passed` in `main.rs`.
+    #[test]
+    fn calibration_fails_zero_disk_samples() {
+        let a = assess_disk(
+            &[],
+            DEFAULT_DISK_THRESHOLD_MB_PER_HOUR,
+            DEFAULT_DISK_MIN_GROWTH_MB,
+            DEFAULT_DISK_CEILING_MB,
+        );
+        assert!(!a.passed, "zero disk samples must fail as a blind monitor");
+    }
+
+    /// A flat disk-usage series (durable dir stopped growing) MUST PASS —
+    /// otherwise the gate false-FAILs every healthy in-place-overwrite run.
+    #[test]
+    fn calibration_passes_flat_disk_series() {
+        let samples = linear_disk_series(500.0, 72, 0.0);
+        let a = assess_disk(
+            &samples,
+            DEFAULT_DISK_THRESHOLD_MB_PER_HOUR,
+            DEFAULT_DISK_MIN_GROWTH_MB,
+            DEFAULT_DISK_CEILING_MB,
+        );
+        assert!(
+            a.passed,
+            "flat disk series must pass; slope={:.3} reason={:?}",
+            a.slope_mb_per_hour, a.reason
+        );
+    }
+
+    /// A steep, clearly-linear disk-growth series (well above the loosely
+    /// calibrated pre-566 threshold) MUST be flagged by `assess_disk`'s
+    /// `passed` field — this only proves the assessment's own slope clause is
+    /// correctly wired, NOT that it gates the run (it is report-only in
+    /// `main.rs`; see AC3/AC2).
+    #[test]
+    fn calibration_flags_steep_linear_disk_growth() {
+        let samples = linear_disk_series(200.0, 24, 200.0);
+        let a = assess_disk(
+            &samples,
+            DEFAULT_DISK_THRESHOLD_MB_PER_HOUR,
+            DEFAULT_DISK_MIN_GROWTH_MB,
+            DEFAULT_DISK_CEILING_MB,
+        );
+        assert!(
+            !a.passed,
+            "steep 200 MB/h disk growth must be flagged; slope={:.1} reason={:?}",
+            a.slope_mb_per_hour, a.reason
+        );
+        assert!(a.slope_mb_per_hour > DEFAULT_DISK_THRESHOLD_MB_PER_HOUR);
     }
 }

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -74,6 +74,7 @@
 //! `passed: bool` as load-bearing everywhere — see `main.rs`'s run-end
 //! verdict-assembly for the authoritative gating decision.
 
+use std::path::Path;
 use std::process::Command;
 
 /// Calibrated slope ceiling (MB/hour) for the 72h soak's memory assertion.
@@ -357,6 +358,74 @@ fn least_squares_slope_per_hour_bytes(samples: &[TombstoneSample]) -> f64 {
     } else {
         num / den
     }
+}
+
+/// Calibrated slope ceiling (MB/hour) for the soak's on-disk data-dir growth
+/// assertion.
+///
+/// PRE-566 PLACEHOLDER: loosely calibrated so the deliberately-unbounded
+/// pre-TODO-566 OR-Map tombstone growth (which grows the durable dir linearly
+/// by design, see the module-level "Critical fence" rationale in the parent
+/// spec) does not spuriously trip this clause during a bounded/short soak.
+/// This is NOT the tight bounded-expectation value TODO-566/Gap 2 will
+/// calibrate once the leak is bounded — do not read this as a proven bound.
+pub const DEFAULT_DISK_THRESHOLD_MB_PER_HOUR: f64 = 50.0;
+
+/// Absolute-growth guard (MB) for the disk slope clause.
+///
+/// PRE-566 PLACEHOLDER (see [`DEFAULT_DISK_THRESHOLD_MB_PER_HOUR`] doc) — not
+/// the tight bounded-expectation guard TODO-566/Gap 2 will calibrate.
+pub const DEFAULT_DISK_MIN_GROWTH_MB: f64 = 100.0;
+
+/// Hard ceiling (MB) on peak on-disk data-dir size.
+///
+/// PRE-566 PLACEHOLDER (see [`DEFAULT_DISK_THRESHOLD_MB_PER_HOUR`] doc) — not
+/// the tight bounded-expectation ceiling TODO-566/Gap 2 will calibrate.
+pub const DEFAULT_DISK_CEILING_MB: f64 = 4096.0;
+
+/// One on-disk data-dir size sample (`du -sk <dir>`, KiB -> MB).
+#[derive(Debug, Clone, Copy)]
+pub struct DiskSample {
+    pub elapsed_secs: f64,
+    pub disk_mb: f64,
+}
+
+/// Verdict of a disk-growth assessment. Mirrors [`MemoryAssessment`]'s shape so
+/// callers (soak `main.rs`) can report RSS, tombstone bytes, and disk uniformly.
+#[derive(Debug, Clone)]
+pub struct DiskAssessment {
+    pub samples: usize,
+    pub first_mb: f64,
+    pub peak_mb: f64,
+    pub last_mb: f64,
+    pub slope_mb_per_hour: f64,
+    pub passed: bool,
+    pub reason: Option<String>,
+}
+
+/// Sample the on-disk size of `dir` in megabytes via `du -sk` (KiB on both
+/// macOS and Linux with `-k`). Returns `None` if `du` fails or its output
+/// cannot be parsed (mirrors `sample_rss_mb`'s `None`-on-failure contract).
+pub fn sample_disk_mb(dir: &Path) -> Option<f64> {
+    todo!("G2 fills in the du -sk shell-out body")
+}
+
+/// Assess a series of on-disk data-dir samples for bounded growth. Mirrors
+/// [`assess`]'s shape and clauses verbatim (empty-samples blind-monitor
+/// branch, least-squares slope via the shared OLS helper, growth/threshold and
+/// ceiling clauses) so RSS, tombstone-byte, and disk gates report uniformly.
+///
+/// * `threshold_mb_per_hour` — maximum tolerated growth slope.
+/// * `min_growth_mb` — absolute growth (peak − first) below which slope is
+///   treated as noise (guards tiny/short runs).
+/// * `ceiling_mb` — hard cap on peak on-disk size.
+pub fn assess_disk(
+    samples: &[DiskSample],
+    threshold_mb_per_hour: f64,
+    min_growth_mb: f64,
+    ceiling_mb: f64,
+) -> DiskAssessment {
+    todo!("G2 fills in the assess_disk body")
 }
 
 // This bench target is `harness = false` (it owns `main`), so these `#[test]`


### PR DESCRIPTION
## What

Adds a **durable-dir disk-usage monitor** to the G4b soak harness so a lazy-loaded leak that keeps process RSS flat while the redb/WAL on-disk footprint grows without bound becomes *observable*. Today `monitor.rs` samples only `ps -o rss=`; nothing watches disk, so such a leak reads as a false GREEN.

Split child of SPEC-341 (harness half). Sibling **SPEC-341b** (restart-survivable tombstone-bytes gauge, server-boot path) is disjoint and tracked separately.

## Changes (harness-only, 2 files)

- **`benches/soak_harness/monitor.rs`** — `sample_disk_mb` (`du -sk`, KiB→MB, `None`-on-failure, mirroring `sample_rss_mb`); `DiskSample`/`DiskAssessment`/`assess_disk` mirroring the RSS `assess` (empty→blind-fail, growth/threshold/ceiling clauses); `DEFAULT_DISK_*` **pre-566 placeholder** constants; 3 calibration tests (empty→fail / flat→pass / steep→flagged). Collapsed the two duplicate OLS helpers into one shared `least_squares_slope_per_hour(&[(f64, f64)])` used by all three assessments (RSS, tombstone-bytes, disk) — no third `_disk` copy.
- **`benches/soak_harness/main.rs`** — disk sampler task on the shared `sampler_start` clock over the **resolved local `data_dir` binding** (not the raw `config.data_dir` `Option`, which is `None` on the default/CI path); `assess_disk` at verdict time; disk assessment printed next to RSS/tombstone.

## Report-only fence (critical)

Pre-TODO-566 the default OR-churn grows disk **linearly by design** (unique-tag-per-iteration tombstones). Hard-gating the disk *slope* would RED the blocking no-crash Soak Smoke G4b run — exactly the SPEC-340 regression class. So the disk **slope is report-only** (routed to `pending_gates`, mirroring SPEC-340's byte slope); **only the zero-sample `disk_blind_monitor` clause is ANDed into `passed`**. `assess_disk(&[])` fails **closed**. Gate-flip (Gap 4.2) + tight recalibration (Gap 2) are fenced to a post-566 tail (TODO-567).

## Verification (local, pre-merge)

- `cargo fmt -p topgun-server --check` — clean
- `cargo clippy --all-targets --all-features -p topgun-server -- -D warnings` — clean
- `cargo test --release -p topgun-server --lib` — 1534 passed / 0 failed / 1 ignored
- `cargo test --release -p topgun-server --test soak_monitor_calibration` — 14/14
- Re-ran the exact blocking Soak Smoke G4b invocation (`--crash-interval 0`, or-churn on) → `.passed == true`; disk slope surfaced report-only, never in the `passed` boolean.

SPEC-340's byte-slope wiring/`report.rs` untouched (only the internal OLS call site now uses the shared helper).