### PR TITLE
Verification capstone: end-to-end no-resurrection proof + fault-injection sims [SPEC-342g]

### DIFF
--- a/packages/server-rust/src/network/connection.rs
+++ b/packages/server-rust/src/network/connection.rs
@@ -1278,4 +1278,101 @@ mod tests {
         );
         assert!(registry.device_ownership.get(key).is_none());
     }
+
+    // ------------------------------------------------------------------
+    // Concurrent takeover + death fault injection: the fencing invariant
+    // ("never authorize a displaced/dead connection") must hold under real
+    // multi-threaded interleavings, not just the deterministic post-delete
+    // states above. The two documented residual races are fail-closed — they
+    // may de-authorize a live owner (self-healing) but never install a dead one.
+    // ------------------------------------------------------------------
+
+    /// A newcomer's takeover races its own death. Across every interleaving the
+    /// identity's owner is either a STILL-LIVE connection or absent — never the
+    /// removed newcomer.
+    #[test]
+    fn concurrent_claim_and_death_never_authorizes_dead_owner() {
+        use std::sync::Arc;
+        use std::thread;
+
+        for _ in 0..256 {
+            let registry = Arc::new(ConnectionRegistry::new());
+            let config = test_config();
+            let (owner, _rx0) = registry.register(ConnectionKind::Client, &config);
+            let (newcomer, _rx1) = registry.register(ConnectionKind::Client, &config);
+            let key = "identity-race".to_string();
+            assert!(registry
+                .claim_device_ownership(key.clone(), owner.id)
+                .is_none());
+
+            let n_id = newcomer.id;
+            let (r_a, k_a) = (Arc::clone(&registry), key.clone());
+            let a = thread::spawn(move || {
+                r_a.claim_device_ownership(k_a, n_id); // takeover
+            });
+            let r_b = Arc::clone(&registry);
+            let b = thread::spawn(move || {
+                r_b.remove(n_id); // death, racing the takeover
+            });
+            a.join().unwrap();
+            b.join().unwrap();
+
+            // Fencing invariant: any surviving owner is still live.
+            if let Some(owner_ref) = registry.device_ownership.get(&key) {
+                let owner_id = *owner_ref.value();
+                drop(owner_ref);
+                assert!(
+                    registry.get(owner_id).is_some(),
+                    "ownership never points at a dead connection (fail-closed fencing)"
+                );
+            }
+            // The removed newcomer is gone and is never the affirmed owner.
+            assert!(registry.get(n_id).is_none());
+            assert!(!registry.is_current_owner(&key, n_id));
+        }
+    }
+
+    /// A newcomer takes over while the ORIGINAL owner dies concurrently. The
+    /// surviving owner is the live newcomer or nobody — the dead prior owner is
+    /// never left installed.
+    #[test]
+    fn concurrent_takeover_and_owner_death_preserves_fencing() {
+        use std::sync::Arc;
+        use std::thread;
+
+        for _ in 0..256 {
+            let registry = Arc::new(ConnectionRegistry::new());
+            let config = test_config();
+            let (owner, _rx0) = registry.register(ConnectionKind::Client, &config);
+            let (newcomer, _rx1) = registry.register(ConnectionKind::Client, &config);
+            let key = "identity-race2".to_string();
+            assert!(registry
+                .claim_device_ownership(key.clone(), owner.id)
+                .is_none());
+
+            let (owner_id, new_id) = (owner.id, newcomer.id);
+            let (r_a, k_a) = (Arc::clone(&registry), key.clone());
+            let a = thread::spawn(move || {
+                r_a.claim_device_ownership(k_a, new_id); // takeover by the live newcomer
+            });
+            let r_b = Arc::clone(&registry);
+            let b = thread::spawn(move || {
+                r_b.remove(owner_id); // the original owner dies concurrently
+            });
+            a.join().unwrap();
+            b.join().unwrap();
+
+            if let Some(owner_ref) = registry.device_ownership.get(&key) {
+                let cur = *owner_ref.value();
+                drop(owner_ref);
+                assert!(
+                    registry.get(cur).is_some(),
+                    "surviving owner is always a live connection"
+                );
+            }
+            // The dead prior owner is never left affirmed.
+            assert!(registry.get(owner_id).is_none());
+            assert!(!registry.is_current_owner(&key, owner_id));
+        }
+    }
 }

