### PR TITLE
fix(server): pre-soak durability + keyspace hardening batch (SPEC-344)

### DIFF
--- a/packages/server-rust/src/service/middleware/authorization.rs
+++ b/packages/server-rust/src/service/middleware/authorization.rs
@@ -88,9 +88,12 @@ where
         // trusted origins never reach here (they early-return in `call`), so the
         // server's own internal writes to these maps stay exempt. Ops with an empty
         // `map_name` (bypass group, `SqlQuery`/`VectorSearch`/`QuerySyncInit`)
-        // cannot name a reserved map, so they fall through unaffected.
-        if is_reserved_map_name(&map_name) {
-            return Box::pin(async move { Err(OperationError::Forbidden { map_name }) });
+        // cannot name a reserved map, so they fall through unaffected. For an
+        // `OpBatch` EVERY op is inspected (not just the classified first one) —
+        // each op is applied by its own `map_name`, so a reserved map in a
+        // non-first position must still be rejected.
+        if let Some(reserved) = reserved_target_map_name(&op, &map_name) {
+            return Box::pin(async move { Err(OperationError::Forbidden { map_name: reserved }) });
         }
         let Some(action) = action else {
             return Box::pin(self.inner.call(op));
@@ -236,11 +239,34 @@ const RESERVED_MAP_PREFIXES: [&str; 2] = ["_topgun_", "__topgun_"];
 
 /// Whether `map_name` names a reserved internal map (see [`RESERVED_MAP_PREFIXES`]).
 /// Deliberately narrow: only the `_topgun_`/`__topgun_` families are reserved, so
-/// other leading-underscore names (`_internal`, `tags`, …) stay valid.
+/// other leading-underscore names (`_internal`, `tags`, …) stay valid. The prefix
+/// match is ASCII-case-insensitive so a `_TOPGUN_*` variant cannot slip past the
+/// guard if any downstream layer folds map-name case.
 fn is_reserved_map_name(map_name: &str) -> bool {
-    RESERVED_MAP_PREFIXES
-        .iter()
-        .any(|prefix| map_name.starts_with(prefix))
+    let bytes = map_name.as_bytes();
+    RESERVED_MAP_PREFIXES.iter().any(|prefix| {
+        let p = prefix.as_bytes();
+        bytes.len() >= p.len() && bytes[..p.len()].eq_ignore_ascii_case(p)
+    })
+}
+
+/// The reserved map name a client-origin op would target, if any.
+///
+/// `classify_operation` reports only `ops.first()`'s map for an `OpBatch`, but
+/// `handle_op_batch` applies EVERY op by its own `map_name` — so the guard must
+/// scan all of them, else a batch like `[{tags}, {_topgun_device_credentials}]`
+/// smuggles a reserved write past the single-map check. For every other op family
+/// the classified `map_name` is the one resource, so it is checked directly.
+fn reserved_target_map_name(op: &Operation, classified_map_name: &str) -> Option<String> {
+    if let Operation::OpBatch { payload, .. } = op {
+        return payload
+            .payload
+            .ops
+            .iter()
+            .find(|client_op| is_reserved_map_name(&client_op.map_name))
+            .map(|client_op| client_op.map_name.clone());
+    }
+    is_reserved_map_name(classified_map_name).then(|| classified_map_name.to_string())
 }
 
 /// Maps an `Operation` variant to a `PermissionAction` and a `map_name`.
@@ -1064,6 +1090,68 @@ mod tests {
         assert!(
             matches!(resp, Err(OperationError::Forbidden { .. })),
             "client-origin read of a reserved credential map must be Forbidden, got {resp:?}"
+        );
+    }
+
+    /// Helper: an Anonymous `OpBatch` whose ops target `maps` in order (multi-op).
+    fn anon_op_batch_multi(maps: &[&str]) -> Operation {
+        let mut ctx = OperationContext::new(33, service_names::CRDT, make_timestamp(), 5000);
+        ctx.caller_origin = CallerOrigin::Anonymous;
+        Operation::OpBatch {
+            ctx,
+            payload: topgun_core::messages::sync::OpBatchMessage {
+                payload: topgun_core::messages::sync::OpBatchPayload {
+                    ops: maps
+                        .iter()
+                        .map(|m| topgun_core::messages::base::ClientOp {
+                            map_name: (*m).to_string(),
+                            key: "k".to_string(),
+                            ..Default::default()
+                        })
+                        .collect(),
+                    ..Default::default()
+                },
+            },
+        }
+    }
+
+    /// AC7 (multi-op regression): `classify_operation` reports only `ops.first()`,
+    /// so a reserved map in a NON-FIRST batch position must still be rejected —
+    /// otherwise `[{tags}, {_topgun_…}]` smuggles the reserved write past the
+    /// single-map check (the device-hijack door R4 exists to close). Also asserts a
+    /// case-variant prefix cannot evade the guard, and an all-non-reserved batch
+    /// still passes. RED without the per-op scan in `reserved_target_map_name`.
+    #[tokio::test]
+    async fn reserved_namespace_rejected_when_not_first_op_in_batch() {
+        let store = Arc::new(InMemoryPolicyStore::new()); // empty → AllowAll (NO_AUTH)
+        let evaluator = Arc::new(PolicyEvaluator::new(store));
+        let layer = AuthorizationLayer::new(evaluator);
+        let mut svc = layer.layer(AlwaysOkService);
+
+        // Reserved map in a non-first position: the innocuous first op must not shield it.
+        for smuggle in [
+            anon_op_batch_multi(&["tags", "_topgun_device_credentials"]),
+            anon_op_batch_multi(&["tags", "_internal", "__topgun_policies"]),
+            // Case-variant prefix must not evade the ASCII-case-insensitive check.
+            anon_op_batch_multi(&["tags", "_TOPGUN_device_credentials"]),
+        ] {
+            let resp = ServiceExt::ready(&mut svc)
+                .await
+                .unwrap()
+                .call(smuggle)
+                .await;
+            assert!(
+                matches!(resp, Err(OperationError::Forbidden { .. })),
+                "reserved map in a non-first batch position must be Forbidden, got {resp:?}"
+            );
+        }
+
+        // An all-non-reserved multi-op batch still passes.
+        let clean = anon_op_batch_multi(&["tags", "_internal"]);
+        let resp = ServiceExt::ready(&mut svc).await.unwrap().call(clean).await;
+        assert!(
+            resp.is_ok(),
+            "all-non-reserved batch must pass, got {resp:?}"
         );
     }
 }

--- a/packages/server-rust/src/service/middleware/authorization.rs
+++ b/packages/server-rust/src/service/middleware/authorization.rs
@@ -76,6 +76,22 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<OperationResponse, OperationError>> + Send>> {
         let evaluator = Arc::clone(&self.evaluator);
         let (action, map_name) = classify_operation(&op);
+        // Reserved internal keyspace guard (resource-keyed, not op-family-keyed).
+        // No client-origin op — Client / HttpClient / Anonymous, all of which reach
+        // this method — may target the server's own control-plane maps
+        // (`_topgun_*` device credentials + tombstone cursors, `__topgun_*` RBAC
+        // policies). This sits at the classification point so it fires for EVERY
+        // client op family that names a map: writes (`OpBatch`/`ClientOp`/
+        // `ORMapPushDiff`) AND reads (a NO_AUTH client must not enumerate the
+        // credential-hash rows either). It runs BEFORE the `should_evaluate` gate
+        // below, so the NO_AUTH `GateDecision::AllowAll` passthrough cannot skip it;
+        // trusted origins never reach here (they early-return in `call`), so the
+        // server's own internal writes to these maps stay exempt. Ops with an empty
+        // `map_name` (bypass group, `SqlQuery`/`VectorSearch`/`QuerySyncInit`)
+        // cannot name a reserved map, so they fall through unaffected.
+        if is_reserved_map_name(&map_name) {
+            return Box::pin(async move { Err(OperationError::Forbidden { map_name }) });
+        }
         let Some(action) = action else {
             return Box::pin(self.inner.call(op));
         };
@@ -209,6 +225,22 @@ where
         PolicyDecision::Allow => fut.await,
         PolicyDecision::Deny => Err(OperationError::Forbidden { map_name }),
     }
+}
+
+/// Reserved internal map-name prefixes. Maps under these belong to the server's
+/// own control plane — `_topgun_*` (device credentials, tombstone cursors) and
+/// `__topgun_*` (RBAC policies) — and must never be the target of a client-origin
+/// operation. A single `_topgun_` match does NOT cover `__topgun_` (the second
+/// character differs), so both are listed explicitly.
+const RESERVED_MAP_PREFIXES: [&str; 2] = ["_topgun_", "__topgun_"];
+
+/// Whether `map_name` names a reserved internal map (see [`RESERVED_MAP_PREFIXES`]).
+/// Deliberately narrow: only the `_topgun_`/`__topgun_` families are reserved, so
+/// other leading-underscore names (`_internal`, `tags`, …) stay valid.
+fn is_reserved_map_name(map_name: &str) -> bool {
+    RESERVED_MAP_PREFIXES
+        .iter()
+        .any(|prefix| map_name.starts_with(prefix))
 }
 
 /// Maps an `Operation` variant to a `PermissionAction` and a `map_name`.
