### PR TITLE
Soak monitor: readied bounded-plateau instrument (report-only, honest) [SPEC-342h]

### DIFF
--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -18,12 +18,13 @@
 //!    halves are scoped to the capability each actually delivers.
 //! 3. **Bounded memory:** the OR-Map tombstone-bytes gauge
 //!    (`topgun_ormap_tombstone_bytes_total`, scraped from the server's own
-//!    `GET /metrics`) is sampled every interval and its slope is asserted
-//!    against a tight per-hour threshold — a direct, residency-independent
-//!    leak signal with no allocator/cache noise floor. Server RSS is sampled
-//!    in parallel and asserted against a looser slope as a secondary/backstop
-//!    gate; neither replaces the other (e.g. unbounded OR-Map tombstone
-//!    growth, TODO-479/480).
+//!    `GET /metrics`) is sampled every interval and its bounded-plateau slope
+//!    (last-half-window OLS, boot-recompute-gap samples excluded — see
+//!    `monitor.rs`) is asserted against a tight per-hour threshold — a direct,
+//!    residency-independent leak signal with no allocator/cache noise floor,
+//!    and a HARD gate now that the M4 tombstone bound is proven landed. Server
+//!    RSS is sampled in parallel and asserted against a looser slope as a
+//!    coarse, non-tombstone backstop gate; neither replaces the other.
 //! 4. **Zero panics:** any panic marker in server output, or any un-requested
 //!    exit, fails the run with the captured context.
 //!
@@ -68,10 +69,11 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use client::SoakClient;
 use model::{compare, next_stamp, Model};
 use monitor::{
-    assess, assess_disk, assess_tombstone_bytes, sample_disk_mb, sample_rss_mb, DiskAssessment,
-    DiskSample, MemSample, TombstoneAssessment, TombstoneSample, DEFAULT_DISK_CEILING_MB,
-    DEFAULT_DISK_MIN_GROWTH_MB, DEFAULT_DISK_THRESHOLD_MB_PER_HOUR,
-    DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+    assess, assess_disk, assess_tombstone_bytes, exclude_boot_gap_samples, sample_disk_mb,
+    sample_rss_mb, BootGap, DiskAssessment, DiskSample, MemSample, TombstoneAssessment,
+    TombstoneSample, DEFAULT_DISK_CEILING_MB, DEFAULT_DISK_MIN_GROWTH_MB,
+    DEFAULT_DISK_THRESHOLD_MB_PER_HOUR, DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+    DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
 };
 use or_noloss::{missing_acked_adds, OrLedger};
 use process::{resolve_server_binary, ServerConfig, ServerSupervisor};
@@ -164,6 +166,15 @@ impl Default for Config {
             mode_requested: false,
         }
     }
+}
+
+/// The sampler-start clock plus the mutable boot-recompute-gap window list,
+/// bundled so `recovery_checkpoint` (which records a gap around every
+/// `kill -9` + restart) takes one parameter instead of two — keeping the
+/// function under clippy's argument-count lint without an `#[allow]`.
+struct BootGapClock {
+    sampler_start: Instant,
+    boot_gaps: Arc<Mutex<Vec<BootGap>>>,
 }
 
 /// Shared atomic counters mutated by churn clients.
@@ -387,8 +398,15 @@ async fn run_soak(config: &Config) -> i32 {
     // non-200, or the metric line absent) is skipped rather than recorded as a
     // bogus point, mirroring `sample_rss_mb`'s `None`-on-gone-process contract.
     let tombstone_samples: Arc<Mutex<Vec<TombstoneSample>>> = Arc::new(Mutex::new(Vec::new()));
+    // Boot-recompute-gap windows recorded around each `kill -9` + restart
+    // cycle (`recovery_checkpoint` records both `start_secs` and, once the
+    // restarted process signals health-ready, `end_secs`). The tombstone
+    // sampler below excludes any sample landing inside one of these windows
+    // so a spurious pre-reconcile read never pollutes the OLS slope.
+    let boot_gaps: Arc<Mutex<Vec<BootGap>>> = Arc::new(Mutex::new(Vec::new()));
     {
         let samples = Arc::clone(&tombstone_samples);
+        let boot_gaps = Arc::clone(&boot_gaps);
         let stop = Arc::clone(&stop);
         let interval = config.mem_sample_interval;
         let start = sampler_start;
@@ -400,10 +418,21 @@ async fn run_soak(config: &Config) -> i32 {
                 }
                 if let Some(bytes) = scrape_tombstone_bytes(&http, port).await {
                     let elapsed = start.elapsed().as_secs_f64();
-                    samples.lock().push(TombstoneSample {
+                    let candidate = TombstoneSample {
                         elapsed_secs: elapsed,
                         bytes,
-                    });
+                    };
+                    // The exclusion predicate is a pure, retain-style helper in
+                    // `monitor.rs` (unit-tested directly by the calibration
+                    // target's synthetic boot-gap sequence, AC11) — this loop
+                    // only calls it, so the filtering logic is never
+                    // duplicated or buried here.
+                    let gaps_snapshot = boot_gaps.lock().clone();
+                    if !exclude_boot_gap_samples(std::slice::from_ref(&candidate), &gaps_snapshot)
+                        .is_empty()
+                    {
+                        samples.lock().push(candidate);
+                    }
                 }
                 tokio::time::sleep(interval).await;
             }
@@ -440,6 +469,11 @@ async fn run_soak(config: &Config) -> i32 {
             }
         });
     }
+
+    let boot_gap_clock = BootGapClock {
+        sampler_start,
+        boot_gaps: Arc::clone(&boot_gaps),
+    };
 
     // --- Orchestration loop ---
     let start = Instant::now();
