### PR TITLE
Injective map-name scheme: forbid ':' + unreachability closure for legacy colon-named stores [SPEC-343]

### DIFF
--- a/apps/docs-astro/src/content/docs/guides/realtime-collaboration.mdx
+++ b/apps/docs-astro/src/content/docs/guides/realtime-collaboration.mdx
@@ -214,7 +214,7 @@ const client = new TopGunClient({
 await client.start();
 
 // Shared map — persistent, CRDT-merged
-const docMap = client.getMap('doc:room-1');
+const docMap = client.getMap('doc-room-1');
 
 docMap.set('block-1', {
   author: 'alice',

--- a/apps/docs-astro/src/content/docs/reference/client.mdx
+++ b/apps/docs-astro/src/content/docs/reference/client.mdx
@@ -147,6 +147,8 @@ getMap<K = string, V = any>(name: string): LWWMap<K, V>;
 
 Returns an `LWWMap` (last-write-wins CRDT) for the given name. Creates the map on first call and restores its state from storage asynchronously.
 
+Map names may not contain `:` — that character is reserved for the storage layer's internal key namespacing. Keys inside a map (e.g. `'post:123'`) may still contain `:` freely. Calling `getMap` with an empty name or a name containing `:` throws an `Error` immediately, before any storage access.
+
 ```typescript
 const users = client.getMap<string, User>('users');
 users.set('u1', { name: 'Alice' });
@@ -160,7 +162,7 @@ getORMap<K extends keyof TSchema & string>(name: K): ORMap<string, TSchema[K]>;
 getORMap<K = string, V = any>(name: string): ORMap<K, V>;
 ```
 
-Returns an `ORMap` (observed-remove CRDT) for multi-value-per-key data.
+Returns an `ORMap` (observed-remove CRDT) for multi-value-per-key data. The same map-name rule as `getMap` applies: no `:` in the name, keys are unrestricted, and an invalid name throws an `Error` immediately.
 
 ```typescript
 const tags = client.getORMap<string, string>('tags');

--- a/packages/adapters/src/IDBAdapter.ts
+++ b/packages/adapters/src/IDBAdapter.ts
@@ -55,6 +55,12 @@ export class IDBAdapter implements IStorageAdapter {
   private async initializeInternal(dbName: string): Promise<void> {
     try {
       this.dbPromise = openDB(dbName, 2, {
+        // Additive-only invariant: this upgrade MUST NOT drop, clear, or rewrite
+        // existing kv_store/meta_store keys. The map-name → storage-key scheme is
+        // kept injective for new data by forbidding ':' in map names at creation
+        // (no destructive key migration); legacy colon-named record data
+        // re-converges from the server, so an existing colon-free store simply
+        // opens and restores all prior records with no data loss.
         upgrade(db) {
           if (!db.objectStoreNames.contains('kv_store')) {
             db.createObjectStore('kv_store', { keyPath: 'key' });

--- a/packages/adapters/src/__tests__/IDBAdapter.migration.test.ts
+++ b/packages/adapters/src/__tests__/IDBAdapter.migration.test.ts
@@ -1,0 +1,62 @@
+import { IDBAdapter } from '../IDBAdapter';
+
+// SPEC-343 AC7 — the forbid decision adds no destructive key migration; an
+// existing (colon-free) store must simply re-open and restore every prior record
+// with no data loss. This exercises a pre-populated adapter across a close/reopen
+// cycle over the SAME database (the additive schema-version-2 upgrade path).
+describe('IDBAdapter migration is non-destructive (SPEC-343 AC7)', () => {
+  let dbCounter = 0;
+  const getUniqueDbName = () => `migration_db_${Date.now()}_${dbCounter++}`;
+
+  it('an existing colon-free store opens and restores all prior records after reopen', async () => {
+    const dbName = getUniqueDbName();
+
+    // 1. Pre-populate a store: KV records (LWW + OR shapes), meta, and a pending op —
+    //    all under colon-free map names (the only names creatable post-forbid).
+    const first = new IDBAdapter();
+    await first.initialize(dbName);
+    await first.waitForReady();
+
+    await first.put('users:alice', { value: { name: 'Alice' }, hlc: '1-0-n1' });
+    await first.put('tags:post:123', [{ value: 'x', tag: 't1', hlc: '2-0-n1' }]);
+    await first.setMeta('__sys__:tags:tombstones', ['t0']);
+    await first.setMeta('lastSyncTimestamp', 12345);
+    const opId = await first.appendOpLog({
+      key: 'alice',
+      op: 'PUT',
+      value: { name: 'Alice' },
+      synced: 0,
+      mapName: 'users',
+    });
+    expect(opId).toBeGreaterThan(0);
+
+    await first.close();
+
+    // 2. Reopen a fresh adapter over the SAME database — re-runs the additive
+    //    version-2 upgrade (must not drop/rewrite kv_store or meta_store).
+    const reopened = new IDBAdapter();
+    await reopened.initialize(dbName);
+    await reopened.waitForReady();
+    try {
+      // 3. Every prior record survives — no data loss.
+      expect(await reopened.get('users:alice')).toEqual({
+        value: { name: 'Alice' },
+        hlc: '1-0-n1',
+      });
+      // A colon-in-KEY record round-trips unchanged (keys were never restricted).
+      expect(await reopened.get('tags:post:123')).toEqual([
+        { value: 'x', tag: 't1', hlc: '2-0-n1' },
+      ]);
+      expect(await reopened.getMeta('__sys__:tags:tombstones')).toEqual(['t0']);
+      expect(await reopened.getMeta('lastSyncTimestamp')).toBe(12345);
+
+      const keys = (await reopened.getAllKeys()).sort();
+      expect(keys).toEqual(['tags:post:123', 'users:alice']);
+
+      const pending = await reopened.getPendingOps();
+      expect(pending.map((p) => p.key)).toEqual(['alice']);
+    } finally {
+      await reopened.close();
+    }
+  });
+});

--- a/packages/client/src/SyncEngine.ts
+++ b/packages/client/src/SyncEngine.ts
@@ -23,6 +23,7 @@ import type { QueryFilter } from './QueryHandle';
 import type { HybridQueryHandle, HybridQueryFilter } from './HybridQueryHandle';
 import { TopicHandle } from './TopicHandle';
 import { logger } from './utils/logger';
+import { isValidMapName, keyBelongsToLongerHeldName } from './utils/mapName';
 import { SyncStateMachine, StateChangeEvent } from './SyncStateMachine';
 import { SyncState } from './SyncState';
 import type {
@@ -805,16 +806,33 @@ export class SyncEngine {
     const pendingOps = await this.storageAdapter.getPendingOps();
     // Clear and push to existing array (preserves BackpressureController reference)
     this.opLog.length = 0;
+    // The OP_BATCH flush is held-set-independent, so a persisted op under a
+    // forbidden (non-injective) map name is the one path that could reach the
+    // server despite map-creation being forbidden for such names. Shed those
+    // entries at load — non-throwing (never invoke the throwing guard in the
+    // restore loop); an invalid entry is dropped, not fatal.
+    let droppedInvalidName = 0;
     for (const op of pendingOps) {
       const restored = {
         ...op,
         id: String(op.id),
         synced: false,
       } as unknown as OpLogEntry;
+      if (!isValidMapName(restored.mapName)) {
+        droppedInvalidName++;
+        continue;
+      }
       this.opLog.push(restored);
       // Surface restored pending ops to the per-record sync-state tracker so
       // they project to 'pending' or 'local-only' immediately on engine boot.
       this.recordSyncStateTracker.onAppend(restored);
+    }
+
+    if (droppedInvalidName > 0) {
+      logger.warn(
+        { count: droppedInvalidName },
+        'Dropped restored pending operations with an invalid (non-injective) map name; they will not be flushed to the server',
+      );
     }
 
     if (this.opLog.length > 0) {
@@ -881,6 +899,17 @@ export class SyncEngine {
    * close. The caller (startMerkleSync) converts the throw into a
    * connection-wide ACK suppression (heldSetIncomplete) instead.
    */
+  /**
+   * The current connection's held-OR-Map snapshot (or `null` before the first
+   * sync of a connection). Exposed so the `TopGunClient` primary OR-Map restore
+   * path shares the SAME longest-held-name discriminator used by
+   * `instantiateAndRestoreOrMap` — both restore seams must skip a matched key
+   * that belongs to a LONGER held name.
+   */
+  public getHeldOrMapNames(): Set<string> | null {
+    return this.heldOrMapNames;
+  }
+
   private async computeHeldOrMapNames(): Promise<Set<string>> {
     await this.backfillLegacyOrMapMarkers();
     const held = new Set<string>();
@@ -911,19 +940,32 @@ export class SyncEngine {
    * - Scans ALL keys (never a sample): a missed add-only map with a single key is
    *   exactly the bug. A name is classified OR the moment ANY key under its prefix
    *   holds an ARRAY (the ORMap records-array shape; an LWWRecord is always a single
-   *   object, never a bare array), so a `:`-prefix collision (TODO-577) between the
-   *   FIRST-colon-split name and an LWW *value* only ever ADDS a phantom OR name
-   *   (over-conservative: coverage 0 until it syncs), never hides a real one.
-   * - KNOWN GAP (TODO-577, latent until the durability watermark activates): the
-   *   first-colon split (`indexOf(':')`) means a map whose NAME contains a colon
-   *   (`"a:b"`, data key `"a:b:k"`) is attributed to `"a"`, so its own `:ormap`
-   *   marker is never stamped. If a sibling `"a"` also exists and syncs while `"a:b"`
-   *   is never re-opened this session, the min-barrier CAN advance past `"a:b"`'s
-   *   un-received tombstones — i.e. this colon-in-NAME case CAN hide a real map,
-   *   unlike the colon-in-value case above. Legacy-backfill-only (every post-fix map
-   *   stamps its marker under its full name; `HELD_ORMAP_META_RE`'s greedy capture
-   *   recovers colon names correctly). Closed by forbidding `:` in map names or an
-   *   injective key scheme — see TODO-577.
+   *   object, never a bare array). The name is derived by the FIRST colon
+   *   (`indexOf(':')`) and this derivation is KEPT deliberately: marking every colon
+   *   prefix instead would stamp a phantom held name for ordinary composite KEYS
+   *   (`tags` + key `post:123` → phantom `tags:post`), which would then prefix-restore
+   *   its sibling's records and push a duplicate polluted server map — strictly worse
+   *   than the residual below.
+   *
+   *   Consequences of first-colon derivation for legacy colon-named maps (`":"` in a
+   *   map NAME is now forbidden at map creation, so this only concerns hypothetical
+   *   pre-forbid stores):
+   *   - Accepted residual: legacy raw `a:b:k` keys prefix-leak into map `a` as key
+   *     `b:k` on restore. This is a pre-existing restore-pollution class inherent to
+   *     the flat non-injective scheme, orthogonal to tombstone prune; the leaked data
+   *     re-converges from the server (authoritative), it does not resurrect anything.
+   *   - Add-only / unmarked legacy `a:b` (no durable `:tombstones`, no pre-forbid
+   *     `:ormap` marker): closed by forbid + unreachability. Post-forbid `a:b` is
+   *     unopenable (getMap/getORMap reject it), unmarked (first-colon backfill stamps
+   *     `a`, never `a:b`), and therefore unheld and never instantiated — so no ACK
+   *     path ever runs under `a:b`.
+   *   - Marked legacy `a:b` (durable `:tombstones` OR a pre-forbid `:ormap` marker):
+   *     surfaced-as-held by the greedy `HELD_ORMAP_META_RE` capture and instantiated
+   *     internally via `instantiateAndRestoreOrMap` (which bypasses the creation
+   *     guard), but safely gated — it enters the snapshot at coverage 0, applies its
+   *     tombstones on restore, is ACK-gated, and the loadOpLog name-filter plus the
+   *     longest-held-name restore-guard block push pollution. Held and gated, NOT
+   *     resurrected.
    * - Gated by a durable done-flag set ONLY on success. A throw propagates to
    *   `computeHeldOrMapNames` → the connection fail-closes (heldSetIncomplete) and
    *   the scan is retried on the next connection. This makes the upgrade path safe
@@ -997,6 +1039,12 @@ export class SyncEngine {
       for (const fullKey of keys) {
         if (!fullKey.startsWith(prefix)) continue;
         const keyPart = fullKey.substring(prefix.length);
+        // Skip a prefix-matched key that actually belongs to a LONGER held name
+        // (the flat scheme is not injective for legacy colon-named stores). The
+        // held-set is the discriminator, shared with TopGunClient.restoreORMap.
+        if (keyBelongsToLongerHeldName(mapName, keyPart, this.heldOrMapNames)) {
+          continue;
+        }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- restored KV value shape is validated by the Array.isArray guard below; ORMapRecord value type is erased at the storage layer
         const data = await this.storageAdapter.get<any>(fullKey);
         if (Array.isArray(data)) {

--- a/packages/client/src/SyncEngine.ts
+++ b/packages/client/src/SyncEngine.ts
@@ -905,9 +905,13 @@ export class SyncEngine {
    * path shares the SAME longest-held-name discriminator used by
    * `instantiateAndRestoreOrMap` — both restore seams must skip a matched key
    * that belongs to a LONGER held name.
+   *
+   * Returns a defensive copy: this is a public accessor and the discriminator's
+   * correctness depends on the held-set, so callers must never mutate internal
+   * sync state in place.
    */
   public getHeldOrMapNames(): Set<string> | null {
-    return this.heldOrMapNames;
+    return this.heldOrMapNames ? new Set(this.heldOrMapNames) : null;
   }
 
   private async computeHeldOrMapNames(): Promise<Set<string>> {

--- a/packages/client/src/TopGunClient.ts
+++ b/packages/client/src/TopGunClient.ts
@@ -46,6 +46,7 @@ import type { HybridSearchSubscribeOptions } from './HybridSearchHandle';
 import { HybridQueryHandle } from './HybridQueryHandle';
 import type { HybridQueryFilter } from './HybridQueryHandle';
 import { logger } from './utils/logger';
+import { assertValidMapName, keyBelongsToLongerHeldName } from './utils/mapName';
 import { SyncState } from './SyncState';
 import type { StateChangeEvent } from './SyncStateMachine';
 import type {
@@ -635,6 +636,9 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
   public getMap<K = string, V = any>(name: string): LWWMap<K, V>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- implementation signature uses any to satisfy both overloads; actual type flows from the selected overload
   public getMap(name: string): LWWMap<any, any> {
+    // Reject an invalid name BEFORE any registry/restore side effect so a
+    // rejected name leaves this.maps and the sync registry untouched.
+    assertValidMapName(name);
     if (this.maps.has(name)) {
       const map = this.maps.get(name);
       if (map instanceof LWWMap) {
@@ -728,6 +732,9 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
   public getORMap<K = string, V = any>(name: string): ORMap<K, V>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- implementation signature uses any to satisfy both overloads; actual type flows from the selected overload
   public getORMap(name: string): ORMap<any, any> {
+    // Reject an invalid name BEFORE any registry/restore side effect so a
+    // rejected name leaves this.maps and the sync registry untouched.
+    assertValidMapName(name);
     if (this.maps.has(name)) {
       const map = this.maps.get(name);
       if (map instanceof ORMap) {
@@ -826,9 +833,18 @@ export class TopGunClient<TSchema extends Record<string, any> = any> {
       // 2. Restore Items
       const keys = await this.storageAdapter.getAllKeys();
       const mapPrefix = `${name}:`;
+      // Longest-held-name discriminator: the flat key scheme is not injective
+      // for legacy colon-named stores, so a key matched by prefix `name:` may
+      // actually belong to a LONGER held name (e.g. `a:b:k` belongs to `a:b`,
+      // not `a`). Share the held-set from the SyncEngine so this seam and
+      // instantiateAndRestoreOrMap skip the same keys.
+      const heldNames = this.syncEngine.getHeldOrMapNames();
       for (const fullKey of keys) {
         if (fullKey.startsWith(mapPrefix)) {
           const keyPart = fullKey.substring(mapPrefix.length);
+          if (keyBelongsToLongerHeldName(name, keyPart, heldNames)) {
+            continue;
+          }
 
           const data = await this.storageAdapter.get(fullKey);
           if (Array.isArray(data)) {

--- a/packages/client/src/__tests__/MapNameSyncEngine.test.ts
+++ b/packages/client/src/__tests__/MapNameSyncEngine.test.ts
@@ -1,0 +1,275 @@
+import { SyncEngine, SyncEngineConfig } from '../SyncEngine';
+import { IStorageAdapter, OpLogEntry } from '../IStorageAdapter';
+import { serialize, deserialize } from '@topgunbuild/core';
+import { SingleServerProvider } from '../connection/SingleServerProvider';
+import * as loggerModule from '../utils/logger';
+import { assertValidMapName } from '../utils/mapName';
+
+// --- Mock WebSocket (mirrors SyncEngine.test.ts) ---
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static OPEN = 1;
+  static CLOSED = 3;
+
+  readyState: number = MockWebSocket.OPEN;
+  binaryType = 'blob';
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: ArrayBuffer | string }) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: ((error: any) => void) | null = null;
+  sentMessages: any[] = [];
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+    setTimeout(() => {
+      if (this.onopen) this.onopen();
+    }, 0);
+  }
+  send(data: Uint8Array | string) {
+    if (data instanceof Uint8Array) this.sentMessages.push(deserialize(data));
+    else this.sentMessages.push(JSON.parse(data));
+  }
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    if (this.onclose) this.onclose({ code: 1000, reason: 'Normal closure' });
+  }
+  simulateMessage(message: any) {
+    if (this.onmessage) {
+      const data = serialize(message);
+      this.onmessage({ data: new Uint8Array(data).buffer });
+    }
+  }
+  static reset() {
+    MockWebSocket.instances = [];
+  }
+  static getLastInstance(): MockWebSocket | undefined {
+    return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  }
+}
+(global as any).WebSocket = MockWebSocket;
+
+let uuidCounter = 0;
+(global as any).crypto = { randomUUID: () => `test-uuid-${++uuidCounter}` };
+
+const BACKFILL_DONE_KEY = '__sys__:ormapBackfillDone';
+
+// Stateful in-memory adapter so backfill markers written via setMeta are visible
+// to the subsequent getAllMetaKeys held-set enumeration (the jest.fn mock in
+// SyncEngine.test.ts intentionally does not round-trip meta writes).
+class MemAdapter implements IStorageAdapter {
+  kv = new Map<string, any>();
+  meta = new Map<string, any>();
+  pending: OpLogEntry[] = [];
+  throwOnGet = new Set<string>();
+
+  async initialize(): Promise<void> {}
+  async close(): Promise<void> {}
+  async get<V>(key: string): Promise<any> {
+    if (this.throwOnGet.has(key)) throw new Error(`injected read failure for ${key}`);
+    return this.kv.get(key) as V | undefined;
+  }
+  async put(key: string, value: any): Promise<void> {
+    this.kv.set(key, value);
+  }
+  async remove(key: string): Promise<void> {
+    this.kv.delete(key);
+  }
+  async getMeta(key: string): Promise<any> {
+    return this.meta.get(key);
+  }
+  async setMeta(key: string, value: any): Promise<void> {
+    this.meta.set(key, value);
+  }
+  async batchPut(entries: Map<string, any>): Promise<void> {
+    for (const [k, v] of entries) this.kv.set(k, v);
+  }
+  async appendOpLog(entry: Omit<OpLogEntry, 'id'>): Promise<number> {
+    const id = this.pending.length + 1;
+    this.pending.push({ ...entry, id } as OpLogEntry);
+    return id;
+  }
+  async getPendingOps(): Promise<OpLogEntry[]> {
+    return this.pending;
+  }
+  async markOpsSynced(): Promise<void> {}
+  async deleteOp(): Promise<void> {}
+  async commitWrite(): Promise<number> {
+    return 1;
+  }
+  async getAllKeys(): Promise<string[]> {
+    return Array.from(this.kv.keys());
+  }
+  async getAllMetaKeys(): Promise<string[]> {
+    return Array.from(this.meta.keys());
+  }
+}
+
+function makeConfig(storageAdapter: IStorageAdapter): SyncEngineConfig {
+  return {
+    nodeId: 'test-node',
+    connectionProvider: new SingleServerProvider({ url: 'ws://localhost:8080' }),
+    storageAdapter,
+    reconnectInterval: 1000,
+    heartbeat: { enabled: false },
+  };
+}
+
+const ts = () => ({ millis: Date.now(), counter: 0, nodeId: 'test' });
+const orRecord = (value: string, tag: string) => [{ value, tag, timestamp: ts() }];
+
+describe('SPEC-343 SyncEngine map-name folds', () => {
+  let syncEngine: SyncEngine | undefined;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    MockWebSocket.reset();
+    uuidCounter = 0;
+  });
+
+  afterEach(() => {
+    if (syncEngine) {
+      syncEngine.close();
+      syncEngine = undefined;
+    }
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  // AC3b — no phantom held-name from an ordinary composite KEY.
+  describe('AC3b — composite KEY never produces a phantom held-name', () => {
+    it('key "post:123" under map "tags" yields held name "tags", NOT "tags:post"', async () => {
+      const storage = new MemAdapter();
+      // Real OR-Map "tags" with composite key "post:123" → storage key "tags:post:123".
+      storage.kv.set('tags:post:123', orRecord('x', 't1'));
+      // Backfill NOT yet done → the first-colon backfill runs during the snapshot.
+
+      syncEngine = new SyncEngine(makeConfig(storage));
+      await jest.runAllTimersAsync();
+      await (syncEngine as any).startMerkleSync();
+
+      const held: Set<string> = (syncEngine as any).heldOrMapNames;
+      expect(held.has('tags')).toBe(true);
+      expect(held.has('tags:post')).toBe(false);
+
+      // The first-colon backfill stamps only "tags" — never a phantom "tags:post".
+      expect(storage.meta.has('__sys__:tags:ormap')).toBe(true);
+      expect(storage.meta.has('__sys__:tags:post:ormap')).toBe(false);
+
+      // No phantom map is instantiated (so no sync-init/push can ever run for it).
+      const maps: Map<string, unknown> = (syncEngine as any).maps;
+      expect(maps.has('tags')).toBe(true);
+      expect(maps.has('tags:post')).toBe(false);
+    });
+  });
+
+  // AC4 — unreachability of an add-only, unmarked legacy colon-named map "a:b".
+  describe('AC4 — legacy colon-named "a:b" is unreachable (unheld, uninstantiated)', () => {
+    it('held-set surfaces "a" but not "a:b"; no marker/instance/ACK path under "a:b"', async () => {
+      const storage = new MemAdapter();
+      storage.kv.set('a:k', orRecord('own', 't-a'));
+      storage.kv.set('a:b:k', orRecord('sibling', 't-ab')); // the legacy colon-named store
+
+      syncEngine = new SyncEngine(makeConfig(storage));
+      await jest.runAllTimersAsync();
+      await (syncEngine as any).startMerkleSync();
+
+      const held: Set<string> = (syncEngine as any).heldOrMapNames;
+      expect(held.has('a')).toBe(true);
+      // First-colon backfill attributes "a:b:k" to "a" → "a:b" is never surfaced.
+      expect(held.has('a:b')).toBe(false);
+
+      // No "a:b" existence marker is ever stamped.
+      expect(storage.meta.has('__sys__:a:ormap')).toBe(true);
+      expect(storage.meta.has('__sys__:a:b:ormap')).toBe(false);
+
+      // "a:b" is never instantiated → no CLIENT_APPLY_ACK path runs under it.
+      const maps: Map<string, unknown> = (syncEngine as any).maps;
+      expect(maps.has('a:b')).toBe(false);
+
+      // And it can never be opened: getORMap('a:b') is forbidden at the boundary.
+      expect(() => assertValidMapName('a:b')).toThrow(/":"/);
+    });
+  });
+
+  // AC5 — loadOpLog name-filter (RED without the fix).
+  describe('AC5 — a persisted op under a forbidden name is dropped at loadOpLog', () => {
+    it('drops mapName "a:b" (warn+count) and never flushes it in OP_BATCH', async () => {
+      const storage = new MemAdapter();
+      // Already-migrated device so the held-set enumeration stays inert for this test.
+      storage.meta.set(BACKFILL_DONE_KEY, true);
+      storage.pending = [
+        { id: 1, mapName: 'a:b', opType: 'PUT', key: 'k', synced: 0, timestamp: ts() } as any,
+        { id: 2, mapName: 'users', opType: 'PUT', key: 'u1', synced: 0, timestamp: ts() } as any,
+      ];
+
+      const warnSpy = jest.spyOn(loggerModule.logger, 'warn');
+
+      syncEngine = new SyncEngine(makeConfig(storage));
+      syncEngine.setAuthToken('test-token');
+      await jest.runAllTimersAsync();
+
+      const ws = MockWebSocket.getLastInstance()!;
+      ws.sentMessages = [];
+      ws.simulateMessage({ type: 'AUTH_ACK' });
+      await jest.runAllTimersAsync();
+
+      const opBatch = ws.sentMessages.find((m) => m.type === 'OP_BATCH');
+      expect(opBatch).toBeDefined();
+      const mapNames = opBatch.payload.ops.map((o: any) => o.mapName);
+      // The forbidden-name op was shed at load — only the valid op flushes.
+      // (Pre-fix loadOpLog had NO name-filter, so BOTH ops would flush here and
+      // this assertion would fail — the RED-without-fix property.)
+      expect(mapNames).toEqual(['users']);
+      expect(mapNames).not.toContain('a:b');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ count: 1 }),
+        expect.stringContaining('invalid (non-injective) map name'),
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  // AC5b — longest-held-name restore-guard inside instantiateAndRestoreOrMap.
+  describe('AC5b — instantiateAndRestoreOrMap skips a key owned by a LONGER held name', () => {
+    it('restoring "a" with both "a" and "a:b" held does NOT absorb "a:b:k"', async () => {
+      const storage = new MemAdapter();
+      storage.kv.set('a:k1', orRecord('own', 't-own'));
+      storage.kv.set('a:b:k', orRecord('sibling', 't-sib'));
+
+      syncEngine = new SyncEngine(makeConfig(storage));
+      await jest.runAllTimersAsync();
+
+      // Reset the registry so instantiateAndRestoreOrMap runs a fresh restore (the
+      // boot-time connection flow may already have instantiated "a" under a held-set
+      // that did not yet include the longer name).
+      (syncEngine as any).maps.clear();
+      // Drive the shared discriminator: both names held for this connection.
+      (syncEngine as any).heldOrMapNames = new Set(['a', 'a:b']);
+
+      const mapA = await (syncEngine as any).instantiateAndRestoreOrMap('a');
+
+      expect(mapA.get('k1')).toEqual(['own']);
+      // "b:k" belongs to the LONGER held name "a:b" → skipped, not merged into "a".
+      expect(mapA.get('b:k')).toEqual([]);
+    });
+  });
+
+  // AC6 — backfill fail-closed preserved.
+  describe('AC6 — a storage error mid-backfill fail-closes the connection', () => {
+    it('leaves the done-flag unset and sets heldSetIncomplete (ACKs suppressed)', async () => {
+      const storage = new MemAdapter();
+      storage.kv.set('a:k', orRecord('v', 't'));
+      storage.throwOnGet.add('a:k'); // read failure mid-scan
+      // Backfill-done deliberately UNSET so the scan actually runs.
+
+      syncEngine = new SyncEngine(makeConfig(storage));
+      await jest.runAllTimersAsync();
+      await (syncEngine as any).startMerkleSync();
+
+      expect((syncEngine as any).heldSetIncomplete).toBe(true);
+      // The done-flag is set ONLY on a fully-successful scan → it stays unset here.
+      expect(storage.meta.has(BACKFILL_DONE_KEY)).toBe(false);
+    });
+  });
+});

--- a/packages/client/src/__tests__/MapNameValidation.test.ts
+++ b/packages/client/src/__tests__/MapNameValidation.test.ts
@@ -1,0 +1,220 @@
+import { TopGunClient } from '../TopGunClient';
+import { IStorageAdapter, OpLogEntry } from '../IStorageAdapter';
+import { LWWRecord, ORMapRecord } from '@topgunbuild/core';
+
+// Minimal in-memory storage adapter (mirrors ORMapPersistence.test.ts) — these
+// tests exercise the local map-creation guard + restore seams, no network.
+class MemoryStorageAdapter implements IStorageAdapter {
+  kvStore: Map<string, any> = new Map();
+  metaStore: Map<string, any> = new Map();
+  private opLog: OpLogEntry[] = [];
+  private _pendingOps: OpLogEntry[] = [];
+
+  async initialize(_dbName: string): Promise<void> {}
+  async close(): Promise<void> {}
+
+  async get<V>(key: string): Promise<LWWRecord<V> | ORMapRecord<V>[] | any | undefined> {
+    return this.kvStore.get(key);
+  }
+  async put(key: string, value: any): Promise<void> {
+    this.kvStore.set(key, value);
+  }
+  async remove(key: string): Promise<void> {
+    this.kvStore.delete(key);
+  }
+  async getMeta(key: string): Promise<any> {
+    return this.metaStore.get(key);
+  }
+  async setMeta(key: string, value: any): Promise<void> {
+    this.metaStore.set(key, value);
+  }
+  async batchPut(entries: Map<string, any>): Promise<void> {
+    for (const [key, value] of entries) this.kvStore.set(key, value);
+  }
+  async appendOpLog(entry: Omit<OpLogEntry, 'id'>): Promise<number> {
+    const id = this.opLog.length + 1;
+    const newEntry = { ...entry, id, synced: 0 } as OpLogEntry;
+    this.opLog.push(newEntry);
+    this._pendingOps.push(newEntry);
+    return id;
+  }
+  async getPendingOps(): Promise<OpLogEntry[]> {
+    return this._pendingOps;
+  }
+  async markOpsSynced(lastId: number): Promise<void> {
+    this._pendingOps = this._pendingOps.filter((op) => op.id! > lastId);
+    this.opLog = this.opLog.filter((op) => op.id! > lastId);
+  }
+  async deleteOp(id: number): Promise<void> {
+    this._pendingOps = this._pendingOps.filter((op) => op.id !== id);
+    this.opLog = this.opLog.filter((op) => op.id !== id);
+  }
+  async commitWrite(
+    mutations: Array<{ store: 'kv' | 'meta'; type: 'put' | 'remove'; key: string; value?: any }>,
+    op: Omit<OpLogEntry, 'id'>,
+  ): Promise<number> {
+    for (const m of mutations) {
+      const target = m.store === 'meta' ? this.metaStore : this.kvStore;
+      if (m.type === 'remove') target.delete(m.key);
+      else target.set(m.key, m.value);
+    }
+    return this.appendOpLog(op);
+  }
+  async getAllKeys(): Promise<string[]> {
+    return Array.from(this.kvStore.keys());
+  }
+  async getAllMetaKeys(): Promise<string[]> {
+    return Array.from(this.metaStore.keys());
+  }
+}
+
+// Mock WebSocket — local-only tests never dial out; keep Jest's worker from being
+// held open by the real undici connection-timeout (see ORMapPersistence.test.ts).
+const originalWebSocket = (globalThis as any).WebSocket;
+(globalThis as any).WebSocket = class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  readyState = 1;
+  binaryType = 'arraybuffer';
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: any }) => void) | null = null;
+  onerror: ((error: any) => void) | null = null;
+  send = jest.fn();
+  close = jest.fn();
+  constructor(public url: string) {
+    queueMicrotask(() => {
+      if (this.onopen) this.onopen();
+    });
+  }
+};
+
+afterAll(() => {
+  (globalThis as any).WebSocket = originalWebSocket;
+});
+
+describe('Map-name validation guard (getMap/getORMap)', () => {
+  let storage: MemoryStorageAdapter;
+  let client: TopGunClient;
+  const extraClients: TopGunClient[] = [];
+
+  beforeEach(() => {
+    storage = new MemoryStorageAdapter();
+    client = new TopGunClient({ serverUrl: 'ws://localhost:1234', storage });
+  });
+
+  afterEach(async () => {
+    await client.close();
+    for (const c of extraClients) await c.close();
+    extraClients.length = 0;
+  });
+
+  // AC1
+  describe('AC1 — colon in a map NAME is rejected, colon-free names succeed', () => {
+    it('getMap("a:b") throws an Error identifying ":"', () => {
+      expect(() => client.getMap('a:b')).toThrow(/":"/);
+    });
+
+    it('getORMap("a:b") throws an Error identifying ":"', () => {
+      expect(() => client.getORMap('a:b')).toThrow(/":"/);
+    });
+
+    it('getMap("a-b") and getORMap("a-b") succeed unchanged', () => {
+      expect(() => client.getMap('a-b')).not.toThrow();
+      expect(() => client.getORMap('or-a-b')).not.toThrow();
+    });
+  });
+
+  // AC2 — guard runs BEFORE registration/restore
+  describe('AC2 — a rejected name leaves this.maps and the sync registry unmodified', () => {
+    it('getMap rejection creates no partial map in either registry', () => {
+      const clientMaps: Map<string, unknown> = (client as any).maps;
+      const syncMaps: Map<string, unknown> = (client as any).syncEngine.maps;
+      const beforeClient = clientMaps.size;
+      const beforeSync = syncMaps.size;
+
+      expect(() => client.getMap('bad:name')).toThrow();
+
+      expect(clientMaps.has('bad:name')).toBe(false);
+      expect(syncMaps.has('bad:name')).toBe(false);
+      expect(clientMaps.size).toBe(beforeClient);
+      expect(syncMaps.size).toBe(beforeSync);
+    });
+
+    it('getORMap rejection creates no partial map in either registry', () => {
+      const clientMaps: Map<string, unknown> = (client as any).maps;
+      const syncMaps: Map<string, unknown> = (client as any).syncEngine.maps;
+
+      expect(() => client.getORMap('bad:name')).toThrow();
+
+      expect(clientMaps.has('bad:name')).toBe(false);
+      expect(syncMaps.has('bad:name')).toBe(false);
+    });
+  });
+
+  // AC3 — colon in a KEY is still allowed and round-trips through persistence
+  describe('AC3 — colon in a map KEY is allowed and round-trips', () => {
+    it('getORMap("tags").add("post:123", "x") persists and restores', async () => {
+      const map = client.getORMap<string, string>('tags');
+      map.add('post:123', 'x');
+      await new Promise((r) => setTimeout(r, 10));
+
+      // The composite key persists under the injective storage key "tags:post:123".
+      const stored = await storage.get('tags:post:123');
+      expect(Array.isArray(stored)).toBe(true);
+      expect((stored as any[]).map((rec) => rec.value)).toContain('x');
+
+      // Round-trip: a fresh client over the SAME storage restores the key intact.
+      const reopened = new TopGunClient({ serverUrl: 'ws://localhost:1234', storage });
+      extraClients.push(reopened);
+      const restored = reopened.getORMap<string, string>('tags');
+      await new Promise((r) => setTimeout(r, 50));
+      expect(restored.get('post:123')).toEqual(['x']);
+    });
+  });
+
+  // AC3c — empty-string name rejected, registry unmodified
+  describe('AC3c — empty-string name is rejected', () => {
+    it('getMap("") and getORMap("") throw', () => {
+      expect(() => client.getMap('')).toThrow(/empty/);
+      expect(() => client.getORMap('')).toThrow(/empty/);
+    });
+
+    it('the rejection leaves this.maps and the sync registry unmodified', () => {
+      const clientMaps: Map<string, unknown> = (client as any).maps;
+      const syncMaps: Map<string, unknown> = (client as any).syncEngine.maps;
+      const beforeClient = clientMaps.size;
+      const beforeSync = syncMaps.size;
+
+      expect(() => client.getMap('')).toThrow();
+
+      expect(clientMaps.has('')).toBe(false);
+      expect(syncMaps.has('')).toBe(false);
+      expect(clientMaps.size).toBe(beforeClient);
+      expect(syncMaps.size).toBe(beforeSync);
+    });
+  });
+
+  // AC5b — longest-held-name restore-guard in the TopGunClient primary restore path
+  describe('AC5b — TopGunClient restore path skips a key owned by a LONGER held name', () => {
+    it('restoring map "a" does NOT absorb "a:b:k" when both "a" and "a:b" are held', async () => {
+      // Seed a legacy store: sibling "a" holds key "k1"; a colon-named "a:b" holds
+      // key "k" (storage key "a:b:k"). Both are surfaced in the connection held-set.
+      const ts = { millis: Date.now(), counter: 0, nodeId: 'A' };
+      storage.kvStore.set('a:k1', [{ value: 'own', timestamp: ts, tag: 't-own' }]);
+      storage.kvStore.set('a:b:k', [{ value: 'sibling', timestamp: ts, tag: 't-sib' }]);
+
+      // Drive the shared discriminator: both names held for this connection.
+      (client as any).syncEngine.heldOrMapNames = new Set(['a', 'a:b']);
+
+      const mapA = client.getORMap<string, string>('a');
+      await new Promise((r) => setTimeout(r, 50));
+
+      // "a" restores its own key but NOT the longer-name key "b:k".
+      expect(mapA.get('k1')).toEqual(['own']);
+      expect(mapA.get('b:k')).toEqual([]);
+    });
+  });
+});

--- a/packages/client/src/__tests__/mapName.test.ts
+++ b/packages/client/src/__tests__/mapName.test.ts
@@ -1,0 +1,76 @@
+import { isValidMapName, assertValidMapName, keyBelongsToLongerHeldName } from '../utils/mapName';
+
+describe('mapName predicates', () => {
+  describe('isValidMapName', () => {
+    it.each([
+      // colon-free names are valid
+      ['users', true],
+      ['a-b', true],
+      ['a/b', true],
+      ['a_b', true],
+      ['doc-room-1', true],
+      ['post123', true],
+      ['__sys__', true],
+      // any colon anywhere is invalid
+      ['a:b', false],
+      [':leading', false],
+      ['trailing:', false],
+      ['a:b:c', false],
+      // empty string is invalid (no injective key prefix, no map identity)
+      ['', false],
+    ])('isValidMapName(%j) === %s', (name, expected) => {
+      expect(isValidMapName(name as string)).toBe(expected);
+    });
+  });
+
+  describe('assertValidMapName', () => {
+    it('does not throw for a colon-free name', () => {
+      expect(() => assertValidMapName('a-b')).not.toThrow();
+      expect(() => assertValidMapName('users')).not.toThrow();
+    });
+
+    it('throws an Error identifying ":" as the offending character', () => {
+      expect(() => assertValidMapName('a:b')).toThrow(Error);
+      // Message names the ":" separator and suggests a colon-free replacement.
+      expect(() => assertValidMapName('a:b')).toThrow(/":"/);
+      expect(() => assertValidMapName('a:b')).toThrow(/not allowed in map names/);
+      expect(() => assertValidMapName('a:b')).toThrow(/a-b/);
+    });
+
+    it('throws a distinct, empty-specific message for the empty name', () => {
+      expect(() => assertValidMapName('')).toThrow(Error);
+      expect(() => assertValidMapName('')).toThrow(/must not be empty/);
+      // The empty-name path must NOT reuse the colon message.
+      expect(() => assertValidMapName('')).not.toThrow(/":" character is not allowed/);
+    });
+  });
+
+  describe('keyBelongsToLongerHeldName (longest-held-name discriminator)', () => {
+    it('returns false when the held-set is null (no snapshot yet)', () => {
+      expect(keyBelongsToLongerHeldName('a', 'b:k', null)).toBe(false);
+    });
+
+    it('returns false when no longer held name owns the key', () => {
+      expect(keyBelongsToLongerHeldName('a', 'b:k', new Set(['a']))).toBe(false);
+    });
+
+    it('returns true when a longer held name owns the key', () => {
+      // remainder "b:k" under "a" → candidate "a:b"; held → belongs to the longer map
+      expect(keyBelongsToLongerHeldName('a', 'b:k', new Set(['a', 'a:b']))).toBe(true);
+    });
+
+    it('tests EVERY colon-prefix of the remainder', () => {
+      // remainder "x:y:k" under "a" → candidates "a:x" and "a:x:y"
+      expect(keyBelongsToLongerHeldName('a', 'x:y:k', new Set(['a:x:y']))).toBe(true);
+      expect(keyBelongsToLongerHeldName('a', 'x:y:k', new Set(['a:x']))).toBe(true);
+      expect(keyBelongsToLongerHeldName('a', 'x:y:k', new Set(['a:z']))).toBe(false);
+    });
+
+    it('a remainder with no colon can never belong to a longer name', () => {
+      // The ordinary composite-KEY case: real map "tags", key "post123" → no phantom owner.
+      expect(keyBelongsToLongerHeldName('tags', 'post123', new Set(['tags', 'tags:post']))).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/packages/client/src/utils/mapName.ts
+++ b/packages/client/src/utils/mapName.ts
@@ -17,7 +17,10 @@
  * AND by the non-throwing oplog-restore filter (which must shed, not throw).
  */
 export function isValidMapName(name: string): boolean {
-  if (name.length === 0) return false;
+  // Guard non-string input first: the untyped getMap/getORMap overloads let a
+  // JS caller pass a non-string, which would otherwise throw a cryptic
+  // `undefined.length` TypeError instead of a clear map-name rejection.
+  if (typeof name !== 'string' || name.length === 0) return false;
   if (name.includes(':')) return false;
   return true;
 }
@@ -30,9 +33,9 @@ export function isValidMapName(name: string): boolean {
  */
 export function assertValidMapName(name: string): void {
   if (isValidMapName(name)) return;
-  if (name.length === 0) {
+  if (typeof name !== 'string' || name.length === 0) {
     throw new Error(
-      'Invalid map name: name must not be empty. A map name is its durable storage-key prefix and cannot be blank.',
+      'Invalid map name: name must not be empty and must be a string. A map name is its durable storage-key prefix and cannot be blank.',
     );
   }
   throw new Error(

--- a/packages/client/src/utils/mapName.ts
+++ b/packages/client/src/utils/mapName.ts
@@ -1,0 +1,72 @@
+/**
+ * Client persistence stores every record under the flat key `${mapName}:${key}`
+ * and restores a map by `fullKey.startsWith(`${mapName}:`)`. That scheme is only
+ * injective while no map name contains a `:`: if one name is a colon-prefix of
+ * another (`"foo"` vs `"foo:bar"`), restoring `"foo"` also matches
+ * `"foo:bar:someKey"` and merges a sibling map's records into the wrong map.
+ * We forbid `:` in persisted map NAMES so the key scheme stays injective for all
+ * new data. Map KEYS (and topics) are a separate keyspace and are NOT restricted.
+ *
+ * An empty name is rejected too: it has no injective key prefix and is not a
+ * valid map identity.
+ */
+
+/**
+ * Boolean predicate — never throws. Returns `false` when `name` contains `:` or
+ * is the empty string, `true` otherwise. Used by the throwing map-creation guard
+ * AND by the non-throwing oplog-restore filter (which must shed, not throw).
+ */
+export function isValidMapName(name: string): boolean {
+  if (name.length === 0) return false;
+  if (name.includes(':')) return false;
+  return true;
+}
+
+/**
+ * Throwing guard for the map-creation boundary (`getMap`/`getORMap`). Rejects a
+ * name that fails `isValidMapName` with a clear, actionable error. Must NOT be
+ * called inside restore/replay loops — those shed invalid entries via
+ * `isValidMapName` directly instead of aborting.
+ */
+export function assertValidMapName(name: string): void {
+  if (isValidMapName(name)) return;
+  if (name.length === 0) {
+    throw new Error(
+      'Invalid map name: name must not be empty. A map name is its durable storage-key prefix and cannot be blank.',
+    );
+  }
+  throw new Error(
+    `Invalid map name "${name}": the ":" character is not allowed in map names because it is the storage key-scheme separator (records persist under "\${mapName}:\${key}"). Use "-", "/", or "_" instead (e.g. "${name.replace(
+      /:/g,
+      '-',
+    )}"). Note: ":" is still allowed in map KEYS and in topic names.`,
+  );
+}
+
+/**
+ * Longest-held-name restore discriminator (shared by both OR-Map restore seams:
+ * `TopGunClient.restoreORMap` and `SyncEngine.instantiateAndRestoreOrMap`).
+ *
+ * The flat `${mapName}:${key}` scheme is not injective for legacy colon-named
+ * stores, so a key matched by prefix `${mapName}:` may actually belong to a
+ * LONGER held name. When restoring map `mapName`, a matched key with remainder
+ * `keyPart` is owned by a longer map iff some colon-prefix of `keyPart`, joined
+ * back onto `mapName`, is itself a held name (e.g. remainder `b:k` under `a`
+ * yields candidate `a:b` — if `a:b` is held, `a:b:k` belongs to `a:b`, not `a`).
+ * The held-set is the discriminator; when it is `null` (before the first sync of
+ * a connection) no longer name is known and nothing is skipped.
+ */
+export function keyBelongsToLongerHeldName(
+  mapName: string,
+  keyPart: string,
+  held: Set<string> | null,
+): boolean {
+  if (!held) return false;
+  let idx = keyPart.indexOf(':');
+  while (idx !== -1) {
+    const longer = `${mapName}:${keyPart.substring(0, idx)}`;
+    if (held.has(longer)) return true;
+    idx = keyPart.indexOf(':', idx + 1);
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Closes TODO-577 — the last gate (user decision 2026-07-08) before SPEC-342j may activate the tombstone-prune durability watermark. Client-only TS; full SpecFlow lifecycle (4 audit cycles incl. a cross-vendor-escalated design fork, review APPROVED, client gate 750/750).

### What ships
- **Forbid `:` in map names** at `getMap()`/`getORMap()` (`assertValidMapName`, clear error, runs before any registration/restore; keys and topics unrestricted). Makes the `${mapName}:${key}` storage scheme injective for all new data.
- **Resurrection sub-case closed by UNREACHABILITY**: post-forbid a legacy colon-named map is unopenable, unmarked (first-colon backfill kept), unheld, never auto-instantiated — no path writes under that name. The design fork (mark-all-prefixes vs first-colon) was resolved against live-code verification: mark-all-prefixes would have made auto-instantiated phantom maps prefix-swallow sibling records and push them server-side as duplicate maps.
- **`loadOpLog` legacy filter** — pending oplog entries for invalid (colon) map names are dropped at load with a logged count; this was the one verified bypass of unreachability (OP_BATCH flush is held-set-independent).
- **Longest-held-name restore-guard** in both restore paths (SyncEngine auto-instantiate + TopGunClient primary): a prefix-scan no longer swallows keys that belong to a longer held map name.
- Docs: colon-named example replaced; map-name rule documented under the API reference.
- Honest residual documented (not reworded away): raw legacy `a:b:k` keys can still prefix-leak into map `a` on restore — pre-existing class, orthogonal to prune activation, hypothetical pre-1.0 stores.

## Test evidence
- client Jest **750/750** (incl. RED-without-fix regression for the legacy discovery case, oplog-filter, restore-guard, non-destructive IDB migration AC7), tsc/eslint/prettier clean.
- Review-gate /xreview hardening applied (`6331c93e` defensive copy; non-string guard `16e52de2`).

## Unblocks
`/sf:run SPEC-342j` (durability watermark → prune activation): `depends_on [342b ✓, 342c ✓]` + this gate.