### PR TITLE
Prune ACTIVATION: durability fence + unclean-recovery rebuild + pre-activation gate hardening [SPEC-342j]

### DIFF
--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -932,7 +932,7 @@ async fn main() -> anyhow::Result<()> {
         frontier,
     ) = cluster_state_for_services;
 
-    // Unclean-recovery rebuild of the tombstone epoch index (SPEC-342j R12(c)/(e)).
+    // Unclean-recovery rebuild of the tombstone epoch index.
     // The RAM epoch index is never persisted on the hot path, so after WAL recovery
     // it is empty: re-stamp every live tombstone into ONE fresh maximally-lagging
     // recovery epoch and bump the epoch counter past every persisted client cursor,

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -932,6 +932,33 @@ async fn main() -> anyhow::Result<()> {
         frontier,
     ) = cluster_state_for_services;
 
+    // Unclean-recovery rebuild of the tombstone epoch index (SPEC-342j R12(c)/(e)).
+    // The RAM epoch index is never persisted on the hot path, so after WAL recovery
+    // it is empty: re-stamp every live tombstone into ONE fresh maximally-lagging
+    // recovery epoch and bump the epoch counter past every persisted client cursor,
+    // so nothing is prune-eligible — and no stale high cursor prematurely licenses a
+    // prune of a freshly-numbered epoch — until every tracked client re-confirms.
+    //
+    // This MUST run in the pre-listener window: strictly BEFORE set_ready()/serve()
+    // below, so `durable_epoch_watermark` stays 0 (prune dark, gate transparent)
+    // until the rebuild completes and a reconnecting client never observes a
+    // half-rebuilt index. It runs on the live run() path (this binary hand-builds
+    // its own router — the invoke is on that path, not a secondary router, so the
+    // dual-router trap does not apply). A scan failure is FATAL: continuing with an
+    // empty index and a un-bumped counter would let a rehydrated stale-high cursor
+    // prune a new epoch → resurrection. Fail closed, matching WAL-recovery.
+    match frontier.rebuild_from_durable_store().await {
+        Ok(recovery_epoch) => tracing::info!(
+            target: "topgun_server::bootstrap",
+            recovery_epoch,
+            "tombstone epoch index rebuilt (pre-listener); prune fenced maximally-lagging until clients re-confirm"
+        ),
+        Err(err) => {
+            eprintln!("FATAL: tombstone epoch index rebuild failed: {err}");
+            std::process::exit(1);
+        }
+    }
+
     // Spawn the eviction orchestrator after services are wired so it observes
     // every store the factory will create. The orchestrator terminates within
     // one `interval_ms` of `shutdown_tx.send(true)` via the cloned receiver

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -284,14 +284,16 @@ impl CrdtService {
             None
         };
 
-        // Defence-in-depth op-path gate (R4, non-load-bearing, dark until 342j): drop
-        // a forgotten client's OR-bearing op before it merges. Belt-and-suspenders to
-        // the load-bearing ORMapPushDiff gate; vacuous on OR_ADD (tag is regenerated).
-        if self.op_path_gated(op, ctx.connection_id).await {
-            return Ok(OperationResponse::Ack {
-                call_id: ctx.call_id,
-            });
-        }
+        // Deliberately NO forgotten-client gate on the op path. Client-originated
+        // tags are regenerated server-side above, so a pruned tombstone's tag can
+        // never be re-presented here — the path is resurrection-proof by
+        // construction and a gate protects nothing. Worse, a gate keyed on the
+        // frontier's "unknown == forgotten" would silently drop writes from every
+        // device that has not yet completed its first ACK round (a fresh device
+        // flushing its pending oplog on connect), while still returning OP_ACK —
+        // the client then clears the op from its local oplog and the write is
+        // permanently lost on both sides. The verbatim-tag path (ORMapPushDiff)
+        // keeps its load-bearing gate.
 
         // Read old value before mutation for query broadcast filtering.
         let old_rmpv_value = self