@@ -895,6 +927,143 @@ mod tests {
         assert!(
             matches!(result, Err(OperationError::Forbidden { .. })),
             "tombstone write against owner condition should be denied, got {result:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // R4: reserved internal keyspace guard at the authz checkpoint.
+    // -----------------------------------------------------------------------
+
+    /// Helper: an Anonymous `OpBatch` (write) whose single op targets `map_name`.
+    fn anon_op_batch_op(map_name: &str) -> Operation {
+        let mut ctx = OperationContext::new(30, service_names::CRDT, make_timestamp(), 5000);
+        ctx.caller_origin = CallerOrigin::Anonymous;
+        Operation::OpBatch {
+            ctx,
+            payload: topgun_core::messages::sync::OpBatchMessage {
+                payload: topgun_core::messages::sync::OpBatchPayload {
+                    ops: vec![topgun_core::messages::base::ClientOp {
+                        map_name: map_name.to_string(),
+                        key: "k".to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+            },
+        }
+    }
+
+    /// Helper: an Anonymous `ORMapPushDiff` (write) targeting `map_name` — the
+    /// message-type-swap door that bypasses the `crdt.rs` data-plane arms.
+    fn anon_ormap_push_diff_op(map_name: &str) -> Operation {
+        let mut ctx = OperationContext::new(31, service_names::SYNC, make_timestamp(), 5000);
+        ctx.caller_origin = CallerOrigin::Anonymous;
+        Operation::ORMapPushDiff {
+            ctx,
+            payload: topgun_core::messages::sync::ORMapPushDiff {
+                payload: topgun_core::messages::sync::ORMapPushDiffPayload {
+                    map_name: map_name.to_string(),
+                    entries: Vec::new(),
+                },
+            },
+        }
+    }
+
+    /// Helper: a TRUSTED-origin (`Forwarded`) `ClientOp` write targeting `map_name`.
+    /// Trusted origins early-return before the guard, so an internal write to a
+    /// reserved map must still succeed.
+    fn trusted_write_op(map_name: &str) -> Operation {
+        let record = LWWRecord {
+            value: Some(rmpv::Value::Boolean(true)),
+            timestamp: make_timestamp(),
+            ttl_ms: None,
+        };
+        let mut ctx = OperationContext::new(32, service_names::CRDT, make_timestamp(), 5000);
+        ctx.caller_origin = CallerOrigin::Forwarded;
+        Operation::ClientOp {
+            ctx,
+            payload: topgun_core::messages::sync::ClientOpMessage {
+                payload: topgun_core::messages::base::ClientOp {
+                    map_name: map_name.to_string(),
+                    key: "k".to_string(),
+                    record: Some(Some(record)),
+                    ..Default::default()
+                },
+            },
+        }
+    }
+
+    /// AC7: at the authz checkpoint a CLIENT-origin op targeting a reserved
+    /// internal map is REJECTED across op families — `OpBatch`/`ClientOp` writes,
+    /// `ORMapPushDiff` (the Audit-v2 C2 message-swap door), AND a read — while a
+    /// non-reserved map passes and a TRUSTED-origin write to a reserved map still
+    /// succeeds. An EMPTY policy store makes `should_evaluate` return `AllowAll`
+    /// (the `TOPGUN_NO_AUTH` posture), so this proves the guard fires BEFORE that
+    /// permit — no policy store configured.
+    #[tokio::test]
+    async fn reserved_namespace_rejected_for_client_origin_under_no_auth() {
+        let store = Arc::new(InMemoryPolicyStore::new()); // empty → AllowAll (NO_AUTH)
+        let evaluator = Arc::new(PolicyEvaluator::new(store));
+        let layer = AuthorizationLayer::new(evaluator);
+        let mut svc = layer.layer(AlwaysOkService);
+
+        let reserved_ops = [
+            anon_op_batch_op("_topgun_device_credentials"), // OpBatch write
+            anon_write_op("_topgun_tombstone_cursors_v2"),  // ClientOp write
+            anon_ormap_push_diff_op("_topgun_device_credentials"), // ORMapPushDiff door
+            anon_query_op("__topgun_policies"),             // read + double-underscore prefix
+        ];
+        for op in reserved_ops {
+            let resp = ServiceExt::ready(&mut svc).await.unwrap().call(op).await;
+            assert!(
+                matches!(resp, Err(OperationError::Forbidden { .. })),
+                "client-origin op to a reserved map must be Forbidden, got {resp:?}"
+            );
+        }
+
+        // Non-reserved leading-underscore / plain maps are unaffected (guard narrow).
+        for accepted in [anon_write_op("_internal"), anon_write_op("tags")] {
+            let resp = ServiceExt::ready(&mut svc)
+                .await
+                .unwrap()
+                .call(accepted)
+                .await;
+            assert!(
+                resp.is_ok(),
+                "client op to a non-reserved map must pass, got {resp:?}"
+            );
+        }
+
+        // A trusted-origin write to a reserved map still succeeds — internal cursor
+        // persistence + device-auth are not broken.
+        let resp = ServiceExt::ready(&mut svc)
+            .await
+            .unwrap()
+            .call(trusted_write_op("_topgun_tombstone_cursors_v2"))
+            .await;
+        assert!(
+            resp.is_ok(),
+            "trusted-origin write to a reserved map must succeed, got {resp:?}"
+        );
+    }
+
+    /// AC7b: read-side closure — a client-origin READ of the credential map is
+    /// Forbidden, so a NO_AUTH client cannot enumerate the stored credential hashes.
+    #[tokio::test]
+    async fn reserved_namespace_read_rejected_for_client_origin() {
+        let store = Arc::new(InMemoryPolicyStore::new());
+        let evaluator = Arc::new(PolicyEvaluator::new(store));
+        let layer = AuthorizationLayer::new(evaluator);
+        let mut svc = layer.layer(AlwaysOkService);
+
+        let resp = ServiceExt::ready(&mut svc)
+            .await
+            .unwrap()
+            .call(anon_query_op("_topgun_device_credentials"))
+            .await;
+        assert!(
+            matches!(resp, Err(OperationError::Forbidden { .. })),
+            "client-origin read of a reserved credential map must be Forbidden, got {resp:?}"
         );
     }
 }

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -1439,25 +1439,48 @@ impl MapDataStore for WriteBehindDataStore {
         // Remove from staging
         self.staging.remove(&(map.to_string(), key.to_string()));
 
-        // Decrement pending count and resolve the buffered entry's durability
-        // sequence if the key was actually in the queue — this direct flush
-        // supersedes it, so its sequence must not stall the flushed watermark.
-        if let Some(removed) = &removed {
+        // Decrement pending count if the key was actually in the queue — this
+        // direct flush supersedes the buffered entry, which leaves the queue now.
+        if removed.is_some() {
             self.pending_count.fetch_sub(1, Ordering::Relaxed);
+        }
+
+        // Persist the caller-provided value directly to the inner store.
+        let now = now_millis();
+        let result = self.inner.add(map, key, value, 0, now).await;
+
+        // Resolve the superseded entry's durability sequence ONLY AFTER inner.add
+        // returns — matching the flush-loop ordering. The prefix-complete flushed
+        // watermark must never advance past a sequence whose bytes are not yet
+        // durable in the inner store; resolving before the add would expose it as
+        // flushed while the write is still in flight. On Err the WAL frame still
+        // backstops durability (a discarded write is a re-sync event), so the
+        // sequence MUST still be resolved here — leaving it pending would stall the
+        // watermark forever and freeze the tombstone durability fence.
+        if let Some(removed) = &removed {
             self.resolve_pending(removed.sequence);
         }
 
-        // Persist the caller-provided value directly to the inner store
-        let now = now_millis();
-        self.inner.add(map, key, value, 0, now).await
+        result
     }
 
     fn reset(&self) {
         self.queues.clear();
         self.staging.clear();
-        self.sequence.store(0, Ordering::Relaxed);
         self.pending_count.store(0, Ordering::Relaxed);
-        self.pending_seqs().clear();
+        // Take the pending-sequence lock across BOTH the counter reset and the
+        // set clear. `assign_tracked_sequence` locks `pending_seqs` FIRST and only
+        // then touches `sequence`, so holding the lock here makes reset mutually
+        // exclusive with it. Doing the two as separate operations leaves a window
+        // where a concurrent assign runs between them — counter reset to 0, then
+        // assign takes seq 0 and inserts it, then our clear wipes it — stranding
+        // counter=1 with an empty pending set while seq 0 is still buffered, which
+        // would let the watermark jump past the un-flushed write.
+        {
+            let mut pending = self.pending_seqs();
+            self.sequence.store(0, Ordering::Relaxed);
+            pending.clear();
+        }
         self.inner.reset();
     }
 
@@ -1661,6 +1684,13 @@ mod tests {
         calls: Arc<Mutex<Vec<SpyCall>>>,
         /// Pre-seeded values returned by `load()`.
         seeded: DashMap<(String, String), RecordValue>,
+        /// When set, `add` returns `Err` — simulates an inner-store durability
+        /// failure so the flush error path can be exercised.
+        fail_add: std::sync::atomic::AtomicBool,
+        /// Optional handshake: on the first `add`, signal `entered` then park on
+        /// `proceed` before returning. Lets a test read the outer store's
+        /// `flushed_watermark()` while a flush's inner add is in flight.
+        add_gate: Mutex<Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>>,
     }
 
     impl SpyDataStore {
@@ -1668,6 +1698,8 @@ mod tests {
             Self {
                 calls: Arc::new(Mutex::new(Vec::new())),
                 seeded: DashMap::new(),
+                fail_add: std::sync::atomic::AtomicBool::new(false),
+                add_gate: Mutex::new(None),
             }
         }
 
@@ -1679,6 +1711,22 @@ mod tests {
         fn seed(&self, map: &str, key: &str, value: RecordValue) {
             self.seeded
                 .insert((map.to_string(), key.to_string()), value);
+        }
+
+        /// Make every subsequent `add` fail (inner-store durability failure).
+        fn set_fail_add(&self, fail: bool) {
+            self.fail_add
+                .store(fail, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        /// Install a one-shot gate on `add`. Returns `(entered, proceed)`: the
+        /// store fires `entered` when it reaches the gated `add` and then awaits
+        /// `proceed` before returning.
+        fn install_add_gate(&self) -> (Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>) {
+            let entered = Arc::new(tokio::sync::Notify::new());
+            let proceed = Arc::new(tokio::sync::Notify::new());
+            *self.add_gate.lock().unwrap() = Some((Arc::clone(&entered), Arc::clone(&proceed)));
+            (entered, proceed)
         }
     }
 
@@ -1696,6 +1744,16 @@ mod tests {
                 map: map.to_string(),
                 key: key.to_string(),
             });
+            // If a gate is installed, consume it: signal that the add is now in
+            // flight, then park until the test lets it proceed.
+            let gate = self.add_gate.lock().unwrap().take();
+            if let Some((entered, proceed)) = gate {
+                entered.notify_one();
+                proceed.notified().await;
+            }
+            if self.fail_add.load(std::sync::atomic::Ordering::Relaxed) {
+                anyhow::bail!("SpyDataStore: simulated inner-store add failure");
+            }
             Ok(())
         }
 
@@ -2150,6 +2208,145 @@ mod tests {
             store.flushed_watermark(),
             assigned,
             "after a full drain every assigned sequence is durable, so the watermark reaches it"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RED-without-fix: `flush_key` must resolve the superseded sequence AFTER
+    // `inner.add` returns, not before. Gate the inner add so we can observe the
+    // watermark while the flush is parked mid-add — it must still sit at the
+    // buffered sequence. Resolving before the add (the pre-fix bug) advances the
+    // watermark past a write whose bytes are not yet durable, licensing a prune
+    // of a tombstone the inner store has not persisted.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn flush_key_resolves_watermark_after_inner_add_not_before() {
+        let spy = Arc::new(SpyDataStore::new());
+        let (entered, proceed) = spy.install_add_gate();
+        let inner: Arc<dyn MapDataStore> = spy;
+        let config = WriteBehindConfig {
+            write_delay_ms: 60_000,
+            flush_interval_ms: 60_000,
+            ..WriteBehindConfig::default()
+        };
+        let store = WriteBehindDataStore::new(inner, config);
+
+        // Buffer a write so flush_key has a queued (tracked) sequence to supersede.
+        store.add("m", "k", &dummy_value(), 0, 1).await.unwrap();
+        let buffered_seq = store.flushed_watermark();
+        let assigned = store.assigned_write_sequence();
+        assert!(
+            buffered_seq < assigned,
+            "precondition: the buffered write is not yet byte-durable"
+        );
+
+        // Run flush_key concurrently; it parks inside the gated inner add.
+        let flush_store = Arc::clone(&store);
+        let flush = tokio::spawn(async move {
+            flush_store
+                .flush_key("m", "k", &dummy_value_with(42), false)
+                .await
+        });
+
+        // Block until the flush is inside inner.add — bytes are NOT durable yet.
+        entered.notified().await;
+        assert_eq!(
+            store.flushed_watermark(),
+            buffered_seq,
+            "watermark must stay at the buffered sequence while inner.add is in flight — \
+             resolving before the add would falsely report the write as durable"
+        );
+
+        // Let the add complete; the sequence is now durable and resolvable.
+        proceed.notify_one();
+        flush.await.unwrap().unwrap();
+        assert_eq!(
+            store.flushed_watermark(),
+            assigned,
+            "after inner.add returns the resolved sequence lets the watermark advance"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // A failed `inner.add` during `flush_key` must STILL resolve the superseded
+    // sequence. The WAL frame backstops durability on `Err` (a discarded write is
+    // a re-sync event), so leaving the sequence pending would pin the flushed
+    // watermark below it forever and freeze the tombstone durability fence.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn flush_key_error_path_still_resolves_no_watermark_stall() {
+        let spy = Arc::new(SpyDataStore::new());
+        spy.set_fail_add(true);
+        let inner: Arc<dyn MapDataStore> = spy;
+        let config = WriteBehindConfig {
+            write_delay_ms: 60_000,
+            flush_interval_ms: 60_000,
+            ..WriteBehindConfig::default()
+        };
+        let store = WriteBehindDataStore::new(inner, config);
+
+        store.add("m", "k", &dummy_value(), 0, 1).await.unwrap();
+        let assigned = store.assigned_write_sequence();
+        assert!(
+            store.flushed_watermark() < assigned,
+            "precondition: buffered, not durable"
+        );
+
+        // flush_key hits the failing inner.add and surfaces the error ...
+        let result = store.flush_key("m", "k", &dummy_value_with(7), false).await;
+        assert!(
+            result.is_err(),
+            "flush_key must surface the inner-store durability failure"
+        );
+
+        // ... yet the superseded sequence is resolved anyway, so the watermark is
+        // not stalled below the assigned counter.
+        assert_eq!(
+            store.flushed_watermark(),
+            assigned,
+            "error path must resolve the pulled sequence so the watermark still advances"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC4: `reset` clears the counter and the pending set under a single
+    // `pending_seqs` critical section, so a concurrent `assign_tracked_sequence`
+    // (which locks pending_seqs before touching the counter) cannot interleave and
+    // strand counter=1 with an empty set while a sequence is still buffered. This
+    // checks the resulting consistent postcondition: watermark and counter agree.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn reset_clears_watermark_state_consistently() {
+        let inner: Arc<dyn MapDataStore> = Arc::new(SpyDataStore::new());
+        let config = WriteBehindConfig {
+            write_delay_ms: 60_000,
+            flush_interval_ms: 60_000,
+            ..WriteBehindConfig::default()
+        };
+        let store = WriteBehindDataStore::new(inner, config);
+
+        // Advance the counter and leave writes buffered (pending non-empty).
+        store.add("m", "k1", &dummy_value(), 0, 1).await.unwrap();
+        store.add("m", "k2", &dummy_value(), 0, 1).await.unwrap();
+        assert!(store.assigned_write_sequence() > 0);
+        assert!(store.flushed_watermark() < store.assigned_write_sequence());
+
+        store.reset();
+
+        // After reset the counter is 0 and the pending set is empty, so the
+        // watermark is 0 — no stranded sequence pinning it above the counter.
+        assert_eq!(
+            store.assigned_write_sequence(),
+            0,
+            "reset zeroes the counter"
+        );
+        assert_eq!(
+            store.flushed_watermark(),
+            0,
+            "reset leaves no pending sequence, so the watermark is 0 (counter and set agree)"
         );
     }
 

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -1465,22 +1465,29 @@ impl MapDataStore for WriteBehindDataStore {
     }
 
     fn reset(&self) {
+        // Hold the pending-sequence lock across ALL watermark-state clears — the
+        // queues, staging, pending_count, the sequence counter, AND the pending set
+        // — so a `reset` presents a single consistent wipe. `assign_tracked_sequence`
+        // locks `pending_seqs` FIRST and only then touches `sequence`, so holding the
+        // lock here serializes reset against the counter/pending half of an assign;
+        // clearing queues/staging/pending_count inside the same critical section
+        // keeps them from drifting out of step with the counter (e.g. a stranded
+        // staging entry under a reset counter, which would freeze the watermark).
+        //
+        // Precondition: `reset` is a teardown / full-clear operation (test harnesses
+        // and quiesced admin clears) — it is NOT called concurrently with live
+        // tracked writers. An assign's second phase (its staging insert) runs OUTSIDE
+        // this lock, so the lock cannot make reset fully atomic against an in-flight
+        // writer; the invariant that no writer races reset is what guarantees
+        // consistency, and the lock is defense-in-depth that keeps the counter/pending
+        // pair coherent.
+        let mut pending = self.pending_seqs();
         self.queues.clear();
         self.staging.clear();
         self.pending_count.store(0, Ordering::Relaxed);
-        // Take the pending-sequence lock across BOTH the counter reset and the
-        // set clear. `assign_tracked_sequence` locks `pending_seqs` FIRST and only
-        // then touches `sequence`, so holding the lock here makes reset mutually
-        // exclusive with it. Doing the two as separate operations leaves a window
-        // where a concurrent assign runs between them — counter reset to 0, then
-        // assign takes seq 0 and inserts it, then our clear wipes it — stranding
-        // counter=1 with an empty pending set while seq 0 is still buffered, which
-        // would let the watermark jump past the un-flushed write.
-        {
-            let mut pending = self.pending_seqs();
-            self.sequence.store(0, Ordering::Relaxed);
-            pending.clear();
-        }
+        self.sequence.store(0, Ordering::Relaxed);
+        pending.clear();
+        drop(pending);
         self.inner.reset();
     }
 

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -546,6 +546,13 @@ impl TombstoneFrontier {
         // must not panic in `tokio::spawn`.
         let (persist_tx, persist_worker) = match store.as_ref() {
             Some(store) if tokio::runtime::Handle::try_current().is_ok() => {
+                // Unbounded on purpose: the messages are tiny (client id + epoch), the
+                // single worker drains them fast (one buffered store write each), and
+                // the `Forget`/`Barrier` variants carry oneshots that must never be
+                // dropped — so a bounded channel could not simply drop-on-full. A
+                // best-effort cursor persist whose loss only costs a resync does not
+                // justify back-pressuring the ACK read loop. Bounding it under a real
+                // sustained-burst OOM budget is a post-soak hardening follow-up.
                 let (tx, rx) = mpsc::unbounded_channel();
                 let handle = tokio::spawn(cursor_persist_worker(Arc::clone(store), rx));
                 (Mutex::new(Some(tx)), Mutex::new(Some(handle)))
@@ -691,22 +698,29 @@ impl TombstoneFrontier {
         claimed: Epoch,
         conn: ConnectionId,
     ) -> bool {
-        // Compute + apply the advance under the lock, then drop it.
-        let advanced = self.lock().advance_on_ack(client, claimed, conn);
-        let Some(epoch) = advanced else {
-            return false;
+        // Compute + apply the advance AND enqueue the offloaded persist while STILL
+        // holding the state lock. The durable write itself is offloaded (the ACK read
+        // loop never awaits redb — that stays off the hot path), but the enqueue must
+        // be under the lock so the worker observes advances and forgets in the SAME
+        // order as their in-memory effects. If the enqueue happened after the lock
+        // dropped, a concurrent `forget_client` could interleave and enqueue its
+        // delete BEFORE this advance, letting the worker delete then re-persist and
+        // resurrect a forgotten cursor. `enqueue_persist` is a non-blocking channel
+        // send, so holding the std Mutex across it is safe (no await under the lock).
+        let advanced = {
+            let mut state = self.lock();
+            let advanced = state.advance_on_ack(client, claimed, conn);
+            if let Some(epoch) = advanced {
+                if !self.enqueue_persist(PersistMsg::Advance {
+                    client: client.clone(),
+                    epoch,
+                }) {
+                    debug!(client = %client, epoch, "cursor advance not enqueued (no persistence worker)");
+                }
+            }
+            advanced
         };
-        // Offload the durable persist onto the background worker: the in-memory
-        // advance above already fed the live LWM under the lock, and the redb write
-        // is a best-effort durability continuation. Awaiting it inline would
-        // head-of-line-block this per-connection ACK read loop under an ACK burst or
-        // a slow disk. A non-blocking enqueue keeps the loop free; the worker's FIFO
-        // serialization + high-water check keep the persisted cursor monotone.
-        self.enqueue_persist(PersistMsg::Advance {
-            client: client.clone(),
-            epoch,
-        });
-        true
+        advanced.is_some()
     }
 
     /// Whether `client` has regressed below `claim` reported at sync-initiation
@@ -798,14 +812,14 @@ impl TombstoneFrontier {
     /// premature prune), and 342f's orphan TTL is the backstop for a genuinely
     /// abandoned row.
     pub async fn forget_client(&self, client: &ClientId) {
-        self.lock().forget_client(client);
-        // Route the durable delete through the SAME worker queue as the offloaded
-        // advances, then await it. FIFO ordering makes the delete run strictly after
-        // every prior offloaded advance for this client, closing the resurrection
-        // window a detached persist would open (a persist landing after the delete
-        // would re-create the stale row). If no worker is wired (no store), this is
-        // a no-op — the in-memory forget above already ran.
+        // Do the in-memory forget AND enqueue the durable delete under the SAME state
+        // lock (see `confirm_apply_ack`): FIFO then orders the delete strictly after
+        // every prior offloaded advance for this client — a late advance can no longer
+        // land after the delete and resurrect the stale row. Enqueue is a non-blocking
+        // send; the `done` oneshot is awaited AFTER the lock drops.
         let rx = {
+            let mut state = self.lock();
+            state.forget_client(client);
             let (done_tx, done_rx) = oneshot::channel();
             if self.enqueue_persist(PersistMsg::Forget {
                 client: client.clone(),
@@ -816,9 +830,22 @@ impl TombstoneFrontier {
                 None
             }
         };
-        if let Some(rx) = rx {
+        match rx {
             // A dropped sender (worker gone) resolves to Err — never hang.
-            let _ = rx.await;
+            Some(rx) => {
+                let _ = rx.await;
+            }
+            // No worker (no store, or already shut down): the delete was NOT enqueued,
+            // so fall back to a direct durable delete. A forgotten client's row must
+            // never survive to be rehydrated at its stale cursor on restart.
+            None => {
+                if let Some(store) = self.store.as_ref() {
+                    let now = i64::try_from(now_millis()).unwrap_or(i64::MAX);
+                    if let Err(e) = store.remove(CURSOR_MAP, client, now).await {
+                        debug!(client = %client, "cursor forget fallback delete failed: {e}");
+                    }
+                }
+            }
         }
     }
 
@@ -1043,12 +1070,20 @@ async fn cursor_persist_worker(
         match msg {
             PersistMsg::Advance { client, epoch } => {
                 if !high_water.contains_key(&client) {
-                    let seed = load_cursor(store.as_ref(), &client)
-                        .await
-                        .ok()
-                        .flatten()
-                        .unwrap_or(0);
-                    high_water.insert(client.clone(), seed);
+                    match load_cursor(store.as_ref(), &client).await {
+                        Ok(seed) => {
+                            high_water.insert(client.clone(), seed.unwrap_or(0));
+                        }
+                        Err(e) => {
+                            // Do NOT seed 0 on a transient load error — that would let
+                            // this advance clobber a higher cursor a previous process
+                            // persisted (monotonicity regression). Skip; a later advance
+                            // re-attempts the seed. Best-effort and safe: a missed
+                            // advance leaves a lower persisted cursor = less prune.
+                            debug!(client = %client, epoch, "cursor seed load failed: {e}; deferring advance");
+                            continue;
+                        }
+                    }
                 }
                 let current = high_water.get(&client).copied().unwrap_or(0);
                 if epoch > current {
@@ -2167,6 +2202,89 @@ mod persistence_tests {
         f.shutdown().await;
     }
 
+    // -----------------------------------------------------------------------
+    // R3(a) — a transient seed-load error must NOT seed the worker high-water to
+    // 0. If it did, a lower advance would clobber a higher cursor a previous
+    // process persisted (a cross-restart monotonicity regression). The worker
+    // instead defers the advance. RED without the fix: seed=0 → 50 > 0 → clobbers
+    // the durable 100 down to 50.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn worker_defers_advance_on_seed_load_error_no_regression() {
+        let (path, _dir) = temp_store();
+        let inner: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&path).expect("open"));
+        let c: ClientId = "a5:alice|dev-1".into();
+        // A previous process persisted a high cursor.
+        persist_cursor(inner.as_ref(), &c, 100).await.unwrap();
+
+        // The worker's store fails every `load`, so the seed load errors.
+        let store: Arc<dyn MapDataStore> =
+            Arc::new(GatedAddStore::new_failing_load(Arc::clone(&inner)));
+        let f = TombstoneFrontier::new(Some(store));
+
+        f.enqueue_advance_for_test(&c, 50);
+        f.quiesce_persists().await;
+
+        // Read the true durable value directly from the inner store: unchanged.
+        assert_eq!(
+            load_cursor(inner.as_ref(), &c).await.unwrap(),
+            Some(100),
+            "a seed-load error defers the advance; the higher durable cursor is not clobbered"
+        );
+        f.shutdown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // R3 forget-wins under concurrency (STRESS test): an ACK advance racing a
+    // forget for the same client must never resurrect the durable cursor. Both
+    // methods enqueue their durability op WHILE holding the frontier lock, so the
+    // worker sees advances and forgets in the same order as their in-memory effects
+    // — whenever the client ends untracked in memory, its durable row is gone too.
+    // This exercises the concurrent path and guards against gross regressions; it is
+    // NOT a deterministic RED (the pre-fix advance→enqueue window is only a few
+    // instructions, so it is rarely hit). The fix's real guarantee is structural:
+    // the enqueue is inside the frontier lock, so enqueue order == in-memory order.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_confirm_then_forget_never_resurrects_durable_cursor() {
+        for _ in 0..200 {
+            let (path, _dir) = temp_store();
+            let store: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&path).expect("open"));
+            let c: ClientId = "a5:alice|dev-1".into();
+            let f = Arc::new(TombstoneFrontier::new(Some(Arc::clone(&store))));
+            f.set_delivered(CONN_A, 1000);
+
+            let f1 = Arc::clone(&f);
+            let c1 = c.clone();
+            let t1 = tokio::spawn(async move {
+                f1.confirm_apply_ack(&c1, 50, CONN_A).await;
+            });
+            let f2 = Arc::clone(&f);
+            let c2 = c.clone();
+            let t2 = tokio::spawn(async move {
+                f2.forget_client(&c2).await;
+            });
+            let _ = tokio::join!(t1, t2);
+            // Drain any racing advance the worker has not yet processed.
+            f.quiesce_persists().await;
+
+            // Whenever the forget won in memory (client untracked), the durable row
+            // must be absent — a late advance must not have resurrected it. If the
+            // advance re-tracked the client instead, that is legitimate re-admission
+            // and the durable row is allowed.
+            if !f.is_tracked(&c) {
+                assert_eq!(
+                    load_cursor(store.as_ref(), &c).await.unwrap(),
+                    None,
+                    "a forgotten client's durable cursor must not be resurrected by a racing advance"
+                );
+            }
+            f.shutdown().await;
+        }
+    }
+
     // A one-shot gate letting a test park the worker inside the store's `add`.
     struct AddGate {
         /// Fired when a gated `add` is entered (before it delegates).
@@ -2190,7 +2308,9 @@ mod persistence_tests {
     struct GatedAddStore {
         inner: Arc<dyn MapDataStore>,
         gate: Arc<AddGate>,
+        gate_add: std::sync::atomic::AtomicBool,
         gated_once: std::sync::atomic::AtomicBool,
+        fail_load: std::sync::atomic::AtomicBool,
     }
 
     impl GatedAddStore {
@@ -2198,7 +2318,21 @@ mod persistence_tests {
             Self {
                 inner,
                 gate,
+                gate_add: std::sync::atomic::AtomicBool::new(true),
                 gated_once: std::sync::atomic::AtomicBool::new(false),
+                fail_load: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+
+        /// A wrapper whose `load` always errors (no add-gate) — for exercising the
+        /// worker's seed-load-error path.
+        fn new_failing_load(inner: Arc<dyn MapDataStore>) -> Self {
+            Self {
+                inner,
+                gate: Arc::new(AddGate::new()),
+                gate_add: std::sync::atomic::AtomicBool::new(false),
+                gated_once: std::sync::atomic::AtomicBool::new(false),
+                fail_load: std::sync::atomic::AtomicBool::new(true),
             }
         }
     }
@@ -2214,9 +2348,10 @@ mod persistence_tests {
             now: i64,
         ) -> anyhow::Result<()> {
             // Gate only the first add so the barrier/quiesce path is not blocked.
-            if !self
-                .gated_once
-                .swap(true, std::sync::atomic::Ordering::SeqCst)
+            if self.gate_add.load(std::sync::atomic::Ordering::SeqCst)
+                && !self
+                    .gated_once
+                    .swap(true, std::sync::atomic::Ordering::SeqCst)
             {
                 self.gate.entered.notify_one();
                 self.gate.release.notified().await;
@@ -2242,6 +2377,9 @@ mod persistence_tests {
             self.inner.remove_backup(map, key, now).await
         }
         async fn load(&self, map: &str, key: &str) -> anyhow::Result<Option<RecordValue>> {
+            if self.fail_load.load(std::sync::atomic::Ordering::SeqCst) {
+                anyhow::bail!("GatedAddStore: simulated load failure");
+            }
             self.inner.load(map, key).await
         }
         async fn load_all(

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -59,7 +59,7 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use topgun_core::hlc::Timestamp;
 use topgun_core::types::Value;
@@ -510,10 +510,12 @@ enum PersistMsg {
     /// worker's high-water for that client).
     Advance { client: ClientId, epoch: Epoch },
     /// Delete `client`'s durable cursor row. FIFO ordering guarantees this runs
-    /// after every prior `Advance` for the client; `done` signals completion.
+    /// after every prior `Advance` for the client; `done` reports the durable-delete
+    /// OUTCOME (`true` = row removed, `false` = the store delete failed) so the caller
+    /// can fall back to a direct retry when the worker's own delete did not land.
     Forget {
         client: ClientId,
-        done: oneshot::Sender<()>,
+        done: oneshot::Sender<bool>,
     },
     /// Drain barrier: signals `done` once every message enqueued before it has been
     /// processed. Lets a caller await outstanding persists without stopping the worker.
@@ -527,6 +529,21 @@ impl std::fmt::Debug for TombstoneFrontier {
             .field("tracked_clients", &tracked)
             .field("has_store", &self.store.is_some())
             .finish_non_exhaustive()
+    }
+}
+
+/// Recover a poisoned mutex guard instead of propagating the panic, logging the
+/// recovery so the underlying panic is not silent. Safe for every mutex this frontier
+/// holds: they guard best-effort state (a stale-but-consistent frontier snapshot, or an
+/// `Option` handle), and cursor-loss only degrades to a resync — but a poisoned lock
+/// still signals a prior panic worth surfacing.
+fn recover_poisoned<T>(guard: &'static str) -> impl FnOnce(std::sync::PoisonError<T>) -> T {
+    move |poison| {
+        warn!(
+            guard,
+            "recovered a poisoned tombstone-frontier mutex (a prior holder panicked)"
+        );
+        poison.into_inner()
     }
 }
 
@@ -573,7 +590,7 @@ impl TombstoneFrontier {
         let guard = self
             .persist_tx
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+            .unwrap_or_else(recover_poisoned("persist_tx"));
         match guard.as_ref() {
             Some(tx) => tx.send(msg).is_ok(),
             None => false,
@@ -623,12 +640,12 @@ impl TombstoneFrontier {
         let _ = self
             .persist_tx
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(recover_poisoned("persist_tx"))
             .take();
         let handle = self
             .persist_worker
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(recover_poisoned("persist_worker"))
             .take();
         if let Some(handle) = handle {
             let _ = handle.await;
@@ -639,9 +656,7 @@ impl TombstoneFrontier {
         // A poisoned frontier mutex means a prior panic while holding it; recover the
         // guard rather than propagate the panic — the frontier is best-effort and a
         // stale-but-consistent snapshot is safe (cursor-loss degrades to resync).
-        self.state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        self.state.lock().unwrap_or_else(recover_poisoned("state"))
     }
 
     /// Inject the server's current max stamped epoch (the global bound). Settable so
@@ -830,18 +845,20 @@ impl TombstoneFrontier {
                 None
             }
         };
-        // Whether the durable delete still needs a direct fallback. Two cases:
-        //   * `None`  — the delete was never enqueued (no store, or worker already
-        //     shut down).
-        //   * `Some(rx)` that resolves to `Err` — the delete WAS enqueued but the
-        //     worker died/was dropped before processing it (the oneshot sender was
-        //     dropped without sending), so it may never have run.
-        // Both fall through to the same direct `store.remove`. It is idempotent, so
-        // running it even when the worker did delete first is harmless. A forgotten
-        // client's row must never survive to be rehydrated at its stale cursor on
-        // restart.
+        // Whether the durable delete still needs a direct fallback. Three cases:
+        //   * `None`         — never enqueued (no store, or worker already shut down).
+        //   * `Some(Err(_))` — enqueued, but the worker died/was dropped before
+        //     processing it (the oneshot sender was dropped without sending), so the
+        //     delete may never have run.
+        //   * `Some(Ok(false))` — the worker RAN but its `store.remove` FAILED
+        //     (transient store error). Without this branch the failure would be
+        //     silently reported as success and the row would linger.
+        // Only `Some(Ok(true))` — a confirmed durable delete — skips the fallback.
+        // The fallback is the same direct `store.remove`; it is idempotent, so running
+        // it even when the worker did delete first is harmless. A forgotten client's
+        // row must never survive to be rehydrated at its stale cursor on restart.
         let needs_fallback = match rx {
-            Some(rx) => rx.await.is_err(),
+            Some(rx) => !rx.await.unwrap_or(false),
             None => true,
         };
         if needs_fallback {
@@ -1106,11 +1123,22 @@ async fn cursor_persist_worker(
             }
             PersistMsg::Forget { client, done } => {
                 let now = i64::try_from(now_millis()).unwrap_or(i64::MAX);
-                if let Err(e) = store.remove(CURSOR_MAP, &client, now).await {
-                    debug!(client = %client, "cursor forget delete failed: {e}");
-                }
+                // Report the DURABLE-DELETE OUTCOME, not merely "the worker saw the
+                // message". A swallowed store error here previously still signalled
+                // success, so `forget_client` skipped its idempotent fallback delete
+                // exactly when the delete had failed — leaving the forgotten row alive
+                // to be rehydrated at its stale cursor (the resurrection hazard the
+                // fallback exists to close). Report `false` on failure so the caller
+                // retries.
+                let removed = match store.remove(CURSOR_MAP, &client, now).await {
+                    Ok(()) => true,
+                    Err(e) => {
+                        debug!(client = %client, "cursor forget delete failed: {e}");
+                        false
+                    }
+                };
                 high_water.remove(&client);
-                let _ = done.send(());
+                let _ = done.send(removed);
             }
             PersistMsg::Barrier { done } => {
                 let _ = done.send(());
@@ -1808,6 +1836,45 @@ mod persistence_tests {
         assert_eq!(f.cursor(&c), None, "no stale cursor resurrected");
     }
 
+    /// The worker is ALIVE and processes the forget, but its `store.remove` FAILS
+    /// (transient durable error). `forget_client` must still run its idempotent
+    /// fallback delete: the worker reports the delete OUTCOME through the oneshot, so a
+    /// failed durable delete is no longer silently signalled as success. Pre-fix the
+    /// worker sent `()` unconditionally, so the fallback was skipped and the forgotten
+    /// row could survive → stale-cursor resurrection on the next rehydrate.
+    #[tokio::test]
+    async fn forget_fallback_fires_when_worker_store_remove_fails() {
+        use std::sync::atomic::Ordering::SeqCst;
+        let (path, _dir) = temp_store();
+        let c: ClientId = "a5:alice|dev-1".into();
+        let inner: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&path).expect("open"));
+
+        let faulty = GatedAddStore::new_failing_remove(Arc::clone(&inner));
+        let remove_calls = faulty.remove_calls_handle();
+        let store: Arc<dyn MapDataStore> = Arc::new(faulty);
+        let f = TombstoneFrontier::new(Some(store));
+
+        // Establish + persist a cursor (the persist path uses `add`, never `remove`).
+        f.set_delivered(CONN_A, 100);
+        assert!(f.confirm_apply_ack(&c, 50, CONN_A).await);
+        f.quiesce_persists().await;
+
+        // Count only the removes issued by the forget path.
+        remove_calls.store(0, SeqCst);
+        f.forget_client(&c).await;
+
+        // The worker attempts the durable delete (fails), reports `false`, and
+        // `forget_client` retries via its idempotent fallback → at least TWO attempts.
+        // Pre-fix this was exactly ONE (worker signalled success → fallback skipped).
+        let attempts = remove_calls.load(SeqCst);
+        assert!(
+            attempts >= 2,
+            "worker delete + fallback delete must both be attempted when the worker's \
+             store.remove fails; got {attempts} attempt(s)"
+        );
+        f.shutdown().await;
+    }
+
     /// A freshly-minted identity has no persisted cursor: rehydrate is a no-op and it
     /// stays untracked (unknown → gated), pinning nothing.
     #[tokio::test]
@@ -2316,6 +2383,10 @@ mod persistence_tests {
         gate_add: std::sync::atomic::AtomicBool,
         gated_once: std::sync::atomic::AtomicBool,
         fail_load: std::sync::atomic::AtomicBool,
+        /// When set, every `remove` fails (models a transient durable-delete error).
+        fail_remove: std::sync::atomic::AtomicBool,
+        /// Counts `remove` attempts so a test can prove the forget fallback fired.
+        remove_calls: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     impl GatedAddStore {
@@ -2326,6 +2397,8 @@ mod persistence_tests {
                 gate_add: std::sync::atomic::AtomicBool::new(true),
                 gated_once: std::sync::atomic::AtomicBool::new(false),
                 fail_load: std::sync::atomic::AtomicBool::new(false),
+                fail_remove: std::sync::atomic::AtomicBool::new(false),
+                remove_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             }
         }
 
@@ -2338,7 +2411,30 @@ mod persistence_tests {
                 gate_add: std::sync::atomic::AtomicBool::new(false),
                 gated_once: std::sync::atomic::AtomicBool::new(false),
                 fail_load: std::sync::atomic::AtomicBool::new(true),
+                fail_remove: std::sync::atomic::AtomicBool::new(false),
+                remove_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             }
+        }
+
+        /// A wrapper whose `remove` always errors (no add-gate) — for exercising the
+        /// worker-alive-but-`store.remove`-fails forget path. The returned counter
+        /// counts every `remove` attempt.
+        fn new_failing_remove(inner: Arc<dyn MapDataStore>) -> Self {
+            Self {
+                inner,
+                gate: Arc::new(AddGate::new()),
+                gate_add: std::sync::atomic::AtomicBool::new(false),
+                gated_once: std::sync::atomic::AtomicBool::new(false),
+                fail_load: std::sync::atomic::AtomicBool::new(false),
+                fail_remove: std::sync::atomic::AtomicBool::new(true),
+                remove_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            }
+        }
+
+        /// Shared handle to the `remove` attempt counter (clone before wrapping the
+        /// store in `Arc<dyn MapDataStore>`).
+        fn remove_calls_handle(&self) -> Arc<std::sync::atomic::AtomicUsize> {
+            Arc::clone(&self.remove_calls)
         }
     }
 
@@ -2376,6 +2472,11 @@ mod persistence_tests {
                 .await
         }
         async fn remove(&self, map: &str, key: &str, now: i64) -> anyhow::Result<()> {
+            self.remove_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if self.fail_remove.load(std::sync::atomic::Ordering::SeqCst) {
+                anyhow::bail!("GatedAddStore: simulated remove failure");
+            }
             self.inner.remove(map, key, now).await
         }
         async fn remove_backup(&self, map: &str, key: &str, now: i64) -> anyhow::Result<()> {

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -830,20 +830,25 @@ impl TombstoneFrontier {
                 None
             }
         };
-        match rx {
-            // A dropped sender (worker gone) resolves to Err — never hang.
-            Some(rx) => {
-                let _ = rx.await;
-            }
-            // No worker (no store, or already shut down): the delete was NOT enqueued,
-            // so fall back to a direct durable delete. A forgotten client's row must
-            // never survive to be rehydrated at its stale cursor on restart.
-            None => {
-                if let Some(store) = self.store.as_ref() {
-                    let now = i64::try_from(now_millis()).unwrap_or(i64::MAX);
-                    if let Err(e) = store.remove(CURSOR_MAP, client, now).await {
-                        debug!(client = %client, "cursor forget fallback delete failed: {e}");
-                    }
+        // Whether the durable delete still needs a direct fallback. Two cases:
+        //   * `None`  — the delete was never enqueued (no store, or worker already
+        //     shut down).
+        //   * `Some(rx)` that resolves to `Err` — the delete WAS enqueued but the
+        //     worker died/was dropped before processing it (the oneshot sender was
+        //     dropped without sending), so it may never have run.
+        // Both fall through to the same direct `store.remove`. It is idempotent, so
+        // running it even when the worker did delete first is harmless. A forgotten
+        // client's row must never survive to be rehydrated at its stale cursor on
+        // restart.
+        let needs_fallback = match rx {
+            Some(rx) => rx.await.is_err(),
+            None => true,
+        };
+        if needs_fallback {
+            if let Some(store) = self.store.as_ref() {
+                let now = i64::try_from(now_millis()).unwrap_or(i64::MAX);
+                if let Err(e) = store.remove(CURSOR_MAP, client, now).await {
+                    debug!(client = %client, "cursor forget fallback delete failed: {e}");
                 }
             }
         }

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -865,7 +865,10 @@ impl TombstoneFrontier {
             if let Some(store) = self.store.as_ref() {
                 let now = i64::try_from(now_millis()).unwrap_or(i64::MAX);
                 if let Err(e) = store.remove(CURSOR_MAP, client, now).await {
-                    debug!(client = %client, "cursor forget fallback delete failed: {e}");
+                    // Both the worker delete AND this fallback failed — a genuinely
+                    // stuck durable row. Surface at `warn!` (not `debug!`) so operators
+                    // can detect it; 342f's orphan TTL is the eventual backstop.
+                    warn!(client = %client, "cursor forget fallback delete failed: {e}");
                 }
             }
         }
@@ -1131,13 +1134,24 @@ async fn cursor_persist_worker(
                 // fallback exists to close). Report `false` on failure so the caller
                 // retries.
                 let removed = match store.remove(CURSOR_MAP, &client, now).await {
-                    Ok(()) => true,
+                    Ok(()) => {
+                        // Drop the in-memory high-water ONLY once the durable row is
+                        // actually gone. If the delete FAILED the stale row still lives
+                        // in the store, so retaining its high-water keeps a later
+                        // re-admission `Advance`'s seed consistent with the store:
+                        // otherwise the worker would re-seed from the store (or from 0
+                        // if the failed delete nonetheless removed the row) and a LOWER
+                        // re-admission cursor could clobber the higher value the client
+                        // previously reached — a durable monotonicity regression that
+                        // can drop the low-water-mark below an already-pruned watermark.
+                        high_water.remove(&client);
+                        true
+                    }
                     Err(e) => {
-                        debug!(client = %client, "cursor forget delete failed: {e}");
+                        warn!(client = %client, "cursor forget delete failed: {e}");
                         false
                     }
                 };
-                high_water.remove(&client);
                 let _ = done.send(removed);
             }
             PersistMsg::Barrier { done } => {
@@ -2228,6 +2242,59 @@ mod persistence_tests {
     }
 
     // -----------------------------------------------------------------------
+    // R3(a) — a forget whose durable delete FAILS must RETAIN the worker's
+    // high-water. Modelled with a "lost-ack" delete: the row IS removed durably
+    // but the store reports Err, so the worker observes a failed forget delete
+    // over an actually-emptied store. If the worker cleared its high-water on
+    // that failure, a later LOWER advance for the same client would re-seed from
+    // the now-empty store (seed 0) and persist the regressed cursor — dropping
+    // the durable cursor below the value the client previously reached (and below
+    // an already-pruned watermark). Clearing high-water only on a confirmed Ok
+    // delete prevents that. RED without the fix: the durable cursor comes back
+    // as Some(50).
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn forget_failed_ack_delete_retains_high_water_no_lower_reseed_regression() {
+        let (path, _dir) = temp_store();
+        let inner: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&path).expect("open"));
+        // `remove` durably deletes the row but reports Err (lost ack) → the worker sees
+        // a failed forget delete over an actually-emptied store.
+        let store: Arc<dyn MapDataStore> =
+            Arc::new(GatedAddStore::new_lossy_remove(Arc::clone(&inner)));
+        let c: ClientId = "a5:alice|dev-1".into();
+        let f = TombstoneFrontier::new(Some(store));
+
+        // Establish a high durable cursor (100).
+        f.enqueue_advance_for_test(&c, 100);
+        f.quiesce_persists().await;
+        assert_eq!(load_cursor(inner.as_ref(), &c).await.unwrap(), Some(100));
+
+        // Forget: the worker's delete lands durably (row gone) but reports Err, so the
+        // worker must RETAIN high-water[c]=100 rather than clearing it.
+        f.forget_client(&c).await;
+        f.quiesce_persists().await;
+        assert_eq!(
+            load_cursor(inner.as_ref(), &c).await.unwrap(),
+            None,
+            "the lost-ack delete still removed the durable row"
+        );
+
+        // A later LOWER advance (50) must NOT regress the durable cursor: the retained
+        // high-water (100) drops it. Without the fix the cleared high-water re-seeds
+        // from the emptied store (0) and persists 50.
+        f.enqueue_advance_for_test(&c, 50);
+        f.quiesce_persists().await;
+        assert_eq!(
+            load_cursor(inner.as_ref(), &c).await.unwrap(),
+            None,
+            "a failed-ack forget retains high-water so a lower re-advance cannot re-seed \
+             from the emptied store and persist a regressed cursor"
+        );
+        f.shutdown().await;
+    }
+
+    // -----------------------------------------------------------------------
     // R3(b) — the durable persist is OFFLOADED off the ACK read loop. The
     // in-memory LWM advances synchronously in `confirm_apply_ack` (returns true,
     // cursor == 50) while the durable write is still parked inside the store's
@@ -2385,6 +2452,12 @@ mod persistence_tests {
         fail_load: std::sync::atomic::AtomicBool,
         /// When set, every `remove` fails (models a transient durable-delete error).
         fail_remove: std::sync::atomic::AtomicBool,
+        /// When set, `remove` DELETES the row via the inner store but STILL reports
+        /// `Err` — models a delete that landed durably but whose ack was lost (a
+        /// transient error on the response path). Exercises the worker's
+        /// clear-high-water-only-on-`Ok` invariant: the row is gone yet the worker saw
+        /// a failure, so it must NOT re-seed a re-admission from the emptied store.
+        lossy_remove: std::sync::atomic::AtomicBool,
         /// Counts `remove` attempts so a test can prove the forget fallback fired.
         remove_calls: Arc<std::sync::atomic::AtomicUsize>,
     }
@@ -2398,6 +2471,7 @@ mod persistence_tests {
                 gated_once: std::sync::atomic::AtomicBool::new(false),
                 fail_load: std::sync::atomic::AtomicBool::new(false),
                 fail_remove: std::sync::atomic::AtomicBool::new(false),
+                lossy_remove: std::sync::atomic::AtomicBool::new(false),
                 remove_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             }
         }
@@ -2412,6 +2486,7 @@ mod persistence_tests {
                 gated_once: std::sync::atomic::AtomicBool::new(false),
                 fail_load: std::sync::atomic::AtomicBool::new(true),
                 fail_remove: std::sync::atomic::AtomicBool::new(false),
+                lossy_remove: std::sync::atomic::AtomicBool::new(false),
                 remove_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             }
         }
@@ -2427,6 +2502,24 @@ mod persistence_tests {
                 gated_once: std::sync::atomic::AtomicBool::new(false),
                 fail_load: std::sync::atomic::AtomicBool::new(false),
                 fail_remove: std::sync::atomic::AtomicBool::new(true),
+                lossy_remove: std::sync::atomic::AtomicBool::new(false),
+                remove_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            }
+        }
+
+        /// A wrapper whose `remove` DELETES the row through the inner store but then
+        /// reports `Err` (delete landed, ack lost). Drives the worker's
+        /// clear-high-water-only-on-`Ok` invariant: the durable row is gone yet the
+        /// worker observed a failure.
+        fn new_lossy_remove(inner: Arc<dyn MapDataStore>) -> Self {
+            Self {
+                inner,
+                gate: Arc::new(AddGate::new()),
+                gate_add: std::sync::atomic::AtomicBool::new(false),
+                gated_once: std::sync::atomic::AtomicBool::new(false),
+                fail_load: std::sync::atomic::AtomicBool::new(false),
+                fail_remove: std::sync::atomic::AtomicBool::new(false),
+                lossy_remove: std::sync::atomic::AtomicBool::new(true),
                 remove_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             }
         }
@@ -2476,6 +2569,11 @@ mod persistence_tests {
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             if self.fail_remove.load(std::sync::atomic::Ordering::SeqCst) {
                 anyhow::bail!("GatedAddStore: simulated remove failure");
+            }
+            if self.lossy_remove.load(std::sync::atomic::Ordering::SeqCst) {
+                // The delete DOES land durably, but the ack is "lost": report Err.
+                self.inner.remove(map, key, now).await?;
+                anyhow::bail!("GatedAddStore: simulated lost-ack remove (row deleted)");
             }
             self.inner.remove(map, key, now).await
         }

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -56,7 +56,7 @@
 //! pins the low-water-mark at its true confirmed-apply cursor instead of falling
 //! through the "unknown == forgotten" path (which would let the LWM jump forward).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
 use tracing::{debug, warn};
@@ -730,7 +730,16 @@ impl TombstoneFrontier {
                     client: client.clone(),
                     epoch,
                 }) {
-                    debug!(client = %client, epoch, "cursor advance not enqueued (no persistence worker)");
+                    // Distinguish the two no-worker cases: with no durable store the
+                    // miss is expected (memory-only mode, debug), but with a store
+                    // configured it means the worker already shut down while ACKs are
+                    // still arriving — every such advance is non-durable and will be
+                    // re-earned by resync after restart, which operators should see.
+                    if self.store.is_some() {
+                        warn!(client = %client, epoch, "cursor advance not persisted (persistence worker stopped)");
+                    } else {
+                        debug!(client = %client, epoch, "cursor advance not enqueued (no durable store)");
+                    }
                 }
             }
             advanced
@@ -1091,12 +1100,20 @@ async fn cursor_persist_worker(
     mut rx: mpsc::UnboundedReceiver<PersistMsg>,
 ) {
     let mut high_water: HashMap<ClientId, Epoch> = HashMap::new();
+    // Clients whose seed load has already warned. A PERSISTENT store read fault
+    // stalls a client's cursor durability indefinitely (each advance defers), and
+    // this arm runs per-ACK — so surface the FIRST failure per client at `warn!`
+    // for operators and keep the per-advance repeats at `debug!` to avoid flooding
+    // the hot path. A later successful seed clears the flag so a NEW fault warns
+    // again. Bounded by client count, like `high_water`.
+    let mut seed_load_warned: HashSet<ClientId> = HashSet::new();
     while let Some(msg) = rx.recv().await {
         match msg {
             PersistMsg::Advance { client, epoch } => {
                 if !high_water.contains_key(&client) {
                     match load_cursor(store.as_ref(), &client).await {
                         Ok(seed) => {
+                            seed_load_warned.remove(&client);
                             high_water.insert(client.clone(), seed.unwrap_or(0));
                         }
                         Err(e) => {
@@ -1105,7 +1122,11 @@ async fn cursor_persist_worker(
                             // persisted (monotonicity regression). Skip; a later advance
                             // re-attempts the seed. Best-effort and safe: a missed
                             // advance leaves a lower persisted cursor = less prune.
-                            debug!(client = %client, epoch, "cursor seed load failed: {e}; deferring advance");
+                            if seed_load_warned.insert(client.clone()) {
+                                warn!(client = %client, epoch, "cursor seed load failed: {e}; deferring advance (repeats logged at debug)");
+                            } else {
+                                debug!(client = %client, epoch, "cursor seed load failed: {e}; deferring advance");
+                            }
                             continue;
                         }
                     }

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -69,6 +69,8 @@ use crate::storage::map_data_store::MapDataStore;
 use crate::storage::record::RecordValue;
 use crate::tombstone_frontier::{CausalFrontier, ClientId, Epoch, GateToken, PruneSafety};
 use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
 
 /// Default epoch width (stamped tombstone ops per epoch) when
 /// `TOPGUN_EPOCH_WIDTH` is unset. The server-authoritative epoch counter
@@ -489,6 +491,33 @@ pub struct TombstoneFrontier {
     /// Best-effort persistence backend. `None` in tests that exercise only the
     /// in-memory advance logic; persistence then no-ops (cursor-loss is safe).
     store: Option<Arc<dyn MapDataStore>>,
+    /// Sender to the single background cursor-persistence worker. Cursor durability
+    /// (advance-persist + forget-delete) is offloaded here so the per-connection ACK
+    /// read loop never awaits a redb write. A single FIFO consumer serializes all
+    /// durability ops per client, which is what makes the persisted cursor monotone
+    /// (a stale racing advance is dropped by the worker's high-water check) AND keeps
+    /// a `forget` delete ordered strictly after every prior advance for that client
+    /// (no resurrection). `None` when there is no store (durability no-ops).
+    persist_tx: Mutex<Option<mpsc::UnboundedSender<PersistMsg>>>,
+    /// Join handle for the worker, so `shutdown` can await its exit (releasing the
+    /// store `Arc` it holds — required before a redb file can be reopened).
+    persist_worker: Mutex<Option<JoinHandle<()>>>,
+}
+
+/// A unit of work for the background cursor-persistence worker.
+enum PersistMsg {
+    /// Persist `client`'s advanced cursor (monotone: dropped if not above the
+    /// worker's high-water for that client).
+    Advance { client: ClientId, epoch: Epoch },
+    /// Delete `client`'s durable cursor row. FIFO ordering guarantees this runs
+    /// after every prior `Advance` for the client; `done` signals completion.
+    Forget {
+        client: ClientId,
+        done: oneshot::Sender<()>,
+    },
+    /// Drain barrier: signals `done` once every message enqueued before it has been
+    /// processed. Lets a caller await outstanding persists without stopping the worker.
+    Barrier { done: oneshot::Sender<()> },
 }
 
 impl std::fmt::Debug for TombstoneFrontier {
@@ -497,17 +526,105 @@ impl std::fmt::Debug for TombstoneFrontier {
         f.debug_struct("TombstoneFrontier")
             .field("tracked_clients", &tracked)
             .field("has_store", &self.store.is_some())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
 impl TombstoneFrontier {
     /// Build a frontier over an optional persistence backend.
+    ///
+    /// When a store is present a single background persistence worker is spawned;
+    /// this must therefore be called from within a tokio runtime (it always is —
+    /// server init and every `#[tokio::test]` provide one).
     #[must_use]
     pub fn new(store: Option<Arc<dyn MapDataStore>>) -> Self {
+        // Spawn the persistence worker only when a store is wired AND we are inside
+        // a tokio runtime. Every production construction is on the async server
+        // boot path (`serve` / `#[tokio::main]`), so the worker is always spawned
+        // there; the runtime guard only covers a synchronous non-runtime unit test
+        // that builds the router without ever exercising cursor persistence — it
+        // must not panic in `tokio::spawn`.
+        let (persist_tx, persist_worker) = match store.as_ref() {
+            Some(store) if tokio::runtime::Handle::try_current().is_ok() => {
+                let (tx, rx) = mpsc::unbounded_channel();
+                let handle = tokio::spawn(cursor_persist_worker(Arc::clone(store), rx));
+                (Mutex::new(Some(tx)), Mutex::new(Some(handle)))
+            }
+            _ => (Mutex::new(None), Mutex::new(None)),
+        };
         Self {
             state: Mutex::new(FrontierState::new()),
             store,
+            persist_tx,
+            persist_worker,
+        }
+    }
+
+    /// Enqueue a durability message onto the worker if one is wired. Returns
+    /// `false` if there is no worker (no store, or already shut down).
+    fn enqueue_persist(&self, msg: PersistMsg) -> bool {
+        let guard = self
+            .persist_tx
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match guard.as_ref() {
+            Some(tx) => tx.send(msg).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Enqueue a raw `Advance` directly, bypassing the in-memory monotone advance.
+    /// Test-only: lets a test deliver advances to the worker OUT OF ORDER (as a
+    /// displaced-owner race would) to prove the worker's high-water drops a stale
+    /// lower epoch.
+    #[cfg(test)]
+    fn enqueue_advance_for_test(&self, client: &ClientId, epoch: Epoch) {
+        self.enqueue_persist(PersistMsg::Advance {
+            client: client.clone(),
+            epoch,
+        });
+    }
+
+    /// Await every cursor-durability message enqueued so far (advances + forgets)
+    /// without stopping the worker. Used by tests/consumers that read the durable
+    /// cursor state right after an ACK, and anywhere a durability checkpoint is
+    /// needed before reading the store back.
+    pub async fn quiesce_persists(&self) {
+        let rx = {
+            let (done_tx, done_rx) = oneshot::channel();
+            if self.enqueue_persist(PersistMsg::Barrier { done: done_tx }) {
+                Some(done_rx)
+            } else {
+                None
+            }
+        };
+        if let Some(rx) = rx {
+            // A dropped sender (worker gone) resolves to Err — never hang.
+            let _ = rx.await;
+        }
+    }
+
+    /// Stop the background persistence worker and await its exit. Closing the
+    /// channel drains any buffered messages first (tokio mpsc delivers them before
+    /// `recv` returns `None`), so this is also a full flush; awaiting the handle
+    /// then releases the store `Arc` the worker holds (required before reopening a
+    /// redb file). Idempotent.
+    pub async fn shutdown(&self) {
+        // Drop the sender to close the channel so the worker's recv loop ends.
+        // Recover from a poisoned lock rather than panic — a poisoned mutex only
+        // means a prior panic while holding it; the Option is still consistent.
+        let _ = self
+            .persist_tx
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        let handle = self
+            .persist_worker
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(handle) = handle {
+            let _ = handle.await;
         }
     }
 
@@ -562,26 +679,33 @@ impl TombstoneFrontier {
     /// The caller MUST have already verified the ACK came from the current owner of
     /// `client` (connection-ownership fencing) — this method does not re-check
     /// ownership (it has no registry handle), only the delivered/global bounds.
+    // Kept `async` deliberately: the durable persist that used to be awaited here is
+    // now offloaded to the background worker (non-blocking enqueue), so the body no
+    // longer awaits — but this is a stable public API awaited by the websocket ACK
+    // read loop and by sim/domain tests across other files. Dropping `async` would
+    // ripple `.await` removals through every caller for no behavioural gain.
+    #[allow(clippy::unused_async)]
     pub async fn confirm_apply_ack(
         &self,
         client: &ClientId,
         claimed: Epoch,
         conn: ConnectionId,
     ) -> bool {
-        // Compute + apply the advance under the lock, then drop it BEFORE any await
-        // (the std Mutex guard is not held across the persist await).
+        // Compute + apply the advance under the lock, then drop it.
         let advanced = self.lock().advance_on_ack(client, claimed, conn);
         let Some(epoch) = advanced else {
             return false;
         };
-        if let Some(store) = self.store.as_ref() {
-            if let Err(e) = persist_cursor(store.as_ref(), client, epoch).await {
-                // Best-effort: a failed persist is safe (cursor-loss → resync). The
-                // in-memory advance already happened, so the live LWM is correct until
-                // restart; only durability across restart is affected.
-                debug!(client = %client, epoch, "cursor persist failed: {e}");
-            }
-        }
+        // Offload the durable persist onto the background worker: the in-memory
+        // advance above already fed the live LWM under the lock, and the redb write
+        // is a best-effort durability continuation. Awaiting it inline would
+        // head-of-line-block this per-connection ACK read loop under an ACK burst or
+        // a slow disk. A non-blocking enqueue keeps the loop free; the worker's FIFO
+        // serialization + high-water check keep the persisted cursor monotone.
+        self.enqueue_persist(PersistMsg::Advance {
+            client: client.clone(),
+            epoch,
+        });
         true
     }
 
@@ -675,11 +799,26 @@ impl TombstoneFrontier {
     /// abandoned row.
     pub async fn forget_client(&self, client: &ClientId) {
         self.lock().forget_client(client);
-        if let Some(store) = self.store.as_ref() {
-            let now = i64::try_from(now_millis()).unwrap_or(i64::MAX);
-            if let Err(e) = store.remove(CURSOR_MAP, client, now).await {
-                debug!(client = %client, "cursor forget delete failed: {e}");
+        // Route the durable delete through the SAME worker queue as the offloaded
+        // advances, then await it. FIFO ordering makes the delete run strictly after
+        // every prior offloaded advance for this client, closing the resurrection
+        // window a detached persist would open (a persist landing after the delete
+        // would re-create the stale row). If no worker is wired (no store), this is
+        // a no-op — the in-memory forget above already ran.
+        let rx = {
+            let (done_tx, done_rx) = oneshot::channel();
+            if self.enqueue_persist(PersistMsg::Forget {
+                client: client.clone(),
+                done: done_tx,
+            }) {
+                Some(done_rx)
+            } else {
+                None
             }
+        };
+        if let Some(rx) = rx {
+            // A dropped sender (worker gone) resolves to Err — never hang.
+            let _ = rx.await;
         }
     }
 
@@ -881,6 +1020,63 @@ fn encode_epoch(epoch: Epoch) -> Vec<u8> {
 fn decode_epoch(bytes: &[u8]) -> Option<Epoch> {
     let arr: [u8; 8] = bytes.try_into().ok()?;
     Some(Epoch::from_be_bytes(arr))
+}
+
+/// Background worker draining one frontier's cursor-persistence queue.
+///
+/// A SINGLE FIFO consumer serializes all cursor durability, which is what makes
+/// the persisted cursor monotone under a blind-clobber store (`MapDataStore::add`
+/// is last-write-by-arrival, not a timestamp LWW merge): it keeps an in-memory
+/// high-water per client and writes only on a STRICT advance, so a stale racing
+/// advance is dropped rather than clobbering a higher value. The high-water is
+/// SEEDED from the durable store the first time a client is seen, so a fresh
+/// worker after a restart can never regress a cursor a previous process persisted
+/// higher. `Forget` deletes the durable row and clears the high-water; FIFO
+/// ordering runs it strictly after every prior advance for that client, so a
+/// forgotten client cannot be resurrected by a late persist.
+async fn cursor_persist_worker(
+    store: Arc<dyn MapDataStore>,
+    mut rx: mpsc::UnboundedReceiver<PersistMsg>,
+) {
+    let mut high_water: HashMap<ClientId, Epoch> = HashMap::new();
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            PersistMsg::Advance { client, epoch } => {
+                if !high_water.contains_key(&client) {
+                    let seed = load_cursor(store.as_ref(), &client)
+                        .await
+                        .ok()
+                        .flatten()
+                        .unwrap_or(0);
+                    high_water.insert(client.clone(), seed);
+                }
+                let current = high_water.get(&client).copied().unwrap_or(0);
+                if epoch > current {
+                    match persist_cursor(store.as_ref(), &client, epoch).await {
+                        Ok(()) => {
+                            high_water.insert(client, epoch);
+                        }
+                        Err(e) => {
+                            // Best-effort: leave the high-water unchanged so a later
+                            // equal-or-higher advance retries the durable write.
+                            debug!(client = %client, epoch, "cursor persist failed: {e}");
+                        }
+                    }
+                }
+            }
+            PersistMsg::Forget { client, done } => {
+                let now = i64::try_from(now_millis()).unwrap_or(i64::MAX);
+                if let Err(e) = store.remove(CURSOR_MAP, &client, now).await {
+                    debug!(client = %client, "cursor forget delete failed: {e}");
+                }
+                high_water.remove(&client);
+                let _ = done.send(());
+            }
+            PersistMsg::Barrier { done } => {
+                let _ = done.send(());
+            }
+        }
+    }
 }
 
 /// Persist `client`'s cursor into the reserved redb keyspace as an LWW record.
@@ -1485,6 +1681,10 @@ mod persistence_tests {
             let f = TombstoneFrontier::new(Some(store));
             f.set_delivered(CONN_A, 100);
             assert!(f.confirm_apply_ack(&c, 77, CONN_A).await);
+            // Cursor persistence is offloaded to a background worker; stop it and
+            // await its exit so the write lands AND the store handle is released
+            // before the file is reopened below.
+            f.shutdown().await;
         }
 
         // Second "process": a brand-new frontier over the same file. Before rehydrate
@@ -1515,6 +1715,9 @@ mod persistence_tests {
             f.set_delivered(CONN_A, 1000);
             assert!(f.confirm_apply_ack(&lagging, 5, CONN_A).await);
             assert!(f.confirm_apply_ack(&ahead, 500, CONN_A).await);
+            // Offloaded persistence: stop the worker and release the store handle
+            // before the redb file is reopened below.
+            f.shutdown().await;
         }
 
         // Fresh frontier (server restarted). The lagging device reconnects; rehydrate
@@ -1652,6 +1855,9 @@ mod persistence_tests {
             f.set_delivered(CONN_A, 1000);
             assert!(f.confirm_apply_ack(&client, 50, CONN_A).await);
             assert_eq!(f.cursor(&client), Some(50));
+            // The cursor persist is offloaded; checkpoint it so epoch 50 is durable
+            // in the shared store before the recovery frontier rebuilds from it.
+            f.quiesce_persists().await;
             // kill -9: drop the frontier — the RAM epoch index is gone.
         }
 
@@ -1858,5 +2064,255 @@ mod persistence_tests {
             Some(legacy),
             "the untouched legacy blob survives a sweep that reclaims a stamped epoch"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // R3(a) — persisted cursor is monotone by construction. Two advances reach
+    // the worker OUT OF ORDER (a displaced owner's delayed persist racing the new
+    // owner's higher persist). The single FIFO worker's high-water drops the
+    // lower one, so the durable cursor never regresses. RED without the high-water
+    // check: the worker would write 100 then 50 and the durable cursor would be 50.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn persist_cursor_monotone_out_of_order_lower_epoch_loses() {
+        let (path, _dir) = temp_store();
+        let store: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&path).expect("open"));
+        let c: ClientId = "a5:alice|dev-1".into();
+        let f = TombstoneFrontier::new(Some(Arc::clone(&store)));
+
+        f.enqueue_advance_for_test(&c, 100);
+        f.enqueue_advance_for_test(&c, 50);
+        f.quiesce_persists().await;
+
+        assert_eq!(
+            load_cursor(store.as_ref(), &c).await.unwrap(),
+            Some(100),
+            "a lower racing advance must never overwrite a higher persisted cursor"
+        );
+        f.shutdown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // R3(a) — cross-restart monotonicity. A previous process persisted a high
+    // cursor; a fresh frontier's worker starts with an empty high-water. A lower
+    // advance must not clobber the durable higher value: the worker SEEDS its
+    // high-water from the store on first sight. RED without the seed: an empty
+    // high-water treats 50 as an advance and clobbers the persisted 100.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn persist_cursor_seeds_high_water_from_store_no_restart_regression() {
+        let (path, _dir) = temp_store();
+        let store: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&path).expect("open"));
+        let c: ClientId = "a5:alice|dev-1".into();
+        persist_cursor(store.as_ref(), &c, 100).await.unwrap();
+
+        let f = TombstoneFrontier::new(Some(Arc::clone(&store)));
+        f.enqueue_advance_for_test(&c, 50);
+        f.quiesce_persists().await;
+
+        assert_eq!(
+            load_cursor(store.as_ref(), &c).await.unwrap(),
+            Some(100),
+            "worker seeds high-water from the durable store → no cross-restart regression"
+        );
+        f.shutdown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // R3(b) — the durable persist is OFFLOADED off the ACK read loop. The
+    // in-memory LWM advances synchronously in `confirm_apply_ack` (returns true,
+    // cursor == 50) while the durable write is still parked inside the store's
+    // `add`, proving the ACK path does not await the redb write. After releasing
+    // the write and a durability checkpoint, the value is persisted.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn confirm_apply_ack_advances_lwm_without_awaiting_the_persist() {
+        let (path, _dir) = temp_store();
+        let inner: Arc<dyn MapDataStore> = Arc::new(RedbDataStore::new(&path).expect("open"));
+        let gate = Arc::new(AddGate::new());
+        let store: Arc<dyn MapDataStore> =
+            Arc::new(GatedAddStore::new(Arc::clone(&inner), Arc::clone(&gate)));
+        let c: ClientId = "a5:alice|dev-1".into();
+        let f = TombstoneFrontier::new(Some(store));
+        f.set_delivered(CONN_A, 100);
+
+        // The in-memory cursor (live LWM) advances immediately, even though the
+        // offloaded durable write is about to block.
+        assert!(f.confirm_apply_ack(&c, 50, CONN_A).await);
+        assert_eq!(
+            f.cursor(&c),
+            Some(50),
+            "in-memory LWM advanced synchronously in confirm_apply_ack"
+        );
+
+        // The worker has reached the durable write and is parked inside add().
+        gate.entered.notified().await;
+        assert_eq!(
+            load_cursor(inner.as_ref(), &c).await.unwrap(),
+            None,
+            "durable write has not completed while the in-memory LWM already reads 50"
+        );
+
+        // Release the write and checkpoint: now it is durable.
+        gate.release.notify_one();
+        f.quiesce_persists().await;
+        assert_eq!(
+            load_cursor(inner.as_ref(), &c).await.unwrap(),
+            Some(50),
+            "the offloaded persist lands after release + durability checkpoint"
+        );
+        f.shutdown().await;
+    }
+
+    // A one-shot gate letting a test park the worker inside the store's `add`.
+    struct AddGate {
+        /// Fired when a gated `add` is entered (before it delegates).
+        entered: tokio::sync::Notify,
+        /// A gated `add` awaits this before delegating to the inner store.
+        release: tokio::sync::Notify,
+    }
+
+    impl AddGate {
+        fn new() -> Self {
+            Self {
+                entered: tokio::sync::Notify::new(),
+                release: tokio::sync::Notify::new(),
+            }
+        }
+    }
+
+    /// Test store wrapper that parks the FIRST `add` on a gate so a test can observe
+    /// the in-memory LWM advancing while the durable write is still in flight. Every
+    /// other method delegates to the inner store unchanged.
+    struct GatedAddStore {
+        inner: Arc<dyn MapDataStore>,
+        gate: Arc<AddGate>,
+        gated_once: std::sync::atomic::AtomicBool,
+    }
+
+    impl GatedAddStore {
+        fn new(inner: Arc<dyn MapDataStore>, gate: Arc<AddGate>) -> Self {
+            Self {
+                inner,
+                gate,
+                gated_once: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MapDataStore for GatedAddStore {
+        async fn add(
+            &self,
+            map: &str,
+            key: &str,
+            value: &RecordValue,
+            expiration_time: i64,
+            now: i64,
+        ) -> anyhow::Result<()> {
+            // Gate only the first add so the barrier/quiesce path is not blocked.
+            if !self
+                .gated_once
+                .swap(true, std::sync::atomic::Ordering::SeqCst)
+            {
+                self.gate.entered.notify_one();
+                self.gate.release.notified().await;
+            }
+            self.inner.add(map, key, value, expiration_time, now).await
+        }
+        async fn add_backup(
+            &self,
+            map: &str,
+            key: &str,
+            value: &RecordValue,
+            expiration_time: i64,
+            now: i64,
+        ) -> anyhow::Result<()> {
+            self.inner
+                .add_backup(map, key, value, expiration_time, now)
+                .await
+        }
+        async fn remove(&self, map: &str, key: &str, now: i64) -> anyhow::Result<()> {
+            self.inner.remove(map, key, now).await
+        }
+        async fn remove_backup(&self, map: &str, key: &str, now: i64) -> anyhow::Result<()> {
+            self.inner.remove_backup(map, key, now).await
+        }
+        async fn load(&self, map: &str, key: &str) -> anyhow::Result<Option<RecordValue>> {
+            self.inner.load(map, key).await
+        }
+        async fn load_all(
+            &self,
+            map: &str,
+            keys: &[String],
+        ) -> anyhow::Result<Vec<(String, RecordValue)>> {
+            self.inner.load_all(map, keys).await
+        }
+        async fn enumerate_leaves(
+            &self,
+            map: &str,
+            is_backup: bool,
+            sink: &mut dyn crate::storage::map_data_store::LeafSink,
+        ) -> anyhow::Result<()> {
+            self.inner.enumerate_leaves(map, is_backup, sink).await
+        }
+        async fn scan_values(
+            &self,
+            map: &str,
+            is_backup: bool,
+            max_batch_cost: u64,
+        ) -> anyhow::Result<crate::storage::map_data_store::ScanBatch> {
+            self.inner.scan_values(map, is_backup, max_batch_cost).await
+        }
+        async fn scan_values_batched(
+            &self,
+            map: &str,
+            is_backup: bool,
+            cursor: crate::storage::map_data_store::ScanCursor,
+            max_batch_cost: u64,
+        ) -> anyhow::Result<crate::storage::map_data_store::ScanBatch> {
+            self.inner
+                .scan_values_batched(map, is_backup, cursor, max_batch_cost)
+                .await
+        }
+        async fn remove_all(&self, map: &str, keys: &[String]) -> anyhow::Result<()> {
+            self.inner.remove_all(map, keys).await
+        }
+        async fn list_maps(&self) -> anyhow::Result<Vec<String>> {
+            self.inner.list_maps().await
+        }
+        fn is_loadable(&self, key: &str) -> bool {
+            self.inner.is_loadable(key)
+        }
+        fn pending_operation_count(&self) -> u64 {
+            self.inner.pending_operation_count()
+        }
+        async fn soft_flush(&self) -> anyhow::Result<u64> {
+            self.inner.soft_flush().await
+        }
+        fn assigned_write_sequence(&self) -> u64 {
+            self.inner.assigned_write_sequence()
+        }
+        fn flushed_watermark(&self) -> u64 {
+            self.inner.flushed_watermark()
+        }
+        async fn hard_flush(&self) -> anyhow::Result<()> {
+            self.inner.hard_flush().await
+        }
+        async fn flush_key(
+            &self,
+            map: &str,
+            key: &str,
+            value: &RecordValue,
+            is_backup: bool,
+        ) -> anyhow::Result<()> {
+            self.inner.flush_key(map, key, value, is_backup).await
+        }
+        fn reset(&self) {
+            self.inner.reset();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes the four pre-soak durability/keyspace follow-ups (TODO-576/580/575/571) that gate the one 72h G4b soak. Three Rust files modified; R1 resolved as verification-only.

- **R2 — write-behind flushed-watermark ordering** (`write_behind.rs`): `flush_key` resolves the superseded pending seq only AFTER `inner.add` returns (error path still resolves — WAL backstops), so the durability watermark can no longer report a key flushed before the durable write landed; `reset` holds the `pending_seqs` lock across the counter reset + set clear.
- **R3 — tombstone cursor persistence offload** (`tombstone_frontier_impl.rs`): `confirm_apply_ack` no longer awaits redb on the per-connection ACK read loop; cursor durability moves to a single FIFO background worker. Monotone by construction (per-client high-water seeded from the store, never seeded 0 on load error, cleared only on a confirmed `Ok` durable delete); forget-wins preserved by enqueuing Advance/Forget under the state lock; `forget_client` retries its idempotent fallback on worker-reported delete failure. First-occurrence `warn!` diagnosability on worker-stopped and persistent seed-load faults.
- **R4 — reserved map namespace** (`authorization.rs`): client-origin ops (Client/HttpClient/Anonymous) targeting `_topgun_*`/`__topgun_*` maps are rejected at the authz `classify_operation` checkpoint — writes AND reads, covering `ClientOp`, every op in an `OpBatch`, and `ORMapPushDiff` — after the trusted-origin bypass and before the NO_AUTH `AllowAll` gate. Closes the NO_AUTH device-credential injection/enumeration vectors.

## Review trail

4 audit + 4 review cycles; every review round included a cross-vendor adversarial pass (glm-5.2) with all confirmed-real findings fixed and RED/GREEN-verified (forget-wins enqueue-order, seed-0 regression, worker-reported delete failure, failed-delete high-water retention, multi-op OpBatch guard bypass). Two structurally-real but not-prod-reachable `forget_client` vectors (zero prod callers) are pinned as blocker-gate TODO-583 for the future forget-driver spec.

## Testing

- `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --release -p topgun-server --lib`: 1617 passed / 0 failed / 1 ignored (incl. new RED-verified regression tests per fix)
- `pnpm test:sim`: 18 passed / 0 failed