### PR TITLE
feat(sf-341b): restart-survivable OR-Map tombstone-bytes gauge via boot reconciliation

### DIFF
--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -93,6 +93,7 @@ use topgun_server::storage::eviction_orchestrator::EvictionOrchestrator;
 use topgun_server::storage::factory::{ObserverFactory, RecordStoreFactory};
 use topgun_server::storage::impls::StorageConfig;
 use topgun_server::storage::map_data_store::MapDataStore;
+use topgun_server::storage::record::{set_tombstone_bytes, RecordValue};
 use topgun_server::storage::merkle_sync::{MerkleObserverFactory, MerkleSyncManager};
 use topgun_server::storage::mutation_observer::MutationObserver;
 use topgun_server::storage::wal::{Wal, WalFsyncPolicy, WalRecovery, WalWriter};
@@ -162,6 +163,107 @@ async fn select_datastore() -> anyhow::Result<(Arc<dyn MapDataStore>, StorageBac
             "Unknown STORAGE_BACKEND='{other}' (expected: redb, postgres, null)"
         ),
     }
+}
+
+/// One-time startup reconciliation of the OR-Map tombstone-bytes gauge.
+///
+/// Runs exactly once, after WAL recovery completes and strictly before the
+/// listener accepts connections, for durable backends only. Walks the full
+/// persisted primary keyspace via the cursor-batched scan surface, sums
+/// `tag.len()` over every tombstone string in every persisted `OrMap` record,
+/// and re-baselines the gauge to that absolute total via [`set_tombstone_bytes`].
+/// This makes the scraped `topgun_ormap_tombstone_bytes_total` series survive a
+/// `kill -9` restart — the gauge otherwise resets to 0 on every process start
+/// and never re-counts rehydrated (redb-persisted) tombstones.
+///
+/// Never runs on any read/write/rehydration path — boot-only, exactly-once. On
+/// scan failure it logs a WARN and leaves the process-local gauge at its default
+/// (0): reconciliation is a monitoring-accuracy improvement, not a durability
+/// invariant, so a failed reconcile degrades to today's process-local behavior
+/// rather than aborting startup.
+///
+/// Legacy `RecordValue::OrTombstones { tags }` blobs are deliberately excluded
+/// from the sum. The live `add_tombstone_bytes` gauge never counts them either:
+/// the read path folds their tags into the unified `OrMap.tombstones` view
+/// WITHOUT emitting to the gauge, so summing them here would over-count relative
+/// to the live gauge this seed re-baselines.
+///
+/// `list_maps` on the redb backend enumerates primary partitions only, so backup
+/// tombstones are excluded — correct for the single-node soak/demo tier this
+/// targets; a future cluster/backup-accounting revisit is out of scope here.
+async fn reconcile_tombstone_bytes(store: Arc<dyn MapDataStore>) {
+    let maps = match store.list_maps().await {
+        Ok(maps) => maps,
+        Err(err) => {
+            tracing::warn!(
+                target: "topgun_server::bootstrap",
+                error = %err,
+                "tombstone-bytes reconciliation skipped: list_maps failed; gauge stays process-local"
+            );
+            return;
+        }
+    };
+
+    let mut total: u64 = 0;
+    let mut records_scanned: u64 = 0;
+
+    for map in &maps {
+        // Walk the whole map: first batch, then follow the cursor until exhausted
+        // so every record is visited regardless of map size. Each batch is itself
+        // cost-bounded, keeping resident cost under the TOPGUN_MAX_RAM_MB ceiling —
+        // a memory-safety property, not just a startup-latency one.
+        let mut batch = match store.scan_values(map, false, 0).await {
+            Ok(batch) => batch,
+            Err(err) => {
+                tracing::warn!(
+                    target: "topgun_server::bootstrap",
+                    map = %map,
+                    error = %err,
+                    "tombstone-bytes reconciliation skipped: scan_values failed; gauge stays process-local"
+                );
+                return;
+            }
+        };
+
+        loop {
+            for (_key, value) in &batch.records {
+                records_scanned += 1;
+                if let RecordValue::OrMap { tombstones, .. } = value {
+                    for tag in tombstones {
+                        total += tag.len() as u64;
+                    }
+                }
+            }
+
+            match batch.next_cursor.take() {
+                None => break,
+                Some(cursor) => {
+                    batch = match store.scan_values_batched(map, false, cursor, 0).await {
+                        Ok(next) => next,
+                        Err(err) => {
+                            tracing::warn!(
+                                target: "topgun_server::bootstrap",
+                                map = %map,
+                                error = %err,
+                                "tombstone-bytes reconciliation skipped: scan_values_batched failed; gauge stays process-local"
+                            );
+                            return;
+                        }
+                    };
+                }
+            }
+        }
+    }
+
+    set_tombstone_bytes(total);
+
+    tracing::info!(
+        target: "topgun_server::bootstrap",
+        tombstone_bytes = total,
+        records_scanned = records_scanned,
+        maps = maps.len(),
+        "OR-Map tombstone-bytes gauge reconciled from persisted keyspace"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -522,6 +624,14 @@ async fn main() -> anyhow::Result<()> {
                         eprintln!("FATAL: WAL recovery failed: {err}");
                         std::process::exit(1);
                     }
+
+                    // Re-baseline the OR-Map tombstone-bytes gauge from the now-
+                    // recovered durable keyspace, before the listener accepts any
+                    // connections, so the scraped metric survives kill -9 restarts
+                    // instead of sawtoothing back to 0 on every process start.
+                    // Clone the Arc here because `inner_data_store` is moved into
+                    // the write-behind wrap below — the walk reads through the clone.
+                    reconcile_tombstone_bytes(Arc::clone(&inner_data_store)).await;
 
                     // Seed the live sequence counter to one past the highest
                     // sequence ever durably observed. Computed AFTER recovery so

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -93,9 +93,9 @@ use topgun_server::storage::eviction_orchestrator::EvictionOrchestrator;
 use topgun_server::storage::factory::{ObserverFactory, RecordStoreFactory};
 use topgun_server::storage::impls::StorageConfig;
 use topgun_server::storage::map_data_store::MapDataStore;
-use topgun_server::storage::record::{set_tombstone_bytes, RecordValue};
 use topgun_server::storage::merkle_sync::{MerkleObserverFactory, MerkleSyncManager};
 use topgun_server::storage::mutation_observer::MutationObserver;
+use topgun_server::storage::record::{set_tombstone_bytes, RecordValue};
 use topgun_server::storage::wal::{Wal, WalFsyncPolicy, WalRecovery, WalWriter};
 
 // ---------------------------------------------------------------------------

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -44,8 +44,12 @@ static OR_TOMBSTONE_BYTES: AtomicU64 = AtomicU64::new(0);
 /// would silently double-count (it is additive). No `add_tombstone_bytes` call
 /// site is reachable before `set_ready()` today, so the boot seed is the sole
 /// gauge mutator in the recovery→ready window; this flag turns a future refactor
-/// that violates that ordering into a loud `debug_assert` failure rather than a
-/// silent double-count.
+/// that violates that ordering into a loud failure — a `tracing::error!` in every
+/// build (the soak harness and production run release, where `debug_assert!` is a
+/// no-op) plus a hard `debug_assert!` in debug/test — rather than a silent
+/// double-count of the Prometheus counter the harness scrapes. Written with
+/// `Release` / read with `Acquire` so the boot seed reliably observes a prior arm
+/// even if the two ever run on different threads.
 static TOMBSTONE_ADD_FIRED: AtomicBool = AtomicBool::new(false);
 
 /// Adds `n` bytes to the process-global OR-Map tombstone-bytes gauge and
@@ -61,9 +65,10 @@ static TOMBSTONE_ADD_FIRED: AtomicBool = AtomicBool::new(false);
 /// it without changing what it reveals.
 pub fn add_tombstone_bytes(n: u64) {
     // Arm the tripwire that makes the boot-seed dual-write asymmetry fail loud
-    // (see TOMBSTONE_ADD_FIRED). A single relaxed store on the write path is
-    // negligible next to the map mutation that precedes it.
-    TOMBSTONE_ADD_FIRED.store(true, Ordering::Relaxed);
+    // (see TOMBSTONE_ADD_FIRED). A single store on the write path is negligible
+    // next to the map mutation that precedes it; `Release` pairs with the boot
+    // seed's `Acquire` load so the seed reliably observes this arm cross-thread.
+    TOMBSTONE_ADD_FIRED.store(true, Ordering::Release);
     OR_TOMBSTONE_BYTES.fetch_add(n, Ordering::Relaxed);
     metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(n);
 }
@@ -136,9 +141,21 @@ pub fn set_tombstone_bytes(total: u64) {
     // The Prometheus increment below is additive; correct only on a fresh-zero
     // recorder. No add_tombstone_bytes site is reachable before this boot seed,
     // so the tripwire must still be un-armed here — otherwise the counter the
-    // harness scrapes would silently double-count.
+    // harness scrapes would silently double-count. Fail loud in EVERY build: the
+    // soak harness and production run release, where `debug_assert!` alone is a
+    // no-op, so an error log carries the signal there while the debug_assert hard
+    // -fails tests.
+    let armed = TOMBSTONE_ADD_FIRED.load(Ordering::Acquire);
+    if armed {
+        tracing::error!(
+            target: "topgun_server::bootstrap",
+            "set_tombstone_bytes boot seed ran after add_tombstone_bytes — the additive \
+             Prometheus counter will double-count; the recovery→ready gauge-window invariant \
+             was violated by a reachable pre-set_ready write path"
+        );
+    }
     debug_assert!(
-        !TOMBSTONE_ADD_FIRED.load(Ordering::Relaxed),
+        !armed,
         "set_tombstone_bytes boot seed ran after add_tombstone_bytes — the additive \
          Prometheus counter would double-count"
     );

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -3,7 +3,7 @@
 //! Defines the core data structures stored in [`StorageEngine`](super::StorageEngine):
 //! [`Record`], [`RecordMetadata`], [`RecordValue`], and [`OrMapEntry`].
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 use topgun_core::hlc::Timestamp;
@@ -33,6 +33,21 @@ static WRITE_TOKEN: AtomicU64 = AtomicU64::new(1);
 /// operation needs to be ordered against it.
 static OR_TOMBSTONE_BYTES: AtomicU64 = AtomicU64::new(0);
 
+/// Fail-loud tripwire recording whether [`add_tombstone_bytes`] has fired in
+/// this process.
+///
+/// [`set_tombstone_bytes`] pairs an **absolute** `AtomicU64` store with an
+/// **additive** Prometheus `increment`. The one-time boot seed is only correct
+/// on a fresh recorder: if any `add_tombstone_bytes` landed between recorder
+/// install and the boot seed, the `AtomicU64` would still self-correct (it is a
+/// store), but the Prometheus counter — the sink the soak harness scrapes —
+/// would silently double-count (it is additive). No `add_tombstone_bytes` call
+/// site is reachable before `set_ready()` today, so the boot seed is the sole
+/// gauge mutator in the recovery→ready window; this flag turns a future refactor
+/// that violates that ordering into a loud `debug_assert` failure rather than a
+/// silent double-count.
+static TOMBSTONE_ADD_FIRED: AtomicBool = AtomicBool::new(false);
+
 /// Adds `n` bytes to the process-global OR-Map tombstone-bytes gauge and
 /// emits the same delta to the `topgun_ormap_tombstone_bytes_total`
 /// Prometheus counter (mirrors the `topgun_operations_total` emit pattern in
@@ -45,6 +60,10 @@ static OR_TOMBSTONE_BYTES: AtomicU64 = AtomicU64::new(0);
 /// this gauge exists to expose, and a constant per-entry factor only scales
 /// it without changing what it reveals.
 pub fn add_tombstone_bytes(n: u64) {
+    // Arm the tripwire that makes the boot-seed dual-write asymmetry fail loud
+    // (see TOMBSTONE_ADD_FIRED). A single relaxed store on the write path is
+    // negligible next to the map mutation that precedes it.
+    TOMBSTONE_ADD_FIRED.store(true, Ordering::Relaxed);
     OR_TOMBSTONE_BYTES.fetch_add(n, Ordering::Relaxed);
     metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(n);
 }
@@ -85,6 +104,45 @@ pub fn sub_tombstone_bytes(n: u64) {
 #[must_use]
 pub fn tombstone_bytes() -> u64 {
     OR_TOMBSTONE_BYTES.load(Ordering::Relaxed)
+}
+
+/// Re-baselines the OR-Map tombstone-bytes gauge to an absolute `total`.
+///
+/// This is the **only** absolute-set path for the gauge. It exists exclusively
+/// for the one-time startup reconciliation that runs after WAL recovery
+/// completes (see `bin/topgun_server.rs`): both the process-local
+/// [`OR_TOMBSTONE_BYTES`] atomic and the exported Prometheus
+/// `topgun_ormap_tombstone_bytes_total` counter reset to zero on every process
+/// start and never re-count rehydrated (redb-persisted) tombstones, so without
+/// this boot seed the scraped series sawtooths back to 0 on every `kill -9`
+/// restart and the cross-restart leak becomes invisible. It MUST NEVER be called
+/// on the hot read/write path — only once, at boot, before the listener accepts
+/// connections.
+///
+/// It performs BOTH writes, in order, because the two are **separate sinks**:
+///  1. `OR_TOMBSTONE_BYTES.store(total)` re-baselines the in-process `AtomicU64`
+///     — an absolute store, never `fetch_add`: a per-rehydration increment would
+///     reintroduce the eviction double-count the gauge's cardinal rule forbids.
+///  2. `metrics::counter!(...).increment(total)` seeds the Prometheus counter,
+///     which is a *different* sink living in the process `PrometheusHandle`
+///     recorder. The soak harness scrapes THIS counter via `GET /metrics`, not
+///     the `AtomicU64`; on a fresh process the recorder's counter starts at
+///     0/absent, so a single `increment(total)` from zero lands the exported
+///     series at `total` while staying a legal monotonic-from-zero `_total`
+///     counter (a Prometheus counter has no `.set`/`.store`). A `.store()`-only
+///     path would never reach the sink the harness actually reads.
+pub fn set_tombstone_bytes(total: u64) {
+    OR_TOMBSTONE_BYTES.store(total, Ordering::Relaxed);
+    // The Prometheus increment below is additive; correct only on a fresh-zero
+    // recorder. No add_tombstone_bytes site is reachable before this boot seed,
+    // so the tripwire must still be un-armed here — otherwise the counter the
+    // harness scrapes would silently double-count.
+    debug_assert!(
+        !TOMBSTONE_ADD_FIRED.load(Ordering::Relaxed),
+        "set_tombstone_bytes boot seed ran after add_tombstone_bytes — the additive \
+         Prometheus counter would double-count"
+    );
+    metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(total);
 }
 
 /// Minimum elapsed milliseconds before a read access updates `last_access_time`.

--- a/packages/server-rust/tests/soak_tombstone_restart.rs
+++ b/packages/server-rust/tests/soak_tombstone_restart.rs
@@ -1,0 +1,155 @@
+//! AC1 behavioral proof: the OR-Map tombstone-bytes gauge survives `kill -9`.
+//!
+//! The gauge (`topgun_ormap_tombstone_bytes_total`, scraped from the server's
+//! own `GET /metrics`) is a process-local counter that resets to 0 on every
+//! process start and never re-counts rehydrated (redb-persisted) tombstones.
+//! The startup reconciliation walks the recovered OR-Map keyspace once, after
+//! WAL recovery and before the listener opens, and boot-seeds the gauge to the
+//! persisted tombstone total. This test proves that end-to-end against a REAL
+//! out-of-process server on a REAL redb + WAL:
+//!
+//!   seed N unique-tag OR removes  →  pre-kill gauge == T (> 0)
+//!   kill -9  →  relaunch against the same data dir
+//!   FIRST post-restart scrape == T  (not 0)
+//!
+//! The load-bearing sub-assertion (guards the Prometheus dead-sink failure mode
+//! directly): the first post-restart scrape reads T with NO intervening
+//! post-restart `add_tombstone_bytes` — reconciliation ALONE, not a subsequent
+//! write, must produce the scraped value. So the test issues zero OR mutations
+//! between relaunch and the scrape. Code inspection is not a substitute.
+//!
+//! The out-of-process supervisor (`kill -9` + relaunch against the same
+//! `data_dir`) and the WebSocket client are reused verbatim from the soak
+//! harness (`benches/soak_harness/{process,client,or_noloss}.rs`), pulled in by
+//! `#[path]` so this exercises the exact bench source. The bench is declared
+//! `harness = false`, so its own `#[test]`s never run under `cargo test`;
+//! re-including the modules here puts this proof under the standard libtest
+//! harness. `allow(dead_code)` covers bench items this test does not reference.
+
+#[path = "../benches/soak_harness/or_noloss.rs"]
+#[allow(dead_code)]
+mod or_noloss;
+
+#[path = "../benches/soak_harness/client.rs"]
+#[allow(dead_code)]
+mod client;
+
+#[path = "../benches/soak_harness/process.rs"]
+#[allow(dead_code)]
+mod process;
+
+use std::time::Duration;
+
+use client::SoakClient;
+use process::{resolve_server_binary, ServerConfig, ServerSupervisor};
+
+/// JWT secret shared with `SoakClient` (mirrors the soak harness default).
+const JWT_SECRET: &str = "test-e2e-secret";
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+const OR_MAP: &str = "ork_map";
+const OR_KEY: &str = "ork";
+/// Number of unique-tag OR removes to seed.
+const N_TOMBS: usize = 50;
+
+/// Scrape `topgun_ormap_tombstone_bytes_total` from the running server's
+/// `GET /metrics`. Returns `None` on any transient failure (connection refused
+/// mid-restart, non-2xx, unreadable body, or the metric line simply absent) —
+/// mirroring the soak harness `scrape_tombstone_bytes` contract, so an absent
+/// line is treated as "no sample" rather than a spurious 0.
+async fn scrape_tombstone_bytes(port: u16) -> Option<u64> {
+    let url = format!("http://127.0.0.1:{port}/metrics");
+    let resp = reqwest::Client::new().get(&url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body = resp.text().await.ok()?;
+    parse_tombstone_bytes_total(&body)
+}
+
+/// Parse the `topgun_ormap_tombstone_bytes_total` sample value out of a
+/// Prometheus text exposition body.
+fn parse_tombstone_bytes_total(body: &str) -> Option<u64> {
+    const METRIC: &str = "topgun_ormap_tombstone_bytes_total";
+    let labelled_prefix = format!("{METRIC}{{");
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        let name = parts.next()?;
+        if name == METRIC || name.starts_with(&labelled_prefix) {
+            let value = parts.next()?;
+            return value
+                .parse::<u64>()
+                .ok()
+                .or_else(|| value.parse::<f64>().ok().map(|f| f as u64));
+        }
+    }
+    None
+}
+
+/// Seed N unique-tag OR removes, scrape the gauge (T > 0), `kill -9`, relaunch,
+/// then assert the FIRST post-restart scrape reads T with no intervening write.
+///
+/// `per_op` WAL fsync makes each acked remove durable in the WAL before its
+/// `OP_ACK`, so recovery deterministically replays every tombstone into the
+/// inner store — which the boot reconciliation then walks. No sleep-for-flush
+/// race: durability is established at ack time, not by the write-behind timer.
+#[tokio::test(flavor = "multi_thread")]
+async fn tombstone_bytes_gauge_survives_kill9() {
+    let data_dir = tempfile::tempdir().expect("create temp data dir");
+    let port = ServerSupervisor::pick_free_port().expect("pick free port");
+
+    let supervisor = ServerSupervisor::new(ServerConfig {
+        binary: resolve_server_binary(),
+        data_dir: data_dir.path().to_path_buf(),
+        port,
+        jwt_secret: JWT_SECRET.to_string(),
+        wal_fsync_policy: "per_op".to_string(),
+    });
+
+    supervisor.start(READY_TIMEOUT).await.expect("server start");
+
+    // Seed N unique-tag OR removes. Each remove appends its client tag to the
+    // key's tombstone set and increments the gauge by that tag's byte length.
+    // Tags are `tomb-000000`..`tomb-0000NN` — a fixed 11-byte width — so the
+    // accumulated total is exactly N * 11.
+    let mut c = SoakClient::connect(supervisor.addr(), 0, JWT_SECRET)
+        .await
+        .expect("client connect");
+    for i in 0..N_TOMBS {
+        let tag = format!("tomb-{i:06}");
+        assert_eq!(tag.len(), 11, "tag width must stay fixed for exact accounting");
+        c.or_add(OR_MAP, OR_KEY, &tag, i as i64, 1, i as u32)
+            .await
+            .expect("or_add");
+        c.or_remove(OR_MAP, OR_KEY, &tag).await.expect("or_remove");
+    }
+    drop(c);
+
+    let expected: u64 = N_TOMBS as u64 * 11;
+
+    // Pre-kill: the live gauge reflects the accumulated tombstone bytes.
+    let pre = scrape_tombstone_bytes(port)
+        .await
+        .expect("pre-kill /metrics must expose the gauge");
+    assert!(pre > 0, "pre-kill gauge must be non-zero after seeding removes");
+    assert_eq!(pre, expected, "pre-kill gauge should equal N * tag_len");
+
+    // kill -9 + relaunch against the same data dir (real WAL recovery).
+    supervisor.restart(READY_TIMEOUT).await.expect("server restart");
+
+    // FIRST post-restart scrape, with NO intervening OR mutation. The value must
+    // come from boot reconciliation alone. On a fresh process without the seed
+    // this would read 0/absent; a non-zero T here proves the gauge survives.
+    let post = scrape_tombstone_bytes(port)
+        .await
+        .expect("post-restart /metrics must expose the reconciled gauge");
+    assert_eq!(
+        post, pre,
+        "first post-restart scrape must reflect the reconciled total ({pre}), not 0"
+    );
+
+    supervisor.shutdown().await;
+}

--- a/packages/server-rust/tests/soak_tombstone_restart.rs
+++ b/packages/server-rust/tests/soak_tombstone_restart.rs
@@ -26,6 +26,22 @@
 //! re-including the modules here puts this proof under the standard libtest
 //! harness. `allow(dead_code)` covers bench items this test does not reference.
 
+// Mirror the soak harness's crate-level pedantic allow list: this test pulls in
+// the bench `client`/`process`/`or_noloss` modules by `#[path]`, so it must
+// carry the same allows they were written against (e.g. `doc_markdown` for
+// prose like "MsgPack", the intentional lossy `.0`-float→byte-count cast in the
+// Prometheus parser). Kept in sync with `benches/soak_harness/main.rs`.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::similar_names,
+    clippy::doc_markdown,
+    clippy::too_many_lines,
+    clippy::struct_excessive_bools
+)]
+
 #[path = "../benches/soak_harness/or_noloss.rs"]
 #[allow(dead_code)]
 mod or_noloss;
@@ -49,7 +65,7 @@ const READY_TIMEOUT: Duration = Duration::from_secs(30);
 const OR_MAP: &str = "ork_map";
 const OR_KEY: &str = "ork";
 /// Number of unique-tag OR removes to seed.
-const N_TOMBS: usize = 50;
+const N_TOMBS: u32 = 50;
 
 /// Scrape `topgun_ormap_tombstone_bytes_total` from the running server's
 /// `GET /metrics`. Returns `None` on any transient failure (connection refused
@@ -125,14 +141,14 @@ async fn tombstone_bytes_gauge_survives_kill9() {
             11,
             "tag width must stay fixed for exact accounting"
         );
-        c.or_add(OR_MAP, OR_KEY, &tag, i as i64, 1, i as u32)
+        c.or_add(OR_MAP, OR_KEY, &tag, i64::from(i), 1, i)
             .await
             .expect("or_add");
         c.or_remove(OR_MAP, OR_KEY, &tag).await.expect("or_remove");
     }
     drop(c);
 
-    let expected: u64 = N_TOMBS as u64 * 11;
+    let expected: u64 = u64::from(N_TOMBS) * 11;
 
     // Pre-kill: the live gauge reflects the accumulated tombstone bytes.
     let pre = scrape_tombstone_bytes(port)

--- a/packages/server-rust/tests/soak_tombstone_restart.rs
+++ b/packages/server-rust/tests/soak_tombstone_restart.rs
@@ -120,7 +120,11 @@ async fn tombstone_bytes_gauge_survives_kill9() {
         .expect("client connect");
     for i in 0..N_TOMBS {
         let tag = format!("tomb-{i:06}");
-        assert_eq!(tag.len(), 11, "tag width must stay fixed for exact accounting");
+        assert_eq!(
+            tag.len(),
+            11,
+            "tag width must stay fixed for exact accounting"
+        );
         c.or_add(OR_MAP, OR_KEY, &tag, i as i64, 1, i as u32)
             .await
             .expect("or_add");
@@ -134,11 +138,17 @@ async fn tombstone_bytes_gauge_survives_kill9() {
     let pre = scrape_tombstone_bytes(port)
         .await
         .expect("pre-kill /metrics must expose the gauge");
-    assert!(pre > 0, "pre-kill gauge must be non-zero after seeding removes");
+    assert!(
+        pre > 0,
+        "pre-kill gauge must be non-zero after seeding removes"
+    );
     assert_eq!(pre, expected, "pre-kill gauge should equal N * tag_len");
 
     // kill -9 + relaunch against the same data dir (real WAL recovery).
-    supervisor.restart(READY_TIMEOUT).await.expect("server restart");
+    supervisor
+        .restart(READY_TIMEOUT)
+        .await
+        .expect("server restart");
 
     // FIRST post-restart scrape, with NO intervening OR mutation. The value must
     // come from boot reconciliation alone. On a fresh process without the seed

--- a/packages/server-rust/tests/soak_tombstone_restart.rs
+++ b/packages/server-rust/tests/soak_tombstone_restart.rs
@@ -174,7 +174,9 @@ async fn tombstone_bytes_gauge_survives_kill9() {
         .expect("post-restart /metrics must expose the reconciled gauge");
     assert_eq!(
         post, pre,
-        "first post-restart scrape must reflect the reconciled total ({pre}), not 0"
+        "first post-restart scrape must reflect the reconciled total: post={post} pre={pre} — \
+         post==0 means boot reconciliation didn't run; post≈2×pre means WAL replay armed \
+         add_tombstone_bytes before the boot seed, double-counting the additive Prometheus counter"
     );
 
     supervisor.shutdown().await;


### PR DESCRIPTION
## Summary

Makes the OR-Map tombstone-bytes gauge **survive `kill -9` restarts** so the 72h G4b soak's byte instrument stops sawtoothing to 0 on every crash and can honestly detect a cross-restart leak. This is the load-bearing prerequisite for TODO-566's tombstone bound ever being *provable* on the byte instrument.

Split child of SPEC-341 (server-boot half). Sibling #107 (SPEC-341a, harness disk monitor) already merged.

## What changed

- **`storage/record.rs`** — new `set_tombstone_bytes(total)`: the only absolute-set path. Does an absolute `AtomicU64.store(total)` (never `fetch_add`) **plus** a one-time Prometheus `increment(total)` so the fresh-recorder counter the soak harness scrapes off `/metrics` lands at `total`. Adds a fail-loud `TOMBSTONE_ADD_FIRED` tripwire that emits a `tracing::error!` in **every** build (release included) if the recovery→ready gauge-window invariant is ever violated. `add/sub/tombstone_bytes` semantics unchanged.
- **`bin/topgun_server.rs`** — new `reconcile_tombstone_bytes`: cursor-batched full keyspace walk (`list_maps` → `scan_values` + `scan_values_batched` until `next_cursor == None`, `is_backup=false`) that sums `tag.len()` over every persisted `RecordValue::OrMap.tombstones` and calls `set_tombstone_bytes(total)` **once**, strictly after `recovery.run` returns `Ok` and before `set_ready()`, guarded to `Redb | Postgres`, reading through an `Arc::clone` taken before the store's move into write-behind. Scan error → WARN and degrade to the process-local gauge (no `exit(1)`).
- **`tests/soak_tombstone_restart.rs`** *(new)* — AC1 behavioral proof: out-of-process real `topgun-server` on real redb+WAL, seeds N unique-tag OR removes, scrapes gauge (T>0), real SIGKILL, relaunches on the same data dir, asserts the **first** post-restart scrape reads T with **no** intervening `add_tombstone_bytes`.

## Acceptance criteria

- **AC1** gauge survives restart — behavioral kill-9 test green (out-of-process, first-scrape-no-intervening-add).
- **AC2** monotonic across restarts (no sawtooth) — proven for one restart cycle; multi-restart/multi-batch variant deferred to the post-566 tail (TODO-567).
- **AC3** exactly-once, post-recovery, absolute — single `set_tombstone_bytes` call site, correctly positioned, durable-guarded; gauge-window invariant holds.
- **AC4** SPEC-340 untouched — no slope flipped to a hard gate; report-only wiring unchanged.
- **AC5** gate green — `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo test --release -p topgun-server --lib` (1534/0/1) all pass locally.

## Review trail

- Audit v1 NEEDS_REVISION (wrong-sink + undercount criticals) → Audit v2 APPROVED.
- Review v1 APPROVED (0 critical / 0 major / 2 non-blocking minors, both deferred to TODO-567).
- Cross-vendor `/xreview` (glm-5.2) run at impl-time **and** re-run at the review gate over the full diff (incl. the HIGH-1 release-tripwire fix): 2 HIGH / 3 MED / 2 LOW, **all resolve** — triggers refuted against live code (recovery never calls `add_tombstone_bytes` before boot seed) or spec-audited-by-design (WARN-and-degrade). Nothing confirmed-real.

## Constraints honored

Report-only slope untouched (no hard-gate flip — fenced to post-566); absolute `store`, never per-rehydration `fetch_add`; boot-only, never hot path; `u64` byte totals; 2-file code change (no 5th file, reuses existing `MapDataStore` scan surface).