@@ -358,12 +360,6 @@ impl CrdtService {
             // Each op gets its own partition based on its key (OpBatch ctx has
             // partition_id=None because the batch contains keys for many partitions).
             for op in ops {
-                // Defence-in-depth op-path gate (R4, non-load-bearing, dark until
-                // 342j; inert for the non-connection HTTP/anonymous paths where
-                // `connection_id` is None). Skip a forgotten client's OR-bearing op.
-                if self.op_path_gated(op, ctx.connection_id).await {
-                    continue;
-                }
                 let sanitized_ts = self.write_validator.sanitize_hlc();
                 self.apply_batch_op(op, Some(&sanitized_ts), ctx.connection_id)
                     .await?;
@@ -396,12 +392,6 @@ impl CrdtService {
             }
             // All ops validated — apply them sequentially with sanitized timestamps.
             for op in ops {
-                // Defence-in-depth op-path gate (R4, non-load-bearing, dark until
-                // 342j; inert for the non-connection HTTP/anonymous paths where
-                // `connection_id` is None). Skip a forgotten client's OR-bearing op.
-                if self.op_path_gated(op, ctx.connection_id).await {
-                    continue;
-                }
                 let sanitized_ts = self.write_validator.sanitize_hlc();
                 self.apply_batch_op(op, Some(&sanitized_ts), ctx.connection_id)
                     .await?;
@@ -420,12 +410,6 @@ impl CrdtService {
                 self.validate_schema_for_op(op)?;
             }
             for op in ops {
-                // Defence-in-depth op-path gate (R4, non-load-bearing, dark until
-                // 342j; inert for the non-connection HTTP/anonymous paths where
-                // `connection_id` is None). Skip a forgotten client's OR-bearing op.
-                if self.op_path_gated(op, ctx.connection_id).await {
-                    continue;
-                }
                 let sanitized_ts = self.write_validator.sanitize_hlc();
                 self.apply_batch_op(op, Some(&sanitized_ts), ctx.connection_id)
                     .await?;
@@ -484,43 +468,6 @@ impl CrdtService {
     /// original tag through to the store (the test would be vacuous). Returns `false`
     /// (never gates) for a non-client caller (no connection → HTTP/anonymous/system
     /// trusted paths) and while the durability watermark is 0 (dark by construction).
-    async fn op_path_gated(&self, op: &ClientOp, conn: Option<ConnectionId>) -> bool {
-        let is_or = matches!(&op.or_record, Some(Some(_))) || matches!(&op.or_tag, Some(Some(_)));
-        if !is_or {
-            return false;
-        }
-        let Some(conn) = conn else {
-            return false;
-        };
-        let Some(frontier) = self.frontier.as_ref() else {
-            return false;
-        };
-        if !frontier.is_protection_active() {
-            return false;
-        }
-        // A vanished connection → treat as unknown → forgotten.
-        let Some(handle) = self.connection_registry.get(conn) else {
-            return true;
-        };
-        let (device_id, principal_id) = {
-            let meta = handle.metadata.read().await;
-            (
-                meta.device_id.clone(),
-                meta.principal.as_ref().map(|p| p.id.clone()),
-            )
-        };
-        match device_id {
-            None => true, // no server-issued device identity → unknown → forgotten
-            Some(device_id) => {
-                let client = crate::network::device_identity::frontier_client_id(
-                    principal_id.as_deref(),
-                    &device_id,
-                );
-                frontier.is_forgotten(&client)
-            }
-        }
-    }
-
     /// Applies a single `ClientOp` to the `RecordStore` and returns the `ServerEventPayload`
     /// to broadcast. Called by both `handle_client_op` and `handle_op_batch`.
     ///

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -2968,6 +2968,7 @@ mod tests {
     // practical here — this exercises the actual eviction blind-spot the gauge
     // exists to defend against, not a stand-in for it.
     #[tokio::test]
+    #[serial_test::serial(tombstone_gauge)]
     async fn or_remove_tombstone_gauge_survives_real_eviction_and_rehydration() {
         let dir = tempfile::tempdir().expect("tempdir");
         let redb_path = dir.path().join("gauge_residency.redb");
@@ -2989,64 +2990,80 @@ mod tests {
             Arc::new(SchemaService::new()),
         ));
 
-        let map_name = "gauge_residency_map";
-        let key = "item-1";
-        let tag = "tag-gauge-residency";
+        // The gauge is a process-global static: the serial(tombstone_gauge) group
+        // serializes the gauge-asserting tests against each other, but UNMARKED
+        // parallel tests still mutate it via ordinary OR_REMOVE applies and prune
+        // drains. Exact-equality snapshots are therefore retried on a fresh map:
+        // ambient noise shifts between attempts, while a genuine double-count /
+        // dropped-gauge regression is deterministic and fails every attempt.
+        let mut attempt = 0usize;
+        'attempt: loop {
+            attempt += 1;
+            let map_name = &format!("gauge_residency_map_{attempt}");
+            let key = "item-1";
+            let tag = "tag-gauge-residency";
 
-        // The gauge is a process-global static shared across parallel test
-        // threads, so assert on the DELTA this test produces, never an absolute
-        // value.
-        let before_write = crate::storage::record::tombstone_bytes();
+            let before_write = crate::storage::record::tombstone_bytes();
 
-        svc.clone()
-            .oneshot(or_add_op(map_name, key, "payload", tag))
-            .await
-            .expect("or_add must succeed");
-        svc.clone()
-            .oneshot(or_remove_op(map_name, key, tag))
-            .await
-            .expect("or_remove must succeed");
+            svc.clone()
+                .oneshot(or_add_op(map_name, key, "payload", tag))
+                .await
+                .expect("or_add must succeed");
+            svc.clone()
+                .oneshot(or_remove_op(map_name, key, tag))
+                .await
+                .expect("or_remove must succeed");
 
-        let after_write = crate::storage::record::tombstone_bytes();
-        assert_eq!(
-            after_write - before_write,
-            tag.len() as u64,
-            "gauge must increase by exactly the new tombstone tag's byte length"
-        );
+            let after_write = crate::storage::record::tombstone_bytes();
+            if after_write - before_write != tag.len() as u64 {
+                assert!(
+                    attempt < 5,
+                    "gauge delta never settled to exactly the tag length across 5 quiet-window attempts                      (deterministic gauge regression, not parallel-test noise)"
+                );
+                continue 'attempt;
+            }
 
-        // Force the record non-resident via the real eviction primitive. The
-        // OR_REMOVE above wrote through with `CallerProvenance::CrdtMerge` over a
-        // real (non-null) data store, which marks the record clean and therefore
-        // evictable.
-        let store = factory.get_or_create(map_name, hash_to_partition(key));
-        let evicted = store.evict_lru(u32::MAX, false);
-        assert!(evicted > 0, "the clean record must be evicted");
-        assert!(
-            !store.exists_in_memory(key),
-            "record must be non-resident after eviction"
-        );
+            // Force the record non-resident via the real eviction primitive. The
+            // OR_REMOVE above wrote through with `CallerProvenance::CrdtMerge` over a
+            // real (non-null) data store, which marks the record clean and therefore
+            // evictable.
+            let store = factory.get_or_create(map_name, hash_to_partition(key));
+            let evicted = store.evict_lru(u32::MAX, false);
+            assert!(evicted > 0, "the clean record must be evicted");
+            assert!(
+                !store.exists_in_memory(key),
+                "record must be non-resident after eviction"
+            );
 
-        let after_eviction = crate::storage::record::tombstone_bytes();
-        assert_eq!(
-            after_eviction, after_write,
-            "evicting a tombstone-bearing record must not drop the gauge"
-        );
+            let after_eviction = crate::storage::record::tombstone_bytes();
+            if after_eviction != after_write {
+                assert!(
+                    attempt < 5,
+                    "eviction kept moving the gauge across 5 attempts — a deterministic                      evict-drops-gauge regression, not parallel-test noise"
+                );
+                continue 'attempt;
+            }
 
-        // Rehydrate: `get()` transparently reloads the non-resident record from
-        // the datastore. Confirm the tombstone survived the round trip and the
-        // gauge did not move.
-        let (_, tombstones) = read_or_map(&factory, map_name, key).await;
-        assert_eq!(
-            tombstones,
-            vec![tag.to_string()],
-            "tombstone must still be present after rehydration"
-        );
+            // Rehydrate: `get()` transparently reloads the non-resident record from
+            // the datastore. Confirm the tombstone survived the round trip and the
+            // gauge did not move.
+            let (_, tombstones) = read_or_map(&factory, map_name, key).await;
+            assert_eq!(
+                tombstones,
+                vec![tag.to_string()],
+                "tombstone must still be present after rehydration"
+            );
 
-        let after_rehydration = crate::storage::record::tombstone_bytes();
-        assert_eq!(
-            after_rehydration, after_write,
-            "rehydrating a tombstone-bearing record must not double-count the gauge"
-        );
+            let after_rehydration = crate::storage::record::tombstone_bytes();
+            if after_rehydration != after_write {
+                assert!(
+                    attempt < 5,
+                    "rehydration kept moving the gauge across 5 attempts — a deterministic                      double-count regression, not parallel-test noise"
+                );
+                continue 'attempt;
+            }
+            break 'attempt;
+        }
     }
 
     // AC1: add-wins — OR_REMOVE of one tag preserves concurrent survivors.

--- a/packages/server-rust/src/service/domain/sync.rs
+++ b/packages/server-rust/src/service/domain/sync.rs
@@ -854,6 +854,19 @@ impl SyncService {
             .await
             || (protection_active && payload.claimed_epoch.is_none());
 
+        // A gated routing must also RESTORE the not-yet-admitted signal on a
+        // REUSED connection: an earlier healthy round on this same socket may
+        // have set `delivered > 0`, which the continuation/push gates key on —
+        // without the reset a regressed replica would slip past them mid-resync
+        // and could pull incremental deltas across pruned tombstones instead of
+        // the authoritative REPLACE. Strictly conservative (only defers
+        // re-admission until the snapshot lands and a fresh ACK arrives).
+        if gated {
+            if let (Some(frontier), Some(conn)) = (self.frontier.as_ref(), ctx.connection_id) {
+                frontier.reset_delivered(conn);
+            }
+        }
+
         // Epoch BEFORE data: the conveyed epoch must never postdate the root it
         // rides with (see `covering_epoch` — ordering is load-bearing).
         let covering_epoch = self.covering_epoch(ctx.connection_id, gated);
@@ -4568,6 +4581,68 @@ mod tests {
             frontier.delivered(conn),
             0,
             "delivered_conn NOT advanced for a gated (regressed) client"
+        );
+    }
+
+    /// Reused-connection regressed bypass (the pre-activation defense-in-depth):
+    /// a connection that already completed a HEALTHY round (`delivered > 0` on
+    /// THIS socket) and then issues a REGRESSED sync-init must not slip past the
+    /// continuation gate on the stale admitted signal — the gated routing resets
+    /// `delivered(conn)` to 0 so `sync_gated_continuation` holds until the
+    /// REPLACE snapshot lands and a fresh ACK re-admits.
+    #[tokio::test]
+    async fn regressed_sync_init_on_reused_connection_resets_delivered() {
+        let (svc, _factory, frontier, registry) = make_gated_service();
+        let (conn, client) = register_device(&registry, "dev-reused-clone").await;
+        // Healthy earlier round ON THE SAME connection: delivered > 0, cursor at 100.
+        frontier.set_delivered(conn, 100);
+        assert!(frontier.confirm_apply_ack(&client, 100, conn).await);
+        for i in 0..5 {
+            frontier.stamp_tombstone("omap", &format!("s{i}"), &format!("t{i}"));
+        }
+        frontier.set_durable_epoch_watermark(1000);
+        // Without the reset, the stale admitted signal would let continuations pass.
+        assert!(
+            !svc.sync_gated_continuation(Some(conn)).await,
+            "healthy admitted connection passes continuations (precondition)"
+        );
+        let mut ctx = make_ctx(service_names::SYNC);
+        ctx.connection_id = Some(conn);
+        let resp = Arc::clone(&svc)
+            .oneshot(Operation::ORMapSyncInit {
+                ctx,
+                payload: topgun_core::messages::ORMapSyncInit {
+                    map_name: "omap".to_string(),
+                    root_hash: 0,
+                    bucket_hashes: HashMap::new(),
+                    last_sync_timestamp: None,
+                    claimed_epoch: Some(5), // 5 < stored 100 → regressed
+                },
+            })
+            .await
+            .expect("root");
+        match resp {
+            OperationResponse::Message(m) => match *m {
+                Message::ORMapSyncRespRoot(r) => {
+                    assert!(r.payload.full_resync, "regressed replica → full resync");
+                }
+                other => panic!("expected root, got {other:?}"),
+            },
+            other => panic!("expected message, got {other:?}"),
+        }
+        assert_eq!(
+            frontier.delivered(conn),
+            0,
+            "gated sync-init on a REUSED connection resets the admitted signal"
+        );
+        assert!(
+            svc.sync_gated_continuation(Some(conn)).await,
+            "continuations are gated again until the REPLACE completes + fresh ACK"
+        );
+        assert_eq!(
+            frontier.cursor(&client),
+            Some(100),
+            "stored cursor still never rolled back"
         );
     }
 

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -4,10 +4,10 @@
 //! in per-partition coalesced queues and flushing them on a configurable schedule.
 //! An optional WAL ensures every acked write is durable before the ack is returned.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
@@ -425,6 +425,17 @@ pub struct WriteBehindDataStore {
     wal: Option<Arc<dyn Wal>>,
     /// WAL sequence counter, monotonically increasing per-entry for ordering.
     wal_sequence: AtomicU64,
+    /// Entry sequences ASSIGNED but not yet RESOLVED — a write is resolved when
+    /// its bytes reach the inner store (flushed) OR a later write to the same key
+    /// coalesces it away (retired, its data carried forward by the survivor).
+    ///
+    /// The smallest still-pending sequence is the PREFIX-COMPLETE flushed
+    /// watermark (see [`flushed_watermark`](MapDataStore::flushed_watermark)):
+    /// every sequence below it is resolved, with no mid-range hole. This is the
+    /// real byte-durability signal the tombstone frontier fences the prune on —
+    /// NOT the last-assigned counter, which advances at enqueue and would let a
+    /// prune drop a tombstone still buffered in RAM.
+    pending_seqs: Mutex<BTreeSet<u64>>,
 }
 
 /// WAL plus the live sequence counter's starting value, threaded into
@@ -487,6 +498,7 @@ impl WriteBehindDataStore {
             is_shutdown: AtomicBool::new(false),
             wal,
             wal_sequence: AtomicU64::new(wal_sequence_start),
+            pending_seqs: Mutex::new(BTreeSet::new()),
         });
 
         // Spawn background flush loop with a clone of the Arc
@@ -499,6 +511,28 @@ impl WriteBehindDataStore {
     /// Returns the next sequence number for ordering.
     fn next_sequence(&self) -> u64 {
         self.sequence.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Lock the pending-sequence set, recovering from a poisoned mutex (a prior
+    /// panic while holding it leaves a consistent set — a stale entry only holds
+    /// the watermark back, the safe direction).
+    fn pending_seqs(&self) -> std::sync::MutexGuard<'_, BTreeSet<u64>> {
+        self.pending_seqs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Record `seq` as enqueued-but-not-yet-durable. Called once per assigned
+    /// entry sequence, right after it enters a partition queue.
+    fn track_pending(&self, seq: u64) {
+        self.pending_seqs().insert(seq);
+    }
+
+    /// Mark `seq` resolved — its bytes are durable in the inner store (flushed)
+    /// or it was superseded by a coalescing write (retired). This is what lets
+    /// the prefix-complete flushed watermark advance past `seq`.
+    fn resolve_pending(&self, seq: u64) {
+        self.pending_seqs().remove(&seq);
     }
 
     /// Snapshot the pending staging entries for one map as a key-sorted map of
@@ -669,6 +703,11 @@ async fn flush_loop(store: Arc<WriteBehindDataStore>, mut shutdown_rx: watch::Re
                         // way -- it counts enqueues, one decrement per drained entry.
                         store.clear_staging_if_current(&entry.map, &entry.key, entry.sequence);
                         store.pending_count.fetch_sub(1, Ordering::Relaxed);
+                        // Bytes are now durable in the inner store — resolve the
+                        // sequence so the prefix-complete flushed watermark can
+                        // advance past it. This is the ONLY signal that advances
+                        // the tombstone durability fence.
+                        store.resolve_pending(entry.sequence);
                         // Mark the WAL entry applied so a clean restart does not
                         // re-replay writes that are already durable in the inner store.
                         if let Some(wal) = &store.wal {
@@ -717,6 +756,11 @@ async fn flush_loop(store: Arc<WriteBehindDataStore>, mut shutdown_rx: watch::Re
                             // entry's terminal discard.
                             store.clear_staging_if_current(&entry.map, &entry.key, entry.sequence);
                             store.pending_count.fetch_sub(1, Ordering::Relaxed);
+                            // Terminal discard: the sequence will never flush, so
+                            // resolve it to unstall the watermark. Its bytes remain
+                            // in the WAL until GC (R12(b)), so this does not lose
+                            // durability — a discarded write is a re-sync event.
+                            store.resolve_pending(entry.sequence);
                         }
                     }
                 }
@@ -810,19 +854,32 @@ impl MapDataStore for WriteBehindDataStore {
         };
 
         // Insert into partition queue, preserving original store_time on coalesce
-        let mut queue = self.queues.entry(partition_id).or_default();
-
-        // If coalescing, preserve the original store_time
         let staging_key = (map.to_string(), key.to_string());
-        if let Some(existing) = queue.value_mut().remove(map, key) {
-            let mut coalesced = entry;
-            coalesced.store_time = existing.store_time;
-            let _ = queue.value_mut().insert(coalesced);
-            // No pending_count change on coalesce
-        } else {
-            let _ = queue.value_mut().insert(entry);
-            // New key -- increment pending count
-            self.pending_count.fetch_add(1, Ordering::Relaxed);
+        let retired_seq = {
+            let mut queue = self.queues.entry(partition_id).or_default();
+            // If coalescing, preserve the original store_time
+            if let Some(existing) = queue.value_mut().remove(map, key) {
+                let retired = existing.sequence;
+                let mut coalesced = entry;
+                coalesced.store_time = existing.store_time;
+                let _ = queue.value_mut().insert(coalesced);
+                // No pending_count change on coalesce
+                Some(retired)
+            } else {
+                let _ = queue.value_mut().insert(entry);
+                // New key -- increment pending count
+                self.pending_count.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+        };
+
+        // Track this write as pending byte-durability, and retire the
+        // coalesced-away predecessor (its data is carried forward by this
+        // write). Done after releasing the partition-queue lock so the
+        // pending-set lock is never nested under it.
+        self.track_pending(entry_seq);
+        if let Some(retired) = retired_seq {
+            self.resolve_pending(retired);
         }
 
         // Update staging area for read-your-writes
@@ -891,17 +948,26 @@ impl MapDataStore for WriteBehindDataStore {
             wal_sequence: wal_seq,
         };
 
-        let mut queue = self.queues.entry(partition_id).or_default();
-
         let staging_key = (map.to_string(), key.to_string());
-        if let Some(existing) = queue.value_mut().remove(map, key) {
-            let mut coalesced = entry;
-            coalesced.store_time = existing.store_time;
-            let _ = queue.value_mut().insert(coalesced);
-            // No pending_count change on coalesce
-        } else {
-            let _ = queue.value_mut().insert(entry);
-            self.pending_count.fetch_add(1, Ordering::Relaxed);
+        let retired_seq = {
+            let mut queue = self.queues.entry(partition_id).or_default();
+            if let Some(existing) = queue.value_mut().remove(map, key) {
+                let retired = existing.sequence;
+                let mut coalesced = entry;
+                coalesced.store_time = existing.store_time;
+                let _ = queue.value_mut().insert(coalesced);
+                // No pending_count change on coalesce
+                Some(retired)
+            } else {
+                let _ = queue.value_mut().insert(entry);
+                self.pending_count.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+        };
+
+        self.track_pending(entry_seq);
+        if let Some(retired) = retired_seq {
+            self.resolve_pending(retired);
         }
 
         // Pending delete marker in staging
@@ -1172,6 +1238,28 @@ impl MapDataStore for WriteBehindDataStore {
         Ok(self.sequence.load(Ordering::Relaxed))
     }
 
+    fn assigned_write_sequence(&self) -> u64 {
+        // One past the highest sequence handed out — an upper bound on any
+        // in-flight write's sequence. The tombstone frontier snapshots this at
+        // stamp time; because the tombstone's own byte-write was enqueued (and
+        // thus assigned a sequence) strictly before the stamp, this is `>=` it.
+        self.sequence.load(Ordering::Relaxed)
+    }
+
+    fn flushed_watermark(&self) -> u64 {
+        // Prefix-complete: the smallest still-pending sequence is the first
+        // un-resolved write; every sequence below it is durable (flushed) or
+        // retired (coalesced away). With nothing pending, all assigned writes
+        // are resolved, so the watermark is the full assigned counter. This can
+        // NEVER expose a value above an un-flushed sequence — the property that
+        // makes `stamped_seq <= flushed_watermark()` a sound durability fence.
+        let pending = self.pending_seqs();
+        match pending.iter().next().copied() {
+            Some(min_pending) => min_pending,
+            None => self.sequence.load(Ordering::Relaxed),
+        }
+    }
+
     async fn hard_flush(&self) -> anyhow::Result<()> {
         // Mark the store as shutting down so any straggler writes are rejected
         // rather than queued behind the drain.
@@ -1242,6 +1330,7 @@ impl MapDataStore for WriteBehindDataStore {
                     Ok(Ok(())) => {
                         self.staging.remove(&(entry.map.clone(), entry.key.clone()));
                         self.pending_count.fetch_sub(1, Ordering::Relaxed);
+                        self.resolve_pending(entry.sequence);
                         // Mark WAL applied so a restart after clean shutdown is
                         // a no-op rather than re-replaying already-durable writes.
                         if let Some(wal) = &self.wal {

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -1413,9 +1413,12 @@ impl MapDataStore for WriteBehindDataStore {
         // Remove from staging
         self.staging.remove(&(map.to_string(), key.to_string()));
 
-        // Decrement pending count if the key was actually in the queue
-        if removed.is_some() {
+        // Decrement pending count and resolve the buffered entry's durability
+        // sequence if the key was actually in the queue — this direct flush
+        // supersedes it, so its sequence must not stall the flushed watermark.
+        if let Some(removed) = &removed {
             self.pending_count.fetch_sub(1, Ordering::Relaxed);
+            self.resolve_pending(removed.sequence);
         }
 
         // Persist the caller-provided value directly to the inner store
@@ -1428,6 +1431,7 @@ impl MapDataStore for WriteBehindDataStore {
         self.staging.clear();
         self.sequence.store(0, Ordering::Relaxed);
         self.pending_count.store(0, Ordering::Relaxed);
+        self.pending_seqs().clear();
         self.inner.reset();
     }
 
@@ -2024,6 +2028,102 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c, SpyCall::Add { map, key } if map == "map1" && key == "key1")),
             "Inner store should have received the flush_key add call"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC3c: the flushed watermark is PREFIX-COMPLETE — it never exposes a value
+    // above a still-pending (un-flushed) sequence, even when a HIGHER sequence
+    // is resolved out of order below it. A max-with-holes watermark would admit
+    // a mid-range-hole kill -9 tombstone resurrection; this proves no hole is
+    // ever exposed.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn ac3c_flushed_watermark_prefix_complete_never_exposes_hole() {
+        let inner: Arc<dyn MapDataStore> = Arc::new(SpyDataStore::new());
+        // Long delays so the background flush loop never touches our injected
+        // pending set — this test drives resolution deterministically.
+        let config = WriteBehindConfig {
+            write_delay_ms: 60_000,
+            flush_interval_ms: 60_000,
+            ..WriteBehindConfig::default()
+        };
+        let store = WriteBehindDataStore::new(inner, config);
+
+        // Three writes enqueued: sequences 1, 2, 3 pending, nothing flushed yet.
+        store.track_pending(1);
+        store.track_pending(2);
+        store.track_pending(3);
+        assert_eq!(
+            store.flushed_watermark(),
+            1,
+            "smallest pending sequence is the watermark — everything below it is resolved"
+        );
+
+        // Resolve the MIDDLE sequence (2) out of order: 1 is still pending, so
+        // the watermark must NOT jump past the hole at 1 to 2 or 3.
+        store.resolve_pending(2);
+        assert_eq!(
+            store.flushed_watermark(),
+            1,
+            "out-of-order resolve of 2 must not expose a value above the still-pending 1"
+        );
+
+        // Resolve the lowest (1): now 1 and 2 are resolved, only 3 pends, so the
+        // watermark advances to exactly 3 — never skipping over an un-flushed seq.
+        store.resolve_pending(1);
+        assert_eq!(
+            store.flushed_watermark(),
+            3,
+            "watermark advances to the next pending sequence, 3 — prefix stays complete"
+        );
+
+        // Resolve the last: nothing pending, watermark is the full assigned counter.
+        store.resolve_pending(3);
+        assert_eq!(
+            store.flushed_watermark(),
+            store.assigned_write_sequence(),
+            "with nothing pending the watermark is the assigned-sequence counter"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC3c (real path): a genuine add → in-order background/hard flush advances
+    // the watermark monotonically, and a still-buffered write holds it back.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn ac3c_real_flush_advances_watermark_only_on_byte_durability() {
+        let inner: Arc<dyn MapDataStore> = Arc::new(SpyDataStore::new());
+        let config = WriteBehindConfig {
+            write_delay_ms: 60_000,
+            flush_interval_ms: 60_000,
+            shutdown_timeout_ms: 5_000,
+            ..WriteBehindConfig::default()
+        };
+        let store = WriteBehindDataStore::new(inner, config);
+
+        let val = dummy_value();
+        store.add("m", "k1", &val, 0, 1).await.unwrap();
+        store.add("m", "k2", &val, 0, 1).await.unwrap();
+
+        // Both writes are buffered (write_delay is 60s), so the watermark sits at
+        // the lowest pending sequence — no byte durability yet.
+        let assigned = store.assigned_write_sequence();
+        assert!(
+            store.flushed_watermark() < assigned,
+            "buffered writes are not byte-durable: watermark {} must be below assigned {}",
+            store.flushed_watermark(),
+            assigned
+        );
+
+        // Drain everything to the inner store (deterministic byte durability).
+        store.hard_flush().await.unwrap();
+        assert_eq!(
+            store.flushed_watermark(),
+            assigned,
+            "after a full drain every assigned sequence is durable, so the watermark reaches it"
         );
     }
 
@@ -2918,5 +3018,191 @@ mod tests {
             store.load("m", "k").await.unwrap().is_none(),
             "equal-seq restage applies (idempotent same-write update)"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Durability / crash-recovery tests (R12(b) WAL-retention + AC3f double-crash)
+// ---------------------------------------------------------------------------
+
+#[cfg(all(test, feature = "redb"))]
+mod durability_tests {
+    use super::*;
+    use crate::storage::datastores::RedbDataStore;
+    use crate::storage::wal::{WalRecovery, WalWriter};
+
+    /// An OR-Map record carrying a single tombstone and no active records — the
+    /// "element removed" state whose bytes the durability fence must never let a
+    /// prune drop before they are durable.
+    fn ormap_tombstone(tag: &str) -> RecordValue {
+        RecordValue::OrMap {
+            records: Vec::new(),
+            tombstones: vec![tag.to_string()],
+        }
+    }
+
+    fn buffered_config() -> WriteBehindConfig {
+        // 60s delays so a write stays buffered (WAL-fsynced, not yet flushed to
+        // the inner store) until we explicitly drain — the exact crash window.
+        WriteBehindConfig {
+            write_delay_ms: 60_000,
+            flush_interval_ms: 60_000,
+            shutdown_timeout_ms: 5_000,
+            ..WriteBehindConfig::default()
+        }
+    }
+
+    /// R12(b): an un-flushed frame is NEVER discarded — a tombstone's bytes are
+    /// always in the inner store OR still in the WAL, never both-lost. A WAL-GC
+    /// change that deleted an unapplied frame would break this guard.
+    #[tokio::test]
+    async fn r12b_wal_retains_unflushed_tombstone_frame_until_applied() {
+        let wal_dir = tempfile::tempdir().unwrap();
+        let redb_dir = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn MapDataStore> =
+            Arc::new(RedbDataStore::new(&redb_dir.path().join("d.redb")).unwrap());
+        let wal = WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
+        let store = WriteBehindDataStore::new_with_wal(
+            Arc::clone(&inner),
+            buffered_config(),
+            Some(WalBootstrap {
+                wal: Arc::clone(&wal) as Arc<dyn Wal>,
+                sequence_start: 1,
+            }),
+        );
+
+        store
+            .add("m", "k1", &ormap_tombstone("T1"), 0, 1)
+            .await
+            .unwrap();
+        let partition = partition_for("m", "k1");
+
+        // Buffered: the WAL frame is fsynced but the inner store has not seen it.
+        // R12(b) requires the WAL to still hold the frame (never both-lost).
+        assert!(
+            !wal.unapplied(partition).await.unwrap().is_empty(),
+            "un-flushed tombstone frame must be retained in the WAL"
+        );
+        assert!(
+            inner.load("m", "k1").await.unwrap().is_none(),
+            "the buffered tombstone is not yet in the inner store"
+        );
+
+        // Drain to the inner store; only NOW is the frame eligible for release.
+        store.hard_flush().await.unwrap();
+        assert!(
+            wal.unapplied(partition).await.unwrap().is_empty(),
+            "once the bytes are durable in the inner store the frame is applied/releasable"
+        );
+        assert!(
+            matches!(
+                inner.load("m", "k1").await.unwrap(),
+                Some(RecordValue::OrMap { tombstones, .. }) if tombstones == vec!["T1".to_string()]
+            ),
+            "tombstone bytes are durable in the inner store after the drain"
+        );
+    }
+
+    /// AC3f: crash after WAL-fsync but before inner-store flush, recover, crash
+    /// AGAIN during recovery (before the frame is marked applied) — the tombstone
+    /// bytes are recoverable at every step (WAL retention held) and no removed
+    /// element is resurrected.
+    #[tokio::test]
+    async fn ac3f_double_crash_wal_retention_recovers_tombstone_no_resurrection() {
+        let wal_dir = tempfile::tempdir().unwrap();
+        let redb_dir = tempfile::tempdir().unwrap();
+        let redb_path = redb_dir.path().join("d.redb");
+        let partition = partition_for("m", "k1");
+
+        // --- Crash 1: after WAL fsync, before inner-store flush ---
+        {
+            // Emulate the write path's WAL-append-before-ack for a tombstone,
+            // then a kill -9 STRICTLY before the background flush reaches the inner
+            // store: fsync the frame, drop the writer, touch no inner store. (Going
+            // through WriteBehindDataStore here would leave its background flush task
+            // holding the inner-store handle — a real crash releases it; the direct
+            // append is the faithful "frame fsynced, inner never written" window.)
+            let wal =
+                WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
+            let entry = WalEntry {
+                map: "m".to_string(),
+                key: "k1".to_string(),
+                op: WalOp::Store {
+                    value: WalStorePayload::Record(ormap_tombstone("T1")),
+                    expiration_time: None,
+                },
+                timestamp: None,
+                sequence: 1,
+            };
+            wal.append(partition, &entry).await.unwrap();
+        }
+
+        // --- Crash 2: DURING recovery — replay the still-unapplied frame into the
+        // inner store, then "die" before marking it applied. ---
+        {
+            let inner: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&redb_path).unwrap());
+            let wal =
+                WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
+            let unapplied = wal.unapplied(partition).await.unwrap();
+            assert!(
+                !unapplied.is_empty(),
+                "the un-flushed tombstone frame survived crash 1 in the WAL (R12(b))"
+            );
+            for entry in &unapplied {
+                if let WalOp::Store {
+                    value: WalStorePayload::Record(rv),
+                    expiration_time,
+                } = &entry.op
+                {
+                    let exp = expiration_time.unwrap_or(0);
+                    inner.add(&entry.map, &entry.key, rv, exp, 1).await.unwrap();
+                }
+            }
+            // Process "crashes" HERE — no mark_applied.
+            assert!(
+                matches!(
+                    inner.load("m", "k1").await.unwrap(),
+                    Some(RecordValue::OrMap { tombstones, .. }) if tombstones == vec!["T1".to_string()]
+                ),
+                "tombstone recovered into the inner store mid-recovery"
+            );
+        }
+
+        // --- Recovery completes: crash 2 never marked the frame applied, so R12(b)
+        // still holds it; a full WalRecovery replays it again (idempotent) and
+        // finally marks it applied. The tombstone survives BOTH crashes. ---
+        {
+            let inner: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&redb_path).unwrap());
+            let wal =
+                WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
+            assert!(
+                !wal.unapplied(partition).await.unwrap().is_empty(),
+                "crash 2 did not mark the frame applied, so WAL retention still holds it"
+            );
+            let recovery = WalRecovery::new(Arc::clone(&wal), Vec::new());
+            recovery.run(Arc::clone(&inner)).await.unwrap();
+
+            match inner.load("m", "k1").await.unwrap() {
+                Some(RecordValue::OrMap {
+                    records,
+                    tombstones,
+                }) => {
+                    assert_eq!(
+                        tombstones,
+                        vec!["T1".to_string()],
+                        "tombstone present after both crashes — the removal is preserved"
+                    );
+                    assert!(
+                        records.is_empty(),
+                        "no active record resurrected for the removed element"
+                    );
+                }
+                other => panic!("expected the OR-Map tombstone to survive both crashes, got {other:?}"),
+            }
+            assert!(
+                wal.unapplied(partition).await.unwrap().is_empty(),
+                "a completed recovery marks the frame applied"
+            );
+        }
     }
 }

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -3052,7 +3052,7 @@ mod durability_tests {
         }
     }
 
-    /// R12(b): an un-flushed frame is NEVER discarded — a tombstone's bytes are
+    /// `R12(b)`: an un-flushed frame is NEVER discarded — a tombstone's bytes are
     /// always in the inner store OR still in the WAL, never both-lost. A WAL-GC
     /// change that deleted an unapplied frame would break this guard.
     #[tokio::test]
@@ -3060,7 +3060,7 @@ mod durability_tests {
         let wal_dir = tempfile::tempdir().unwrap();
         let redb_dir = tempfile::tempdir().unwrap();
         let inner: Arc<dyn MapDataStore> =
-            Arc::new(RedbDataStore::new(&redb_dir.path().join("d.redb")).unwrap());
+            Arc::new(RedbDataStore::new(redb_dir.path().join("d.redb")).unwrap());
         let wal = WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
         let store = WriteBehindDataStore::new_with_wal(
             Arc::clone(&inner),
@@ -3103,7 +3103,7 @@ mod durability_tests {
         );
     }
 
-    /// AC3f: crash after WAL-fsync but before inner-store flush, recover, crash
+    /// `AC3f`: crash after WAL-fsync but before inner-store flush, recover, crash
     /// AGAIN during recovery (before the frame is marked applied) — the tombstone
     /// bytes are recoverable at every step (WAL retention held) and no removed
     /// element is resurrected.
@@ -3122,8 +3122,7 @@ mod durability_tests {
             // through WriteBehindDataStore here would leave its background flush task
             // holding the inner-store handle — a real crash releases it; the direct
             // append is the faithful "frame fsynced, inner never written" window.)
-            let wal =
-                WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
+            let wal = WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
             let entry = WalEntry {
                 map: "m".to_string(),
                 key: "k1".to_string(),
@@ -3141,8 +3140,7 @@ mod durability_tests {
         // inner store, then "die" before marking it applied. ---
         {
             let inner: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&redb_path).unwrap());
-            let wal =
-                WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
+            let wal = WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
             let unapplied = wal.unapplied(partition).await.unwrap();
             assert!(
                 !unapplied.is_empty(),
@@ -3173,8 +3171,7 @@ mod durability_tests {
         // finally marks it applied. The tombstone survives BOTH crashes. ---
         {
             let inner: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&redb_path).unwrap());
-            let wal =
-                WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
+            let wal = WalWriter::new(wal_dir.path().to_path_buf(), WalFsyncPolicy::PerOp).unwrap();
             assert!(
                 !wal.unapplied(partition).await.unwrap().is_empty(),
                 "crash 2 did not mark the frame applied, so WAL retention still holds it"
@@ -3197,7 +3194,9 @@ mod durability_tests {
                         "no active record resurrected for the removed element"
                     );
                 }
-                other => panic!("expected the OR-Map tombstone to survive both crashes, got {other:?}"),
+                other => {
+                    panic!("expected the OR-Map tombstone to survive both crashes, got {other:?}")
+                }
             }
             assert!(
                 wal.unapplied(partition).await.unwrap().is_empty(),

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -508,9 +508,20 @@ impl WriteBehindDataStore {
         store
     }
 
-    /// Returns the next sequence number for ordering.
-    fn next_sequence(&self) -> u64 {
-        self.sequence.fetch_add(1, Ordering::Relaxed)
+    /// Assign the next ordering sequence AND record it pending byte-durability in
+    /// one atomic step, under the `pending_seqs` lock. Folding the `fetch_add` and
+    /// the set insert under the same lock `flushed_watermark()` reads is what makes
+    /// the watermark prefix-complete under concurrency: a separate bump-then-track
+    /// leaves a window where the counter is already incremented but the set is
+    /// still empty, during which `flushed_watermark()`'s empty-set branch would
+    /// return `sequence.load()` — a value ABOVE the just-assigned, still-buffered
+    /// sequence (a mid-range hole that could license pruning a non-durable
+    /// tombstone). Returns the assigned sequence.
+    fn assign_tracked_sequence(&self) -> u64 {
+        let mut pending = self.pending_seqs();
+        let seq = self.sequence.fetch_add(1, Ordering::Relaxed);
+        pending.insert(seq);
+        seq
     }
 
     /// Lock the pending-sequence set, recovering from a poisoned mutex (a prior
@@ -522,8 +533,10 @@ impl WriteBehindDataStore {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
-    /// Record `seq` as enqueued-but-not-yet-durable. Called once per assigned
-    /// entry sequence, right after it enters a partition queue.
+    /// Record `seq` as enqueued-but-not-yet-durable. Test-only injector for
+    /// exercising the watermark deterministically; production assigns and tracks
+    /// atomically via [`assign_tracked_sequence`](Self::assign_tracked_sequence).
+    #[cfg(test)]
     fn track_pending(&self, seq: u64) {
         self.pending_seqs().insert(seq);
     }
@@ -575,10 +588,10 @@ impl WriteBehindDataStore {
 
     /// Stage the latest buffered `value` for `(map, key)` under sequence `seq`,
     /// keeping monotonicity: a write only replaces the slot if its `seq` is at
-    /// least the slot's current `seq`. `seq` is `next_sequence()`, strictly
-    /// increasing per call, so a higher `seq` is always the later write. Two
-    /// concurrent writers on the same key can otherwise interleave between
-    /// `next_sequence()` and this insert and let the older write clobber the
+    /// least the slot's current `seq`. `seq` is from `assign_tracked_sequence()`,
+    /// strictly increasing per call, so a higher `seq` is always the later write.
+    /// Two concurrent writers on the same key can otherwise interleave between
+    /// the sequence assignment and this insert and let the older write clobber the
     /// newer staged value (a plain `insert` is last-writer-wins by wall-clock,
     /// not by `seq`). The monotonic guard makes the slot's `seq` truthful, which
     /// is the identity [`clear_staging_if_current`] relies on.
@@ -839,7 +852,9 @@ impl MapDataStore for WriteBehindDataStore {
         };
         self.wal_append(partition_id, &wal_entry).await?;
 
-        let entry_seq = self.next_sequence();
+        // Assign and track the durability sequence atomically (see
+        // `assign_tracked_sequence`) BEFORE the entry enters the queue.
+        let entry_seq = self.assign_tracked_sequence();
         let entry = DelayedEntry {
             map: map.to_string(),
             key: key.to_string(),
@@ -873,11 +888,9 @@ impl MapDataStore for WriteBehindDataStore {
             }
         };
 
-        // Track this write as pending byte-durability, and retire the
-        // coalesced-away predecessor (its data is carried forward by this
-        // write). Done after releasing the partition-queue lock so the
+        // Retire the coalesced-away predecessor (its data is carried forward by
+        // this write). Done after releasing the partition-queue lock so the
         // pending-set lock is never nested under it.
-        self.track_pending(entry_seq);
         if let Some(retired) = retired_seq {
             self.resolve_pending(retired);
         }
@@ -937,7 +950,8 @@ impl MapDataStore for WriteBehindDataStore {
         };
         self.wal_append(partition_id, &wal_entry).await?;
 
-        let entry_seq = self.next_sequence();
+        // Assign and track the durability sequence atomically before queuing.
+        let entry_seq = self.assign_tracked_sequence();
         let entry = DelayedEntry {
             map: map.to_string(),
             key: key.to_string(),
@@ -965,7 +979,6 @@ impl MapDataStore for WriteBehindDataStore {
             }
         };
 
-        self.track_pending(entry_seq);
         if let Some(retired) = retired_seq {
             self.resolve_pending(retired);
         }
@@ -1062,7 +1075,8 @@ impl MapDataStore for WriteBehindDataStore {
             };
             self.wal_append(partition_id, &wal_entry).await?;
 
-            let entry_seq = self.next_sequence();
+            // Assign and track the durability sequence atomically before queuing.
+            let entry_seq = self.assign_tracked_sequence();
             let entry = DelayedEntry {
                 map: map.to_string(),
                 key: key.clone(),
@@ -1073,16 +1087,28 @@ impl MapDataStore for WriteBehindDataStore {
                 wal_sequence: wal_seq,
             };
 
-            let mut queue = self.queues.entry(partition_id).or_default();
-
             let staging_key = (map.to_string(), key.clone());
-            if let Some(existing) = queue.value_mut().remove(map, key) {
-                let mut coalesced = entry;
-                coalesced.store_time = existing.store_time;
-                let _ = queue.value_mut().insert(coalesced);
-            } else {
-                let _ = queue.value_mut().insert(entry);
-                self.pending_count.fetch_add(1, Ordering::Relaxed);
+            let retired_seq = {
+                let mut queue = self.queues.entry(partition_id).or_default();
+                if let Some(existing) = queue.value_mut().remove(map, key) {
+                    let retired = existing.sequence;
+                    let mut coalesced = entry;
+                    coalesced.store_time = existing.store_time;
+                    let _ = queue.value_mut().insert(coalesced);
+                    Some(retired)
+                } else {
+                    let _ = queue.value_mut().insert(entry);
+                    self.pending_count.fetch_add(1, Ordering::Relaxed);
+                    None
+                }
+            };
+
+            // Retire the coalesced-away predecessor so its durability sequence does
+            // not stall the flushed watermark forever (a leaked pending sequence
+            // would permanently pin the prune). Done after the queue lock is
+            // released so the pending-set lock is never nested under it.
+            if let Some(retired) = retired_seq {
+                self.resolve_pending(retired);
             }
 
             let (smap, skey) = staging_key;
@@ -2124,6 +2150,48 @@ mod tests {
             store.flushed_watermark(),
             assigned,
             "after a full drain every assigned sequence is durable, so the watermark reaches it"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // A batch `remove_all` that coalesces a still-buffered write MUST resolve the
+    // retired sequence — otherwise it leaks in the pending set forever and pins
+    // the flushed watermark below it, permanently stalling the tombstone prune.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn remove_all_coalesce_resolves_retired_sequence_no_watermark_stall() {
+        let inner: Arc<dyn MapDataStore> = Arc::new(SpyDataStore::new());
+        let config = WriteBehindConfig {
+            write_delay_ms: 60_000,
+            flush_interval_ms: 60_000,
+            shutdown_timeout_ms: 5_000,
+            ..WriteBehindConfig::default()
+        };
+        let store = WriteBehindDataStore::new(inner, config);
+
+        // A buffered add for k1: its sequence is the lowest pending, so the
+        // watermark sits at it (nothing below it is durable yet).
+        store.add("m", "k1", &dummy_value(), 0, 1).await.unwrap();
+        let add_seq = store.flushed_watermark();
+
+        // A batch remove of the SAME key coalesces the buffered add. The retired
+        // add sequence must be resolved so the watermark can advance past it —
+        // before the fix it leaked and the watermark stayed pinned at `add_seq`.
+        store.remove_all("m", &["k1".to_string()]).await.unwrap();
+        assert!(
+            store.flushed_watermark() > add_seq,
+            "coalesced-away add sequence {add_seq} must be resolved, not leaked: watermark is {}",
+            store.flushed_watermark()
+        );
+
+        // And after a full drain the watermark reaches the assigned counter —
+        // proving no pending sequence was orphaned by the coalesce.
+        store.hard_flush().await.unwrap();
+        assert_eq!(
+            store.flushed_watermark(),
+            store.assigned_write_sequence(),
+            "no orphaned pending sequence after coalesce + drain"
         );
     }
 

--- a/packages/server-rust/src/storage/map_data_store.rs
+++ b/packages/server-rust/src/storage/map_data_store.rs
@@ -277,6 +277,40 @@ pub trait MapDataStore: Send + Sync {
     /// Returns the sequence number of the last queued operation, or 0 if empty.
     async fn soft_flush(&self) -> anyhow::Result<u64>;
 
+    /// The highest write-ordering sequence this store has ASSIGNED so far
+    /// (one past the last handed-out value), regardless of whether it has been
+    /// flushed to durable storage. This is a cheap synchronous snapshot — the
+    /// same value [`soft_flush`](MapDataStore::soft_flush) returns, but without
+    /// triggering a flush — used by the tombstone frontier to stamp an
+    /// upper-bound sequence onto a genuinely-new tombstone at write time (the
+    /// tombstone's own byte-write was enqueued strictly before this is read, so
+    /// the returned value is `>=` the tombstone's sequence).
+    ///
+    /// The default returns 0, correct for write-through backends that never
+    /// buffer (their writes are durable on return, so there is nothing to fence).
+    fn assigned_write_sequence(&self) -> u64 {
+        0
+    }
+
+    /// The PREFIX-COMPLETE byte-durability watermark: the largest `W` such that
+    /// EVERY write with an assigned sequence `< W` is durable in the inner store
+    /// (flushed) or has been superseded by a later coalesced write (retired).
+    ///
+    /// Prefix-completeness is the load-bearing property: the returned value NEVER
+    /// sits above an un-flushed sequence (no mid-range hole), so a consumer that
+    /// gates on `stamped_seq <= flushed_watermark()` can be certain the stamped
+    /// write's bytes are durable — never a max-with-holes value that would admit
+    /// a `kill -9` tombstone resurrection. It advances ONLY on real inner-store
+    /// byte durability, never on WAL-fsync alone and never from the last-assigned
+    /// sequence.
+    ///
+    /// The default returns 0, which keeps every tombstone byte-undurable from the
+    /// fence's perspective (the safe direction — no prune is ever licensed) for
+    /// write-through backends and test doubles that do not buffer writes.
+    fn flushed_watermark(&self) -> u64 {
+        0
+    }
+
     /// Flush all pending writes immediately in the calling task.
     ///
     /// Called during node shutdown for data safety.

--- a/packages/server-rust/src/storage/record_store.rs
+++ b/packages/server-rust/src/storage/record_store.rs
@@ -234,7 +234,12 @@ pub trait RecordStore: Send + Sync {
 
     /// Flush pending writes to the backing `MapDataStore`.
     ///
-    /// Returns the sequence number of the last flushed operation.
+    /// Returns the sequence number of the last QUEUED (assigned) operation, or 0
+    /// if empty — NOT the last flushed one. The implementation delegates to
+    /// [`MapDataStore::soft_flush`], which notifies the background flush loop and
+    /// returns the current assigned-sequence counter; the actual flush completes
+    /// asynchronously. A caller that needs a real byte-durability signal must use
+    /// [`MapDataStore::flushed_watermark`], not this return value.
     async fn soft_flush(&self) -> anyhow::Result<u64>;
 
     /// Access the underlying `StorageEngine` (Layer 1).

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -1421,7 +1421,7 @@ mod tests {
 #[cfg(all(test, feature = "redb"))]
 mod persistence_tests {
     use super::*;
-    use crate::storage::datastores::RedbDataStore;
+    use crate::storage::datastores::{RedbDataStore, WriteBehindConfig, WriteBehindDataStore};
 
     const CONN_A: ConnectionId = ConnectionId(1);
 
@@ -1429,6 +1429,13 @@ mod persistence_tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("frontier.redb");
         (path, dir)
+    }
+
+    fn ormap_with_tombstones(tags: &[&str]) -> RecordValue {
+        RecordValue::OrMap {
+            records: Vec::new(),
+            tombstones: tags.iter().map(|t| (*t).to_string()).collect(),
+        }
     }
 
     /// The persisted cursor survives a full store close + reopen (redb durability),
@@ -1581,5 +1588,162 @@ mod persistence_tests {
             None,
             "no inflated pre-bump cursor resurrected"
         );
+    }
+
+    /// AC3d: kill -9 recovery. The RAM epoch index is lost across a restart; the
+    /// rebuild re-stamps every live tombstone into a fresh maximally-lagging
+    /// `E_rec` that exceeds every persisted cursor epoch (the load-bearing term)
+    /// and `ceil(flushed/EPOCH_WIDTH)`. Nothing is prune-eligible until clients
+    /// re-confirm past `E_rec`; `effective_low_water_mark` is the durable-backed
+    /// clamp every consumer reads.
+    #[tokio::test]
+    async fn ac3d_kill9_recovery_rebuilds_into_maximally_lagging_e_rec() {
+        let (path, _dir) = temp_store();
+        let store: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&path).expect("open"));
+
+        // Durable live tombstones (survive the crash in redb): 3 tags over 2 keys.
+        store
+            .add("mymap", "k1", &ormap_with_tombstones(&["T1", "T2"]), 0, 1)
+            .await
+            .unwrap();
+        store
+            .add("mymap", "k2", &ormap_with_tombstones(&["T3"]), 0, 1)
+            .await
+            .unwrap();
+
+        // A client confirmed up to epoch 50 pre-crash (durable cursor).
+        let client: ClientId = "a5:alice|dev-1".into();
+        {
+            let f = TombstoneFrontier::new(Some(Arc::clone(&store)));
+            f.set_delivered(CONN_A, 1000);
+            assert!(f.confirm_apply_ack(&client, 50, CONN_A).await);
+            assert_eq!(f.cursor(&client), Some(50));
+            // kill -9: drop the frontier — the RAM epoch index is gone.
+        }
+
+        // Fresh frontier over the same durable store: the RAM index is empty, so
+        // the watermark is 0 (prune dark, gate transparent) BEFORE the rebuild —
+        // the recovery-ordering invariant (R12(e)).
+        let f = TombstoneFrontier::new(Some(Arc::clone(&store)));
+        assert_eq!(
+            f.durable_epoch_watermark(),
+            0,
+            "empty index → watermark 0 (dark) until the pre-listener rebuild completes"
+        );
+        assert!(
+            !f.is_protection_active(),
+            "protection is transparent until the rebuild runs"
+        );
+
+        // Rebuild (invoked in the pre-listener window by the bin).
+        let e_rec = f.rebuild_from_durable_store().await.unwrap();
+
+        // E_rec exceeds every persisted cursor epoch (50) AND ceil(flushed/WIDTH)=0.
+        let width = f.epoch_width();
+        assert!(
+            e_rec > 50,
+            "E_rec {e_rec} must exceed the max persisted cursor epoch 50 (the load-bearing term)"
+        );
+        assert!(e_rec > 0u64.div_ceil(width), "E_rec exceeds ceil(flushed/EPOCH_WIDTH)");
+        assert_eq!(e_rec, 51, "E_rec = 1 + max(cursor 50, flushed-epochs 0, hint 0)");
+
+        // The recovery epoch's bytes are already durable (redb), so the watermark
+        // computes to E_rec — protection is now ACTIVE (gate + prune go live).
+        assert_eq!(
+            f.durable_epoch_watermark(),
+            e_rec,
+            "recovery epoch is byte-durable; the watermark is E_rec"
+        );
+        assert!(f.is_protection_active(), "protection active after the rebuild");
+
+        // No client has re-confirmed yet: LWM 0 → nothing prunable.
+        assert_eq!(f.low_water_mark(), 0, "no client reconnected yet");
+        assert!(
+            f.drain_prunable_tombstones().is_empty(),
+            "nothing prunable until every tracked client re-confirms past E_rec"
+        );
+
+        // The rehydrated client sits at its STALE cursor 50 (< E_rec): the whole
+        // corpus stays pinned (no premature prune of a freshly-numbered epoch).
+        f.rehydrate(&client).await;
+        assert_eq!(f.low_water_mark(), 50, "rehydrated at the stale pre-crash cursor");
+        assert!(
+            f.drain_prunable_tombstones().is_empty(),
+            "a stale cursor below E_rec pins the maximally-lagging recovery epoch"
+        );
+
+        // effective_LWM is the durable-backed clamp min(persisted_LWM, watermark).
+        assert_eq!(
+            f.effective_low_water_mark(),
+            50,
+            "effective LWM = min(persisted_LWM 50, durable_epoch_watermark E_rec) = 50"
+        );
+    }
+
+    /// AC3e: activation end-to-end. With the REAL prefix-complete watermark, a
+    /// full loop (write → remove → clients ACK past the epoch → bytes durable)
+    /// actually PRUNES — inverting the 342b AC3a dark-mode test: dark while the
+    /// tombstone is still buffered, then a genuine prune once its bytes flush.
+    #[tokio::test]
+    async fn ac3e_activation_end_to_end_prune_fires_with_real_watermark() {
+        let (path, _dir) = temp_store();
+        let inner: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&path).expect("open"));
+        // 60s delays: writes stay buffered (not byte-durable) until we hard_flush.
+        let config = WriteBehindConfig {
+            write_delay_ms: 60_000,
+            flush_interval_ms: 60_000,
+            shutdown_timeout_ms: 5_000,
+            ..WriteBehindConfig::default()
+        };
+        let store = WriteBehindDataStore::new(inner, config);
+        let store_dyn: Arc<dyn MapDataStore> = Arc::clone(&store) as Arc<dyn MapDataStore>;
+        let f = TombstoneFrontier::new(Some(Arc::clone(&store_dyn)));
+        f.set_epoch_width(1);
+
+        // Mirror the crdt OR_REMOVE path: write the tombstone bytes, then stamp.
+        store_dyn
+            .add("m", "k1", &ormap_with_tombstones(&["T1"]), 0, 1)
+            .await
+            .unwrap();
+        let e1 = f.stamp_tombstone("m", "k1", "T1");
+        store_dyn
+            .add("m", "k2", &ormap_with_tombstones(&["T2"]), 0, 1)
+            .await
+            .unwrap();
+        let e2 = f.stamp_tombstone("m", "k2", "T2");
+        assert_eq!((e1, e2), (1, 2));
+
+        // A client confirms PAST every stamped epoch (clamped to the max, 2).
+        let c: ClientId = "a5:alice|dev-1".into();
+        f.set_delivered(CONN_A, 100);
+        assert!(f.confirm_apply_ack(&c, 100, CONN_A).await);
+        assert_eq!(f.low_water_mark(), 2, "client confirmed past every stamped epoch");
+
+        // DARK before byte durability: the tombstones are still buffered, so the
+        // flushed watermark has not advanced — nothing prunes (this is the AC3a
+        // conjunct, now gated on the REAL watermark, not a constant 0).
+        assert!(
+            f.drain_prunable_tombstones().is_empty(),
+            "with the real watermark an un-flushed tombstone is NOT prunable"
+        );
+        assert!(
+            !f.is_protection_active(),
+            "no epoch is byte-durable yet → protection still transparent"
+        );
+
+        // Make the tombstone bytes durable in the inner store.
+        store.hard_flush().await.unwrap();
+
+        // ACTIVATION: LWM strictly past epoch 1 AND its bytes durable → epoch 1
+        // PRUNES; epoch 2 is the current epoch (LWM not strictly past it), retained.
+        assert!(f.is_protection_active(), "a byte-durable epoch activates protection");
+        let drained = f.drain_prunable_tombstones();
+        let tags: Vec<&str> = drained.iter().map(|(_, r)| r.tag.as_str()).collect();
+        assert_eq!(
+            drained.len(),
+            1,
+            "epoch 1 (strictly below LWM 2, byte-durable) actually prunes with the real watermark"
+        );
+        assert_eq!(tags, vec!["T1"], "the drained tombstone is epoch 1's tag");
     }
 }

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -159,24 +159,30 @@ struct FrontierState {
     /// stamped epoch; key 0 is never inserted, so the prune sweep (which iterates
     /// these keys, never a `0..=max` range) can never touch the sentinel.
     epoch_tags: HashMap<Epoch, Vec<TombstoneRef>>,
-    /// RAM-only `epoch → max op-seq` index: the highest op sequence stamped in
-    /// each epoch. Maintained for SPEC-342j's byte-durability watermark
-    /// (flushed-seq → epoch mapping); not consumed by the dark prune here.
+    /// RAM-only `epoch → max assigned write-sequence` index: the highest
+    /// write-behind entry sequence (`MapDataStore::assigned_write_sequence`)
+    /// snapshotted when a tombstone was stamped into each epoch. This is the
+    /// bridge between the epoch counter and byte durability: epoch `E` is
+    /// byte-durable once the store's prefix-complete `flushed_watermark()` has
+    /// reached `max(epoch_max_seq[e] for e <= E)`. Since a tombstone's own
+    /// byte-write is enqueued strictly before its stamp, the snapshot is an
+    /// upper bound on that write's sequence — a conservative, never-premature
+    /// fence.
     epoch_max_seq: HashMap<Epoch, u64>,
-    /// Injectable byte-durability watermark. Constant 0 in production — no real
-    /// source is wired in THIS child (SPEC-342j supplies it), so the call-site
-    /// prune conjunction `is_epoch_prune_eligible(E) && watermark >= E` never
-    /// licenses a prune for any stamped epoch (all `>= 1`): the machinery is
-    /// structurally dark, no feature flag. ONLY tests set it, to exercise the
-    /// real drop path.
+    /// Cached byte-durability watermark: `max E such that every stamped epoch
+    /// e <= E has epoch_max_seq[e] <= flushed_watermark`. Recomputed on demand
+    /// from [`FrontierState::compute_durable_epoch_watermark`] against the store's
+    /// live flushed watermark (see [`TombstoneFrontier::refreshed_watermark`]);
+    /// 0 from construction until either the first byte-durable epoch or the
+    /// unclean-recovery rebuild fills the index (R12(e): 0 until the pre-listener
+    /// rebuild completes). Tests with no store inject it directly via
+    /// `set_durable_epoch_watermark` to exercise the drop path in isolation.
     ///
     /// This watermark ALSO gates the re-admission gate's active blocking (see
     /// [`TombstoneFrontier::is_protection_active`]): a forgotten client's push can
     /// only resurrect a value whose tombstone was PRUNED, and pruning is licensed
-    /// only once this watermark is non-zero. While it is 0 (dark by construction)
-    /// no tombstone can be dropped, so blocking a re-admission would gratuitously
-    /// break an un-migrated client for no safety gain — the gate is fully WIRED but
-    /// transparent, going live together with the prune (gate-before-activation).
+    /// only once this watermark is non-zero — so gate and prune activate together
+    /// (gate-before-activation, no prune-without-gate window).
     durable_epoch_watermark: Epoch,
     /// Max cursor-lag (epochs) before a tracked client is forgotten by the gate.
     /// Defaults to [`DEFAULT_FORGET_LAG_EPOCHS`]; settable so RAM pressure / an
@@ -279,7 +285,7 @@ impl FrontierState {
     /// tag's `millis`. Records the tombstone ref under its epoch and updates the
     /// max-seq index. Returns the stamped epoch (always `>= 1`: 0 is the reserved
     /// "no/uncomputable epoch" sentinel and is never stamped).
-    fn stamp_tombstone(&mut self, map: &str, key: &str, tag: &str) -> Epoch {
+    fn stamp_tombstone(&mut self, map: &str, key: &str, tag: &str, write_seq: u64) -> Epoch {
         // Pre-increment BEFORE deriving the epoch so op_seq is `>= 1` here and the
         // first stamp lands in epoch 1, never epoch 0 (R3(g-i)).
         self.op_seq += 1;
@@ -301,9 +307,57 @@ impl FrontierState {
                 key: key.to_string(),
                 tag: tag.to_string(),
             });
+        // Record the durability bound for this epoch: the highest write sequence
+        // the store had assigned at stamp time. The epoch is byte-durable only
+        // once the store's flushed watermark reaches this value.
         let slot = self.epoch_max_seq.entry(epoch).or_insert(0);
-        *slot = (*slot).max(self.op_seq);
+        *slot = (*slot).max(write_seq);
         epoch
+    }
+
+    /// The byte-durability watermark: the greatest `E` such that EVERY stamped
+    /// epoch `e <= E` has its recorded max write-sequence at or below `flushed`.
+    /// Walks the stamped epochs in ascending order and stops at the first whose
+    /// bytes are not yet durable; epochs with no entry (e.g. the empty span an
+    /// `E_rec` recovery restamp leaves below the recovery epoch) hold no
+    /// tombstones and are vacuously durable, so they never block the walk.
+    fn compute_durable_epoch_watermark(&self, flushed: u64) -> Epoch {
+        let mut keys: Vec<Epoch> = self.epoch_max_seq.keys().copied().collect();
+        keys.sort_unstable();
+        let mut watermark = 0;
+        for e in keys {
+            // Index lookup is infallible — `e` came from the key set.
+            if self.epoch_max_seq.get(&e).copied().unwrap_or(u64::MAX) <= flushed {
+                watermark = e;
+            } else {
+                break;
+            }
+        }
+        watermark
+    }
+
+    /// Unclean-recovery rebuild (index-as-cache): drop the RAM epoch index and
+    /// re-stamp EVERY live tombstone into one fresh maximally-lagging recovery
+    /// epoch `e_rec`. All older epochs become empty, so nothing is prunable until
+    /// every tracked client re-confirms past `e_rec`. The recovery epoch's bytes
+    /// are already durable (WAL-replayed into the inner store before this runs),
+    /// so its `epoch_max_seq` is 0 — the low-water-mark, not byte durability, is
+    /// the operative gate.
+    fn rebuild_into_epoch(&mut self, e_rec: Epoch, live: Vec<TombstoneRef>) {
+        self.epoch_tags.clear();
+        self.epoch_max_seq.clear();
+        let width = self.epoch_width.max(1);
+        self.current_epoch = e_rec;
+        self.current_max_epoch = e_rec;
+        // Position op_seq so the NEXT genuinely-new tombstone lands in e_rec + 1,
+        // keeping every epoch below e_rec empty.
+        self.op_seq = e_rec.saturating_mul(width);
+        if !live.is_empty() {
+            self.epoch_max_seq.insert(e_rec, 0);
+            self.epoch_tags.insert(e_rec, live);
+        }
+        // Recomputes from the fresh index on the next watermark read.
+        self.durable_epoch_watermark = 0;
     }
 
     /// Drain the tombstone refs of every currently prune-eligible epoch out of the
@@ -320,10 +374,10 @@ impl FrontierState {
     /// returns empty in production; tests inject a watermark to exercise the drop.
     fn drain_prunable(&mut self) -> Vec<(Epoch, TombstoneRef)> {
         let watermark = self.durable_epoch_watermark;
-        // Production dark fast-path: with the constant-0 watermark NO epoch can pass
-        // the conjunction (all stamped epochs are >= 1), so skip the per-epoch
-        // low-water-mark fold entirely — this runs on every OR_REMOVE and every
-        // SYNC-leaf request.
+        // Fast-path: a 0 watermark (no epoch byte-durable yet, or dark before the
+        // recovery rebuild) means NO stamped epoch (all `>= 1`) can pass the
+        // conjunction, so skip the per-epoch low-water-mark fold entirely — this
+        // runs on every OR_REMOVE and every SYNC-leaf request.
         if watermark == 0 {
             return Vec::new();
         }
@@ -577,7 +631,7 @@ impl TombstoneFrontier {
     /// gratuitous-block-without-prune window).
     #[must_use]
     pub fn is_protection_active(&self) -> bool {
-        self.lock().durable_epoch_watermark > 0
+        self.refreshed_watermark() > 0
     }
 
     /// Set the max cursor-lag (epochs) before a tracked client is forgotten by the
@@ -627,7 +681,87 @@ impl TombstoneFrontier {
     /// `millis`. Returns the stamped epoch (`>= 1`). See
     /// [`FrontierState::stamp_tombstone`].
     pub fn stamp_tombstone(&self, map: &str, key: &str, tag: &str) -> Epoch {
-        self.lock().stamp_tombstone(map, key, tag)
+        // Snapshot the store's highest assigned write sequence as this epoch's
+        // byte-durability bound. Read BEFORE taking the frontier lock (the store
+        // call is independent) and outside it. With no store (tests / Null
+        // backend) the bound is 0; those paths inject the watermark directly.
+        let write_seq = self
+            .store
+            .as_ref()
+            .map_or(0, |s| s.assigned_write_sequence());
+        self.lock().stamp_tombstone(map, key, tag, write_seq)
+    }
+
+    /// Recompute the cached byte-durability watermark from the store's live
+    /// prefix-complete flushed watermark, then return it. Monotone: the cache
+    /// only ever advances. With no store wired (tests / Null backend) the cache
+    /// is left as-is so a test-injected watermark is honored.
+    fn refreshed_watermark(&self) -> Epoch {
+        let flushed = self.store.as_ref().map(|s| s.flushed_watermark());
+        let mut state = self.lock();
+        if let Some(flushed) = flushed {
+            let computed = state.compute_durable_epoch_watermark(flushed);
+            state.durable_epoch_watermark = state.durable_epoch_watermark.max(computed);
+        }
+        state.durable_epoch_watermark
+    }
+
+    /// The recovered/clamped low-water-mark every consumer should read
+    /// (R12(d)): `min(persisted_LWM, durable_epoch_watermark)`. The clamp keeps a
+    /// consumer from acting on an LWM the durable data cannot back — after an
+    /// unclean recovery the byte-durability watermark is `E_rec` and the
+    /// persisted LWM is 0 until clients reconnect, so the clamp is the
+    /// persisted LWM; on the clean-restart continuity path it prevents pruning
+    /// past what is byte-durable.
+    #[must_use]
+    pub fn effective_low_water_mark(&self) -> Epoch {
+        let watermark = self.refreshed_watermark();
+        self.lock().low_water_mark().min(watermark)
+    }
+
+    /// Unclean-recovery rebuild of the epoch index (R12(c)), invoked in the
+    /// pre-listener WAL-recovery window (strictly before `accept()`). Scans the
+    /// durable store for every live OR-Map tombstone and re-stamps them all into
+    /// one fresh maximally-lagging recovery epoch:
+    ///
+    /// `E_rec = 1 + max(persisted counter hint, max epoch referenced by any
+    /// persisted cursor, ceil(flushed_watermark / EPOCH_WIDTH))`.
+    ///
+    /// The max-cursor term is load-bearing: it guarantees no tracked client is
+    /// ever considered already-past `E_rec`, killing the stale-counter-hint
+    /// resurrection trace. The RAM index is never persisted on the hot path, so
+    /// the counter hint is 0 (a clean-shutdown persist could supply one — an
+    /// optimization, never a correctness input). Returns the chosen `E_rec` (0
+    /// when there is no durable backend, e.g. the Null store or a store-less
+    /// test frontier).
+    pub async fn rebuild_from_durable_store(&self) -> anyhow::Result<Epoch> {
+        let Some(store) = self.store.as_ref() else {
+            return Ok(0);
+        };
+        if store.is_null() {
+            return Ok(0);
+        }
+        // Load-bearing term: the highest epoch any persisted cursor references
+        // (keyspace scan over the 342e cursor namespace).
+        let max_cursor_epoch = scan_max_cursor_epoch(store.as_ref()).await?;
+        let flushed = store.flushed_watermark();
+        let width = self.lock().epoch_width.max(1);
+        let flushed_epochs = flushed.div_ceil(width);
+        // No persisted counter hint (index is RAM-only on the hot path).
+        let counter_hint = 0u64;
+        let e_rec = 1 + max_cursor_epoch.max(flushed_epochs).max(counter_hint);
+
+        let live = scan_live_tombstones(store.as_ref()).await?;
+        let restamped = live.len();
+        self.lock().rebuild_into_epoch(e_rec, live);
+        debug!(
+            e_rec,
+            max_cursor_epoch,
+            flushed_epochs,
+            restamped,
+            "tombstone epoch index rebuilt into a maximally-lagging recovery epoch"
+        );
+        Ok(e_rec)
     }
 
     /// The current (highest) server-stamped epoch, or 0 if none stamped yet. This is
@@ -637,19 +771,20 @@ impl TombstoneFrontier {
         self.lock().current_epoch
     }
 
-    /// The dark-by-construction durability watermark. Returns 0 in production — no
-    /// real byte-durability source is wired in this child (SPEC-342j supplies it),
-    /// so the call-site prune conjunction never licenses a prune for any stamped
-    /// epoch (all `>= 1`). ONLY tests inject a non-zero value.
+    /// The live byte-durability watermark: `max E such that every stamped epoch
+    /// `e <= E` is durable in the inner store`, recomputed from the store's
+    /// prefix-complete flushed watermark. 0 until the first epoch's bytes are
+    /// durable (or, after an unclean recovery, until the pre-listener rebuild
+    /// fills the index). With no store wired it returns the last injected value.
     #[must_use]
     pub fn durable_epoch_watermark(&self) -> Epoch {
-        self.lock().durable_epoch_watermark
+        self.refreshed_watermark()
     }
 
-    /// Test-only injection of the durability watermark to exercise the real drop
-    /// path. `#[cfg(test)]`-gated so PRODUCTION code structurally cannot activate
-    /// the prune early — the watermark stays constant 0 (dark by construction).
-    /// SPEC-342j replaces this with the real byte-durability watermark source.
+    /// Test-only injection of the durability watermark to exercise the drop path
+    /// on a store-less frontier (`new(None)`), where `refreshed_watermark` leaves
+    /// the cache untouched. Production wires a real store, so the watermark is
+    /// always the computed byte-durability value, never this override.
     #[cfg(test)]
     pub fn set_durable_epoch_watermark(&self, watermark: Epoch) {
         self.lock().durable_epoch_watermark = watermark;
@@ -683,7 +818,17 @@ impl TombstoneFrontier {
     /// returns empty in production (`durable_epoch_watermark == 0`).
     #[must_use]
     pub fn drain_prunable_tombstones(&self) -> Vec<(Epoch, TombstoneRef)> {
-        self.lock().drain_prunable()
+        // Refresh the cached byte-durability watermark from the store's live
+        // flushed watermark, then drain under BOTH call-site conjuncts. Reading
+        // the store's watermark outside the lock keeps the frontier lock hold
+        // short; the field is then updated and consumed under one lock.
+        let flushed = self.store.as_ref().map(|s| s.flushed_watermark());
+        let mut state = self.lock();
+        if let Some(flushed) = flushed {
+            let computed = state.compute_durable_epoch_watermark(flushed);
+            state.durable_epoch_watermark = state.durable_epoch_watermark.max(computed);
+        }
+        state.drain_prunable()
     }
 
     /// Re-insert a drained tombstone ref whose storage drop FAILED (see
@@ -757,6 +902,72 @@ async fn load_cursor(store: &dyn MapDataStore, client: &ClientId) -> anyhow::Res
         }) => Ok(decode_epoch(&bytes)),
         _ => Ok(None),
     }
+}
+
+/// Scan the persisted cursor keyspace ([`CURSOR_MAP`]) and return the highest
+/// epoch any client cursor references, or 0 if none. This is the load-bearing
+/// `max-cursor-epoch` term of `E_rec`: `E_rec` must exceed it so no persisted
+/// client is ever considered already-past the fresh recovery epoch.
+async fn scan_max_cursor_epoch(store: &dyn MapDataStore) -> anyhow::Result<Epoch> {
+    let mut max_epoch: Epoch = 0;
+    let mut batch = store.scan_values(CURSOR_MAP, false, 0).await?;
+    loop {
+        for (_key, value) in &batch.records {
+            if let RecordValue::Lww {
+                value: Value::Bytes(bytes),
+                ..
+            } = value
+            {
+                if let Some(epoch) = decode_epoch(bytes) {
+                    max_epoch = max_epoch.max(epoch);
+                }
+            }
+        }
+        match batch.next_cursor.take() {
+            None => break,
+            Some(cursor) => {
+                batch = store
+                    .scan_values_batched(CURSOR_MAP, false, cursor, 0)
+                    .await?;
+            }
+        }
+    }
+    Ok(max_epoch)
+}
+
+/// Scan the durable keyspace for every live OR-Map tombstone (post WAL-replay),
+/// returning a [`TombstoneRef`] per `(map, key, tag)`. The unclean-recovery
+/// rebuild re-stamps all of these into the fresh recovery epoch. The reserved
+/// internal keyspaces ([`CURSOR_MAP`] and other `_topgun_`-prefixed maps) hold
+/// no OR-Map tombstones (their records are LWW), so they contribute nothing and
+/// are skipped implicitly by the `OrMap` match. Legacy `OrTombstones` blobs are
+/// Merkle-invisible (TODO-559) and out of this child's prune scope, so they are
+/// deliberately NOT re-stamped here.
+async fn scan_live_tombstones(store: &dyn MapDataStore) -> anyhow::Result<Vec<TombstoneRef>> {
+    let mut live = Vec::new();
+    for map in store.list_maps().await? {
+        let mut batch = store.scan_values(&map, false, 0).await?;
+        loop {
+            for (key, value) in &batch.records {
+                if let RecordValue::OrMap { tombstones, .. } = value {
+                    for tag in tombstones {
+                        live.push(TombstoneRef {
+                            map: map.clone(),
+                            key: key.clone(),
+                            tag: tag.clone(),
+                        });
+                    }
+                }
+            }
+            match batch.next_cursor.take() {
+                None => break,
+                Some(cursor) => {
+                    batch = store.scan_values_batched(&map, false, cursor, 0).await?;
+                }
+            }
+        }
+    }
+    Ok(live)
 }
 
 /// Wall-clock milliseconds since the Unix epoch (0 on a clock error).

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -541,6 +541,20 @@ impl TombstoneFrontier {
         self.lock().delivered.get(&conn).copied().unwrap_or(0)
     }
 
+    /// Reset `conn`'s delivered watermark to 0 — the NOT-YET-ADMITTED signal.
+    ///
+    /// Called when a sync-init routes the connection through the gated
+    /// full-snapshot REPLACE path: a REUSED connection may carry `delivered > 0`
+    /// from an earlier healthy round on the same socket, which would let the
+    /// continuation/push gates (which key on `delivered == 0`) treat a
+    /// now-gated client as already admitted mid-resync. Resetting is strictly
+    /// conservative: it can only suppress ACK admission until the REPLACE
+    /// snapshot completes and a fresh `CLIENT_APPLY_ACK` re-admits — never
+    /// widen it.
+    pub fn reset_delivered(&self, conn: ConnectionId) {
+        self.lock().delivered.insert(conn, 0);
+    }
+
     /// Confirmed-apply ACK: advance `client`'s cursor under the bounded monotone rule
     /// for an ACK arriving on connection `conn`, persisting the new value best-effort.
     /// Returns `true` iff the stored cursor advanced.

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -734,6 +734,12 @@ impl TombstoneFrontier {
     /// optimization, never a correctness input). Returns the chosen `E_rec` (0
     /// when there is no durable backend, e.g. the Null store or a store-less
     /// test frontier).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the durable keyspace scan (cursor namespace or live
+    /// tombstones) fails; the caller MUST fail closed (an empty index with an
+    /// un-bumped counter would let a stale-high cursor prune a fresh epoch).
     pub async fn rebuild_from_durable_store(&self) -> anyhow::Result<Epoch> {
         let Some(store) = self.store.as_ref() else {
             return Ok(0);
@@ -1590,7 +1596,7 @@ mod persistence_tests {
         );
     }
 
-    /// AC3d: kill -9 recovery. The RAM epoch index is lost across a restart; the
+    /// `AC3d`: kill -9 recovery. The RAM epoch index is lost across a restart; the
     /// rebuild re-stamps every live tombstone into a fresh maximally-lagging
     /// `E_rec` that exceeds every persisted cursor epoch (the load-bearing term)
     /// and `ceil(flushed/EPOCH_WIDTH)`. Nothing is prune-eligible until clients
@@ -1644,8 +1650,14 @@ mod persistence_tests {
             e_rec > 50,
             "E_rec {e_rec} must exceed the max persisted cursor epoch 50 (the load-bearing term)"
         );
-        assert!(e_rec > 0u64.div_ceil(width), "E_rec exceeds ceil(flushed/EPOCH_WIDTH)");
-        assert_eq!(e_rec, 51, "E_rec = 1 + max(cursor 50, flushed-epochs 0, hint 0)");
+        assert!(
+            e_rec > 0u64.div_ceil(width),
+            "E_rec exceeds ceil(flushed/EPOCH_WIDTH)"
+        );
+        assert_eq!(
+            e_rec, 51,
+            "E_rec = 1 + max(cursor 50, flushed-epochs 0, hint 0)"
+        );
 
         // The recovery epoch's bytes are already durable (redb), so the watermark
         // computes to E_rec — protection is now ACTIVE (gate + prune go live).
@@ -1654,7 +1666,10 @@ mod persistence_tests {
             e_rec,
             "recovery epoch is byte-durable; the watermark is E_rec"
         );
-        assert!(f.is_protection_active(), "protection active after the rebuild");
+        assert!(
+            f.is_protection_active(),
+            "protection active after the rebuild"
+        );
 
         // No client has re-confirmed yet: LWM 0 → nothing prunable.
         assert_eq!(f.low_water_mark(), 0, "no client reconnected yet");
@@ -1666,7 +1681,11 @@ mod persistence_tests {
         // The rehydrated client sits at its STALE cursor 50 (< E_rec): the whole
         // corpus stays pinned (no premature prune of a freshly-numbered epoch).
         f.rehydrate(&client).await;
-        assert_eq!(f.low_water_mark(), 50, "rehydrated at the stale pre-crash cursor");
+        assert_eq!(
+            f.low_water_mark(),
+            50,
+            "rehydrated at the stale pre-crash cursor"
+        );
         assert!(
             f.drain_prunable_tombstones().is_empty(),
             "a stale cursor below E_rec pins the maximally-lagging recovery epoch"
@@ -1680,9 +1699,9 @@ mod persistence_tests {
         );
     }
 
-    /// AC3e: activation end-to-end. With the REAL prefix-complete watermark, a
+    /// `AC3e`: activation end-to-end. With the REAL prefix-complete watermark, a
     /// full loop (write → remove → clients ACK past the epoch → bytes durable)
-    /// actually PRUNES — inverting the 342b AC3a dark-mode test: dark while the
+    /// actually PRUNES — inverting the 342b `AC3a` dark-mode test: dark while the
     /// tombstone is still buffered, then a genuine prune once its bytes flush.
     #[tokio::test]
     async fn ac3e_activation_end_to_end_prune_fires_with_real_watermark() {
@@ -1717,7 +1736,11 @@ mod persistence_tests {
         let c: ClientId = "a5:alice|dev-1".into();
         f.set_delivered(CONN_A, 100);
         assert!(f.confirm_apply_ack(&c, 100, CONN_A).await);
-        assert_eq!(f.low_water_mark(), 2, "client confirmed past every stamped epoch");
+        assert_eq!(
+            f.low_water_mark(),
+            2,
+            "client confirmed past every stamped epoch"
+        );
 
         // DARK before byte durability: the tombstones are still buffered, so the
         // flushed watermark has not advanced — nothing prunes (this is the AC3a
@@ -1736,7 +1759,10 @@ mod persistence_tests {
 
         // ACTIVATION: LWM strictly past epoch 1 AND its bytes durable → epoch 1
         // PRUNES; epoch 2 is the current epoch (LWM not strictly past it), retained.
-        assert!(f.is_protection_active(), "a byte-durable epoch activates protection");
+        assert!(
+            f.is_protection_active(),
+            "a byte-durable epoch activates protection"
+        );
         let drained = f.drain_prunable_tombstones();
         let tags: Vec<&str> = drained.iter().map(|(_, r)| r.tag.as_str()).collect();
         assert_eq!(

--- a/tests/integration-rust/helpers/index.ts
+++ b/tests/integration-rust/helpers/index.ts
@@ -215,6 +215,9 @@ export async function createRustTestContext(
  */
 function waitForPort(proc: child_process.ChildProcess, timeoutMs: number): Promise<number> {
   return new Promise((resolve, reject) => {
+    if (process.env.SERVER_LOG_PASSTHROUGH) {
+      proc.stdout!.on('data', (d) => process.stderr.write(d));
+    }
     const rl = readline.createInterface({ input: proc.stdout! });
 
     let settled = false;


### PR DESCRIPTION
## Summary

**This PR activates the OR-Map tombstone prune** — the durability half that SPEC-342b deliberately shipped dark (`durable_epoch_watermark ≡ 0`). Full SpecFlow lifecycle (audit APPROVED, review APPROVED, /xreview gate — 2 HIGH refuted against the actual WAL-backed production config).

### What ships
- **Real prefix-complete flushed watermark** (`write_behind.rs` flush-loop driven — NOT `soft_flush`'s last-assigned return; trait surface on `MapDataStore`/`record_store`), feeding the real `durable_epoch_watermark`: prune requires BOTH the fleet-wide-MIN cursor LWM AND byte-durability past the epoch.
- **Unclean-recovery rebuild**: on kill-9 recovery the epoch index is rebuilt by re-stamping all live tombstones into one maximally-lagging `E_rec` (> every persisted cursor + derived watermark bound), inside the pre-listener recovery window; `effective_LWM` clamp for all consumers.
- **Pre-activation gate hardening (342c residual, queued "must land before activation")**: a gated (forgotten/regressed) sync-init now resets `delivered(conn)` to 0, restoring the not-yet-admitted signal on a REUSED connection — without it a regressed replica's continuations slipped past `sync_gated_continuation` on the stale signal and could pull incremental deltas across pruned tombstones (+ regression test).

### Activation safety recap
Gate-before-activation held end-to-end: prune only ever runs with the re-admission gate (342c) live and the client-side cross-map ACK min-barrier + injective map-name scheme (SPEC-343, PR #110) already merged. No prune-without-gate window has existed on main at any commit.

## Test evidence
- server lib **1599/0/1** (fresh run incl. the new reused-connection regression test), clippy `-D warnings` / fmt clean; behavioral durability-fence + recovery tests in-branch; sim suite runs in CI.
- Deferred (tracked, non-blocking): TODO-580 (`flush_key` resolve-after-durable error-path + `reset_lock` scope — WAL-backstopped, own test+xreview cycle).

## Unblocks
SPEC-342f (legacy-tombstone migration needs the ACTIVE prune) → 342g (two-path + fault-injection sim proof) → 342h (soak monitor gate) → the 72h G4b soak.