@@ -488,6 +522,7 @@ async fn run_soak(config: &Config) -> i32 {
                 &jwt_secret,
                 config,
                 &paused,
+                &boot_gap_clock,
             )
             .await
             {
@@ -598,9 +633,10 @@ async fn run_soak(config: &Config) -> i32 {
     );
 
     // --- Assess tombstone-byte growth (direct residency-independent leak
-    // instrument). Coexists with the RSS gate above — neither replaces the other.
-    // The SLOPE clause is report-only today (see below); the blind-monitor clause
-    // (zero samples) hard-gates, mirroring the RSS empty-samples branch.
+    // instrument, the bounded-plateau GATE). Coexists with the RSS gate above
+    // as a coarse non-tombstone backstop — neither replaces the other. The
+    // sampling loop already excluded boot-recompute-gap samples (R9(c)), so
+    // this series is safe to fit directly.
     let tombstone_samples_snapshot = tombstone_samples.lock().clone();
     let tombstones = assess_tombstone_bytes(
         &tombstone_samples_snapshot,
@@ -608,19 +644,20 @@ async fn run_soak(config: &Config) -> i32 {
         DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
     );
 
-    // The tombstone-byte SLOPE clause is REPORT-ONLY today, not a hard gate: the
-    // OR-Map tombstone leak it measures is deliberately unbounded until TODO-566
-    // bounds it, so any or-churn soak REDding on slope is the EXPECTED honest
-    // signal (a real, known leak), not a regression. Hard-gating on it would make
-    // every or-churn soak permanently red — including the blocking no-crash CI
-    // smoke. It is surfaced as a pending (expected-fail) gate below and flips to a
-    // hard gate once TODO-566 bounds the leak (see TODO-563 Gap 4). A process-
-    // local gauge that also resets to 0 on `kill -9`/restart is a further reason
-    // it cannot gate — its slope over a cross-restart sawtooth is untrustworthy.
+    // The tombstone-byte SLOPE clause is now a HARD GATE, not report-only: the
+    // gauge is restart-survivable (`reconcile_tombstone_bytes` re-seeds it at
+    // boot, see monitor.rs), so its series is continuous across `kill -9`
+    // cycles and a trustworthy plateau/leak signal — not a per-life sawtooth.
+    // The M4 OR-Map tombstone bound is proven landed (342a-g), so a slope
+    // breach here is a genuine regression, not an expected/known leak. RSS
+    // above remains a coarse backstop: its large min-growth guard means it
+    // structurally cannot catch a single-digit-MB/KB tombstone leak on a
+    // bounded run, so it is not a substitute for this gate.
     //
-    // The blind-monitor guard, by contrast, DOES hard-gate: zero samples means
-    // the `/metrics` scrape was dead — a real harness defect independent of the
-    // leak magnitude, so a run that monitored nothing must not pass.
+    // The blind-monitor guard hard-gates independently of the slope clause:
+    // zero samples means the `/metrics` scrape was dead — a real harness
+    // defect independent of the leak magnitude, so a run that monitored
+    // nothing must not pass.
     let blind_monitor = tombstones.samples == 0;
 
     // --- Assess disk growth (durable-dir footprint; catches leaks RSS cannot
@@ -644,6 +681,7 @@ async fn run_soak(config: &Config) -> i32 {
         && recovery_failures.is_empty()
         && mem.passed
         && !blind_monitor
+        && tombstones.passed
         && !disk_blind_monitor
         && panic_report.is_none();
 
@@ -659,13 +697,13 @@ async fn run_soak(config: &Config) -> i32 {
             tombstones.reason.clone().unwrap_or_default()
         );
     } else if !tombstones.passed {
-        // Real, expected leak signal — record it as a pending gate (reported,
-        // did NOT fail the run) until TODO-566 makes bounded growth the norm.
-        pending_gates.push(format!(
-            "tombstone-byte slope {:.1} B/h exceeds {:.1} B/h — EXPECTED until \
-             TODO-566 bounds OR-Map tombstones (report-only, did NOT fail the run)",
-            tombstones.slope_bytes_per_hour, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR
-        ));
+        // The bounded-plateau gate (R9(a)): a slope breach here is a genuine
+        // regression against the proven-landed M4 tombstone bound, so it hard
+        // gates the run via `passed` above rather than merely being reported.
+        finished_reason = format!(
+            "tombstone-byte growth assertion failed: {}",
+            tombstones.reason.clone().unwrap_or_default()
+        );
     }
     if disk_blind_monitor {
         finished_reason = format!(
@@ -761,10 +799,10 @@ fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment, disk: &DiskAs
         r.memory.slope_mb_per_hour,
         if r.memory.passed { "ok" } else { "FAIL" }
     );
-    // The byte SLOPE is report-only until TODO-566 bounds the (currently
-    // deliberate) OR-Map tombstone leak; only the blind-monitor (zero-sample)
-    // clause hard-gates today. See the run-end verdict rationale.
-    let tombstone_role = "slope report-only until TODO-566; blind-monitor hard-gates";
+    // The byte SLOPE is now a bounded-plateau HARD GATE (the M4 tombstone
+    // bound is proven landed) alongside the blind-monitor (zero-sample)
+    // clause. See the run-end verdict rationale.
+    let tombstone_role = "slope + blind-monitor both hard-gate";
     println!(
         "tombstone_bytes:   first={} peak={} last={} slope={:.1}B/h samples={} -> {} ({}){}",
         tombstones.first_bytes,
@@ -964,6 +1002,7 @@ async fn recovery_checkpoint(
     jwt: &str,
     config: &Config,
     paused: &Arc<AtomicBool>,
+    boot_gap_clock: &BootGapClock,
 ) -> Result<RecoveryOutcome> {
     paused.store(true, Ordering::SeqCst);
     // Pause new client writes, then choose the pre-kill behavior:
@@ -1022,12 +1061,31 @@ async fn recovery_checkpoint(
         ));
     }
 
-    // kill -9 + restart against the same redb + WAL.
+    // kill -9 + restart against the same redb + WAL. Record the boot-recompute
+    // gap around the restart: `end_secs` starts at `f64::INFINITY` (still
+    // open) so a real-time consumer (the tombstone sampling loop) treats any
+    // sample taken before the restart is confirmed ready as excluded, rather
+    // than briefly seeing no gap at all while the restart is in flight.
+    let gap_start_secs = boot_gap_clock.sampler_start.elapsed().as_secs_f64();
+    boot_gap_clock.boot_gaps.lock().push(BootGap {
+        start_secs: gap_start_secs,
+        end_secs: f64::INFINITY,
+    });
     if let Err(e) = supervisor.restart(config.ready_timeout).await {
         out.hard
             .push(format!("server failed to restart after kill -9: {e}"));
         paused.store(false, Ordering::SeqCst);
+        // Leave the just-pushed gap open (`end_secs = INFINITY`): the run is
+        // already failing via `out.hard`, and an open gap safely excludes
+        // every subsequent tombstone sample rather than risking a stale
+        // pre-reconcile read being treated as trustworthy.
         return Ok(out);
+    }
+    {
+        let gap_end_secs = boot_gap_clock.sampler_start.elapsed().as_secs_f64();
+        if let Some(last) = boot_gap_clock.boot_gaps.lock().last_mut() {
+            last.end_secs = gap_end_secs;
+        }
     }
 
     // Post-recovery snapshot — no writes happened in between. `post_query` reads

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -642,8 +642,9 @@ async fn run_soak(config: &Config) -> i32 {
     );
 
     // --- Assess tombstone-byte growth (direct residency-independent leak
-    // instrument, the bounded-plateau GATE). Coexists with the RSS gate above
-    // as a coarse non-tombstone backstop — neither replaces the other. The
+    // instrument, the bounded-plateau signal — surfaced REPORT-ONLY today, see
+    // the routing note below). Coexists with the RSS gate above as a coarse
+    // non-tombstone backstop — neither replaces the other. The
     // sampling loop already excluded boot-recompute-gap samples (R9(c)), so
     // this series is safe to fit directly.
     let tombstone_samples_snapshot = tombstone_samples.lock().clone();
@@ -1094,9 +1095,11 @@ async fn recovery_checkpoint(
             .push(format!("server failed to restart after kill -9: {e}"));
         paused.store(false, Ordering::SeqCst);
         // Leave the just-pushed gap open (`end_secs = INFINITY`): the run is
-        // already failing via `out.hard`, and an open gap safely excludes
-        // every subsequent tombstone sample rather than risking a stale
-        // pre-reconcile read being treated as trustworthy.
+        // already failing via `out.hard`, and the still-limping server may
+        // serve stale pre-reconcile reads, so excluding subsequent samples is
+        // safer than trusting them. This does NOT blind the sampler forever —
+        // the next `recovery_checkpoint` whose `restart()` reaches health-ready
+        // closes every lingering open gap (see the close-all loop below).
         return Ok(out);
     }
     // Close the boot gap as the FIRST action after `restart()` returns ready
@@ -1104,10 +1107,22 @@ async fn recovery_checkpoint(
     // the new life). Capture the timestamp before taking the lock so lock
     // contention cannot widen the window in which a genuinely-post-reconcile
     // sample would still see the gap open and be wrongly excluded.
+    //
+    // Close EVERY still-open gap, not just the just-pushed one. A prior
+    // `recovery_checkpoint` whose `restart()` FAILED deliberately left its gap
+    // open (`end_secs = INFINITY`) so the still-limping server's stale
+    // pre-reconcile reads stay excluded — but a lone `last_mut()` would close
+    // only this checkpoint's gap and leave that earlier one open forever,
+    // blinding the tombstone sampler for the rest of the run (every later
+    // sample past its `start_secs` would be dropped). Reaching health-ready
+    // here means the gauge is trustworthy again for ALL prior lives, so any
+    // lingering open gap is closed at the same reconcile boundary.
     {
         let gap_end_secs = boot_gap_clock.sampler_start.elapsed().as_secs_f64();
-        if let Some(last) = boot_gap_clock.boot_gaps.lock().last_mut() {
-            last.end_secs = gap_end_secs;
+        for gap in boot_gap_clock.boot_gaps.lock().iter_mut() {
+            if gap.end_secs.is_infinite() {
+                gap.end_secs = gap_end_secs;
+            }
         }
     }
 

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -20,11 +20,19 @@
 //!    (`topgun_ormap_tombstone_bytes_total`, scraped from the server's own
 //!    `GET /metrics`) is sampled every interval and its bounded-plateau slope
 //!    (last-half-window OLS, boot-recompute-gap samples excluded — see
-//!    `monitor.rs`) is asserted against a tight per-hour threshold — a direct,
-//!    residency-independent leak signal with no allocator/cache noise floor,
-//!    and a HARD gate now that the M4 tombstone bound is proven landed. Server
-//!    RSS is sampled in parallel and asserted against a looser slope as a
-//!    coarse, non-tombstone backstop gate; neither replaces the other.
+//!    `monitor.rs`) is computed against a tight per-hour threshold — a direct,
+//!    residency-independent leak signal with no allocator/cache noise floor.
+//!    The slope is surfaced REPORT-ONLY: the exported gauge is additive-only
+//!    (every tombstone-add counts; no prune-side decrement is wired yet, and
+//!    the OR-Map epoch prune is dark until a follow-up supplies the frontier's
+//!    durable-epoch watermark), so under sustained churn it climbs at the
+//!    tombstone-*creation* rate and cannot plateau within a process life —
+//!    hard-gating it would false-RED every healthy long run. Only the
+//!    blind-monitor (zero-sample) clause hard-gates. Server RSS is sampled in
+//!    parallel and asserted against a looser slope as a coarse, non-tombstone
+//!    backstop gate. (Re-promote the slope to a hard gate once the
+//!    prune-activation follow-up makes the gauge track residency and a live
+//!    bounded soak is observed to actually plateau.)
 //! 4. **Zero panics:** any panic marker in server output, or any un-requested
 //!    exit, fails the run with the captured context.
 //!
@@ -646,15 +654,19 @@ async fn run_soak(config: &Config) -> i32 {
         DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
     );
 
-    // The tombstone-byte SLOPE clause is now a HARD GATE, not report-only: the
-    // gauge is restart-survivable (`reconcile_tombstone_bytes` re-seeds it at
-    // boot, see monitor.rs), so its series is continuous across `kill -9`
-    // cycles and a trustworthy plateau/leak signal — not a per-life sawtooth.
-    // The M4 OR-Map tombstone bound is proven landed (342a-g), so a slope
-    // breach here is a genuine regression, not an expected/known leak. RSS
-    // above remains a coarse backstop: its large min-growth guard means it
-    // structurally cannot catch a single-digit-MB/KB tombstone leak on a
-    // bounded run, so it is not a substitute for this gate.
+    // The tombstone-byte SLOPE clause is REPORT-ONLY (mirrors the disk gate
+    // below), NOT a hard gate. The exported gauge (`add_tombstone_bytes`) is
+    // additive-only: it counts every tombstone-add and is never decremented on
+    // prune (no `sub_tombstone_bytes` call site yet), and the OR-Map epoch
+    // prune is dark until a follow-up supplies the frontier's durable-epoch
+    // watermark. So under the soak's sustained OR churn the gauge climbs at the
+    // tombstone-*creation* rate and cannot plateau within a process life —
+    // hard-gating the slope would false-RED the blocking no-crash Soak Smoke
+    // G4b run and any 10-60 min / 72h soak. The slope is surfaced via
+    // `pending_gates` (an honest, non-failing signal) until the prune-activation
+    // follow-up makes the gauge track residency; re-promote to a hard gate then.
+    // RSS above remains a coarse, non-tombstone backstop (its large min-growth
+    // guard cannot catch a single-digit-MB/KB tombstone leak on a bounded run).
     //
     // The blind-monitor guard hard-gates independently of the slope clause:
     // zero samples means the `/metrics` scrape was dead — a real harness
@@ -683,7 +695,6 @@ async fn run_soak(config: &Config) -> i32 {
         && recovery_failures.is_empty()
         && mem.passed
         && !blind_monitor
-        && tombstones.passed
         && !disk_blind_monitor
         && panic_report.is_none();
 
@@ -699,13 +710,17 @@ async fn run_soak(config: &Config) -> i32 {
             tombstones.reason.clone().unwrap_or_default()
         );
     } else if !tombstones.passed {
-        // The bounded-plateau gate (R9(a)): a slope breach here is a genuine
-        // regression against the proven-landed M4 tombstone bound, so it hard
-        // gates the run via `passed` above rather than merely being reported.
-        finished_reason = format!(
-            "tombstone-byte growth assertion failed: {}",
-            tombstones.reason.clone().unwrap_or_default()
-        );
+        // Report-only (mirrors the disk slope below): the additive-only gauge
+        // grows at the tombstone-creation rate under sustained churn and cannot
+        // plateau until a follow-up wires prune-side decrement + frontier-
+        // watermark activation, so a slope breach here is the EXPECTED honest
+        // signal, not a regression. Do NOT AND it into `passed`.
+        pending_gates.push(format!(
+            "tombstone-byte growth slope {:.1} bytes/h exceeds {:.1} bytes/h — \
+             EXPECTED until the OR-Map prune-activation follow-up bounds residency \
+             (report-only, did NOT fail the run)",
+            tombstones.slope_bytes_per_hour, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR
+        ));
     }
     if disk_blind_monitor {
         finished_reason = format!(
@@ -801,10 +816,11 @@ fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment, disk: &DiskAs
         r.memory.slope_mb_per_hour,
         if r.memory.passed { "ok" } else { "FAIL" }
     );
-    // The byte SLOPE is now a bounded-plateau HARD GATE (the M4 tombstone
-    // bound is proven landed) alongside the blind-monitor (zero-sample)
-    // clause. See the run-end verdict rationale.
-    let tombstone_role = "slope + blind-monitor both hard-gate";
+    // The byte SLOPE is REPORT-ONLY (the additive-only gauge cannot plateau
+    // under sustained churn until the OR-Map prune-activation follow-up wires
+    // residency tracking); only the blind-monitor (zero-sample) clause
+    // hard-gates. See the run-end verdict rationale.
+    let tombstone_role = "slope report-only pending prune-activation; blind-monitor hard-gates";
     println!(
         "tombstone_bytes:   first={} peak={} last={} slope={:.1}B/h samples={} -> {} ({}){}",
         tombstones.first_bytes,
@@ -1083,6 +1099,11 @@ async fn recovery_checkpoint(
         // pre-reconcile read being treated as trustworthy.
         return Ok(out);
     }
+    // Close the boot gap as the FIRST action after `restart()` returns ready
+    // (health-ready ⇒ `reconcile_tombstone_bytes` has re-seeded the gauge for
+    // the new life). Capture the timestamp before taking the lock so lock
+    // contention cannot widen the window in which a genuinely-post-reconcile
+    // sample would still see the gap open and be wrongly excluded.
     {
         let gap_end_secs = boot_gap_clock.sampler_start.elapsed().as_secs_f64();
         if let Some(last) = boot_gap_clock.boot_gaps.lock().last_mut() {

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -73,7 +73,7 @@ use monitor::{
     sample_rss_mb, BootGap, DiskAssessment, DiskSample, MemSample, TombstoneAssessment,
     TombstoneSample, DEFAULT_DISK_CEILING_MB, DEFAULT_DISK_MIN_GROWTH_MB,
     DEFAULT_DISK_THRESHOLD_MB_PER_HOUR, DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
-    DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+    DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
 };
 use or_noloss::{missing_acked_adds, OrLedger};
 use process::{resolve_server_binary, ServerConfig, ServerSupervisor};
@@ -426,7 +426,8 @@ async fn run_soak(config: &Config) -> i32 {
                     // `monitor.rs` (unit-tested directly by the calibration
                     // target's synthetic boot-gap sequence, AC11) — this loop
                     // only calls it, so the filtering logic is never
-                    // duplicated or buried here.
+                    // duplicated or buried here, and the tested path is the
+                    // production path.
                     let gaps_snapshot = boot_gaps.lock().clone();
                     if !exclude_boot_gap_samples(std::slice::from_ref(&candidate), &gaps_snapshot)
                         .is_empty()
@@ -642,6 +643,7 @@ async fn run_soak(config: &Config) -> i32 {
         &tombstone_samples_snapshot,
         DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
         DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+        DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
     );
 
     // The tombstone-byte SLOPE clause is now a HARD GATE, not report-only: the

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -285,6 +285,14 @@ fn last_half_window_slope_per_hour(points: &[(f64, f64)]) -> f64 {
 /// six-figure B/h "leak". This span lets the gate suppress that clause until the
 /// fitted window covers enough real time for the per-hour number to mean
 /// anything.
+///
+/// A degenerate last-half window of ≤2 points therefore yields `0.0` and is
+/// intentionally suppressed: a run that produced only one or two samples (a very
+/// short soak) cannot trip even the report-only slope clause regardless of how
+/// linear its growth looks — there is no window to extrapolate over, and the
+/// 120s [`DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS`] floor would suppress it in any
+/// case. Real bounded/72h soaks accumulate hundreds of samples, so this bounds
+/// nothing they rely on.
 fn last_half_window_span_secs(points: &[(f64, f64)]) -> f64 {
     let window = last_half_window(points);
     match (window.first(), window.last()) {
@@ -321,16 +329,19 @@ pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
 
 /// Minimum wall-clock span (seconds) of the last-half fit window before the
-/// per-hour slope clause is allowed to hard-fail the run.
+/// per-hour slope clause is surfaced as a (report-only) breach.
 ///
 /// The slope is a per-hour EXTRAPOLATION (bytes/sec × 3600). Over a sub-minute
 /// window the `3600 / span_secs` amplification is enormous: a healthy short run
 /// that has simply not yet had time to plateau (e.g. the 25s blocking CI "Short
 /// no-crash soak", ~6 samples over ~25s with a few KB of ordinary ramp-up)
-/// extrapolates to a six-figure B/h rate and would false-RED. Below this floor
-/// the slope carries no plateau signal — a leak and a not-yet-plateaued healthy
-/// run are indistinguishable — so the clause is suppressed and the run passes on
-/// the blind-monitor + absolute-growth clauses alone.
+/// extrapolates to a six-figure B/h rate and would surface a spurious breach.
+/// Below this floor the slope carries no plateau signal — a leak and a
+/// not-yet-plateaued healthy run are indistinguishable — so the clause is
+/// suppressed (no breach is emitted for it) and the assessment passes on the
+/// blind-monitor + absolute-growth clauses alone. (The breach is report-only
+/// today regardless — see [`DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR`]; this
+/// floor keeps even the report-only signal from crying wolf on a short run.)
 ///
 /// 120s sits well above the smoke run's ~10-15s last-half span (suppressed) and
 /// well below a real bounded soak's window (a 10-60 min live run's last-half
@@ -369,8 +380,8 @@ pub struct TombstoneAssessment {
 ///   treated as noise. Kept minimal (see [`DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH`]
 ///   doc) rather than mirroring the RSS gate's large guard.
 /// * `min_window_secs` — minimum wall-clock span of the last-half fit window
-///   before the per-hour slope clause is allowed to fail the run (see
-///   [`DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS`]). Guards against a
+///   before the per-hour slope clause is surfaced as a (report-only) breach
+///   (see [`DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS`]). Guards against a
 ///   too-short-to-plateau run false-REDing on the per-hour extrapolation of a
 ///   sub-minute window. Pass `0.0` to disable the guard.
 #[allow(clippy::cast_precision_loss)]

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -259,9 +259,35 @@ fn least_squares_slope_per_hour(points: &[(f64, f64)]) -> f64 {
 /// series even though a full-window fit would still be dragged upward by the
 /// earlier growth. `points.len() / 2` (floor) biases the split toward
 /// INCLUDING more of the recent half on an odd count.
-fn last_half_window_slope_per_hour(points: &[(f64, f64)]) -> f64 {
+///
+/// The slope statistic and the minimum-window-span guard in
+/// [`assess_tombstone_bytes`] MUST agree on which samples make up the "recent
+/// half" — otherwise the guard could clear a window the slope was actually fit
+/// over (or vice versa) — so both derive it from [`last_half_window`].
+fn last_half_window(points: &[(f64, f64)]) -> &[(f64, f64)] {
     let half = points.len() / 2;
-    least_squares_slope_per_hour(&points[half..])
+    &points[half..]
+}
+
+fn last_half_window_slope_per_hour(points: &[(f64, f64)]) -> f64 {
+    least_squares_slope_per_hour(last_half_window(points))
+}
+
+/// Wall-clock span (seconds) covered by the last-half window — `0.0` when that
+/// window has fewer than two points (no meaningful span to extrapolate over).
+///
+/// Gates the per-hour slope clause in [`assess_tombstone_bytes`]: the per-hour
+/// rate is an extrapolation (bytes/sec × 3600), so over a sub-minute window the
+/// `3600 / span` amplification turns a few KB of ordinary ramp-up into a
+/// six-figure B/h "leak". This span lets the gate suppress that clause until the
+/// fitted window covers enough real time for the per-hour number to mean
+/// anything.
+fn last_half_window_span_secs(points: &[(f64, f64)]) -> f64 {
+    let window = last_half_window(points);
+    match (window.first(), window.last()) {
+        (Some(first), Some(last)) if window.len() >= 2 => last.0 - first.0,
+        _ => 0.0,
+    }
 }
 
 /// Calibrated slope ceiling (bytes/hour) for the tombstone-byte gate.
@@ -288,6 +314,26 @@ pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 /// so a one/two-sample run (degenerate least-squares fit) cannot trip the
 /// clause on rounding.
 pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
+
+/// Minimum wall-clock span (seconds) of the last-half fit window before the
+/// per-hour slope clause is allowed to hard-fail the run.
+///
+/// The slope is a per-hour EXTRAPOLATION (bytes/sec × 3600). Over a sub-minute
+/// window the `3600 / span_secs` amplification is enormous: a healthy short run
+/// that has simply not yet had time to plateau (e.g. the 25s blocking CI "Short
+/// no-crash soak", ~6 samples over ~25s with a few KB of ordinary ramp-up)
+/// extrapolates to a six-figure B/h rate and would false-RED. Below this floor
+/// the slope carries no plateau signal — a leak and a not-yet-plateaued healthy
+/// run are indistinguishable — so the clause is suppressed and the run passes on
+/// the blind-monitor + absolute-growth clauses alone.
+///
+/// 120s sits well above the smoke run's ~10-15s last-half span (suppressed) and
+/// well below a real bounded soak's window (a 10-60 min live run's last-half
+/// span is minutes, so a genuine leak still trips the clause; the 72h soak's
+/// span is orders of magnitude above it). The gauge is restart-survivable, so a
+/// crash-enabled long run keeps a continuous series whose window clears the
+/// floor.
+pub const DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS: f64 = 120.0;
 
 /// One tombstone-byte-gauge sample (`topgun_ormap_tombstone_bytes_total`,
 /// scraped over HTTP). `bytes` is `u64` — a counted byte total is a
@@ -317,11 +363,17 @@ pub struct TombstoneAssessment {
 /// * `min_growth_bytes` — absolute growth (peak − first) below which slope is
 ///   treated as noise. Kept minimal (see [`DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH`]
 ///   doc) rather than mirroring the RSS gate's large guard.
+/// * `min_window_secs` — minimum wall-clock span of the last-half fit window
+///   before the per-hour slope clause is allowed to fail the run (see
+///   [`DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS`]). Guards against a
+///   too-short-to-plateau run false-REDing on the per-hour extrapolation of a
+///   sub-minute window. Pass `0.0` to disable the guard.
 #[allow(clippy::cast_precision_loss)]
 pub fn assess_tombstone_bytes(
     samples: &[TombstoneSample],
     threshold_bytes_per_hour: f64,
     min_growth_bytes: f64,
+    min_window_secs: f64,
 ) -> TombstoneAssessment {
     if samples.is_empty() {
         // Same rationale as the RSS gate's empty-samples branch: zero samples
@@ -356,16 +408,31 @@ pub fn assess_tombstone_bytes(
     // correctly reports a genuine plateau even after an earlier ramp (see
     // `last_half_window_slope_per_hour` doc).
     let slope_bytes_per_hour = last_half_window_slope_per_hour(&points);
+    // Span of the window the slope was actually fit over — the per-hour rate is
+    // an extrapolation over exactly this span, so it is what the min-window
+    // guard must clear.
+    let last_half_span_secs = last_half_window_span_secs(&points);
 
     #[allow(clippy::cast_precision_loss)]
     let growth = peak_bytes.saturating_sub(first_bytes) as f64;
     let mut reasons = Vec::new();
 
-    if growth >= min_growth_bytes && slope_bytes_per_hour > threshold_bytes_per_hour {
+    // The per-hour slope clause only carries a plateau/leak signal once the fit
+    // window spans enough wall-clock time (min_window_secs). Below that, the
+    // per-hour extrapolation of a sub-minute window is dominated by the
+    // `3600 / span` amplification — a healthy run that simply has not plateaued
+    // yet is indistinguishable from a leak — so the clause is suppressed and the
+    // run passes on the blind-monitor + absolute-growth clauses alone. A real
+    // unbounded leak still trips it once the run is long enough (the 72h soak's
+    // window is orders of magnitude above the floor).
+    if last_half_span_secs >= min_window_secs
+        && growth >= min_growth_bytes
+        && slope_bytes_per_hour > threshold_bytes_per_hour
+    {
         reasons.push(format!(
             "tombstone-byte growth slope {slope_bytes_per_hour:.1} bytes/h exceeds \
              {threshold_bytes_per_hour:.1} bytes/h (total growth {growth:.0} bytes over {} \
-             samples)",
+             samples, last-half window {last_half_span_secs:.0}s)",
             samples.len()
         ));
     }
@@ -776,6 +843,7 @@ mod tests {
             &samples,
             DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
             DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+            DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
         );
         assert!(
             !a.passed,
@@ -795,6 +863,7 @@ mod tests {
             &samples,
             DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
             DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+            DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
         );
         assert!(
             a.passed,
@@ -812,6 +881,7 @@ mod tests {
             &[],
             DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
             DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+            DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
         );
         assert!(!a.passed, "zero samples must fail as a blind monitor");
     }
@@ -834,6 +904,7 @@ mod tests {
             &byte_samples,
             DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
             DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+            DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
         );
         assert!(
             !bytes_assessment.passed,
@@ -891,6 +962,7 @@ mod tests {
             &samples,
             DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
             DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+            DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
         );
         assert!(
             a.passed,
@@ -995,6 +1067,7 @@ mod tests {
             &filtered,
             DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
             DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+            DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
         );
         assert!(
             a.passed,
@@ -1009,11 +1082,63 @@ mod tests {
             &samples,
             DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
             DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+            DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
         );
         assert!(
             !unfiltered.passed,
             "sanity: the unfiltered series with the boot-gap dip must actually \
              trip the gate, or this test would not be proving anything"
+        );
+    }
+
+    /// Regression lock for the blocking CI "Short no-crash soak must be GREEN"
+    /// gate: a too-short-to-plateau run grows the tombstone gauge by a few KB
+    /// while the keyspace fills but has not had wall-clock time to plateau. Its
+    /// last-half fit window spans only seconds, so the per-hour extrapolation is
+    /// meaningless (a few KB over ~25s reads as a six-figure B/h "leak"). The
+    /// minimum-window-span guard MUST suppress the slope clause so the run
+    /// PASSES. Proven load-bearing: the SAME series with the guard disabled
+    /// (`min_window_secs = 0.0`) FAILS — this is exactly the reproduced smoke
+    /// regression the guard closes.
+    #[test]
+    fn calibration_short_run_below_min_window_passes() {
+        // 6 samples at 5s intervals = 25s total, linear 0 -> 6000 bytes — the
+        // exact shape reproduced FAILing the blocking CI smoke gate.
+        let samples: Vec<TombstoneSample> = (0..6u32)
+            .map(|i| TombstoneSample {
+                elapsed_secs: f64::from(i) * 5.0,
+                bytes: u64::from(i) * 1_200,
+            })
+            .collect();
+
+        // Guard disabled: the sub-minute per-hour slope is enormous and trips
+        // the gate — without this the test would prove nothing.
+        let no_guard = assess_tombstone_bytes(
+            &samples,
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+            0.0,
+        );
+        assert!(
+            !no_guard.passed,
+            "sanity: with the window guard disabled the sub-minute slope must \
+             trip the gate (slope={:.0} B/h) — otherwise this test is vacuous",
+            no_guard.slope_bytes_per_hour
+        );
+        assert!(no_guard.slope_bytes_per_hour > DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR);
+
+        // Real guard: the too-short window is suppressed and the run passes.
+        let guarded = assess_tombstone_bytes(
+            &samples,
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+            DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
+        );
+        assert!(
+            guarded.passed,
+            "a too-short-to-plateau run (last-half window well under the \
+             {:.0}s floor) must pass; slope={:.0} B/h reason={:?}",
+            DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS, guarded.slope_bytes_per_hour, guarded.reason
         );
     }
 

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -64,20 +64,23 @@
 //!
 //! Note on gating responsibility: [`assess_tombstone_bytes`] *computes* the byte
 //! verdict (including its `passed` flag), but whether that verdict gates the run
-//! is decided in `main.rs`, not here. The byte **slope** now GATES the run: the
-//! gauge is restart-survivable (`reconcile_tombstone_bytes` in
-//! `bin/topgun_server.rs` re-seeds it via `set_tombstone_bytes` at boot, before
-//! the listener starts accepting connections), so across a crash-enabled run its
-//! series is CONTINUOUS — not a per-life sawtooth — and the OLS slope is a
-//! trustworthy plateau/leak signal. `main.rs` routes a slope breach to a hard
-//! failure (alongside the blind-monitor zero-sample case, which always
-//! hard-gated). The RSS gate above remains a coarse, non-tombstone backstop
-//! (its large min-growth guard means it structurally cannot catch a
-//! single-digit-MB/KB tombstone leak on a bounded run — see that gate's own doc
-//! above) — it is not replaced, just no longer the only hard gate. So this
-//! module's `passed: bool` on [`TombstoneAssessment`] IS load-bearing; see
-//! `main.rs`'s run-end verdict-assembly for exactly how it combines with the
-//! other gates.
+//! is decided in `main.rs`, not here. The byte **slope** is surfaced
+//! REPORT-ONLY, NOT hard-gated. Although the gauge is restart-survivable
+//! (`reconcile_tombstone_bytes` in `bin/topgun_server.rs` re-seeds it via
+//! `set_tombstone_bytes` at boot), it is ADDITIVE-ONLY within a process life:
+//! every tombstone-add increments it and no prune-side decrement is wired yet
+//! (`sub_tombstone_bytes` has no live call site), and the OR-Map epoch prune is
+//! dark until a follow-up supplies the frontier's durable-epoch watermark. So
+//! under sustained OR churn the gauge climbs at the tombstone-*creation* rate
+//! and cannot plateau — hard-gating the slope would false-RED every healthy
+//! long run. `main.rs` therefore routes a slope breach to its `pending_gates`
+//! (honest, non-failing) channel, exactly like the disk gate; only the
+//! blind-monitor zero-sample case hard-gates. The RSS gate above remains a
+//! coarse, non-tombstone backstop. Re-promote the slope to a hard gate once the
+//! prune-activation follow-up makes the gauge track residency and a live
+//! bounded soak is observed to plateau. (This module's `passed: bool` on
+//! [`TombstoneAssessment`] still drives the report-only signal and the
+//! calibration tests below.)
 //!
 //! ## Boot-recompute-gap exclusion
 //!
@@ -299,9 +302,11 @@ fn last_half_window_span_secs(points: &[(f64, f64)]) -> f64 {
 /// Consumed by `main.rs` (the soak loop scrapes `GET /metrics` and calls
 /// [`assess_tombstone_bytes`] with this threshold alongside the RSS `assess`) and
 /// by the `soak_monitor_calibration` integration target's tests — the harness
-/// wiring has landed, so no `allow(dead_code)` is needed here. This is the
-/// bounded-plateau GATE (hard-fails the run on breach); the RSS gate above is
-/// the coarse backstop.
+/// wiring has landed, so no `allow(dead_code)` is needed here. The slope this
+/// threshold measures is surfaced REPORT-ONLY by `main.rs` (the additive-only
+/// gauge cannot plateau under sustained churn until an OR-Map prune-activation
+/// follow-up wires residency tracking); the blind-monitor zero-sample clause is
+/// the only tombstone hard gate today. RSS above is the coarse backstop.
 pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 
 /// Absolute-growth guard (bytes) for the tombstone-byte slope clause.
@@ -472,6 +477,13 @@ pub struct BootGap {
 }
 
 /// True if `elapsed_secs` falls inside any recorded [`BootGap`].
+///
+/// The window is half-open `[start_secs, end_secs)`, and `start_secs` is
+/// recorded just BEFORE the `kill -9`, so a sample from the still-alive
+/// pre-kill process can be excluded. That conservatism is intentional: dropping
+/// a couple of trustworthy pre-kill samples is strictly safer than ever
+/// admitting a post-kill, pre-reconcile spurious low/zero read into the slope
+/// fit — the gap is deliberately a touch wider than the strict kill→ready span.
 fn in_boot_gap(elapsed_secs: f64, boot_gaps: &[BootGap]) -> bool {
     boot_gaps
         .iter()
@@ -939,10 +951,17 @@ mod tests {
         );
     }
 
-    /// AC10: the realistic M4-bounded shape — tombstone bytes grow while the
-    /// churn stream fills the keyspace, then flatten once the bound engages.
-    /// Only the LAST-HALF window should drive the fitted slope (R9(d)), so
-    /// this must PASS even though the run grew substantially earlier.
+    /// The grow-then-flatten shape a residency-tracking gauge WOULD produce once
+    /// the OR-Map bound engages: tombstone bytes grow while the churn stream
+    /// fills the keyspace, then flatten. Only the LAST-HALF window should drive
+    /// the fitted slope (R9(d)), so this PASSes even though the run grew earlier.
+    ///
+    /// NOTE — this validates the OLS/last-half-window MATH only; it is NOT a
+    /// reachable production PASS today. The `bytes` series here is hand-authored
+    /// to flatten, but the live gauge is additive-only and cannot flatten under
+    /// sustained churn (see `calibration_additive_only_gauge_never_plateaus`
+    /// below) — which is exactly why `main.rs` surfaces the slope report-only
+    /// rather than hard-gating it.
     #[test]
     fn calibration_delayed_plateau_grow_then_flatten_passes() {
         let mut samples = Vec::new();
@@ -968,6 +987,41 @@ mod tests {
             a.passed,
             "delayed-plateau (grow-then-flatten) must pass on the last-half-window \
              slope; slope={:.2} reason={:?}",
+            a.slope_bytes_per_hour, a.reason
+        );
+    }
+
+    /// Pins the REAL production shape and the reason the slope is report-only.
+    ///
+    /// The exported gauge (`add_tombstone_bytes`) is additive-only: it counts
+    /// every tombstone-add and is never decremented on prune, and the OR-Map
+    /// epoch prune is dark until a follow-up supplies the frontier watermark.
+    /// So under sustained OR churn the gauge climbs monotonically at the
+    /// tombstone-*creation* rate and never flattens within a process life — the
+    /// grow-then-flatten shape the plateau statistic looks for cannot occur.
+    /// This test feeds exactly that monotone shape (well past the min-window
+    /// floor) and asserts the assessment reports NOT-passed — which is why
+    /// `main.rs` routes this verdict to `pending_gates` (report-only) instead
+    /// of hard-gating the run. When a prune-activation follow-up makes the gauge
+    /// track residency, replace this with a genuine live-plateau PASS test and
+    /// re-promote the slope to a hard gate.
+    #[test]
+    fn calibration_additive_only_gauge_never_plateaus() {
+        // ~6h of steady creation at 5000 B/h — a multi-hour last-half window
+        // (well past the 120s min-window floor), monotone, no flatten. This is
+        // the shape a real sustained-churn soak actually produces today.
+        let samples = linear_bytes_series(1_000, 6, 5_000);
+        let a = assess_tombstone_bytes(
+            &samples,
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+            DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
+        );
+        assert!(
+            !a.passed,
+            "the additive-only gauge's monotone-growth shape must NOT be reported \
+             as a plateau — this is why the slope is surfaced report-only, not \
+             hard-gated; slope={:.1} reason={:?}",
             a.slope_bytes_per_hour, a.reason
         );
     }

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -64,15 +64,33 @@
 //!
 //! Note on gating responsibility: [`assess_tombstone_bytes`] *computes* the byte
 //! verdict (including its `passed` flag), but whether that verdict gates the run
-//! is decided in `main.rs`, not here. Today the byte **slope** is report-only —
-//! the process-local counter resets to 0 on every `kill -9`, so across a
-//! crash-enabled run its series is a per-life sawtooth whose OLS slope is
-//! untrustworthy, and the OR-Map tombstone leak it measures is deliberately
-//! unbounded until TODO-566. `main.rs` therefore routes a slope breach to its
-//! `pending_gates` channel (surfaced, does NOT fail the run) and hard-gates only
-//! on the blind-monitor (zero-sample) case. So do not read this module's
-//! `passed: bool` as load-bearing everywhere — see `main.rs`'s run-end
-//! verdict-assembly for the authoritative gating decision.
+//! is decided in `main.rs`, not here. The byte **slope** now GATES the run: the
+//! gauge is restart-survivable (`reconcile_tombstone_bytes` in
+//! `bin/topgun_server.rs` re-seeds it via `set_tombstone_bytes` at boot, before
+//! the listener starts accepting connections), so across a crash-enabled run its
+//! series is CONTINUOUS — not a per-life sawtooth — and the OLS slope is a
+//! trustworthy plateau/leak signal. `main.rs` routes a slope breach to a hard
+//! failure (alongside the blind-monitor zero-sample case, which always
+//! hard-gated). The RSS gate above remains a coarse, non-tombstone backstop
+//! (its large min-growth guard means it structurally cannot catch a
+//! single-digit-MB/KB tombstone leak on a bounded run — see that gate's own doc
+//! above) — it is not replaced, just no longer the only hard gate. So this
+//! module's `passed: bool` on [`TombstoneAssessment`] IS load-bearing; see
+//! `main.rs`'s run-end verdict-assembly for exactly how it combines with the
+//! other gates.
+//!
+//! ## Boot-recompute-gap exclusion
+//!
+//! Between a process start and `reconcile_tombstone_bytes` completion there is
+//! a transient window during which the gauge is not yet trustworthy for the
+//! CURRENT life. [`exclude_boot_gap_samples`] is a pure, `retain`-style helper
+//! that drops every sample falling inside a recorded [`BootGap`] before the
+//! series reaches [`assess_tombstone_bytes`], so a spurious pre-reconcile read
+//! (or the very act of a `kill -9` and restart) can never manufacture a false
+//! leak/plateau signal. `main.rs` calls it once per scraped tombstone sample
+//! from the sampling loop; being pure and series-based, it is also driven
+//! directly by `tests::calibration_boot_gap_exclusion_does_not_trip_gate` with
+//! a fully synthetic sequence — no real process required.
 
 use std::path::Path;
 use std::process::Command;
@@ -228,6 +246,24 @@ fn least_squares_slope_per_hour(points: &[(f64, f64)]) -> f64 {
     }
 }
 
+/// Least-squares slope over just the LAST HALF of `points` (by time order),
+/// expressed as a per-hour rate.
+///
+/// This is the plateau/leak statistic for the tombstone-byte gate
+/// ([`assess_tombstone_bytes`]). A first-half/second-half growth RATIO is
+/// unstable as the denominator (first-half growth) approaches zero — exactly
+/// the shape a genuinely-bounded run produces once the M4 tombstone bound
+/// engages. A last-half-window OLS slope has no such singularity: it stays
+/// well-defined and near zero whether the window is perfectly flat or has
+/// tiny jitter, and it correctly reports near-zero on a "grow, then flatten"
+/// series even though a full-window fit would still be dragged upward by the
+/// earlier growth. `points.len() / 2` (floor) biases the split toward
+/// INCLUDING more of the recent half on an odd count.
+fn last_half_window_slope_per_hour(points: &[(f64, f64)]) -> f64 {
+    let half = points.len() / 2;
+    least_squares_slope_per_hour(&points[half..])
+}
+
 /// Calibrated slope ceiling (bytes/hour) for the tombstone-byte gate.
 ///
 /// ~0.5 KB/h. Tight by design — see the module-level "no detection floor" doc:
@@ -237,7 +273,9 @@ fn least_squares_slope_per_hour(points: &[(f64, f64)]) -> f64 {
 /// Consumed by `main.rs` (the soak loop scrapes `GET /metrics` and calls
 /// [`assess_tombstone_bytes`] with this threshold alongside the RSS `assess`) and
 /// by the `soak_monitor_calibration` integration target's tests — the harness
-/// wiring has landed, so no `allow(dead_code)` is needed here.
+/// wiring has landed, so no `allow(dead_code)` is needed here. This is the
+/// bounded-plateau GATE (hard-fails the run on breach); the RSS gate above is
+/// the coarse backstop.
 pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 
 /// Absolute-growth guard (bytes) for the tombstone-byte slope clause.
@@ -314,7 +352,10 @@ pub fn assess_tombstone_bytes(
         .iter()
         .map(|s| (s.elapsed_secs, s.bytes as f64))
         .collect();
-    let slope_bytes_per_hour = least_squares_slope_per_hour(&points);
+    // Last-half-window OLS, not the full-window fit: robust near zero and
+    // correctly reports a genuine plateau even after an earlier ramp (see
+    // `last_half_window_slope_per_hour` doc).
+    let slope_bytes_per_hour = last_half_window_slope_per_hour(&points);
 
     #[allow(clippy::cast_precision_loss)]
     let growth = peak_bytes.saturating_sub(first_bytes) as f64;
@@ -343,6 +384,50 @@ pub fn assess_tombstone_bytes(
             Some(reasons.join("; "))
         },
     }
+}
+
+/// One boot-recompute-gap window: the span (on the `elapsed_secs` clock shared
+/// with [`TombstoneSample`]) between a `kill -9` and the restarted process's
+/// health-ready signal, during which the tombstone-bytes gauge for the new
+/// process life has not yet been re-seeded by `reconcile_tombstone_bytes` and
+/// a scrape could observe a spurious low/zero total.
+///
+/// Constructed by the soak orchestrator (`main.rs`) around each
+/// `ServerSupervisor::restart` call: `start_secs` is recorded immediately
+/// before the kill, `end_secs` immediately after the restart's health-ready
+/// signal fires. `end_secs` is left at `f64::INFINITY` while a restart is
+/// still in flight, so a real-time consumer (the sampling loop) treats the gap
+/// as still-open rather than briefly reappearing as closed.
+#[derive(Debug, Clone, Copy)]
+pub struct BootGap {
+    pub start_secs: f64,
+    pub end_secs: f64,
+}
+
+/// True if `elapsed_secs` falls inside any recorded [`BootGap`].
+fn in_boot_gap(elapsed_secs: f64, boot_gaps: &[BootGap]) -> bool {
+    boot_gaps
+        .iter()
+        .any(|g| elapsed_secs >= g.start_secs && elapsed_secs < g.end_secs)
+}
+
+/// Drop every sample that falls inside a recorded boot-recompute gap.
+///
+/// PURE and `retain`-style: samples and gap windows in, a filtered `Vec` out —
+/// no process/HTTP/clock dependency. `main.rs`'s tombstone sampler calls this
+/// once per scraped sample (so a spurious pre-reconcile read never enters the
+/// series in the first place), and a calibration test drives it directly with
+/// a fully synthetic post-kill 0 -> reconciled-total sequence (AC11) without
+/// spawning any real process.
+pub fn exclude_boot_gap_samples(
+    samples: &[TombstoneSample],
+    boot_gaps: &[BootGap],
+) -> Vec<TombstoneSample> {
+    samples
+        .iter()
+        .copied()
+        .filter(|s| !in_boot_gap(s.elapsed_secs, boot_gaps))
+        .collect()
 }
 
 /// Calibrated slope ceiling (MB/hour) for the soak's on-disk data-dir growth
@@ -729,6 +814,207 @@ mod tests {
             DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
         );
         assert!(!a.passed, "zero samples must fail as a blind monitor");
+    }
+
+    /// AC10: the prune-disabled negative control, as a synthetic calibration
+    /// unit test (no live prune-disable toggle exists in the harness/server —
+    /// the live run is a documented manual step). A sustained byte-growth rate
+    /// realistic for a bounded 10-60 min run (single-digit KB total) MUST FAIL
+    /// — and specifically on the BYTE gate, not RSS: RSS's
+    /// `DEFAULT_MEM_MIN_GROWTH_MB` (80 MB) guard would false-GREEN this exact
+    /// magnitude of growth, so the byte gate is the only instrument that can
+    /// actually deliver the required FAIL.
+    #[test]
+    fn calibration_sustained_growth_fails_byte_gate_not_rss() {
+        // 4 hourly samples (enough points for a non-degenerate last-half OLS
+        // window) at 5000 bytes/h -> ~20 KB total growth over 4h, single-digit
+        // scale next to RSS's 80 MB guard.
+        let byte_samples = linear_bytes_series(1_000, 4, 5_000);
+        let bytes_assessment = assess_tombstone_bytes(
+            &byte_samples,
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+        );
+        assert!(
+            !bytes_assessment.passed,
+            "sustained byte growth must fail the byte gate; slope={:.1} reason={:?}",
+            bytes_assessment.slope_bytes_per_hour, bytes_assessment.reason
+        );
+
+        // Same tiny (single-digit-KB-scale) magnitude of growth, expressed as
+        // an RSS series, must NOT fail the RSS gate — proving the byte gate,
+        // not RSS, is what makes the negative control fail.
+        let rss_samples = vec![
+            MemSample {
+                elapsed_secs: 0.0,
+                rss_mb: 220.0,
+            },
+            MemSample {
+                elapsed_secs: 4.0 * 3600.0,
+                rss_mb: 220.02,
+            },
+        ];
+        let rss_assessment = assess(
+            &rss_samples,
+            DEFAULT_MEM_THRESHOLD_MB_PER_HOUR,
+            DEFAULT_MEM_MIN_GROWTH_MB,
+            2048.0,
+        );
+        assert!(
+            rss_assessment.passed,
+            "a single-digit-KB-scale leak must NOT fail the RSS gate (its 80 MB \
+             min-growth guard structurally cannot see it); reason={:?}",
+            rss_assessment.reason
+        );
+    }
+
+    /// AC10: the realistic M4-bounded shape — tombstone bytes grow while the
+    /// churn stream fills the keyspace, then flatten once the bound engages.
+    /// Only the LAST-HALF window should drive the fitted slope (R9(d)), so
+    /// this must PASS even though the run grew substantially earlier.
+    #[test]
+    fn calibration_delayed_plateau_grow_then_flatten_passes() {
+        let mut samples = Vec::new();
+        for h in 0..=11u32 {
+            samples.push(TombstoneSample {
+                elapsed_secs: f64::from(h) * 3600.0,
+                bytes: 1_000 + u64::from(h) * 1_000,
+            });
+        }
+        for h in 12..=23u32 {
+            samples.push(TombstoneSample {
+                elapsed_secs: f64::from(h) * 3600.0,
+                bytes: 12_000,
+            });
+        }
+        let a = assess_tombstone_bytes(
+            &samples,
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+        );
+        assert!(
+            a.passed,
+            "delayed-plateau (grow-then-flatten) must pass on the last-half-window \
+             slope; slope={:.2} reason={:?}",
+            a.slope_bytes_per_hour, a.reason
+        );
+    }
+
+    /// R9(d) proof: on the same grow-then-flatten shape, the FULL-window slope
+    /// is dragged well above the gate threshold by the earlier growth even
+    /// though the run has genuinely plateaued, while the LAST-HALF-window
+    /// slope correctly reports near-zero. This is why the plateau statistic
+    /// must be last-half-window, not full-window.
+    #[test]
+    fn last_half_window_slope_differs_from_full_window_on_delayed_plateau() {
+        let mut points = Vec::new();
+        for h in 0..=11u32 {
+            points.push((f64::from(h) * 3600.0, 1_000.0 + f64::from(h) * 5_000.0));
+        }
+        for h in 12..=23u32 {
+            points.push((f64::from(h) * 3600.0, 56_000.0));
+        }
+        let full = least_squares_slope_per_hour(&points);
+        let last_half = last_half_window_slope_per_hour(&points);
+        assert!(
+            full > DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            "sanity: the full-window slope on this shape must itself be large \
+             enough to matter (full={full:.1} B/h)"
+        );
+        assert!(
+            last_half.abs() < DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            "the last-half-window slope on a genuinely-flattened tail must be \
+             near zero even though the full-window slope is not \
+             (full={full:.1} B/h, last_half={last_half:.1} B/h)"
+        );
+    }
+
+    /// AC11: a synthetic post-kill sample sequence (a spurious near-zero read
+    /// during the boot-recompute gap, then the reconciled-total jump) must NOT
+    /// pollute the fitted slope. [`exclude_boot_gap_samples`] drops every
+    /// sample inside the recorded [`BootGap`] before the series reaches
+    /// [`assess_tombstone_bytes`], so the gate sees only reconciled, continuous
+    /// data.
+    #[test]
+    fn calibration_boot_gap_exclusion_does_not_trip_gate() {
+        // Life 0 plateaus at 50_000 bytes from t=0 to t=3600 (1h). At t=3605
+        // the process is killed; the restarted process's gauge is not yet
+        // reconciled until t=3610 (a 5s boot-recompute gap) — a scrape taken
+        // at t=3607 during that window reads a spurious near-zero total. From
+        // t=3610 onward, life 1 resumes at a slightly higher plateau (a small
+        // amount of legitimate growth, restart-survivable — not a reset to 0).
+        let samples = vec![
+            TombstoneSample {
+                elapsed_secs: 0.0,
+                bytes: 50_000,
+            },
+            TombstoneSample {
+                elapsed_secs: 1_800.0,
+                bytes: 50_000,
+            },
+            TombstoneSample {
+                elapsed_secs: 3_600.0,
+                bytes: 50_000,
+            },
+            // Spurious boot-gap read: the new process's counter has not yet
+            // been reconciled by `reconcile_tombstone_bytes`.
+            TombstoneSample {
+                elapsed_secs: 3_607.0,
+                bytes: 5,
+            },
+            TombstoneSample {
+                elapsed_secs: 3_610.0,
+                bytes: 50_010,
+            },
+            TombstoneSample {
+                elapsed_secs: 5_400.0,
+                bytes: 50_010,
+            },
+            TombstoneSample {
+                elapsed_secs: 7_200.0,
+                bytes: 50_010,
+            },
+        ];
+        let boot_gaps = vec![BootGap {
+            start_secs: 3_605.0,
+            end_secs: 3_610.0,
+        }];
+
+        let filtered = exclude_boot_gap_samples(&samples, &boot_gaps);
+        assert_eq!(
+            filtered.len(),
+            samples.len() - 1,
+            "exactly the one spurious in-gap sample must be dropped"
+        );
+        assert!(
+            !filtered.iter().any(|s| s.bytes == 5),
+            "the spurious near-zero in-gap sample must be excluded"
+        );
+
+        let a = assess_tombstone_bytes(
+            &filtered,
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+        );
+        assert!(
+            a.passed,
+            "boot-gap-excluded plateau must pass; slope={:.2} reason={:?}",
+            a.slope_bytes_per_hour, a.reason
+        );
+
+        // Sanity: the unfiltered series (spurious dip included) is actually
+        // capable of tripping the gate, or this test would not be proving the
+        // exclusion is load-bearing.
+        let unfiltered = assess_tombstone_bytes(
+            &samples,
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
+        );
+        assert!(
+            !unfiltered.passed,
+            "sanity: the unfiltered series with the boot-gap dip must actually \
+             trip the gate, or this test would not be proving anything"
+        );
     }
 
     /// Build an hourly-sampled disk-usage series with a constant per-hour


### PR DESCRIPTION
## Summary

Harness-only. Readies the soak monitor's tombstone-byte bounded-plateau instrument — last-half-window OLS slope, min-window span guard, boot-recompute-gap sample exclusion, restart-survivable-gauge doc — and keeps it **report-only** (RSS gate remains the coarse hard backstop).

**Why report-only, not a hard gate (Delta deviation, evidenced):** live testing proved a byte-slope hard gate structurally un-passable *today* — the exported `OR_TOMBSTONE_BYTES` gauge is additive-only (`sub_tombstone_bytes` has zero prod call-sites — the prune drops redb tombstones but never decrements the gauge), and the soak client never sends `CLIENT_APPLY_ACK` so the server's low-water-mark never advances and no epoch becomes prune-eligible under the soak. Promoting the gate before the mechanism it measures is proven active end-to-end via the harness's own live positive control would ship an un-passable gate. Tracked as **TODO-584**; the 72h soak (TODO-484) is re-gated on it.

## Pattern recorded
Never promote an acceptance gate to hard-fail until the measured mechanism is proven active end-to-end via the harness's live positive control — synthetic unit tests are insufficient.

## Test evidence
fmt / clippy `-D warnings` clean; calibration 20/20; CI Soak Smoke exit 0 (`passed=True`, empty pendingGates); both negative controls exit 1.

## Follow-up
TODO-584 (High): wire the soak client's confirm-apply ACK loop (advance LWM) + `sub_tombstone_bytes` on prune (net-bytes gauge) + re-promote the hard-gate with a live positive control. Then the 72h G4b soak.