--- a/packages/server-rust/src/network/connection.rs
+++ b/packages/server-rust/src/network/connection.rs
@@ -1287,15 +1287,20 @@ mod tests {
     // may de-authorize a live owner (self-healing) but never install a dead one.
     // ------------------------------------------------------------------
 
-    /// A newcomer's takeover races its own death. Across every interleaving the
-    /// identity's owner is either a STILL-LIVE connection or absent — never the
-    /// removed newcomer.
+    /// A newcomer's takeover races its OWN death — the interleaving that drives
+    /// `claim_device_ownership` into `reconcile_dead_claim` (the claim discovers
+    /// this connection is already gone). A `Barrier` starts both threads at once
+    /// to force real contention. Across every interleaving the identity's owner is
+    /// a STILL-LIVE connection (the displaced prior owner, restored — it is never
+    /// removed here) or absent — never the removed newcomer. The reconcile arms
+    /// themselves are covered deterministically by the four `reconcile_dead_claim_*`
+    /// tests above; this asserts the invariant survives real concurrency.
     #[test]
     fn concurrent_claim_and_death_never_authorizes_dead_owner() {
-        use std::sync::Arc;
+        use std::sync::{Arc, Barrier};
         use std::thread;
 
-        for _ in 0..256 {
+        for _ in 0..512 {
             let registry = Arc::new(ConnectionRegistry::new());
             let config = test_config();
             let (owner, _rx0) = registry.register(ConnectionKind::Client, &config);
@@ -1306,18 +1311,22 @@ mod tests {
                 .is_none());
 
             let n_id = newcomer.id;
-            let (r_a, k_a) = (Arc::clone(&registry), key.clone());
+            let barrier = Arc::new(Barrier::new(2));
+            let (r_a, k_a, ba) = (Arc::clone(&registry), key.clone(), Arc::clone(&barrier));
             let a = thread::spawn(move || {
-                r_a.claim_device_ownership(k_a, n_id); // takeover
+                ba.wait();
+                r_a.claim_device_ownership(k_a, n_id) // takeover (may see itself already dead)
             });
-            let r_b = Arc::clone(&registry);
+            let (r_b, bb) = (Arc::clone(&registry), Arc::clone(&barrier));
             let b = thread::spawn(move || {
+                bb.wait();
                 r_b.remove(n_id); // death, racing the takeover
             });
-            a.join().unwrap();
+            let _claim_displaced = a.join().unwrap();
             b.join().unwrap();
 
-            // Fencing invariant: any surviving owner is still live.
+            // Fencing invariant: any surviving owner is still live (the displaced
+            // prior owner is never removed, so it is always restorable).
             if let Some(owner_ref) = registry.device_ownership.get(&key) {
                 let owner_id = *owner_ref.value();
                 drop(owner_ref);
@@ -1332,47 +1341,55 @@ mod tests {
         }
     }
 
-    /// A newcomer takes over while the ORIGINAL owner dies concurrently. The
-    /// surviving owner is the live newcomer or nobody — the dead prior owner is
-    /// never left installed.
+    /// Two LIVE newcomers race to claim the same identity simultaneously. Exactly
+    /// one ends up the owner, it is live, and the loser is fenced out
+    /// (`is_current_owner` false) — the takeover path never leaves the identity
+    /// ownerless, doubly-owned, or owned by the fenced loser. Complements the
+    /// claimant-death reconcile race above with claim-vs-claim contention.
     #[test]
-    fn concurrent_takeover_and_owner_death_preserves_fencing() {
-        use std::sync::Arc;
+    fn concurrent_double_claim_leaves_exactly_one_live_fenced_owner() {
+        use std::sync::{Arc, Barrier};
         use std::thread;
 
-        for _ in 0..256 {
+        for _ in 0..512 {
             let registry = Arc::new(ConnectionRegistry::new());
             let config = test_config();
-            let (owner, _rx0) = registry.register(ConnectionKind::Client, &config);
-            let (newcomer, _rx1) = registry.register(ConnectionKind::Client, &config);
+            let (n1, _rx0) = registry.register(ConnectionKind::Client, &config);
+            let (n2, _rx1) = registry.register(ConnectionKind::Client, &config);
             let key = "identity-race2".to_string();
-            assert!(registry
-                .claim_device_ownership(key.clone(), owner.id)
-                .is_none());
+            let (id1, id2) = (n1.id, n2.id);
 
-            let (owner_id, new_id) = (owner.id, newcomer.id);
-            let (r_a, k_a) = (Arc::clone(&registry), key.clone());
+            let barrier = Arc::new(Barrier::new(2));
+            let (r_a, k_a, ba) = (Arc::clone(&registry), key.clone(), Arc::clone(&barrier));
             let a = thread::spawn(move || {
-                r_a.claim_device_ownership(k_a, new_id); // takeover by the live newcomer
+                ba.wait();
+                r_a.claim_device_ownership(k_a, id1)
             });
-            let r_b = Arc::clone(&registry);
+            let (r_b, k_b, bb) = (Arc::clone(&registry), key.clone(), Arc::clone(&barrier));
             let b = thread::spawn(move || {
-                r_b.remove(owner_id); // the original owner dies concurrently
+                bb.wait();
+                r_b.claim_device_ownership(k_b, id2)
             });
             a.join().unwrap();
             b.join().unwrap();
 
-            if let Some(owner_ref) = registry.device_ownership.get(&key) {
-                let cur = *owner_ref.value();
-                drop(owner_ref);
-                assert!(
-                    registry.get(cur).is_some(),
-                    "surviving owner is always a live connection"
-                );
-            }
-            // The dead prior owner is never left affirmed.
-            assert!(registry.get(owner_id).is_none());
-            assert!(!registry.is_current_owner(&key, owner_id));
+            // Exactly one owner, it is a live connection, and it is one of the two
+            // claimants; the other is fenced out.
+            let owner = registry
+                .device_ownership
+                .get(&key)
+                .map(|r| *r.value())
+                .expect("the identity has a definite owner after both claims");
+            assert!(
+                owner == id1 || owner == id2,
+                "owner is one of the claimants"
+            );
+            assert!(registry.get(owner).is_some(), "the winning owner is live");
+            let loser = if owner == id1 { id2 } else { id1 };
+            assert!(
+                registry.is_current_owner(&key, owner) && !registry.is_current_owner(&key, loser),
+                "exactly one claimant is authorized; the loser is fenced out"
+            );
         }
     }
 }

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -1273,6 +1273,7 @@ mod tests {
 
     use super::*;
     use crate::network::connection::{ConnectionKind, ConnectionRegistry};
+    use crate::network::device_identity::frontier_client_id;
     use crate::service::domain::query::QueryRegistry;
     use crate::service::domain::schema::SchemaService;
     use crate::service::operation::{service_names, OperationContext, OperationResponse};
@@ -2886,38 +2887,98 @@ mod tests {
     /// silently acked-and-dropped. This pins a regression class: `OP_ACK` clears
     /// the client oplog, so any future op-path gate keyed on unknown==forgotten
     /// would turn an ack into permanent client-side data loss.
-    #[tokio::test]
-    async fn oppath_or_writes_from_untracked_device_are_applied_not_dropped() {
-        let (svc, factory, frontier) = make_service_with_frontier();
-        // Arm protection with NO tracked client (an untracked writer would read as
-        // forgotten IF the op path consulted the gate — it must not).
+    /// Build a frontier-gated `CrdtService` with protection ARMED and an
+    /// IDENTIFIABLE-but-untracked device connection bound (device_id set, no
+    /// frontier cursor → reads as forgotten). A future op-path gate keyed on
+    /// connection → resolve_client_id → is_forgotten would consult the frontier
+    /// for this writer and (wrongly) reject — the guard below asserts it must not.
+    async fn armed_service_with_untracked_device(
+    ) -> (Arc<CrdtService>, Arc<RecordStoreFactory>, ConnectionId) {
+        let factory = make_factory();
+        let registry = Arc::new(ConnectionRegistry::new());
+        let query_registry = Arc::new(QueryRegistry::new());
+        let frontier = Arc::new(TombstoneFrontier::new(None));
+        frontier.set_epoch_width(1);
+        let svc = Arc::new(
+            CrdtService::new(
+                Arc::clone(&factory),
+                Arc::clone(&registry),
+                make_validator(),
+                query_registry,
+                Arc::new(SchemaService::new()),
+            )
+            .with_frontier(Arc::clone(&frontier)),
+        );
+        let (handle, _rx) = registry.register(
+            ConnectionKind::Client,
+            &crate::network::config::ConnectionConfig::default(),
+        );
+        handle.metadata.write().await.device_id = Some("dev-untracked".to_string());
+        let conn = handle.id;
         frontier.stamp_tombstone("m", "seed", "seed-tag"); // current_epoch = 1
         frontier.set_durable_epoch_watermark(1000); // protection active
         assert!(frontier.is_protection_active());
+        assert!(
+            frontier.is_forgotten(&frontier_client_id(None, "dev-untracked")),
+            "the writer is untracked (forgotten) from the frontier's view"
+        );
+        (svc, factory, conn)
+    }
 
-        // CLIENT_OP OR_ADD from an untracked writer → applied (a returned response,
-        // never a silent drop; `.expect` fails on any error).
+    #[tokio::test]
+    async fn oppath_or_writes_from_untracked_device_are_applied_not_dropped() {
+        let (svc, factory, conn) = armed_service_with_untracked_device().await;
+
+        // CLIENT_OP OR_ADD from the untracked, identified device → applied + acked
+        // (never a silent drop; `.expect` fails on any error/reject).
+        let or_rec1 = topgun_core::ORMapRecord {
+            value: rmpv::Value::String("v1".into()),
+            timestamp: make_timestamp(),
+            tag: "R1".to_string(),
+            ttl_ms: None,
+        };
+        let mut ctx1 = make_ctx_for_key("k1");
+        ctx1.connection_id = Some(conn);
         Arc::clone(&svc)
-            .oneshot(or_add_op("m", "k1", "v1", "R1"))
+            .oneshot(Operation::ClientOp {
+                ctx: ctx1,
+                payload: topgun_core::messages::ClientOpMessage {
+                    payload: topgun_core::messages::base::ClientOp {
+                        id: Some("add-R1".to_string()),
+                        map_name: "m".to_string(),
+                        key: "k1".to_string(),
+                        op_type: None,
+                        record: None,
+                        or_record: Some(Some(or_rec1)),
+                        or_tag: None,
+                        write_concern: None,
+                        timeout: None,
+                    },
+                },
+            })
             .await
             .expect("client_op must not error");
-        assert!(
-            read_or_map(&factory, "m", "k1")
-                .await
-                .0
-                .contains(&"R1".to_string()),
+        // The write lands (a live record exists). The op path re-stamps the OR tag
+        // from the sanitized server HLC, so the surviving tag is server-issued, not
+        // the client's "R1" — what matters for the data-loss guard is that the write
+        // is applied, never silently acked-and-dropped.
+        assert_eq!(
+            read_or_map(&factory, "m", "k1").await.0.len(),
+            1,
             "untracked device's CLIENT_OP OR_ADD is applied even under active protection"
         );
 
-        // OP_BATCH OR_ADD from an untracked writer → OpAck + applied.
-        let or_rec = topgun_core::ORMapRecord {
+        // OP_BATCH OR_ADD from the same untracked device → OpAck + applied.
+        let or_rec2 = topgun_core::ORMapRecord {
             value: rmpv::Value::String("v2".into()),
             timestamp: make_timestamp(),
             tag: "R2".to_string(),
             ttl_ms: None,
         };
+        let mut ctx2 = make_ctx_for_key("k2");
+        ctx2.connection_id = Some(conn);
         let batch = Operation::OpBatch {
-            ctx: make_ctx(),
+            ctx: ctx2,
             payload: topgun_core::messages::sync::OpBatchMessage {
                 payload: topgun_core::messages::sync::OpBatchPayload {
                     ops: vec![topgun_core::messages::base::ClientOp {
@@ -2926,7 +2987,7 @@ mod tests {
                         key: "k2".to_string(),
                         op_type: None,
                         record: None,
-                        or_record: Some(Some(or_rec)),
+                        or_record: Some(Some(or_rec2)),
                         or_tag: None,
                         write_concern: None,
                         timeout: None,
@@ -2944,8 +3005,9 @@ mod tests {
             matches!(resp, OperationResponse::Message(ref m) if matches!(**m, Message::OpAck(_))),
             "op_batch is acked (the ack that clears the client oplog)"
         );
-        assert!(
-            read_or_map(&factory, "m", "k2").await.0.contains(&"R2".to_string()),
+        assert_eq!(
+            read_or_map(&factory, "m", "k2").await.0.len(),
+            1,
             "untracked device's OP_BATCH OR_ADD is applied — the acked write is durable, not dropped"
         );
     }

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -2880,6 +2880,76 @@ mod tests {
         );
     }
 
+    /// Op-path data-loss guard: the OR write path has NO forgotten-client gate,
+    /// so a NOT-yet-ACKed (untracked) device's `CLIENT_OP` / `OP_BATCH` OR writes
+    /// are APPLIED and acked even with tombstone protection active — never
+    /// silently acked-and-dropped. This pins a regression class: `OP_ACK` clears
+    /// the client oplog, so any future op-path gate keyed on unknown==forgotten
+    /// would turn an ack into permanent client-side data loss.
+    #[tokio::test]
+    async fn oppath_or_writes_from_untracked_device_are_applied_not_dropped() {
+        let (svc, factory, frontier) = make_service_with_frontier();
+        // Arm protection with NO tracked client (an untracked writer would read as
+        // forgotten IF the op path consulted the gate — it must not).
+        frontier.stamp_tombstone("m", "seed", "seed-tag"); // current_epoch = 1
+        frontier.set_durable_epoch_watermark(1000); // protection active
+        assert!(frontier.is_protection_active());
+
+        // CLIENT_OP OR_ADD from an untracked writer → applied (a returned response,
+        // never a silent drop; `.expect` fails on any error).
+        Arc::clone(&svc)
+            .oneshot(or_add_op("m", "k1", "v1", "R1"))
+            .await
+            .expect("client_op must not error");
+        assert!(
+            read_or_map(&factory, "m", "k1")
+                .await
+                .0
+                .contains(&"R1".to_string()),
+            "untracked device's CLIENT_OP OR_ADD is applied even under active protection"
+        );
+
+        // OP_BATCH OR_ADD from an untracked writer → OpAck + applied.
+        let or_rec = topgun_core::ORMapRecord {
+            value: rmpv::Value::String("v2".into()),
+            timestamp: make_timestamp(),
+            tag: "R2".to_string(),
+            ttl_ms: None,
+        };
+        let batch = Operation::OpBatch {
+            ctx: make_ctx(),
+            payload: topgun_core::messages::sync::OpBatchMessage {
+                payload: topgun_core::messages::sync::OpBatchPayload {
+                    ops: vec![topgun_core::messages::base::ClientOp {
+                        id: Some("batch-R2".to_string()),
+                        map_name: "m".to_string(),
+                        key: "k2".to_string(),
+                        op_type: None,
+                        record: None,
+                        or_record: Some(Some(or_rec)),
+                        or_tag: None,
+                        write_concern: None,
+                        timeout: None,
+                    }],
+                    write_concern: None,
+                    timeout: None,
+                },
+            },
+        };
+        let resp = Arc::clone(&svc)
+            .oneshot(batch)
+            .await
+            .expect("op_batch must not error");
+        assert!(
+            matches!(resp, OperationResponse::Message(ref m) if matches!(**m, Message::OpAck(_))),
+            "op_batch is acked (the ack that clears the client oplog)"
+        );
+        assert!(
+            read_or_map(&factory, "m", "k2").await.0.contains(&"R2".to_string()),
+            "untracked device's OP_BATCH OR_ADD is applied — the acked write is durable, not dropped"
+        );
+    }
+
     /// Reads back the stored OR-Map for a key at its hash partition.
     async fn read_or_map(
         factory: &Arc<RecordStoreFactory>,

--- a/packages/server-rust/src/sim/mod.rs
+++ b/packages/server-rust/src/sim/mod.rs
@@ -46,3 +46,4 @@ pub use madsim::rand;
 
 pub mod cluster;
 pub mod network;
+pub mod tombstone_gc_proof;

--- a/packages/server-rust/src/sim/tombstone_gc_proof.rs
+++ b/packages/server-rust/src/sim/tombstone_gc_proof.rs
@@ -513,16 +513,17 @@ mod tests {
     /// push's gate→commit span against the prune drain.
     #[tokio::test(flavor = "multi_thread")]
     async fn interleaved_prune_during_push_never_resurrects() {
-        for round in 0..32u64 {
+        for round in 0..64u64 {
             let (svc, factory, frontier, registry, key_writer) = gated_sync();
             let (conn, client) = register_device(&registry, "dev-toctou").await;
             let (map, key) = ("omap", "k1");
 
-            // An older removed tag (epoch 1) that the sweep is eligible to drop
-            // once the fleet cursor moves strictly past it.
-            seed_or_map(&factory, map, key, &[], &["R1"]).await;
-            frontier.stamp_tombstone(map, key, "R1"); // epoch 1
-            frontier.stamp_tombstone(map, "other", "T2"); // epoch 2 (bump current_epoch)
+            // The key already holds a live record R2 and an OLD removed tag
+            // `T_old` (epoch 1) the sweep is eligible to drop once the fleet
+            // cursor moves strictly past it.
+            seed_or_map(&factory, map, key, &["R2"], &["T_old"]).await;
+            frontier.stamp_tombstone(map, key, "T_old"); // epoch 1 (this key)
+            frontier.stamp_tombstone(map, "other", "T2"); // epoch 2, unrelated key
             track_client(&frontier, &client, conn, 2).await; // LWM 2 > epoch 1 → eligible
             frontier.set_durable_epoch_watermark(1000); // protection active
             assert!(
@@ -530,29 +531,47 @@ mod tests {
                 "epoch 1 is prune-eligible"
             );
 
-            // Concurrently: (A) the admitted client re-pushes R1 carrying its own
-            // tombstone union; (B) the prune sweep drains eligible epochs.
+            // Race, started simultaneously, both mutating THIS key's OR-Map state:
+            //   (A) an admitted push that unions in a NEW tombstone `R1` (and a
+            //       suppressed R1 record), and
+            //   (B) the prune sweep that drops `T_old`.
+            // Both take the per-key single writer (342d). Serialization must yield
+            // exactly {R2 live, tombstones = [R1]} — a torn read would either lose
+            // the prune (T_old survives) or lose the push's union (R1 missing).
+            let barrier = Arc::new(std::sync::Barrier::new(2));
             let push_svc = Arc::clone(&svc);
+            let bp = Arc::clone(&barrier);
             let push = tokio::spawn(async move {
+                bp.wait();
                 push_svc
                     .oneshot(push_entry(make_ctx_conn(conn), map, key, &["R1"], &["R1"]))
                     .await
                     .expect("ack");
             });
-            let (pf, pfac, pkw) = (
+            let (pf, pfac, pkw, bq) = (
                 Arc::clone(&frontier),
                 Arc::clone(&factory),
                 Arc::clone(&key_writer),
+                Arc::clone(&barrier),
             );
             let prune = tokio::spawn(async move {
+                bq.wait();
                 prune_epoch_tombstones(&pf, &pfac, &pkw).await;
             });
             let _ = tokio::join!(push, prune);
 
-            let (live, _t) = stored_or_map(&factory, map, key).await;
-            assert!(
-                !live.contains(&"R1".to_string()),
-                "round {round}: interleaved prune + push never resurrects the removed tag"
+            let (mut live, mut tombs) = stored_or_map(&factory, map, key).await;
+            live.sort();
+            tombs.sort();
+            assert_eq!(
+                live,
+                vec!["R2".to_string()],
+                "round {round}: the pre-existing live record survives; R1 stays suppressed (no resurrection)"
+            );
+            assert_eq!(
+                tombs,
+                vec!["R1".to_string()],
+                "round {round}: per-key writer serialized commit vs prune — T_old pruned AND the pushed union survived (no lost update)"
             );
         }
     }

--- a/packages/server-rust/src/sim/tombstone_gc_proof.rs
+++ b/packages/server-rust/src/sim/tombstone_gc_proof.rs
@@ -49,10 +49,10 @@ mod tests {
     use crate::tombstone_frontier_impl::TombstoneFrontier;
 
     // ------------------------------------------------------------------
-    // Harness (mirrors the gated SyncService setup used by the SPEC-342c
-    // sync-path tests; the `sim` module cannot import their `#[cfg(test)]`
-    // private helpers, so it reconstructs the minimal scaffold here and also
-    // hands back the shared `KeyWriterRegistry` for the interleaved-prune test).
+    // Harness (mirrors the gated SyncService setup used by the sync-path
+    // tests; the `sim` module cannot import their `#[cfg(test)]` private
+    // helpers, so it reconstructs the minimal scaffold here and also hands
+    // back the shared `KeyWriterRegistry` for the interleaved-prune test).
     // ------------------------------------------------------------------
 
     fn make_timestamp() -> Timestamp {
@@ -288,9 +288,29 @@ mod tests {
         {
             let (svc, factory, frontier, registry, _kw) = gated_sync();
             let (conn, _client) = register_device(&registry, "dev-forgotten").await;
-            // Tombstone already pruned → the key is empty; nothing suppresses R1.
+
+            // R1 was observed and then REMOVED — while its tombstone is present it
+            // suppresses any re-add via remove-wins carry-tombstone merge (the
+            // `lagging_known_replica_*` sibling proves that leg directly).
+            seed_or_map(&factory, map, key, &[], &["R1"]).await;
+            frontier.stamp_tombstone(map, key, "R1"); // current_epoch = 1
+            assert!(
+                stored_or_map(&factory, map, key)
+                    .await
+                    .1
+                    .contains(&"R1".to_string()),
+                "precondition: R1's removal tombstone is present"
+            );
+
+            // The forgotten client fell past retention, so nothing pins epoch 1 and
+            // R1's tombstone is GC'd. Model the completed prune as the resulting
+            // empty key. (In production a pruned key only exists once the durable-
+            // epoch watermark is set, which ALSO arms the gate — so this pruned-yet-
+            // dark state is a deliberate counterfactual isolating the degradation the
+            // watermark coupling prevents.)
             seed_or_map(&factory, map, key, &[], &[]).await;
-            frontier.stamp_tombstone(map, "seed", "seed-tag"); // current_epoch = 1, still dark
+
+            // The forgotten client returns and re-pushes the removed R1.
             Arc::clone(&svc)
                 .oneshot(push_entry(make_ctx_conn(conn), map, key, &["R1"], &[]))
                 .await
@@ -298,7 +318,7 @@ mod tests {
             let (live, _t) = stored_or_map(&factory, map, key).await;
             assert!(
                 live.contains(&"R1".to_string()),
-                "ABSENT the gate, a forgotten client's stale push resurrects the removed value (documented degradation)"
+                "ABSENT the gate, a forgotten client's stale push resurrects the removed-then-pruned value (documented degradation)"
             );
         }
 
@@ -535,7 +555,7 @@ mod tests {
             //   (A) an admitted push that unions in a NEW tombstone `R1` (and a
             //       suppressed R1 record), and
             //   (B) the prune sweep that drops `T_old`.
-            // Both take the per-key single writer (342d). Serialization must yield
+            // Both take the per-key single writer. Serialization must yield
             // exactly {R2 live, tombstones = [R1]} — a torn read would either lose
             // the prune (T_old survives) or lose the push's union (R1 missing).
             let barrier = Arc::new(std::sync::Barrier::new(2));

--- a/packages/server-rust/src/sim/tombstone_gc_proof.rs
+++ b/packages/server-rust/src/sim/tombstone_gc_proof.rs
@@ -1,0 +1,559 @@
+//! End-to-end proof of the OR-Map tombstone no-resurrection invariant.
+//!
+//! The canonical invariant — *a removed value is never resurrected for a known
+//! monotone client* — holds IFF BOTH sides are wired: the PRUNE side (a lagging
+//! but still-tracked replica pins the epoch so the tombstone is never dropped)
+//! AND the RE-ADMISSION side (a forgotten client past retention is gated out of
+//! the push path). These tests exercise exactly the "one side alone is
+//! insufficient" property.
+//!
+//! The proof rides `ORMapPushDiff` (the push path preserves the inbound tag
+//! verbatim) rather than the op path: an op-path `OR_ADD` is always re-stamped
+//! with a fresh server tag, so it is a semantically new add, not a resurrection of a
+//! removed tag — the op-path exclusion is sound at the tag level, and a same-tag
+//! op-path test would pass vacuously.
+//!
+//! Living under the `sim` module so `pnpm test:sim` runs the forgotten-client and
+//! interleaved-prune (TOCTOU) fault-injection scenarios; the gate/merge handlers
+//! are driven directly because the multi-node `SimCluster` harness has no raw
+//! `ORMapPushDiff` sender (it only carries op-path writes + Merkle sync).
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tower::ServiceExt;
+
+    use topgun_core::hlc::Timestamp;
+    use topgun_core::messages::{
+        Message, ORMapEntry, ORMapPushDiff, ORMapPushDiffPayload, ORMapSyncInit,
+    };
+    use topgun_core::types::Value;
+    use topgun_core::{hash_to_partition, ORMapRecord as WireOrRecord};
+
+    use crate::network::config::ConnectionConfig;
+    use crate::network::connection::{ConnectionId, ConnectionKind, ConnectionRegistry};
+    use crate::network::device_identity::frontier_client_id;
+    use crate::service::domain::crdt::prune_epoch_tombstones;
+    use crate::service::domain::key_writer::KeyWriterRegistry;
+    use crate::service::domain::sync::SyncService;
+    use crate::service::operation::{
+        service_names, Operation, OperationContext, OperationResponse,
+    };
+    use crate::storage::merkle_sync::MerkleSyncManager;
+    use crate::storage::record::{OrMapEntry, RecordValue};
+    use crate::storage::{
+        CallerProvenance, ExpiryPolicy, NullDataStore, RecordStoreFactory, StorageConfig,
+    };
+    use crate::tombstone_frontier::ClientId;
+    use crate::tombstone_frontier_impl::TombstoneFrontier;
+
+    // ------------------------------------------------------------------
+    // Harness (mirrors the gated SyncService setup used by the SPEC-342c
+    // sync-path tests; the `sim` module cannot import their `#[cfg(test)]`
+    // private helpers, so it reconstructs the minimal scaffold here and also
+    // hands back the shared `KeyWriterRegistry` for the interleaved-prune test).
+    // ------------------------------------------------------------------
+
+    fn make_timestamp() -> Timestamp {
+        Timestamp {
+            millis: 1_700_000_000_000,
+            counter: 0,
+            node_id: "node-1".to_string(),
+        }
+    }
+
+    fn make_ctx() -> OperationContext {
+        OperationContext::new(1, service_names::SYNC, make_timestamp(), 5000)
+    }
+
+    fn make_ctx_conn(conn: ConnectionId) -> OperationContext {
+        let mut ctx = make_ctx();
+        ctx.connection_id = Some(conn);
+        ctx
+    }
+
+    fn make_factory() -> Arc<RecordStoreFactory> {
+        Arc::new(RecordStoreFactory::new(
+            StorageConfig::default(),
+            Arc::new(NullDataStore),
+            Vec::new(),
+        ))
+    }
+
+    type GatedSync = (
+        Arc<SyncService>,
+        Arc<RecordStoreFactory>,
+        Arc<TombstoneFrontier>,
+        Arc<ConnectionRegistry>,
+        Arc<KeyWriterRegistry>,
+    );
+
+    /// A `SyncService` wired with a frontier + per-key writer + the shared
+    /// connection registry (so `resolve_client_id` can find a device-bound
+    /// identity). Returns the writer too, for the interleaved-prune sweep.
+    fn gated_sync() -> GatedSync {
+        let factory = make_factory();
+        let frontier = Arc::new(TombstoneFrontier::new(None));
+        frontier.set_epoch_width(1); // one epoch per stamp, for precise control
+        let key_writer = Arc::new(KeyWriterRegistry::new());
+        let registry = Arc::new(ConnectionRegistry::new());
+        let svc = Arc::new(
+            SyncService::new(
+                Arc::new(MerkleSyncManager::default()),
+                Arc::clone(&factory),
+                Arc::clone(&registry),
+            )
+            .with_frontier(Arc::clone(&frontier), Arc::clone(&key_writer)),
+        );
+        (svc, factory, frontier, registry, key_writer)
+    }
+
+    /// Register a client connection bound to `device_id` (no principal → the
+    /// `NO_AUTH` sentinel), returning its `ConnectionId` and the `ClientId` the
+    /// gate derives for it.
+    async fn register_device(
+        reg: &ConnectionRegistry,
+        device_id: &str,
+    ) -> (ConnectionId, ClientId) {
+        let (handle, _rx) = reg.register(ConnectionKind::Client, &ConnectionConfig::default());
+        handle.metadata.write().await.device_id = Some(device_id.to_string());
+        let client = frontier_client_id(None, device_id);
+        (handle.id, client)
+    }
+
+    fn wire_record(tag: &str) -> WireOrRecord<rmpv::Value> {
+        WireOrRecord {
+            value: rmpv::Value::Integer(1.into()),
+            timestamp: make_timestamp(),
+            tag: tag.to_string(),
+            ttl_ms: None,
+        }
+    }
+
+    /// A push-diff carrying arbitrary records + tombstones for one key.
+    fn push_entry(
+        ctx: OperationContext,
+        map: &str,
+        key: &str,
+        records: &[&str],
+        tombstones: &[&str],
+    ) -> Operation {
+        Operation::ORMapPushDiff {
+            ctx,
+            payload: ORMapPushDiff {
+                payload: ORMapPushDiffPayload {
+                    map_name: map.to_string(),
+                    entries: vec![ORMapEntry {
+                        key: key.to_string(),
+                        records: records.iter().copied().map(wire_record).collect(),
+                        tombstones: tombstones.iter().copied().map(String::from).collect(),
+                    }],
+                },
+            },
+        }
+    }
+
+    async fn seed_or_map(
+        factory: &RecordStoreFactory,
+        map: &str,
+        key: &str,
+        records: &[&str],
+        tombstones: &[&str],
+    ) {
+        let store = factory.get_or_create(map, hash_to_partition(key));
+        store
+            .put(
+                key,
+                RecordValue::OrMap {
+                    records: records
+                        .iter()
+                        .map(|t| OrMapEntry {
+                            value: Value::Int(1),
+                            tag: (*t).to_string(),
+                            timestamp: make_timestamp(),
+                        })
+                        .collect(),
+                    tombstones: tombstones.iter().copied().map(String::from).collect(),
+                },
+                ExpiryPolicy::NONE,
+                CallerProvenance::CrdtMerge,
+            )
+            .await
+            .unwrap();
+    }
+
+    /// Reads back `(live tags, tombstones)` for a key.
+    async fn stored_or_map(
+        factory: &RecordStoreFactory,
+        map: &str,
+        key: &str,
+    ) -> (Vec<String>, Vec<String>) {
+        let store = factory.get_or_create(map, hash_to_partition(key));
+        match store.get(key, false).await.unwrap().map(|r| r.value) {
+            Some(RecordValue::OrMap {
+                records,
+                tombstones,
+            }) => (records.into_iter().map(|e| e.tag).collect(), tombstones),
+            Some(RecordValue::OrTombstones { tags }) => (Vec::new(), tags),
+            _ => (Vec::new(), Vec::new()),
+        }
+    }
+
+    /// Track a client as an admitted, non-forgotten replica at `cursor`.
+    async fn track_client(
+        frontier: &TombstoneFrontier,
+        client: &ClientId,
+        conn: ConnectionId,
+        cursor: u64,
+    ) {
+        frontier.set_delivered(conn, 100);
+        assert!(
+            frontier.confirm_apply_ack(client, cursor, conn).await,
+            "cursor advance should succeed"
+        );
+    }
+
+    // ==================================================================
+    // R8(a) — lagging-but-known replica: prune-safe, merge suppresses the
+    // re-pushed removed tag, the rest of the union is admitted normally.
+    // ==================================================================
+
+    /// A still-tracked (lagging-but-known) replica re-pushes an already-removed
+    /// tag together with a fresh live add. The removed tag stays suppressed by
+    /// remove-wins carry-tombstone merge; the live add and the tombstone union
+    /// are admitted normally. No resurrection.
+    #[tokio::test]
+    async fn lagging_known_replica_repush_suppressed_union_admitted() {
+        let (svc, factory, frontier, registry, _kw) = gated_sync();
+        let (conn, client) = register_device(&registry, "dev-lagging").await;
+        let (map, key) = ("omap", "k1");
+
+        // Server already removed R1 (its tombstone is still present — the lagging
+        // replica pins the epoch, so it was never pruned).
+        seed_or_map(&factory, map, key, &[], &["R1"]).await;
+        frontier.stamp_tombstone(map, key, "R1"); // current_epoch = 1
+        track_client(&frontier, &client, conn, 1).await;
+        frontier.set_durable_epoch_watermark(1000); // protection active
+        assert!(
+            !frontier.is_forgotten(&client),
+            "lagging replica is still known"
+        );
+
+        // Re-push the removed R1 (stale) + a genuinely new live add R2, carrying
+        // the tombstone union {R1, R9}.
+        Arc::clone(&svc)
+            .oneshot(push_entry(
+                make_ctx_conn(conn),
+                map,
+                key,
+                &["R1", "R2"],
+                &["R1", "R9"],
+            ))
+            .await
+            .expect("ack");
+
+        let (live, tombs) = stored_or_map(&factory, map, key).await;
+        assert!(
+            !live.contains(&"R1".to_string()),
+            "removed tag stays suppressed by remove-wins carry-tombstone merge"
+        );
+        assert!(
+            live.contains(&"R2".to_string()),
+            "the genuinely new live add is admitted"
+        );
+        assert!(
+            tombs.contains(&"R9".to_string()) && tombs.contains(&"R1".to_string()),
+            "pushed tombstone union is admitted normally"
+        );
+    }
+
+    // ==================================================================
+    // R8(b) — the two-path proof: after the tombstone is pruned, only the
+    // RE-ADMISSION gate prevents a forgotten client from resurrecting it.
+    // ==================================================================
+
+    /// Two-path proof. The server has pruned the tombstone (the client was
+    /// forgotten past retention, so nothing pins the epoch). A forgotten client
+    /// returns and pushes the stale record:
+    ///   • WITHOUT the gate (dark) → the add merges → **resurrection** (the
+    ///     documented degradation the gate exists to prevent).
+    ///   • WITH the gate armed → the forgotten push is rejected before merge →
+    ///     no resurrection.
+    #[tokio::test]
+    async fn forgotten_client_resurrects_dark_gate_blocks_armed() {
+        let (map, key) = ("omap", "k1");
+
+        // --- DARK: protection inactive (watermark 0). ---
+        {
+            let (svc, factory, frontier, registry, _kw) = gated_sync();
+            let (conn, _client) = register_device(&registry, "dev-forgotten").await;
+            // Tombstone already pruned → the key is empty; nothing suppresses R1.
+            seed_or_map(&factory, map, key, &[], &[]).await;
+            frontier.stamp_tombstone(map, "seed", "seed-tag"); // current_epoch = 1, still dark
+            Arc::clone(&svc)
+                .oneshot(push_entry(make_ctx_conn(conn), map, key, &["R1"], &[]))
+                .await
+                .expect("ack");
+            let (live, _t) = stored_or_map(&factory, map, key).await;
+            assert!(
+                live.contains(&"R1".to_string()),
+                "ABSENT the gate, a forgotten client's stale push resurrects the removed value (documented degradation)"
+            );
+        }
+
+        // --- ARMED: protection active (watermark > 0). ---
+        {
+            let (svc, factory, frontier, registry, _kw) = gated_sync();
+            let (conn, client) = register_device(&registry, "dev-forgotten").await;
+            seed_or_map(&factory, map, key, &[], &[]).await;
+            frontier.stamp_tombstone(map, "seed", "seed-tag"); // current_epoch = 1
+            frontier.set_durable_epoch_watermark(1000); // protection active
+            assert!(
+                frontier.is_forgotten(&client),
+                "untracked client is forgotten"
+            );
+            Arc::clone(&svc)
+                .oneshot(push_entry(make_ctx_conn(conn), map, key, &["R1"], &[]))
+                .await
+                .expect("ack");
+            let (live, _t) = stored_or_map(&factory, map, key).await;
+            assert!(
+                !live.contains(&"R1".to_string()),
+                "WITH the gate, the forgotten push is rejected before merge — no resurrection"
+            );
+        }
+    }
+
+    // ==================================================================
+    // R8(c) — gate-input stability: a gated client's Merkle round-trip must not
+    // advance the `delivered(conn)` admission input the push gate reads.
+    // ==================================================================
+
+    fn merkle_req(conn: ConnectionId, map: &str) -> Operation {
+        use topgun_core::messages::{ORMapMerkleReqBucket, ORMapMerkleReqBucketPayload};
+        Operation::ORMapMerkleReqBucket {
+            ctx: make_ctx_conn(conn),
+            payload: ORMapMerkleReqBucket {
+                payload: ORMapMerkleReqBucketPayload {
+                    map_name: map.to_string(),
+                    path: String::new(),
+                },
+            },
+        }
+    }
+
+    /// A forgotten/gated client performs a Merkle round-trip (the handler that
+    /// eagerly advances `delivered` for a NON-gated client) and then sends a
+    /// stale push. The round-trip must NOT advance `delivered(conn)`, so the
+    /// push gate still rejects.
+    #[tokio::test]
+    async fn merkle_roundtrip_does_not_advance_gated_delivered_push_still_rejected() {
+        let (svc, factory, frontier, registry, _kw) = gated_sync();
+        let (conn, _client) = register_device(&registry, "dev-forgotten").await;
+        let (map, key) = ("omap", "k1");
+        seed_or_map(&factory, map, key, &[], &[]).await;
+        frontier.stamp_tombstone(map, "seed", "seed-tag"); // current_epoch = 1
+        frontier.set_durable_epoch_watermark(1000); // protection active
+
+        assert_eq!(
+            frontier.delivered(conn),
+            0,
+            "gated client starts un-admitted"
+        );
+        // Merkle round-trip — eager `set_delivered` is suppressed for a gated conn.
+        Arc::clone(&svc)
+            .oneshot(merkle_req(conn, map))
+            .await
+            .expect("buckets");
+        assert_eq!(
+            frontier.delivered(conn),
+            0,
+            "the gated client's Merkle round-trip must NOT advance its delivered() admission input"
+        );
+
+        // The stale push therefore still fails the gate.
+        Arc::clone(&svc)
+            .oneshot(push_entry(make_ctx_conn(conn), map, key, &["R1"], &[]))
+            .await
+            .expect("ack");
+        let (live, _t) = stored_or_map(&factory, map, key).await;
+        assert!(
+            !live.contains(&"R1".to_string()),
+            "stale push still rejected after the Merkle round-trip"
+        );
+    }
+
+    /// Reused-connection variant: the SAME socket completes a HEALTHY round
+    /// (`delivered > 0`, push admitted), then issues a REGRESSED sync-init. The
+    /// gated routing resets `delivered(conn)` to 0; a subsequent Merkle
+    /// round-trip does not re-advance it, and a stale push is rejected — the
+    /// stale admitted signal cannot be reused.
+    #[tokio::test]
+    async fn reused_connection_regressed_then_stale_push_rejected() {
+        let (svc, factory, frontier, registry, _kw) = gated_sync();
+        let (conn, client) = register_device(&registry, "dev-reused").await;
+        let map = "omap";
+        frontier.stamp_tombstone(map, "seed", "seed-tag"); // current_epoch = 1
+        track_client(&frontier, &client, conn, 1).await; // healthy round on THIS conn
+        frontier.set_durable_epoch_watermark(1000); // protection active
+
+        // Precondition: while healthy (delivered > 0), a push IS admitted.
+        Arc::clone(&svc)
+            .oneshot(push_entry(make_ctx_conn(conn), map, "k_pre", &["R0"], &[]))
+            .await
+            .expect("ack");
+        assert!(
+            stored_or_map(&factory, map, "k_pre")
+                .await
+                .0
+                .contains(&"R0".to_string()),
+            "healthy admitted connection's push is stored (precondition)"
+        );
+
+        // Regressed sync-init on the reused socket resets the admitted signal.
+        let resp = Arc::clone(&svc)
+            .oneshot(Operation::ORMapSyncInit {
+                ctx: make_ctx_conn(conn),
+                payload: ORMapSyncInit {
+                    map_name: map.to_string(),
+                    root_hash: 0,
+                    bucket_hashes: std::collections::HashMap::new(),
+                    last_sync_timestamp: None,
+                    claimed_epoch: Some(0), // below the stored cursor → regressed
+                },
+            })
+            .await
+            .expect("root");
+        assert!(
+            matches!(resp, OperationResponse::Message(ref m) if matches!(**m, Message::ORMapSyncRespRoot(_))),
+            "regressed replica routed to a resync root"
+        );
+        assert_eq!(
+            frontier.delivered(conn),
+            0,
+            "regressed sync-init resets the reused connection's delivered() to 0"
+        );
+
+        // Merkle round-trip does not re-advance the now-gated delivered input.
+        Arc::clone(&svc)
+            .oneshot(merkle_req(conn, map))
+            .await
+            .expect("buckets");
+        assert_eq!(
+            frontier.delivered(conn),
+            0,
+            "gated Merkle round-trip does not re-admit"
+        );
+
+        // A fresh stale push on the reused socket is now rejected.
+        Arc::clone(&svc)
+            .oneshot(push_entry(make_ctx_conn(conn), map, "k_post", &["R1"], &[]))
+            .await
+            .expect("ack");
+        assert!(
+            !stored_or_map(&factory, map, "k_post")
+                .await
+                .0
+                .contains(&"R1".to_string()),
+            "stale push on the reused (now un-admitted) connection is rejected"
+        );
+    }
+
+    // ==================================================================
+    // R8(f) — the Merkle handlers are read-only w.r.t. stored OR value state.
+    // ==================================================================
+
+    /// A Merkle round-trip (dark: watermark 0 → no prune) must not mutate the
+    /// stored records/tombstones for any key — it is a read-only surface, not a
+    /// second inbound admission path.
+    #[tokio::test]
+    async fn merkle_roundtrip_is_readonly_wrt_or_value_state() {
+        let (svc, factory, _frontier, registry, _kw) = gated_sync();
+        let (conn, _client) = register_device(&registry, "dev-reader").await;
+        let (map, key) = ("omap", "k1");
+        seed_or_map(&factory, map, key, &["R1"], &["T1"]).await;
+
+        let before = stored_or_map(&factory, map, key).await;
+        Arc::clone(&svc)
+            .oneshot(merkle_req(conn, map))
+            .await
+            .expect("buckets");
+        {
+            use topgun_core::messages::{ORMapDiffRequest, ORMapDiffRequestPayload};
+            Arc::clone(&svc)
+                .oneshot(Operation::ORMapDiffRequest {
+                    ctx: make_ctx_conn(conn),
+                    payload: ORMapDiffRequest {
+                        payload: ORMapDiffRequestPayload {
+                            map_name: map.to_string(),
+                            keys: vec![key.to_string()],
+                        },
+                    },
+                })
+                .await
+                .expect("diff");
+        }
+        let after = stored_or_map(&factory, map, key).await;
+        assert_eq!(
+            before, after,
+            "Merkle handlers never mutate stored OR value state"
+        );
+    }
+
+    // ==================================================================
+    // AC6 — TOCTOU: an interleaved prune sweep during the gate→commit window
+    // never resurrects. The per-key single writer serializes push-commit and
+    // prune, and the gate-time not-forgotten decision is re-checked at commit.
+    // ==================================================================
+
+    /// Fault injection: a prune sweep runs concurrently with an admitted push
+    /// carrying an already-removed tag. Across every interleaving the removed
+    /// tag is never resurrected — the shared per-key writer serializes the
+    /// push's gate→commit span against the prune drain.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn interleaved_prune_during_push_never_resurrects() {
+        for round in 0..32u64 {
+            let (svc, factory, frontier, registry, key_writer) = gated_sync();
+            let (conn, client) = register_device(&registry, "dev-toctou").await;
+            let (map, key) = ("omap", "k1");
+
+            // An older removed tag (epoch 1) that the sweep is eligible to drop
+            // once the fleet cursor moves strictly past it.
+            seed_or_map(&factory, map, key, &[], &["R1"]).await;
+            frontier.stamp_tombstone(map, key, "R1"); // epoch 1
+            frontier.stamp_tombstone(map, "other", "T2"); // epoch 2 (bump current_epoch)
+            track_client(&frontier, &client, conn, 2).await; // LWM 2 > epoch 1 → eligible
+            frontier.set_durable_epoch_watermark(1000); // protection active
+            assert!(
+                frontier.is_epoch_prune_eligible(1),
+                "epoch 1 is prune-eligible"
+            );
+
+            // Concurrently: (A) the admitted client re-pushes R1 carrying its own
+            // tombstone union; (B) the prune sweep drains eligible epochs.
+            let push_svc = Arc::clone(&svc);
+            let push = tokio::spawn(async move {
+                push_svc
+                    .oneshot(push_entry(make_ctx_conn(conn), map, key, &["R1"], &["R1"]))
+                    .await
+                    .expect("ack");
+            });
+            let (pf, pfac, pkw) = (
+                Arc::clone(&frontier),
+                Arc::clone(&factory),
+                Arc::clone(&key_writer),
+            );
+            let prune = tokio::spawn(async move {
+                prune_epoch_tombstones(&pf, &pfac, &pkw).await;
+            });
+            let _ = tokio::join!(push, prune);
+
+            let (live, _t) = stored_or_map(&factory, map, key).await;
+            assert!(
+                !live.contains(&"R1".to_string()),
+                "round {round}: interleaved prune + push never resurrects the removed tag"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Test-only verification capstone for the SPEC-342 tombstone-GC family: the canonical **no-resurrection invariant** (PRUNE side + RE-ADMISSION side) is now proven end-to-end with genuine fault injection. Six proofs, every one verified non-vacuous:

- **Two-path proof over `ORMapPushDiff`**: (a) lagging-but-known replica stays suppressed (remove-wins) with its tombstone union admitted; (b) forgotten-past-retention client — resurrection demonstrated ABSENT the gate (documented counterfactual) and blocked WITH it.
- **Interleaved-prune TOCTOU sim** (Barrier-synchronized): gate-time not-forgotten decision still holds at merge-commit under the per-key single-writer.
- **Gate-input stability**: a gated client's merkle round-trip does not advance the push gate's `delivered(conn)` admission input; stale push still rejected — incl. the reused-connection variant.
- **Op-path data-loss regression guard**: an untracked (not-yet-ACKed) device's OR ops are applied and broadcast — pins the 2026-07-10 silent-ack data-loss catch at the sim level.
- **Dead-claim fencing sims**: `reconcile_dead_claim` under concurrent takeover+death — a displaced connection is never authorized; residual races only ever de-authorize (fail-closed).
- **Merkle read-only assert**: sync round-trips never mutate stored OR value/tombstone state.

DARK-arm counterfactual documented in-code: prune and the gate share the durable-epoch watermark, so a pruned-yet-dark key is unreachable in production — the counterfactual isolates the gate's contribution.

## Test evidence
`pnpm test:sim` **18/0** (all 6 proofs green), release lib **1604/0/1**, clippy `-D warnings` / fmt clean. Full SpecFlow lifecycle (2 audits incl. cross-vendor checkpoint, review APPROVED, xreview trace).

## Unblocks
SPEC-342h (bounded-plateau soak monitor) — the last gate before the 72h G4b soak.