### PR TITLE
Legacy tombstone posture: clean-slate (explicit exclusion + boot warn + docs) [SPEC-342f]

### DIFF
--- a/apps/docs-astro/public/llms-full.txt
+++ b/apps/docs-astro/public/llms-full.txt
@@ -1646,6 +1646,8 @@ getMap<K = string, V = any>(name: string): LWWMap<K, V>;
 
 Returns an `LWWMap` (last-write-wins CRDT) for the given name. Creates the map on first call and restores its state from storage asynchronously.
 
+Map names may not contain `:` — that character is reserved for the storage layer's internal key namespacing. Keys inside a map (e.g. `'post:123'`) may still contain `:` freely. Calling `getMap` with an empty name or a name containing `:` throws an `Error` immediately, before any storage access.
+
 ```typescript
 const users = client.getMap<string, User>('users');
 users.set('u1', { name: 'Alice' });
@@ -1659,7 +1661,7 @@ getORMap<K extends keyof TSchema & string>(name: K): ORMap<string, TSchema[K]>;
 getORMap<K = string, V = any>(name: string): ORMap<K, V>;
 ```
 
-Returns an `ORMap` (observed-remove CRDT) for multi-value-per-key data.
+Returns an `ORMap` (observed-remove CRDT) for multi-value-per-key data. The same map-name rule as `getMap` applies: no `:` in the name, keys are unrestricted, and an invalid name throws an `Error` immediately.
 
 ```typescript
 const tags = client.getORMap<string, string>('tags');

--- a/apps/docs-astro/src/content/docs/deploy/storage-backends.mdx
+++ b/apps/docs-astro/src/content/docs/deploy/storage-backends.mdx
@@ -160,6 +160,29 @@ Consider isolation when:
 
 The `null` backend is used in the TopGun integration test suite for deterministic, stateless test runs. Source: `bin/topgun_server.rs:109` — `"null"` is one of the three accepted values.
 
+## Tombstone reclamation and legacy stores
+
+When an OR-Map entry is removed, the server keeps a small tombstone so the deletion
+converges across every replica. Tombstones are reclaimed automatically once every
+tracked client has synced past them — no operator action is required on a store
+created by a current server.
+
+Stores first written by a **pre-epoch server** may still carry a legacy
+tombstone corpus in an older on-disk form. That corpus is **excluded from
+garbage collection by design**: it is never eligible for automatic reclamation, so
+it can never resurrect a deleted entry. It is inert and safe to leave in place. On
+startup the server logs a one-line `WARN` reporting how many legacy tombstone rows
+it found.
+
+The supported way to reclaim a legacy corpus is to **recreate the datastore**: stop
+the server, start it against a fresh store (a new `TOPGUN_REDB_PATH`, or an empty
+PostgreSQL database), and let clients reconnect. Because every client holds its own
+authoritative local state, CRDT delta-sync restores the live data on reconnect while
+the stale legacy tombstones are simply not recreated. There is intentionally no
+in-place "drop legacy tombstones" switch — dropping a tombstone while a client still
+holds the matching add is exactly the resurrection hazard the tombstone exists to
+prevent.
+
 ## Switching between backends
 
 Data does **not** auto-migrate between backends. If you switch from `redb` to `postgres` (or vice versa), the server starts with an empty store on the new backend. Clients re-sync their local state on reconnect via MerkleTree delta sync.

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -95,7 +95,7 @@ use topgun_server::storage::impls::StorageConfig;
 use topgun_server::storage::map_data_store::MapDataStore;
 use topgun_server::storage::merkle_sync::{MerkleObserverFactory, MerkleSyncManager};
 use topgun_server::storage::mutation_observer::MutationObserver;
-use topgun_server::storage::record::{set_tombstone_bytes, RecordValue};
+use topgun_server::storage::record::{legacy_tombstone_warning, set_tombstone_bytes, RecordValue};
 use topgun_server::storage::wal::{Wal, WalFsyncPolicy, WalRecovery, WalWriter};
 
 // ---------------------------------------------------------------------------
@@ -206,6 +206,11 @@ async fn reconcile_tombstone_bytes(store: Arc<dyn MapDataStore>) {
 
     let mut total: u64 = 0;
     let mut records_scanned: u64 = 0;
+    // Folded into this existing boot-only walk (no second O(keyspace) scan): the
+    // count of legacy tombstone-only blobs, which a clean-slate store never grows
+    // but a rehydrated pre-epoch store still carries. Durable backends only — this
+    // reconcile runs solely under the redb/postgres startup arm.
+    let mut legacy_rows: u64 = 0;
 
     for map in &maps {
         // Walk the whole map: first batch, then follow the cursor until exhausted
@@ -228,10 +233,14 @@ async fn reconcile_tombstone_bytes(store: Arc<dyn MapDataStore>) {
         loop {
             for (_key, value) in &batch.records {
                 records_scanned += 1;
-                if let RecordValue::OrMap { tombstones, .. } = value {
-                    for tag in tombstones {
-                        total += tag.len() as u64;
+                match value {
+                    RecordValue::OrMap { tombstones, .. } => {
+                        for tag in tombstones {
+                            total += tag.len() as u64;
+                        }
                     }
+                    RecordValue::OrTombstones { .. } => legacy_rows += 1,
+                    RecordValue::Lww { .. } => {}
                 }
             }
 
@@ -264,6 +273,14 @@ async fn reconcile_tombstone_bytes(store: Arc<dyn MapDataStore>) {
         maps = maps.len(),
         "OR-Map tombstone-bytes gauge reconciled from persisted keyspace"
     );
+
+    if let Some(warning) = legacy_tombstone_warning(legacy_rows) {
+        tracing::warn!(
+            target: "topgun_server::bootstrap",
+            legacy_tombstone_rows = legacy_rows,
+            "{warning}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -162,6 +162,27 @@ pub fn set_tombstone_bytes(total: u64) {
     metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(total);
 }
 
+/// The startup warning for a detected legacy [`RecordValue::OrTombstones`] corpus,
+/// or `None` when the store holds none.
+///
+/// Pre-epoch stores are not supported for tombstone reclamation: an untouched
+/// legacy blob is excluded from the epoch scan and so never becomes GC-eligible.
+/// The supported way to reclaim such a corpus is a fresh datastore (server wipe +
+/// clients re-sync). This surfaces that at boot so an operator sees the pinned
+/// bytes are deliberate, not a leak.
+///
+/// Kept a pure `count -> Option<message>` decision so it is unit-testable off the
+/// bin-only boot walk that supplies the count.
+#[must_use]
+pub fn legacy_tombstone_warning(legacy_row_count: u64) -> Option<String> {
+    (legacy_row_count > 0).then(|| {
+        format!(
+            "legacy tombstone corpus present ({legacy_row_count} row(s)) — excluded from GC; \
+             recreate the datastore to reclaim"
+        )
+    })
+}
+
 /// Minimum elapsed milliseconds before a read access updates `last_access_time`.
 ///
 /// Coalesces recency updates to bound write amplification under read-heavy load
@@ -577,5 +598,27 @@ mod or_map_tombstone_tests {
             }
             other => panic!("expected OrTombstones, got {other:?}"),
         }
+    }
+
+    /// The boot-warn decision: a non-zero legacy-row count yields a warning
+    /// carrying the count; a clean store (count 0) yields none, so startup on a
+    /// store with no legacy corpus logs nothing.
+    #[test]
+    fn legacy_tombstone_warning_fires_only_with_a_nonzero_count() {
+        assert_eq!(
+            legacy_tombstone_warning(0),
+            None,
+            "a clean store logs no legacy-corpus warning"
+        );
+
+        let warning = legacy_tombstone_warning(3).expect("legacy rows present → warn");
+        assert!(
+            warning.contains('3'),
+            "the warning reports the accurate legacy-row count"
+        );
+        assert!(
+            warning.contains("excluded from GC") && warning.contains("recreate the datastore"),
+            "the warning states the clean-slate reclamation posture"
+        );
     }
 }

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -982,14 +982,15 @@ async fn scan_live_tombstones(store: &dyn MapDataStore) -> anyhow::Result<Vec<To
                     }
                     // Legacy tombstone blobs are out of the prune scope: an
                     // untouched legacy row is deliberately NEVER re-stamped into a
-                    // recovery epoch, so it can never become prune-eligible. An
-                    // explicit no-op arm keeps that invariant visible at the point
-                    // of change — a future "handle every variant" refactor cannot
-                    // silently pull legacy blobs into the epoch index. (A later OR
-                    // write to the key upconverts the record to `OrMap`, after
-                    // which its tags join the protected regime — expected.)
-                    RecordValue::OrTombstones { .. } => {}
-                    RecordValue::Lww { .. } => {}
+                    // recovery epoch, so it can never become prune-eligible. LWW
+                    // records carry no OR-Map tombstones. Both are explicit no-op
+                    // arms so the exclusion is visible at the point of change — a
+                    // future "handle every variant" refactor confronts the named
+                    // `OrTombstones` pattern instead of silently pulling legacy
+                    // blobs into the epoch index. (A later OR write to the key
+                    // upconverts the record to `OrMap`, after which its tags join
+                    // the protected regime — expected.)
+                    RecordValue::OrTombstones { .. } | RecordValue::Lww { .. } => {}
                 }
             }
             match batch.next_cursor.take() {

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -960,23 +960,36 @@ async fn scan_max_cursor_epoch(store: &dyn MapDataStore) -> anyhow::Result<Epoch
 /// rebuild re-stamps all of these into the fresh recovery epoch. The reserved
 /// internal keyspaces ([`CURSOR_MAP`] and other `_topgun_`-prefixed maps) hold
 /// no OR-Map tombstones (their records are LWW), so they contribute nothing and
-/// are skipped implicitly by the `OrMap` match. Legacy `OrTombstones` blobs are
+/// are handled by the explicit `Lww` no-op arm. Legacy `OrTombstones` blobs are
 /// Merkle-invisible (TODO-559) and out of this child's prune scope, so they are
-/// deliberately NOT re-stamped here.
+/// deliberately NOT re-stamped here — an explicit no-op arm makes that exclusion
+/// visible to any future refactor.
 async fn scan_live_tombstones(store: &dyn MapDataStore) -> anyhow::Result<Vec<TombstoneRef>> {
     let mut live = Vec::new();
     for map in store.list_maps().await? {
         let mut batch = store.scan_values(&map, false, 0).await?;
         loop {
             for (key, value) in &batch.records {
-                if let RecordValue::OrMap { tombstones, .. } = value {
-                    for tag in tombstones {
-                        live.push(TombstoneRef {
-                            map: map.clone(),
-                            key: key.clone(),
-                            tag: tag.clone(),
-                        });
+                match value {
+                    RecordValue::OrMap { tombstones, .. } => {
+                        for tag in tombstones {
+                            live.push(TombstoneRef {
+                                map: map.clone(),
+                                key: key.clone(),
+                                tag: tag.clone(),
+                            });
+                        }
                     }
+                    // Legacy tombstone blobs are out of the prune scope: an
+                    // untouched legacy row is deliberately NEVER re-stamped into a
+                    // recovery epoch, so it can never become prune-eligible. An
+                    // explicit no-op arm keeps that invariant visible at the point
+                    // of change — a future "handle every variant" refactor cannot
+                    // silently pull legacy blobs into the epoch index. (A later OR
+                    // write to the key upconverts the record to `OrMap`, after
+                    // which its tags join the protected regime — expected.)
+                    RecordValue::OrTombstones { .. } => {}
+                    RecordValue::Lww { .. } => {}
                 }
             }
             match batch.next_cursor.take() {
@@ -1785,5 +1798,64 @@ mod persistence_tests {
             "epoch 1 (strictly below LWM 2, byte-durable) actually prunes with the real watermark"
         );
         assert_eq!(tags, vec!["T1"], "the drained tombstone is epoch 1's tag");
+    }
+
+    /// An UNTOUCHED legacy `OrTombstones` blob (never rewritten by any OR op) is
+    /// excluded from the frontier epoch scan and NEVER becomes prune-eligible:
+    /// (i) pre-prune, it is absent from the live set `scan_live_tombstones` builds;
+    /// (ii) post-prune, it survives a sweep that reclaims a genuinely stamped epoch.
+    #[tokio::test]
+    async fn ac2_untouched_legacy_ortombstones_never_prune_eligible() {
+        let (path, _dir) = temp_store();
+        let store: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&path).expect("open"));
+
+        // A modern OR-Map tombstone and an untouched legacy blob. The write path
+        // never emits `OrTombstones`, but older servers persisted it — seed it
+        // directly to model a pre-epoch corpus rehydrated on restart.
+        let legacy = RecordValue::OrTombstones {
+            tags: vec!["LEG".to_string()],
+        };
+        store
+            .add("m", "modern", &ormap_with_tombstones(&["MOD"]), 0, 1)
+            .await
+            .unwrap();
+        store.add("m", "legacy", &legacy, 0, 1).await.unwrap();
+
+        // (i) Pre-prune: the epoch scan admits only the modern tag. The legacy blob
+        // never enters the live set, so it can never be stamped into any epoch.
+        let live = scan_live_tombstones(store.as_ref()).await.unwrap();
+        let live_tags: Vec<&str> = live.iter().map(|r| r.tag.as_str()).collect();
+        assert_eq!(
+            live_tags,
+            vec!["MOD"],
+            "the untouched legacy OrTombstones tag is absent from the frontier live set"
+        );
+
+        // Rebuild stamps ONLY the modern tag into the recovery epoch. redb bytes
+        // are durable, so the watermark reaches E_rec and protection activates.
+        let f = TombstoneFrontier::new(Some(Arc::clone(&store)));
+        f.set_epoch_width(1);
+        let e_rec = f.rebuild_from_durable_store().await.unwrap();
+
+        // Drive a client PAST E_rec so the stamped recovery epoch is prune-eligible.
+        f.set_current_max_epoch(e_rec + 1);
+        let c: ClientId = "a5:alice|dev-1".into();
+        f.set_delivered(CONN_A, 1000);
+        assert!(f.confirm_apply_ack(&c, e_rec + 1, CONN_A).await);
+
+        // (ii) Post-prune: the sweep reclaims the stamped epoch, draining ONLY the
+        // modern tag. The legacy blob was never stamped, so no sweep can reach it.
+        let drained = f.drain_prunable_tombstones();
+        let drained_tags: Vec<&str> = drained.iter().map(|(_, r)| r.tag.as_str()).collect();
+        assert_eq!(
+            drained_tags,
+            vec!["MOD"],
+            "only the stamped modern epoch is reclaimed; the legacy tag is never drained"
+        );
+        assert_eq!(
+            store.load("m", "legacy").await.unwrap(),
+            Some(legacy),
+            "the untouched legacy blob survives a sweep that reclaims a stamped epoch"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Re-scoped SPEC-342f (user decision 2026-07-10): the legacy-tombstone MIGRATION machinery was deliberately dropped — pre-epoch stores are handled by a clean-slate posture instead. Untouched legacy `OrTombstones` rows were already resurrection-safe by construction (excluded from the frontier epoch scan → never prune-eligible); this PR makes that posture explicit, visible, and pinned:

- **Explicit exclusion**: `scan_live_tombstones` gains an explicit `RecordValue::OrTombstones {..}` no-op arm with a WHY-comment (was an implicit non-match) + regression pin: an untouched legacy row is absent from the frontier epoch set pre-prune AND survives a sweep that reclaims a stamped epoch.
- **Boot visibility**: legacy-row count folded into the existing boot-only byte-sum reconcile walk (no second keyspace scan, durable backends only) → one `tracing::warn!` with the count and the reclamation guidance.
- **Docs**: ops/self-host posture — supported reclamation path for a pre-epoch corpus is a fresh datastore (clients re-converge via CRDT sync); deliberately NO in-place legacy-tombstone deletion (that would be the resurrection door).
- Scope caveat documented honestly: an OR write to a legacy key upconverts it to the modern representation, after which its tags join the normal protected prune regime.

Full SpecFlow lifecycle: 2 audit cycles (incl. cross-vendor checkpoint that scoped the safety claim), review APPROVED 0/0/0, xreview trace recorded.

## Test evidence
Rust gate green at review (fmt/clippy `-D warnings`, lib suite incl. the new exclusion pin); docs gate covered by doc-tests CI on this PR.

## Unblocks
SPEC-342g (Wave 5 sim proofs) — last code-bearing child before the pre-soak TODO batch and the 72h G4b soak.