### PR TITLE
Tombstone prune: observable (decrementable gauge) + soak-exercised + byte-slope HARD gate [SPEC-345]

### DIFF
--- a/packages/server-rust/benches/soak_harness/client.rs
+++ b/packages/server-rust/benches/soak_harness/client.rs
@@ -26,8 +26,8 @@ use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use topgun_core::hlc::{LWWRecord, ORMapRecord, Timestamp};
 use topgun_core::messages::{
-    AuthMessage, ClientOp, MerkleReqBucketMessage, MerkleReqBucketPayload, Message,
-    ORMapMerkleReqBucket, ORMapMerkleReqBucketPayload, ORMapSyncInit, OpBatchMessage,
+    AuthMessage, ClientApplyAckMessage, ClientOp, MerkleReqBucketMessage, MerkleReqBucketPayload,
+    Message, ORMapMerkleReqBucket, ORMapMerkleReqBucketPayload, ORMapSyncInit, OpBatchMessage,
     OpBatchPayload, Query, QuerySubMessage, QuerySubPayload, QueryUnsubMessage, QueryUnsubPayload,
     SyncInitMessage, WriteConcern,
 };
@@ -53,30 +53,74 @@ pub struct SoakClient {
     ws: Ws,
     /// Stable subject id, reused for log correlation.
     user: String,
+    /// Server-issued device credential captured from `AUTH_ACK`, if any. A
+    /// tracked replica presents this on every reconnect so the server re-binds
+    /// the SAME `(principal, deviceId)` identity across a kill -9 cycle instead
+    /// of minting a fresh, forgotten one — the identity the server's per-device
+    /// causal frontier keys its low-water-mark on.
+    device_token: Option<String>,
+    /// Highest covering epoch this client has ACKed via `ClientApplyAck` on
+    /// this connection, reported back as `claimed_epoch` on the next OR-Map
+    /// sync-init so a regressed replica claim can be detected server-side.
+    last_applied_cursor: Option<u64>,
 }
 
 impl SoakClient {
     /// Open a connection to `addr` and complete the auth handshake as
-    /// `soak-user-{user_idx}`.
+    /// `soak-user-{user_idx}`. Not identity-tracked across reconnects — each
+    /// call presents no prior device token, so the server may mint a new
+    /// device identity. Use [`Self::connect_tracked`] for a replica that must
+    /// keep a stable identity across reconnects (soak's tombstone-prune LWM
+    /// driver).
     pub async fn connect(addr: SocketAddr, user_idx: usize, jwt_secret: &str) -> Result<Self> {
+        Self::connect_tracked(addr, user_idx, jwt_secret, None).await
+    }
+
+    /// Open a connection as a **tracked** replica: presents `device_token`
+    /// (captured from a prior `AUTH_ACK` on this same logical replica, if
+    /// any) so the server re-binds the same `(principal, deviceId)` identity
+    /// instead of minting a fresh one on every reconnect. This is what lets
+    /// the server's per-device confirmed-apply cursor accumulate across a
+    /// churn driver's repeated kill -9 / reconnect cycles, rather than
+    /// resetting to a fresh, forgotten replica every time.
+    ///
+    /// `AUTH_ACK.deviceToken` is populated ONLY on a fresh mint/rotation; a
+    /// plain re-bind of an already-valid presented token omits it (`None`).
+    /// The already-stored token is therefore never clobbered by an ack that
+    /// omits it — only overwritten when the server actually mints or rotates
+    /// one.
+    pub async fn connect_tracked(
+        addr: SocketAddr,
+        user_idx: usize,
+        jwt_secret: &str,
+        device_token: Option<String>,
+    ) -> Result<Self> {
         let url = format!("ws://{addr}/ws");
         let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
             .await
             .map_err(|e| anyhow!("user {user_idx}: ws connect failed: {e}"))?;
 
-        // AUTH_REQUIRED → AUTH(jwt) → AUTH_ACK
+        // AUTH_REQUIRED → AUTH(jwt, device_token) → AUTH_ACK
         let _auth_required = recv_decoded(&mut ws, "AUTH_REQUIRED").await?;
 
         let token = generate_jwt(user_idx, jwt_secret)?;
         let auth = Message::Auth(AuthMessage {
             token,
             protocol_version: None,
-            device_token: None,
+            device_token: device_token.clone(),
         });
         send_encoded(&mut ws, &auth).await?;
 
+        let mut resolved_token = device_token;
         match recv_decoded(&mut ws, "AUTH_ACK").await? {
-            Message::AuthAck(_) => {}
+            Message::AuthAck(ack) => {
+                // Persist-once: never overwrite an already-stored token with the
+                // `None` a plain re-bind sends — that would silently re-mint a
+                // fresh, forgotten replica identity and defeat cursor accumulation.
+                if let Some(tok) = ack.device_token {
+                    resolved_token = Some(tok);
+                }
+            }
             Message::AuthFail(fail) => {
                 let reason = fail.error.unwrap_or_else(|| "unknown".to_string());
                 bail!("user {user_idx}: auth failed: {reason}");
@@ -87,7 +131,17 @@ impl SoakClient {
         Ok(Self {
             ws,
             user: format!("soak-{user_idx}"),
+            device_token: resolved_token,
+            last_applied_cursor: None,
         })
+    }
+
+    /// The server-issued device credential captured from `AUTH_ACK`, if any.
+    /// The churn driver reads this before dropping a connection and passes it
+    /// to the next [`Self::connect_tracked`] call so the replica identity
+    /// survives a kill -9 / reconnect cycle.
+    pub fn device_token(&self) -> Option<&str> {
+        self.device_token.as_deref()
     }
 
     /// PUT `value` at `map`/`key` with `APPLIED` write concern and wait for the
@@ -389,6 +443,47 @@ impl SoakClient {
             Message::SyncRespRoot(r) => Ok(r.payload.root_hash),
             other => bail!("expected SYNC_RESP_ROOT, got {other:?}"),
         }
+    }
+
+    /// Run one confirm-apply round for `map`: an `ORMAP_SYNC_INIT` round trip
+    /// both (re-)establishes this connection's OR-Map sync session and
+    /// carries back the server's current `covering_epoch` (the "root"
+    /// response also serves as the resubscribe step after a reconnect — there
+    /// is no separate subscribe message). If the server has a covering epoch
+    /// to confirm, ACK it via `ClientApplyAck`; this is what advances the
+    /// server's per-device causal frontier and, fleet-wide, the low-water-mark
+    /// that licenses OR-Map tombstone pruning.
+    ///
+    /// `covering_epoch` is `None` when the server has stamped no tombstone yet
+    /// — there is nothing to confirm, so the ack is skipped entirely rather
+    /// than sending a placeholder `cursor: 0` (which would falsely claim epoch
+    /// 0 is durably applied). Returns the epoch that was ACKed, or `None` if
+    /// the round skipped the ack.
+    pub async fn confirm_apply(&mut self, map: &str) -> Result<Option<u64>> {
+        let init = Message::ORMapSyncInit(ORMapSyncInit {
+            map_name: map.to_string(),
+            root_hash: 0,
+            bucket_hashes: HashMap::new(),
+            last_sync_timestamp: None,
+            claimed_epoch: self.last_applied_cursor,
+        });
+        send_encoded(&mut self.ws, &init).await?;
+
+        let covering_epoch = match recv_decoded(&mut self.ws, "ORMAP_SYNC_RESP_ROOT").await? {
+            Message::ORMapSyncRespRoot(r) => r.payload.covering_epoch,
+            other => bail!("expected ORMAP_SYNC_RESP_ROOT, got {other:?}"),
+        };
+
+        let Some(epoch) = covering_epoch else {
+            return Ok(None);
+        };
+
+        // The server does not reply to `ClientApplyAck` — it is handled inline
+        // on the read loop with no ack-of-ack (see `handle_client_apply_ack`).
+        let ack = Message::ClientApplyAck(ClientApplyAckMessage { cursor: epoch });
+        send_encoded(&mut self.ws, &ack).await?;
+        self.last_applied_cursor = Some(epoch);
+        Ok(Some(epoch))
     }
 }
 

--- a/packages/server-rust/benches/soak_harness/client.rs
+++ b/packages/server-rust/benches/soak_harness/client.rs
@@ -144,6 +144,26 @@ impl SoakClient {
         self.device_token.as_deref()
     }
 
+    /// The highest covering epoch this replica has ACKed. The driver reads it
+    /// before a reconnect and re-seeds it via [`Self::resume_from_cursor`] on the
+    /// fresh connection, so the first post-reconnect `ORMAP_SYNC_INIT` presents
+    /// the replica's TRUE last-applied cursor as `claimed_epoch` rather than a
+    /// spurious `None`. Presenting `None` after a reconnect would, under active
+    /// split-brain protection, fail-closed gate this replica's sync — pinning the
+    /// fleet-wide low-water-mark and starving the very prune this harness drives.
+    pub fn last_applied_cursor(&self) -> Option<u64> {
+        self.last_applied_cursor
+    }
+
+    /// Re-seed the last-applied cursor onto a freshly reconnected replica so its
+    /// next `confirm_apply` claims the epoch it had already reached, keeping the
+    /// server-side causal frontier monotonic across a reconnect.
+    pub fn resume_from_cursor(&mut self, cursor: Option<u64>) {
+        if cursor.is_some() {
+            self.last_applied_cursor = cursor;
+        }
+    }
+
     /// PUT `value` at `map`/`key` with `APPLIED` write concern and wait for the
     /// `OP_ACK`. The `(millis, counter)` pair must be monotonically increasing
     /// per key so Last-Write-Wins keeps the latest value; the caller owns that.

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -16,30 +16,43 @@
 //!    is a HARD gate; the **full-scan QUERY** read-back is a tracked
 //!    *expected-fail* gate pending the datastore-backed full-scan, so the two
 //!    halves are scoped to the capability each actually delivers.
-//! 3. **Bounded memory:** the OR-Map tombstone-bytes gauge
-//!    (`topgun_ormap_tombstone_bytes_total`, scraped from the server's own
+//! 3. **Bounded memory:** the decrementable OR-Map tombstone-bytes gauge
+//!    (`topgun_ormap_tombstone_bytes`, scraped from the server's own
 //!    `GET /metrics`) is sampled every interval and its bounded-plateau slope
 //!    (last-half-window OLS, boot-recompute-gap samples excluded — see
 //!    `monitor.rs`) is computed against a tight per-hour threshold — a direct,
 //!    residency-independent leak signal with no allocator/cache noise floor.
-//!    The slope is surfaced REPORT-ONLY: the exported gauge is additive-only
-//!    (every tombstone-add counts; no prune-side decrement is wired yet, and
-//!    the OR-Map epoch prune is dark until a follow-up supplies the frontier's
-//!    durable-epoch watermark), so under sustained churn it climbs at the
-//!    tombstone-*creation* rate and cannot plateau within a process life —
-//!    hard-gating it would false-RED every healthy long run. Only the
-//!    blind-monitor (zero-sample) clause hard-gates. Server RSS is sampled in
-//!    parallel and asserted against a looser slope as a coarse, non-tombstone
-//!    backstop gate. (Re-promote the slope to a hard gate once the
-//!    prune-activation follow-up makes the gauge track residency and a live
-//!    bounded soak is observed to actually plateau.)
+//!    The slope is a HARD gate: a tracked-and-ACKing client
+//!    (`SoakClient::connect_tracked` + `confirm_apply`) is driven alongside the
+//!    churn clients for the run's duration so the server's per-device causal
+//!    frontier — and therefore its low-water-mark — actually advances, which is
+//!    what lets the epoch-scoped prune fire and the gauge genuinely plateau
+//!    under sustained churn instead of only ever growing. The min-window-span
+//!    guard (`DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS`) keeps a
+//!    too-short-to-plateau run (e.g. the 25s blocking smoke) from false-REDing
+//!    on a not-yet-flattened ramp, and the blind-monitor (zero-sample) clause
+//!    hard-gates independently of the slope. Server RSS is sampled in parallel
+//!    and asserted against a looser slope as a coarse, non-tombstone backstop
+//!    gate. The on-disk data-dir slope (below) remains REPORT-ONLY — bounding
+//!    it is a separate, not-yet-landed follow-up.
 //! 4. **Zero panics:** any panic marker in server output, or any un-requested
 //!    exit, fails the run with the captured context.
 //!
 //! Two **negative controls** prove the harness can actually fail:
 //! `--inject-divergence` makes the convergence check go red, and
 //! `--inject-panic` makes the panic capture go red. A soak that cannot fail
-//! proves nothing.
+//! proves nothing. Two more MODES exist specifically to prove the promoted
+//! tombstone-byte hard gate above is honest: `--no-ack` disables the tracked
+//! client's confirm-apply loop (the low-water-mark then never advances, prune
+//! never fires, and the gate must FAIL under sustained churn), and
+//! `--inject-slow-leak` adds a second, deliberately slow-acking tracked client
+//! whose stale cursor repeatedly caps the fleet-wide low-water-mark — a bounded
+//! ramp-then-catch-up pattern used to calibrate the OLS slope's detection floor
+//! against a small, non-instantaneous leak rather than only total blockage.
+//! Independently of the gauge, `scan_redb_tombstone_corpus` opens the server's
+//! own redb file after it exits and sums the real on-disk tombstone corpus —
+//! the positive control's cross-check against a gauge/corpus divergence (e.g. a
+//! legacy `OrTombstones` blob the hot-path gauge never counted on add).
 //!
 //! See `benches/soak_harness/README.md` for usage and the Hetzner 72h runner.
 
@@ -64,7 +77,7 @@ mod or_noloss;
 mod process;
 mod report;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -72,6 +85,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use parking_lot::Mutex;
+use redb::ReadableTable;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 use client::SoakClient;
@@ -88,10 +102,26 @@ use process::{resolve_server_binary, ServerConfig, ServerSupervisor};
 use report::{
     append_progress, utc_timestamp_now, write_report, MemoryReport, ProgressSnapshot, SoakReport,
 };
+use topgun_server::storage::record::RecordValue;
 
 /// Subject index used by the orchestrator's verifier connections. Far above the
 /// churn-client range so it never owns keys or collides with churn auth.
 const VERIFIER_IDX: usize = 1_000_000;
+
+/// Subject index for the tracked-and-ACKing client that drives the server's
+/// low-water-mark forward. Distinct from `VERIFIER_IDX` (and its `+1` sibling)
+/// and the churn-client range so its device identity never collides.
+const TRACKER_IDX: usize = 2_000_000;
+
+/// Subject index for the `--inject-slow-leak` variant's second tracked client.
+const SLOW_LEAK_TRACKER_IDX: usize = 2_000_001;
+
+/// Confirm-apply cadence for the `--inject-slow-leak` tracked client —
+/// deliberately much slower than any reasonable `--confirm-interval`, so its
+/// stale cursor is the binding (minimum) term in the fleet-wide low-water-mark
+/// for most of the run, producing a repeated ramp-then-catch-up pattern rather
+/// than a continuous plateau.
+const SLOW_LEAK_ACK_INTERVAL: Duration = Duration::from_secs(90);
 
 const LWW_MAP: &str = "soak_lww";
 const OR_MAP: &str = "soak_or";
@@ -122,6 +152,24 @@ struct Config {
     progress_output: Option<PathBuf>,
     inject_divergence: bool,
     inject_panic: bool,
+    /// How often the tracked-and-ACKing client (see `TRACKER_IDX`) runs one
+    /// `confirm_apply` round. This is the cadence at which the server's
+    /// per-device causal frontier — and therefore its low-water-mark — can
+    /// advance, which in turn licenses the epoch-scoped tombstone prune.
+    confirm_interval: Duration,
+    /// Negative control: disables the tracked client's confirm-apply loop
+    /// entirely. With no client ever confirming, the low-water-mark stays 0,
+    /// prune never fires, and sustained OR churn must trip the promoted
+    /// tombstone-byte hard gate.
+    no_ack: bool,
+    /// Adds a second tracked client (`SLOW_LEAK_TRACKER_IDX`) that ACKs on a
+    /// much slower cadence than the primary tracker. Because the low-water-mark
+    /// is the MINIMUM cursor across all tracked clients, this caps pruning to
+    /// the slow client's stale confirmations, producing a bounded
+    /// ramp-then-catch-up pattern that exercises the OLS slope gate's
+    /// detection floor against a small, slow leak rather than only the
+    /// `--no-ack` total-blockage case.
+    inject_slow_leak: bool,
     /// Skip the pre-`kill -9` quiesce drain in the recovery checkpoint. When set,
     /// the checkpoint kills the server WITHOUT first letting the write-behind
     /// buffer flush to redb, so post-restart recovery must rely on the WAL alone.
@@ -170,6 +218,9 @@ impl Default for Config {
             progress_output: None,
             inject_divergence: false,
             inject_panic: false,
+            confirm_interval: Duration::from_secs(2),
+            no_ack: false,
+            inject_slow_leak: false,
             no_pre_kill_drain: false,
             mode_requested: false,
         }
@@ -192,6 +243,11 @@ struct SoakMetrics {
     write_errors: AtomicU64,
     reconnects: AtomicU64,
     resends: AtomicU64,
+    /// Count of completed `confirm_apply` rounds that actually ACKed an epoch
+    /// (i.e. `Ok(Some(_))`), across every tracked client. Visibility signal for
+    /// a long soak: this staying at 0 for the whole run means the low-water-mark
+    /// never advanced (expected under `--no-ack`; a bug otherwise).
+    confirms: AtomicU64,
 }
 
 /// Context shared with every churn client task.
@@ -360,6 +416,43 @@ async fn run_soak(config: &Config) -> i32 {
             offline_keys: config.offline_keys,
         };
         churn_handles.push(tokio::spawn(run_churn_client(idx, ctx)));
+    }
+
+    // --- Spawn the tracked-and-ACKing client(s) that drive the server's
+    // low-water-mark ---
+    //
+    // Without at least one client running `connect_tracked` + `confirm_apply`,
+    // the server's per-device causal frontier tracks NO clients at all, so
+    // `low_water_mark()` is vacuously 0 forever and the epoch-scoped prune
+    // never fires regardless of how much churn runs — this is what made the
+    // tombstone-byte slope report-only before this driver existed. The primary
+    // tracker below always spawns (its ack loop is skipped, not the connection,
+    // when `--no-ack` is set — the negative control needs the request/response
+    // shape to still run so a real regression in the harness plumbing itself
+    // would still be caught by other assertions). `--inject-slow-leak` adds a
+    // second tracked client with a much slower ack cadence purely for slope-gate
+    // calibration; see `SLOW_LEAK_ACK_INTERVAL`.
+    churn_handles.push(tokio::spawn(run_tracked_confirm_client(TrackerConfig {
+        supervisor: Arc::clone(&supervisor),
+        jwt_secret: jwt_secret.clone(),
+        stop: Arc::clone(&stop),
+        paused: Arc::clone(&paused),
+        metrics: Arc::clone(&metrics),
+        idx: TRACKER_IDX,
+        confirm_interval: config.confirm_interval,
+        no_ack: config.no_ack,
+    })));
+    if config.inject_slow_leak {
+        churn_handles.push(tokio::spawn(run_tracked_confirm_client(TrackerConfig {
+            supervisor: Arc::clone(&supervisor),
+            jwt_secret: jwt_secret.clone(),
+            stop: Arc::clone(&stop),
+            paused: Arc::clone(&paused),
+            metrics: Arc::clone(&metrics),
+            idx: SLOW_LEAK_TRACKER_IDX,
+            confirm_interval: SLOW_LEAK_ACK_INTERVAL,
+            no_ack: false,
+        })));
     }
 
     // --- Spawn memory + tombstone-bytes + disk samplers ---
@@ -632,6 +725,14 @@ async fn run_soak(config: &Config) -> i32 {
     }
     supervisor.shutdown().await;
 
+    // Positive-control independent corpus assertion (R5): the server process
+    // has just been reaped, so its redb handle is released and this scan can
+    // safely open the same file. REPORT-ONLY (printed in the console summary,
+    // never asserted into `passed`) — see `scan_redb_tombstone_corpus`'s doc
+    // for why a divergence from the gauge's `last_bytes` below is exactly the
+    // failure mode this exists to catch.
+    let redb_tombstone_scan = scan_redb_tombstone_corpus(&data_dir, OR_MAP);
+
     // --- Assess memory (secondary/backstop gate) ---
     let mem_samples = samples.lock().clone();
     let mem = assess(
@@ -642,11 +743,11 @@ async fn run_soak(config: &Config) -> i32 {
     );
 
     // --- Assess tombstone-byte growth (direct residency-independent leak
-    // instrument, the bounded-plateau signal — surfaced REPORT-ONLY today, see
-    // the routing note below). Coexists with the RSS gate above as a coarse
-    // non-tombstone backstop — neither replaces the other. The
-    // sampling loop already excluded boot-recompute-gap samples (R9(c)), so
-    // this series is safe to fit directly.
+    // instrument, the bounded-plateau signal — a HARD gate, see the promotion
+    // note below). Coexists with the RSS gate above as a coarse non-tombstone
+    // backstop — neither replaces the other. The sampling loop already
+    // excluded boot-recompute-gap samples (R9(c)), so this series is safe to
+    // fit directly.
     let tombstone_samples_snapshot = tombstone_samples.lock().clone();
     let tombstones = assess_tombstone_bytes(
         &tombstone_samples_snapshot,
@@ -655,19 +756,28 @@ async fn run_soak(config: &Config) -> i32 {
         DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
     );
 
-    // The tombstone-byte SLOPE clause is REPORT-ONLY (mirrors the disk gate
-    // below), NOT a hard gate. The exported gauge (`add_tombstone_bytes`) is
-    // additive-only: it counts every tombstone-add and is never decremented on
-    // prune (no `sub_tombstone_bytes` call site yet), and the OR-Map epoch
-    // prune is dark until a follow-up supplies the frontier's durable-epoch
-    // watermark. So under the soak's sustained OR churn the gauge climbs at the
-    // tombstone-*creation* rate and cannot plateau within a process life —
-    // hard-gating the slope would false-RED the blocking no-crash Soak Smoke
-    // G4b run and any 10-60 min / 72h soak. The slope is surfaced via
-    // `pending_gates` (an honest, non-failing signal) until the prune-activation
-    // follow-up makes the gauge track residency; re-promote to a hard gate then.
+    // The tombstone-byte SLOPE clause is now a HARD gate (promoted from
+    // report-only): the tracked-and-ACKing client spawned above
+    // (`run_tracked_confirm_client` / `TRACKER_IDX`) drives the server's
+    // per-device causal frontier forward every `confirm_interval`, so the
+    // fleet-wide low-water-mark actually advances and the epoch-scoped prune
+    // fires — the exported gauge (`topgun_ormap_tombstone_bytes`) is
+    // decrementable and is expected to genuinely plateau under sustained churn,
+    // not merely climb at the tombstone-creation rate. Two guards keep this
+    // from false-REDing:
+    //   - the min-window-span guard (`DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS`)
+    //     suppresses the slope clause until the last-half fit window covers
+    //     enough wall-clock time for a per-hour extrapolation to mean anything
+    //     — this is what keeps the 25s blocking Soak Smoke G4b run green even
+    //     though its keyspace has not yet had time to plateau;
+    //   - boot-recompute-gap exclusion (unchanged) keeps a spurious
+    //     post-restart pre-reconcile read from manufacturing a false leak.
     // RSS above remains a coarse, non-tombstone backstop (its large min-growth
     // guard cannot catch a single-digit-MB/KB tombstone leak on a bounded run).
+    // `--no-ack` and `--inject-slow-leak` (see their doc comments on `Config`)
+    // are the negative/slow-leak control modes that prove this gate can
+    // actually fail and actually catches a small sustained leak, not only a
+    // total blockage.
     //
     // The blind-monitor guard hard-gates independently of the slope clause:
     // zero samples means the `/metrics` scrape was dead — a real harness
@@ -696,6 +806,7 @@ async fn run_soak(config: &Config) -> i32 {
         && recovery_failures.is_empty()
         && mem.passed
         && !blind_monitor
+        && tombstones.passed
         && !disk_blind_monitor
         && panic_report.is_none();
 
@@ -711,17 +822,17 @@ async fn run_soak(config: &Config) -> i32 {
             tombstones.reason.clone().unwrap_or_default()
         );
     } else if !tombstones.passed {
-        // Report-only (mirrors the disk slope below): the additive-only gauge
-        // grows at the tombstone-creation rate under sustained churn and cannot
-        // plateau until a follow-up wires prune-side decrement + frontier-
-        // watermark activation, so a slope breach here is the EXPECTED honest
-        // signal, not a regression. Do NOT AND it into `passed`.
-        pending_gates.push(format!(
-            "tombstone-byte growth slope {:.1} bytes/h exceeds {:.1} bytes/h — \
-             EXPECTED until the OR-Map prune-activation follow-up bounds residency \
-             (report-only, did NOT fail the run)",
-            tombstones.slope_bytes_per_hour, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR
-        ));
+        // HARD gate (promoted from report-only): with the tracked-and-ACKing
+        // client driving the low-water-mark, a sustained slope breach past the
+        // min-window-guarded threshold means the epoch-scoped prune is not
+        // keeping up with (or has stopped) bounding tombstone growth — a real
+        // regression, not an expected/known gap. AND it into `passed`.
+        finished_reason = format!(
+            "tombstone-byte growth slope {:.1} bytes/h exceeds {:.1} bytes/h: {}",
+            tombstones.slope_bytes_per_hour,
+            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+            tombstones.reason.clone().unwrap_or_default()
+        );
     }
     if disk_blind_monitor {
         finished_reason = format!(
@@ -777,7 +888,7 @@ async fn run_soak(config: &Config) -> i32 {
         timestamp: utc_timestamp_now(),
     };
 
-    print_summary(&report, &tombstones, &disk);
+    print_summary(&report, &tombstones, &disk, redb_tombstone_scan);
     if let Some(path) = &config.json_output {
         write_report(path, &report);
         println!("wrote JSON report to {}", path.display());
@@ -792,7 +903,12 @@ async fn run_soak(config: &Config) -> i32 {
     i32::from(!passed)
 }
 
-fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment, disk: &DiskAssessment) {
+fn print_summary(
+    r: &SoakReport,
+    tombstones: &TombstoneAssessment,
+    disk: &DiskAssessment,
+    redb_tombstone_scan: Option<u64>,
+) {
     println!("\n=== SOAK SUMMARY ===");
     println!(
         "result:            {}",
@@ -817,11 +933,12 @@ fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment, disk: &DiskAs
         r.memory.slope_mb_per_hour,
         if r.memory.passed { "ok" } else { "FAIL" }
     );
-    // The byte SLOPE is REPORT-ONLY (the additive-only gauge cannot plateau
-    // under sustained churn until the OR-Map prune-activation follow-up wires
-    // residency tracking); only the blind-monitor (zero-sample) clause
-    // hard-gates. See the run-end verdict rationale.
-    let tombstone_role = "slope report-only pending prune-activation; blind-monitor hard-gates";
+    // The byte SLOPE is now a HARD gate: the tracked-and-ACKing client drives
+    // the low-water-mark forward, so the epoch-scoped prune actually fires and
+    // the gauge is expected to plateau under sustained churn (subject to the
+    // min-window-span guard and boot-gap exclusion). See the run-end verdict
+    // rationale.
+    let tombstone_role = "slope + blind-monitor both hard-gate";
     println!(
         "tombstone_bytes:   first={} peak={} last={} slope={:.1}B/h samples={} -> {} ({}){}",
         tombstones.first_bytes,
@@ -836,9 +953,35 @@ fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment, disk: &DiskAs
             .as_ref()
             .map_or_else(String::new, |r| format!(" reason={r}")),
     );
-    // Same report-only stance as tombstone bytes: the disk slope is EXPECTED to
-    // breach pre-TODO-566 under default OR-churn (linear durable-dir growth by
-    // design); only the blind-monitor (zero-sample) clause hard-gates.
+    // Positive-control cross-check (R5): an independent, gauge-free scan of the
+    // real on-disk tombstone corpus, taken after the server process exited. A
+    // large divergence from `tombstones.last_bytes` above means the exported
+    // gauge is not tracking the true corpus (e.g. an un-migrated legacy
+    // `OrTombstones` blob the hot-path gauge never added on read) — REPORT-ONLY,
+    // never asserted into `passed`.
+    match redb_tombstone_scan {
+        Some(scanned_bytes) => {
+            let gauge_bytes = tombstones.last_bytes;
+            let diverged = scanned_bytes != gauge_bytes;
+            println!(
+                "tombstone_corpus_redb_scan: {scanned_bytes} bytes (independent of gauge; last \
+                 gauge value {gauge_bytes} bytes) -> {} (positive-control cross-check, \
+                 report-only)",
+                if diverged { "DIVERGED" } else { "match" }
+            );
+        }
+        None => {
+            println!(
+                "tombstone_corpus_redb_scan: could not scan (missing/corrupt redb file or \
+                 table) — positive-control cross-check skipped, report-only"
+            );
+        }
+    }
+    // Unlike the tombstone-byte slope above (now a hard gate), the disk slope
+    // stays REPORT-ONLY: it is EXPECTED to breach pre-TODO-566 under default
+    // OR-churn (linear durable-dir growth by design, independent of the
+    // tombstone prune this spec drives); only the blind-monitor (zero-sample)
+    // clause hard-gates.
     let disk_role = "slope report-only until TODO-566; blind-monitor hard-gates";
     println!(
         "disk_mb:           first={:.1} peak={:.1} last={:.1} slope={:.1}MB/h samples={} -> {} ({}){}",
@@ -880,12 +1023,18 @@ fn print_summary(r: &SoakReport, tombstones: &TombstoneAssessment, disk: &DiskAs
 // Tombstone-bytes gauge sampling
 // ---------------------------------------------------------------------------
 
-/// Scrape `topgun_ormap_tombstone_bytes_total` from the real running server's
-/// `GET /metrics` (Prometheus text exposition format). Returns `None` on any
-/// transient failure — connection refused (server mid-restart), non-2xx
-/// status, an unreadable body, or the metric line simply not being present —
-/// so the caller skips the sample instead of recording a bogus point. This
-/// mirrors `sample_rss_mb`'s `None`-on-gone-process contract in `monitor.rs`.
+/// Scrape `topgun_ormap_tombstone_bytes` — the DECREMENTABLE gauge, not the
+/// `_total` monotonic creation-rate counter — from the real running server's
+/// `GET /metrics` (Prometheus text exposition format). The plateau/slope signal
+/// this harness gates on MUST come from the decrementable gauge: the `_total`
+/// counter only ever grows (every add, never subtracted on prune), so fitting
+/// a slope against it would always look like an unbounded leak regardless of
+/// whether pruning is actually keeping tombstone residency bounded. Returns
+/// `None` on any transient failure — connection refused (server mid-restart),
+/// non-2xx status, an unreadable body, or the metric line simply not being
+/// present — so the caller skips the sample instead of recording a bogus
+/// point. This mirrors `sample_rss_mb`'s `None`-on-gone-process contract in
+/// `monitor.rs`.
 async fn scrape_tombstone_bytes(http: &reqwest::Client, port: u16) -> Option<u64> {
     let url = format!("http://127.0.0.1:{port}/metrics");
     let resp = http.get(&url).send().await.ok()?;
@@ -893,16 +1042,19 @@ async fn scrape_tombstone_bytes(http: &reqwest::Client, port: u16) -> Option<u64
         return None;
     }
     let body = resp.text().await.ok()?;
-    parse_tombstone_bytes_total(&body)
+    parse_tombstone_bytes_gauge(&body)
 }
 
-/// Parse the `topgun_ormap_tombstone_bytes_total` sample value out of a
-/// Prometheus text exposition body, skipping `# HELP`/`# TYPE` comment lines
-/// and any blank lines. A metric line is `name value` or `name{labels} value`
-/// (space-separated); this counter carries no labels today, but the label-form
-/// prefix match keeps the parser correct if one is ever added.
-fn parse_tombstone_bytes_total(body: &str) -> Option<u64> {
-    const METRIC: &str = "topgun_ormap_tombstone_bytes_total";
+/// Parse the `topgun_ormap_tombstone_bytes` (decrementable gauge) sample value
+/// out of a Prometheus text exposition body, skipping `# HELP`/`# TYPE` comment
+/// lines and any blank lines. A metric line is `name value` or
+/// `name{labels} value` (space-separated); this gauge carries no labels today,
+/// but the label-form prefix match keeps the parser correct if one is ever
+/// added. Exact-name equality (not a bare prefix match) is what keeps this from
+/// also matching the co-resident `topgun_ormap_tombstone_bytes_total` counter
+/// line the same `/metrics` response carries.
+fn parse_tombstone_bytes_gauge(body: &str) -> Option<u64> {
+    const METRIC: &str = "topgun_ormap_tombstone_bytes";
     // Compute the labelled-series prefix once rather than allocating a fresh
     // `String` per scanned line in the hot scrape loop.
     let labelled_prefix = format!("{METRIC}{{");
@@ -926,6 +1078,74 @@ fn parse_tombstone_bytes_total(body: &str) -> Option<u64> {
         }
     }
     None
+}
+
+/// Independent, gauge-free scan of the OR-Map's on-disk tombstone corpus: the
+/// positive control's cross-check that `topgun_ormap_tombstone_bytes` is
+/// actually tracking the real durable byte total, not merely plateauing
+/// because it drifted out of sync with it.
+///
+/// Opens the server's own redb file directly (`{data_dir}/topgun.redb`, the
+/// same layout `RedbDataStore` writes: table `map__{map}`, msgpack-encoded
+/// `RecordValue` values) and sums the UTF-8 byte length of every tombstoned
+/// tag across BOTH tombstone-carrying shapes: the live `RecordValue::OrMap`'s
+/// `tombstones` field, and the legacy `RecordValue::OrTombstones` blob a
+/// pre-migration server may have left on disk. The legacy shape matters here:
+/// the in-process gauge's `sub_tombstone_bytes` call site lives on the CRDT
+/// write path's `OR_REMOVE`/prune handling for the CURRENT `OrMap` shape only
+/// — a decoded legacy `OrTombstones` blob is folded into the read-side merge
+/// view but never re-adds itself to the gauge, so the gauge can silently drift
+/// BELOW the true corpus (toward its saturating-0 floor) while these bytes
+/// remain resident. Comparing this scan's total against the gauge's last
+/// sampled value is exactly what catches that divergence.
+///
+/// MUST run only after `ServerSupervisor::shutdown` has reaped the child
+/// process: redb is single-writer, so the server's own handle on the file must
+/// already be released before this process can open it. This is therefore a
+/// post-teardown assertion, not a live sampler alongside RSS/tombstone-bytes/
+/// disk above. Returns `None` on any failure (file missing, corrupt header,
+/// table absent) — best-effort, mirroring `sample_rss_mb`/`sample_disk_mb`'s
+/// None-on-failure contract — so a scan failure is reported as "could not
+/// scan", never mistaken for a genuinely empty (zero-byte) corpus.
+fn scan_redb_tombstone_corpus(data_dir: &Path, map: &str) -> Option<u64> {
+    let db_path = data_dir.join("topgun.redb");
+    if !db_path.exists() {
+        return None;
+    }
+    let db = redb::Database::open(&db_path).ok()?;
+    let read_txn = db.begin_read().ok()?;
+    let table_name = format!("map__{map}");
+    let table_def: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new(&table_name);
+    let table = match read_txn.open_table(table_def) {
+        Ok(t) => t,
+        // Never-written table (e.g. no OR-Map write ever landed) contributes 0
+        // tombstone bytes — a real, honest answer, not a scan failure.
+        Err(redb::TableError::TableDoesNotExist(_)) => return Some(0),
+        Err(_) => return None,
+    };
+
+    let mut total_bytes: u64 = 0;
+    let iter = table.iter().ok()?;
+    for entry in iter {
+        let (_key_guard, val_guard) = entry.ok()?;
+        let Ok(value) = rmp_serde::from_slice::<RecordValue>(val_guard.value()) else {
+            // An undecodable value is a corrupt/foreign row, not part of this
+            // scan's remit — skip it rather than aborting the whole scan.
+            continue;
+        };
+        match value {
+            RecordValue::OrMap { tombstones, .. } => {
+                total_bytes += tombstones.iter().map(|t| t.len() as u64).sum::<u64>();
+            }
+            // Legacy pre-migration shape — see the function doc's divergence
+            // rationale for why this is exactly what the gauge can miss.
+            RecordValue::OrTombstones { tags } => {
+                total_bytes += tags.iter().map(|t| t.len() as u64).sum::<u64>();
+            }
+            RecordValue::Lww { .. } => {}
+        }
+    }
+    Some(total_bytes)
 }
 
 // ---------------------------------------------------------------------------
@@ -1444,6 +1664,105 @@ async fn connect_with_retry(ctx: &ChurnCtx, idx: usize) -> Option<SoakClient> {
 }
 
 // ---------------------------------------------------------------------------
+// Tracked confirm-apply client (drives the low-water-mark)
+// ---------------------------------------------------------------------------
+
+/// Configuration for a single tracked-and-ACKing replica. Bundled into one
+/// struct (mirroring `ChurnCtx`/`BootGapClock`) so `run_tracked_confirm_client`
+/// takes one parameter instead of clippy's too-many-arguments threshold.
+struct TrackerConfig {
+    supervisor: Arc<ServerSupervisor>,
+    jwt_secret: String,
+    stop: Arc<AtomicBool>,
+    paused: Arc<AtomicBool>,
+    metrics: Arc<SoakMetrics>,
+    idx: usize,
+    confirm_interval: Duration,
+    no_ack: bool,
+}
+
+/// A single tracked-and-ACKing replica: reconnects with `connect_tracked` (so
+/// its `(principal, deviceId)` identity survives across reconnects — the
+/// identity the server's per-device causal frontier keys its cursor on), and
+/// runs `confirm_apply` on `OR_MAP` every `confirm_interval` while connected.
+///
+/// Every acked `confirm_apply` round advances this replica's high-water-mark;
+/// since the server's low-water-mark is the MINIMUM across all tracked
+/// clients, this is what lets the epoch-scoped tombstone prune fire at all.
+/// When `no_ack` is set the confirm-apply call is skipped entirely (not just
+/// the ack) — the connection still exists so the harness's other assertions
+/// keep exercising it, but the server never sees an `ORMAP_SYNC_INIT` from this
+/// replica, so it is never tracked and the low-water-mark stays at its vacuous
+/// 0 for the whole run: the negative control for the promoted hard gate.
+async fn run_tracked_confirm_client(cfg: TrackerConfig) {
+    let mut device_token: Option<String> = None;
+
+    while !cfg.stop.load(Ordering::SeqCst) {
+        while cfg.paused.load(Ordering::SeqCst) && !cfg.stop.load(Ordering::SeqCst) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        if cfg.stop.load(Ordering::SeqCst) {
+            return;
+        }
+
+        let connect = SoakClient::connect_tracked(
+            cfg.supervisor.addr(),
+            cfg.idx,
+            &cfg.jwt_secret,
+            device_token.clone(),
+        )
+        .await;
+        let Ok(mut client) = connect else {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            continue;
+        };
+
+        let mut session_alive = true;
+        while session_alive && !cfg.stop.load(Ordering::SeqCst) {
+            // Hold across a checkpoint quiesce WITHOUT disconnecting, mirroring
+            // the churn client's active-burst pause behavior — a checkpoint's
+            // quiesced read-back must not race a mid-quiesce reconnect.
+            while cfg.paused.load(Ordering::SeqCst) && !cfg.stop.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            if cfg.stop.load(Ordering::SeqCst) {
+                break;
+            }
+
+            if !cfg.no_ack {
+                match client.confirm_apply(OR_MAP).await {
+                    Ok(Some(_)) => {
+                        cfg.metrics.confirms.fetch_add(1, Ordering::Relaxed);
+                    }
+                    // `Ok(None)`: nothing to confirm yet (no tombstone stamped
+                    // yet) — skip, not an error.
+                    Ok(None) => {}
+                    Err(_) => {
+                        session_alive = false;
+                    }
+                }
+            }
+
+            tokio::time::sleep(cfg.confirm_interval).await;
+        }
+
+        // Capture the device token BEFORE dropping so the next reconnect
+        // presents it and keeps the SAME (principal, deviceId) identity —
+        // otherwise every reconnect would mint a fresh, forgotten replica and
+        // the frontier's cursor for it would never accumulate.
+        let token = client.device_token().map(str::to_string);
+        drop(client);
+        if token.is_some() {
+            device_token = token;
+        }
+        if cfg.stop.load(Ordering::SeqCst) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Negative control: divergence
 // ---------------------------------------------------------------------------
 
@@ -1628,6 +1947,9 @@ const KNOWN_FLAGS: &[&str] = &[
     "--progress-output",
     "--inject-divergence",
     "--inject-panic",
+    "--confirm-interval",
+    "--no-ack",
+    "--inject-slow-leak",
     "--no-pre-kill-drain",
     "--smoke",
 ];
@@ -1646,7 +1968,9 @@ fn print_usage() {
          \x20 soak_harness --smoke\n\
          \x20 # negative controls (must exit non-zero == assertion RED)\n\
          \x20 soak_harness --inject-divergence\n\
-         \x20 soak_harness --inject-panic\n\n\
+         \x20 soak_harness --inject-panic\n\
+         \x20 soak_harness --no-ack --duration 3600  # tombstone hard-gate must FAIL\n\
+         \x20 soak_harness --inject-slow-leak --duration 3600  # slope detection-floor calibration\n\n\
          See packages/server-rust/benches/soak_harness/README.md for the full flag list\n\
          and the Hetzner 72h runner."
     );
@@ -1773,6 +2097,19 @@ fn parse_args() -> Config {
             }
             "--inject-panic" => {
                 c.inject_panic = true;
+                i += 1;
+            }
+            "--confirm-interval" => {
+                c.confirm_interval =
+                    Duration::from_secs(parse_u64(&need(i, &args, "--confirm-interval")).max(1));
+                i += 2;
+            }
+            "--no-ack" => {
+                c.no_ack = true;
+                i += 1;
+            }
+            "--inject-slow-leak" => {
+                c.inject_slow_leak = true;
                 i += 1;
             }
             "--no-pre-kill-drain" => {

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -248,6 +248,16 @@ struct SoakMetrics {
     /// a long soak: this staying at 0 for the whole run means the low-water-mark
     /// never advanced (expected under `--no-ack`; a bug otherwise).
     confirms: AtomicU64,
+    /// Highest epoch any tracked client has ACKed via `ClientApplyAck`. The
+    /// server's fleet-wide low-water-mark tracks the MIN across tracked clients,
+    /// so this is an upper bound on the LWM — a diagnostic that the confirm-apply
+    /// path is actually advancing the causal frontier the prune keys off.
+    last_confirmed_epoch: AtomicU64,
+    /// Count of `confirm_apply` rounds that errored (forcing a reconnect). A
+    /// non-`--no-ack` run with this climbing while `confirms` stays flat means a
+    /// harness plumbing failure (the tracked client can't ACK) — NOT a server
+    /// tombstone leak, even though both surface as an unbounded gauge slope.
+    confirm_errors: AtomicU64,
 }
 
 /// Context shared with every churn client task.
@@ -689,7 +699,7 @@ async fn run_soak(config: &Config) -> i32 {
         }
         println!(
             "[{:>6}s] {phase:<8} writes={} errs={} reconnects={} crashes={} steady={} recovery={} \
-             converged={} rss={:.0}MB(peak {:.0})",
+             converged={} confirms={} lastEpoch={} confirmErrs={} rss={:.0}MB(peak {:.0})",
             start.elapsed().as_secs(),
             metrics.total_writes.load(Ordering::Relaxed),
             metrics.write_errors.load(Ordering::Relaxed),
@@ -698,6 +708,9 @@ async fn run_soak(config: &Config) -> i32 {
             steady_checkpoints,
             recovery_checkpoints,
             last_convergence_ok,
+            metrics.confirms.load(Ordering::Relaxed),
+            metrics.last_confirmed_epoch.load(Ordering::Relaxed),
+            metrics.confirm_errors.load(Ordering::Relaxed),
             last,
             peak,
         );
@@ -888,7 +901,17 @@ async fn run_soak(config: &Config) -> i32 {
         timestamp: utc_timestamp_now(),
     };
 
-    print_summary(&report, &tombstones, &disk, redb_tombstone_scan);
+    print_summary(
+        &report,
+        &tombstones,
+        &disk,
+        redb_tombstone_scan,
+        &ConfirmDiagnostics {
+            confirms: metrics.confirms.load(Ordering::Relaxed),
+            last_confirmed_epoch: metrics.last_confirmed_epoch.load(Ordering::Relaxed),
+            confirm_errors: metrics.confirm_errors.load(Ordering::Relaxed),
+        },
+    );
     if let Some(path) = &config.json_output {
         write_report(path, &report);
         println!("wrote JSON report to {}", path.display());
@@ -903,11 +926,22 @@ async fn run_soak(config: &Config) -> i32 {
     i32::from(!passed)
 }
 
+/// Tracked-client confirm-apply diagnostics, surfaced in the summary without
+/// widening the persisted `SoakReport` (report.rs is outside this change's file
+/// budget). Purely a console signal for distinguishing a healthy LWM-advancing
+/// run from a stalled-confirm harness failure.
+struct ConfirmDiagnostics {
+    confirms: u64,
+    last_confirmed_epoch: u64,
+    confirm_errors: u64,
+}
+
 fn print_summary(
     r: &SoakReport,
     tombstones: &TombstoneAssessment,
     disk: &DiskAssessment,
     redb_tombstone_scan: Option<u64>,
+    confirm: &ConfirmDiagnostics,
 ) {
     println!("\n=== SOAK SUMMARY ===");
     println!(
@@ -920,6 +954,12 @@ fn print_summary(
     println!("write_errors:      {}", r.write_errors);
     println!("reconnects:        {}", r.reconnects);
     println!("resends:           {}", r.resends);
+    println!(
+        "confirm_apply:     confirms={} lastEpoch={} errors={} \
+         (tracked client advances the low-water-mark that licenses pruning; \
+         confirms=0 with a climbing gauge = LWM never advanced)",
+        confirm.confirms, confirm.last_confirmed_epoch, confirm.confirm_errors
+    );
     println!("steady_checkpts:   {}", r.steady_checkpoints);
     println!(
         "recovery_checkpts: {} (crashes {})",
@@ -1696,6 +1736,11 @@ struct TrackerConfig {
 /// 0 for the whole run: the negative control for the promoted hard gate.
 async fn run_tracked_confirm_client(cfg: TrackerConfig) {
     let mut device_token: Option<String> = None;
+    // Persisted across reconnects alongside `device_token`: the replica's
+    // last-ACKed covering epoch. Re-seeding it on the fresh connection keeps the
+    // first post-reconnect `claimed_epoch` truthful instead of a spurious `None`,
+    // which would fail-closed gate the replica under active split-brain protection.
+    let mut resume_cursor: Option<u64> = None;
 
     while !cfg.stop.load(Ordering::SeqCst) {
         while cfg.paused.load(Ordering::SeqCst) && !cfg.stop.load(Ordering::SeqCst) {
@@ -1716,6 +1761,7 @@ async fn run_tracked_confirm_client(cfg: TrackerConfig) {
             tokio::time::sleep(Duration::from_millis(200)).await;
             continue;
         };
+        client.resume_from_cursor(resume_cursor);
 
         let mut session_alive = true;
         while session_alive && !cfg.stop.load(Ordering::SeqCst) {
@@ -1731,13 +1777,23 @@ async fn run_tracked_confirm_client(cfg: TrackerConfig) {
 
             if !cfg.no_ack {
                 match client.confirm_apply(OR_MAP).await {
-                    Ok(Some(_)) => {
+                    Ok(Some(epoch)) => {
                         cfg.metrics.confirms.fetch_add(1, Ordering::Relaxed);
+                        cfg.metrics
+                            .last_confirmed_epoch
+                            .fetch_max(epoch, Ordering::Relaxed);
                     }
                     // `Ok(None)`: nothing to confirm yet (no tombstone stamped
                     // yet) — skip, not an error.
                     Ok(None) => {}
-                    Err(_) => {
+                    Err(e) => {
+                        // Surface the failure rather than reconnect-looping
+                        // silently: a swallowed confirm error looks identical to
+                        // a server tombstone leak (LWM never advances → gauge
+                        // climbs → hard gate REDs), so an invisible plumbing bug
+                        // would masquerade as the very defect this gate hunts.
+                        cfg.metrics.confirm_errors.fetch_add(1, Ordering::Relaxed);
+                        eprintln!("[tracker {}] confirm_apply error: {e:#}", cfg.idx);
                         session_alive = false;
                     }
                 }
@@ -1746,14 +1802,19 @@ async fn run_tracked_confirm_client(cfg: TrackerConfig) {
             tokio::time::sleep(cfg.confirm_interval).await;
         }
 
-        // Capture the device token BEFORE dropping so the next reconnect
-        // presents it and keeps the SAME (principal, deviceId) identity —
-        // otherwise every reconnect would mint a fresh, forgotten replica and
-        // the frontier's cursor for it would never accumulate.
+        // Capture the device token AND last-applied cursor BEFORE dropping so the
+        // next reconnect presents the SAME (principal, deviceId) identity and
+        // resumes its causal frontier — otherwise every reconnect would mint a
+        // fresh, forgotten replica whose cursor never accumulates, or reset the
+        // claimed epoch to None and risk a fail-closed gate under protection.
         let token = client.device_token().map(str::to_string);
+        let cursor = client.last_applied_cursor();
         drop(client);
         if token.is_some() {
             device_token = token;
+        }
+        if cursor.is_some() {
+            resume_cursor = cursor;
         }
         if cfg.stop.load(Ordering::SeqCst) {
             return;

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -342,7 +342,7 @@ pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
 
 /// Minimum wall-clock span (seconds) of the last-half fit window before the
-/// per-hour slope clause is surfaced as a (report-only) breach.
+/// per-hour slope clause is allowed to hard-gate the run.
 ///
 /// The slope is a per-hour EXTRAPOLATION (bytes/sec × 3600). Over a sub-minute
 /// window the `3600 / span_secs` amplification is enormous: a healthy short run
@@ -352,9 +352,9 @@ pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
 /// Below this floor the slope carries no plateau signal — a leak and a
 /// not-yet-plateaued healthy run are indistinguishable — so the clause is
 /// suppressed (no breach is emitted for it) and the assessment passes on the
-/// blind-monitor + absolute-growth clauses alone. (The breach is report-only
-/// today regardless — see [`DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR`]; this
-/// floor keeps even the report-only signal from crying wolf on a short run.)
+/// blind-monitor + absolute-growth clauses alone. (The slope is now a HARD gate
+/// once the window clears this floor — see [`DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR`];
+/// this floor is what keeps that hard gate from crying wolf on a short run.)
 ///
 /// 120s sits well above the smoke run's ~10-15s last-half span (suppressed) and
 /// well below a real bounded soak's window (a 10-60 min live run's last-half
@@ -364,9 +364,10 @@ pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
 /// floor.
 pub const DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS: f64 = 120.0;
 
-/// One tombstone-byte-gauge sample (`topgun_ormap_tombstone_bytes_total`,
-/// scraped over HTTP). `bytes` is `u64` — a counted byte total is a
-/// non-negative integer, never a float.
+/// One tombstone-byte-gauge sample (`topgun_ormap_tombstone_bytes`, the
+/// decrementable gauge scraped over HTTP — not the monotonic `_total` counter).
+/// `bytes` is `u64` — a counted byte total is a non-negative integer, never a
+/// float.
 #[derive(Debug, Clone, Copy)]
 pub struct TombstoneSample {
     pub elapsed_secs: f64,

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -49,10 +49,12 @@
 //!
 //! ## Tombstone-byte gate: same slope idea, no detection floor
 //!
-//! `topgun_ormap_tombstone_bytes_total` (sampled over HTTP from `GET /metrics`)
-//! is a direct, residency-independent count of tombstone bytes on the write
-//! path — unlike RSS it carries no allocator retention, no read/GC jitter, and
-//! no cache-warmup wobble. Every unit of observed growth is either a newly
+//! `topgun_ormap_tombstone_bytes` (the DECREMENTABLE gauge, sampled over HTTP
+//! from `GET /metrics` — distinct from the monotonic `_total` creation-rate
+//! counter also exported on the same endpoint) is a direct,
+//! residency-independent count of tombstone bytes on the write path — unlike
+//! RSS it carries no allocator retention, no read/GC jitter, and no
+//! cache-warmup wobble. Every unit of observed growth is either a newly
 //! inserted tombstone or nothing; there is no noise floor to wait out. That is
 //! why [`assess_tombstone_bytes`] uses a much tighter per-hour threshold than
 //! the RSS gate AND does not replicate RSS's large min-growth guard (see
@@ -64,23 +66,32 @@
 //!
 //! Note on gating responsibility: [`assess_tombstone_bytes`] *computes* the byte
 //! verdict (including its `passed` flag), but whether that verdict gates the run
-//! is decided in `main.rs`, not here. The byte **slope** is surfaced
-//! REPORT-ONLY, NOT hard-gated. Although the gauge is restart-survivable
-//! (`reconcile_tombstone_bytes` in `bin/topgun_server.rs` re-seeds it via
-//! `set_tombstone_bytes` at boot), it is ADDITIVE-ONLY within a process life:
-//! every tombstone-add increments it and no prune-side decrement is wired yet
-//! (`sub_tombstone_bytes` has no live call site), and the OR-Map epoch prune is
-//! dark until a follow-up supplies the frontier's durable-epoch watermark. So
-//! under sustained OR churn the gauge climbs at the tombstone-*creation* rate
-//! and cannot plateau — hard-gating the slope would false-RED every healthy
-//! long run. `main.rs` therefore routes a slope breach to its `pending_gates`
-//! (honest, non-failing) channel, exactly like the disk gate; only the
-//! blind-monitor zero-sample case hard-gates. The RSS gate above remains a
-//! coarse, non-tombstone backstop. Re-promote the slope to a hard gate once the
-//! prune-activation follow-up makes the gauge track residency and a live
-//! bounded soak is observed to plateau. (This module's `passed: bool` on
-//! [`TombstoneAssessment`] still drives the report-only signal and the
-//! calibration tests below.)
+//! is decided in `main.rs`, not here. The byte **slope** is now a HARD gate
+//! there. The gauge is restart-survivable (`reconcile_tombstone_bytes` in
+//! `bin/topgun_server.rs` re-seeds it via `set_tombstone_bytes` at boot) AND
+//! decrementable within a process life: every tombstone-add increments it and
+//! a successful prune-drop decrements it (`sub_tombstone_bytes`, wired on the
+//! CRDT write path's remove/prune handling). Decrementing alone is not
+//! sufficient for a plateau, though — the prune only fires once the server's
+//! per-device causal frontier low-water-mark has advanced past a tombstone's
+//! epoch, and the low-water-mark is vacuously 0 (prune NOTHING) until at least
+//! one client actually runs the confirm-apply protocol. `main.rs` therefore
+//! also drives a tracked-and-ACKing client (`SoakClient::connect_tracked` +
+//! `confirm_apply`) alongside the churn clients for the run's duration, which
+//! is what makes the gauge's plateau — and thus the hard gate — reachable in
+//! practice rather than merely possible in principle. `main.rs`'s `--no-ack`
+//! and `--inject-slow-leak` modes are the negative/slow-leak controls that
+//! exercise this: disabling the tracked client's ack loop pins the
+//! low-water-mark at 0 and must trip the gate, and a deliberately
+//! slow-acking second tracked client calibrates the OLS slope's detection
+//! floor against a small, non-instantaneous leak. The blind-monitor
+//! zero-sample case remains a second, independent hard gate (an unreachable
+//! `/metrics` scrape is a harness defect regardless of leak magnitude). The
+//! RSS gate above remains a coarse, non-tombstone backstop. (This module's
+//! `passed: bool` on [`TombstoneAssessment`] drives both the hard-gate
+//! decision in `main.rs` and the calibration tests below — the assessment
+//! itself does not know or care whether its caller treats a breach as
+//! report-only or hard-gating.)
 //!
 //! ## Boot-recompute-gap exclusion
 //!
@@ -311,10 +322,12 @@ fn last_half_window_span_secs(points: &[(f64, f64)]) -> f64 {
 /// [`assess_tombstone_bytes`] with this threshold alongside the RSS `assess`) and
 /// by the `soak_monitor_calibration` integration target's tests — the harness
 /// wiring has landed, so no `allow(dead_code)` is needed here. The slope this
-/// threshold measures is surfaced REPORT-ONLY by `main.rs` (the additive-only
-/// gauge cannot plateau under sustained churn until an OR-Map prune-activation
-/// follow-up wires residency tracking); the blind-monitor zero-sample clause is
-/// the only tombstone hard gate today. RSS above is the coarse backstop.
+/// threshold measures is a HARD gate in `main.rs`: the decrementable gauge is
+/// expected to plateau under sustained churn now that a tracked-and-ACKing
+/// client drives the server's low-water-mark forward (see the module-level
+/// "Tombstone-byte gate" doc above), subject to the min-window-span guard and
+/// boot-gap exclusion. The blind-monitor zero-sample clause is a second,
+/// independent hard gate. RSS above is the coarse backstop.
 pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 
 /// Absolute-growth guard (bytes) for the tombstone-byte slope clause.
@@ -967,12 +980,14 @@ mod tests {
     /// fills the keyspace, then flatten. Only the LAST-HALF window should drive
     /// the fitted slope (R9(d)), so this PASSes even though the run grew earlier.
     ///
-    /// NOTE — this validates the OLS/last-half-window MATH only; it is NOT a
-    /// reachable production PASS today. The `bytes` series here is hand-authored
-    /// to flatten, but the live gauge is additive-only and cannot flatten under
-    /// sustained churn (see `calibration_additive_only_gauge_never_plateaus`
-    /// below) — which is exactly why `main.rs` surfaces the slope report-only
-    /// rather than hard-gating it.
+    /// NOTE — this validates the OLS/last-half-window MATH directly on a
+    /// hand-authored series; it does not itself drive a live server. A real
+    /// run reaches this same grow-then-flatten shape once the tracked-and-ACKing
+    /// client (`main.rs`'s `SoakClient::connect_tracked` + `confirm_apply`)
+    /// advances the low-water-mark far enough for the epoch-scoped prune to
+    /// engage — see `calibration_additive_only_gauge_never_plateaus` below for
+    /// the contrasting shape produced when nothing drives the low-water-mark
+    /// (e.g. `main.rs`'s `--no-ack` negative control).
     #[test]
     fn calibration_delayed_plateau_grow_then_flatten_passes() {
         let mut samples = Vec::new();
@@ -1002,25 +1017,21 @@ mod tests {
         );
     }
 
-    /// Pins the REAL production shape and the reason the slope is report-only.
-    ///
-    /// The exported gauge (`add_tombstone_bytes`) is additive-only: it counts
-    /// every tombstone-add and is never decremented on prune, and the OR-Map
-    /// epoch prune is dark until a follow-up supplies the frontier watermark.
-    /// So under sustained OR churn the gauge climbs monotonically at the
-    /// tombstone-*creation* rate and never flattens within a process life — the
-    /// grow-then-flatten shape the plateau statistic looks for cannot occur.
-    /// This test feeds exactly that monotone shape (well past the min-window
-    /// floor) and asserts the assessment reports NOT-passed — which is why
-    /// `main.rs` routes this verdict to `pending_gates` (report-only) instead
-    /// of hard-gating the run. When a prune-activation follow-up makes the gauge
-    /// track residency, replace this with a genuine live-plateau PASS test and
-    /// re-promote the slope to a hard gate.
+    /// Pins the shape produced when NOTHING drives the low-water-mark forward —
+    /// exactly `main.rs`'s `--no-ack` negative control (or, pre-this-spec, every
+    /// production run, since no client ever ran the confirm-apply protocol at
+    /// all): with the low-water-mark vacuously 0, the epoch-scoped prune never
+    /// fires, so the gauge climbs monotonically at the tombstone-*creation* rate
+    /// and never flattens — the grow-then-flatten shape the plateau statistic
+    /// looks for cannot occur. This test feeds exactly that monotone shape (well
+    /// past the min-window floor) and asserts the assessment reports NOT-passed
+    /// — which is precisely the hard-gate failure `main.rs` now asserts on for
+    /// this scenario (see the module doc's "Tombstone-byte gate" section).
     #[test]
     fn calibration_additive_only_gauge_never_plateaus() {
         // ~6h of steady creation at 5000 B/h — a multi-hour last-half window
         // (well past the 120s min-window floor), monotone, no flatten. This is
-        // the shape a real sustained-churn soak actually produces today.
+        // the shape an unbounded (no-driver / `--no-ack`) soak produces.
         let samples = linear_bytes_series(1_000, 6, 5_000);
         let a = assess_tombstone_bytes(
             &samples,
@@ -1030,9 +1041,9 @@ mod tests {
         );
         assert!(
             !a.passed,
-            "the additive-only gauge's monotone-growth shape must NOT be reported \
-             as a plateau — this is why the slope is surfaced report-only, not \
-             hard-gated; slope={:.1} reason={:?}",
+            "an unbounded monotone-growth shape (no low-water-mark driver) must \
+             NOT be reported as a plateau — this is the hard-gate FAIL `main.rs` \
+             now asserts on; slope={:.1} reason={:?}",
             a.slope_bytes_per_hour, a.reason
         );
     }

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -457,17 +457,16 @@ impl CrdtService {
         Ok(snapshot)
     }
 
-    /// Defence-in-depth op-path gate (R4 — NON-load-bearing, DARK until SPEC-342j).
-    ///
-    /// Whether an OR-bearing op arriving on a direct client connection must be
-    /// dropped because the connection's server-authenticated `(principal, deviceId)`
-    /// identity is forgotten. This mirrors the sync-path push-diff gate purely as
-    /// belt-and-suspenders: the load-bearing re-admission surface is `ORMapPushDiff`,
-    /// and the `OR_ADD` apply path below REGENERATES the tag from the sanitized server
-    /// timestamp, so a same-tag op-path resurrection cannot even carry a client's
-    /// original tag through to the store (the test would be vacuous). Returns `false`
-    /// (never gates) for a non-client caller (no connection → HTTP/anonymous/system
-    /// trusted paths) and while the durability watermark is 0 (dark by construction).
+    /// This path deliberately carries no forgotten-client gate on OR-bearing ops
+    /// arriving over a direct client connection (see the inline comment above the
+    /// admission check inside this function's caller for the full reasoning):
+    /// client-originated tags are server-regenerated below, so a pruned
+    /// tombstone's tag can never be re-presented here, and gating on
+    /// unknown-connection == forgotten would silently drop first-sync writes from
+    /// any device that has not yet completed its first ACK round while still
+    /// returning `OP_ACK` — turning that ack into permanent client-side data loss.
+    /// The verbatim-tag `ORMapPushDiff` sync path keeps the load-bearing gate
+    /// instead.
     /// Applies a single `ClientOp` to the `RecordStore` and returns the `ServerEventPayload`
     /// to broadcast. Called by both `handle_client_op` and `handle_op_batch`.
     ///
@@ -673,10 +672,11 @@ impl CrdtService {
             // would self-deadlock on this key.
             drop(key_guard);
 
-            // Wholesale epoch-drop prune over the OR write path. DARK by construction:
-            // the frontier's `durable_epoch_watermark` is constant 0 in this child, so
-            // the call-site conjunction never licenses a prune for any stamped epoch —
-            // this drains nothing until SPEC-342j supplies the real watermark.
+            // Wholesale epoch-drop prune over the OR write path. Active whenever the
+            // low-water mark has advanced past a stamped epoch AND the durable epoch
+            // watermark has caught up to it — both conjuncts move forward as tracked
+            // clients confirm-apply and the durable backend flushes, so this drains
+            // real tombstones once those two conditions line up.
             if let Some(frontier) = self.frontier.as_ref() {
                 prune_epoch_tombstones(frontier, &self.record_store_factory, &self.key_writer)
                     .await;
@@ -1200,12 +1200,13 @@ fn read_or_map_state(value: Option<RecordValue>) -> (Vec<OrMapEntry>, Vec<String
 /// tag from its OR-Map record in storage (RAM + redb) under the per-key writer,
 /// so a concurrent OR write on the same key cannot flicker a pruned tag back in.
 ///
-/// DARK by construction in THIS child: the frontier's `durable_epoch_watermark`
-/// is constant 0, so the drained set is always empty in production — nothing is
-/// ever dropped. Tests inject a watermark (`set_durable_epoch_watermark`) to
-/// exercise this drop path. SPEC-342j supplies the real watermark that activates
-/// the prune. Shared by the OR write path (`crdt.rs`) and the SYNC leaf
-/// (`sync.rs`).
+/// The real gate is the conjunction of both call-site checks:
+/// `is_epoch_prune_eligible(E)` (derived from the low-water mark) AND
+/// `durable_epoch_watermark >= E`. Neither is a fixed constant — the low-water
+/// mark advances as tracked clients confirm-apply, and the durable watermark
+/// advances as the durable backend catches up, so the drained set grows over
+/// time in production rather than staying permanently empty. Shared by the OR
+/// write path (`crdt.rs`) and the SYNC leaf (`sync.rs`).
 ///
 /// A ref whose storage drop FAILS (read or write error) is handed back to the
 /// frontier via `restore_tombstone_ref` so a later sweep retries it — dropping
@@ -1234,7 +1235,7 @@ pub(crate) async fn prune_epoch_tombstones(
         let before = tombstones.len();
         tombstones.retain(|t| t != &r.tag);
         if tombstones.len() != before {
-            if let Err(e) = store
+            match store
                 .put(
                     &r.key,
                     RecordValue::OrMap {
@@ -1246,8 +1247,14 @@ pub(crate) async fn prune_epoch_tombstones(
                 )
                 .await
             {
-                tracing::warn!(map = %r.map, key = %r.key, epoch, "prune put failed, re-indexing tombstone for retry: {e}");
-                frontier.restore_tombstone_ref(epoch, r);
+                // The tag is durably gone from storage only once `put` succeeds —
+                // decrement here so the gauge tracks bytes actually resident, not
+                // bytes merely removed from an in-memory copy that never landed.
+                Ok(_) => crate::storage::record::sub_tombstone_bytes(r.tag.len() as u64),
+                Err(e) => {
+                    tracing::warn!(map = %r.map, key = %r.key, epoch, "prune put failed, re-indexing tombstone for retry: {e}");
+                    frontier.restore_tombstone_ref(epoch, r);
+                }
             }
         }
     }

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -463,15 +463,15 @@ mod tombstone_bytes_gauge_tests {
     use super::*;
     use std::sync::Mutex;
 
-    // `OR_TOMBSTONE_BYTES` is a single process-global static. No production
-    // call site exists yet (added by later task groups), so the only writers
-    // today are these three tests themselves — but the Rust test harness runs
-    // them concurrently on separate threads, and a delta-based assertion in
-    // one test can still observe an in-flight mutation from another. A
-    // test-local mutex serializes just this module's tests against each
-    // other, which is sufficient today; asserting deltas (rather than
-    // absolute values) additionally keeps these tests robust once real call
-    // sites (G2/G3) start mutating the gauge from other test modules too.
+    // `OR_TOMBSTONE_BYTES` is a single process-global static. The production
+    // writers are the OR_REMOVE add path and the epoch-prune drop path (which
+    // decrements on a successful tombstone drop), so these tests are not the
+    // only mutators — and the Rust test harness runs tests concurrently on
+    // separate threads, where a delta-based assertion in one test can still
+    // observe an in-flight mutation from another. A test-local mutex serializes
+    // just this module's tests against each other; asserting deltas (rather
+    // than absolute values) additionally keeps these tests robust against
+    // concurrent mutation from other test modules.
     static TEST_SERIALIZE: Mutex<()> = Mutex::new(());
 
     #[test]

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -53,9 +53,12 @@ static OR_TOMBSTONE_BYTES: AtomicU64 = AtomicU64::new(0);
 static TOMBSTONE_ADD_FIRED: AtomicBool = AtomicBool::new(false);
 
 /// Adds `n` bytes to the process-global OR-Map tombstone-bytes gauge and
-/// emits the same delta to the `topgun_ormap_tombstone_bytes_total`
-/// Prometheus counter (mirrors the `topgun_operations_total` emit pattern in
-/// `service/middleware/metrics.rs`).
+/// emits the same delta to both exported Prometheus series: the
+/// `topgun_ormap_tombstone_bytes_total` monotonic creation-rate counter
+/// (mirrors the `topgun_operations_total` emit pattern in
+/// `service/middleware/metrics.rs`), and the `topgun_ormap_tombstone_bytes`
+/// gauge — the decrementable series a prune path can move back down, and the
+/// one the soak monitor's plateau/slope fit reads over `GET /metrics`.
 ///
 /// Call sites pass `tag.len() as u64` — the tombstone's contribution is its
 /// removed tag's UTF-8 byte length, which is the direct measure of what grows
@@ -71,34 +74,40 @@ pub fn add_tombstone_bytes(n: u64) {
     TOMBSTONE_ADD_FIRED.store(true, Ordering::Release);
     OR_TOMBSTONE_BYTES.fetch_add(n, Ordering::Relaxed);
     metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(n);
+    // Precision loss only above 2^53 bytes of tombstone data on one process —
+    // not a real-world concern for this monitoring signal.
+    #[allow(clippy::cast_precision_loss)]
+    metrics::gauge!("topgun_ormap_tombstone_bytes").increment(n as f64);
 }
 
-/// Subtracts `n` bytes from the process-global OR-Map tombstone-bytes gauge.
+/// Subtracts `n` bytes from the process-global OR-Map tombstone-bytes gauge,
+/// and mirrors the same decrement onto the exported `topgun_ormap_tombstone_bytes`
+/// Prometheus gauge — the byte-for-byte counterpart of [`add_tombstone_bytes`]'s
+/// increment.
 ///
-/// This is the decrement path for the future OR-Map epoch-GC prune
-/// (TODO-566): once that prune wires in, it will call this function as it
-/// drops fully-superseded tombstone epochs. It is intentionally unused on
-/// today's additive-only write path (nothing yet prunes tombstones), so it is
-/// exercised solely by a unit test to keep it out of `-D warnings` dead-code
-/// territory until the prune lands.
+/// This is the decrement path for the OR-Map epoch-GC prune: it is called as
+/// the prune drops fully-superseded tombstone epochs, passing the same
+/// `tag.len() as u64` accounting [`add_tombstone_bytes`] used when the tag was
+/// first tombstoned, so the two calls are exact inverses over a tag's
+/// lifetime.
 ///
-/// **Prometheus divergence (forward-looking):** unlike [`add_tombstone_bytes`],
-/// this function does NOT emit to `topgun_ormap_tombstone_bytes_total` — that
-/// metric follows the `_total` *monotonic*-counter convention, so it cannot
-/// legally decrease. That is harmless today because usage is purely additive,
-/// but once TODO-566's prune starts calling this decrement path, the exported
-/// Prometheus series will diverge from (stay flat relative to) the
-/// authoritative in-process [`tombstone_bytes`] value. TODO-566 must reconcile
-/// the external surface at that point — e.g. switch the exported metric to a
-/// gauge, or have consumers (soak harness, dashboards) read the in-process
-/// accessor instead of scraping the counter.
+/// Unlike the `topgun_ormap_tombstone_bytes_total` counter (which follows the
+/// `_total` *monotonic* convention and therefore cannot legally decrease),
+/// `topgun_ormap_tombstone_bytes` has no such constraint: it is a plain
+/// Prometheus gauge, so this function's decrement is externally visible over
+/// `GET /metrics` without needing the in-process [`tombstone_bytes`] accessor
+/// — the surface an out-of-process soak monitor actually scrapes.
 ///
-/// Saturating-safe by construction: the future prune is only ever expected to
+/// Saturating-safe by construction: the prune is only ever expected to
 /// subtract bytes it previously observed being added, so it should never
 /// underflow in practice, but `fetch_sub` wraps on underflow rather than
 /// panicking — acceptable for a monitoring counter.
 pub fn sub_tombstone_bytes(n: u64) {
     OR_TOMBSTONE_BYTES.fetch_sub(n, Ordering::Relaxed);
+    // Precision loss only above 2^53 bytes of tombstone data on one process —
+    // not a real-world concern for this monitoring signal.
+    #[allow(clippy::cast_precision_loss)]
+    metrics::gauge!("topgun_ormap_tombstone_bytes").decrement(n as f64);
 }
 
 /// Reads the current value of the process-global OR-Map tombstone-bytes gauge.
@@ -115,27 +124,35 @@ pub fn tombstone_bytes() -> u64 {
 ///
 /// This is the **only** absolute-set path for the gauge. It exists exclusively
 /// for the one-time startup reconciliation that runs after WAL recovery
-/// completes (see `bin/topgun_server.rs`): both the process-local
-/// [`OR_TOMBSTONE_BYTES`] atomic and the exported Prometheus
-/// `topgun_ormap_tombstone_bytes_total` counter reset to zero on every process
-/// start and never re-count rehydrated (redb-persisted) tombstones, so without
-/// this boot seed the scraped series sawtooths back to 0 on every `kill -9`
-/// restart and the cross-restart leak becomes invisible. It MUST NEVER be called
-/// on the hot read/write path — only once, at boot, before the listener accepts
+/// completes (see `bin/topgun_server.rs`): the process-local
+/// [`OR_TOMBSTONE_BYTES`] atomic and both exported Prometheus series
+/// (`topgun_ormap_tombstone_bytes_total` and `topgun_ormap_tombstone_bytes`)
+/// reset to zero/absent on every process start and never re-count rehydrated
+/// (redb-persisted) tombstones, so without this boot seed the scraped series
+/// sawtooths back to 0 on every `kill -9` restart and the cross-restart leak
+/// becomes invisible. Seeding from the true reconciled corpus (rather than a
+/// literal `0`) means a genuine leak still shows as net upward drift from a
+/// real starting point, and a monitor that only trusts non-zero samples sees
+/// one from the first scrape after boot. It MUST NEVER be called on the hot
+/// read/write path — only once, at boot, before the listener accepts
 /// connections.
 ///
-/// It performs BOTH writes, in order, because the two are **separate sinks**:
+/// It performs THREE writes, in order, because they are **separate sinks**:
 ///  1. `OR_TOMBSTONE_BYTES.store(total)` re-baselines the in-process `AtomicU64`
 ///     — an absolute store, never `fetch_add`: a per-rehydration increment would
 ///     reintroduce the eviction double-count the gauge's cardinal rule forbids.
-///  2. `metrics::counter!(...).increment(total)` seeds the Prometheus counter,
-///     which is a *different* sink living in the process `PrometheusHandle`
-///     recorder. The soak harness scrapes THIS counter via `GET /metrics`, not
-///     the `AtomicU64`; on a fresh process the recorder's counter starts at
-///     0/absent, so a single `increment(total)` from zero lands the exported
-///     series at `total` while staying a legal monotonic-from-zero `_total`
-///     counter (a Prometheus counter has no `.set`/`.store`). A `.store()`-only
-///     path would never reach the sink the harness actually reads.
+///  2. `metrics::counter!(...).increment(total)` seeds the monotonic
+///     `_total` Prometheus counter, a *different* sink living in the process
+///     `PrometheusHandle` recorder; on a fresh process it starts at 0/absent,
+///     so a single `increment(total)` from zero lands the exported series at
+///     `total` while staying a legal monotonic-from-zero counter (a Prometheus
+///     counter has no `.set`/`.store`).
+///  3. `metrics::gauge!(...).set(total)` re-baselines the decrementable
+///     `topgun_ormap_tombstone_bytes` gauge — the series the soak monitor's
+///     plateau/slope fit actually scrapes over `GET /metrics`. Unlike the
+///     counter this is a plain absolute `.set`, so it carries no additive
+///     double-count risk and can be called safely even if this boot seed ever
+///     ran more than once.
 pub fn set_tombstone_bytes(total: u64) {
     OR_TOMBSTONE_BYTES.store(total, Ordering::Relaxed);
     // The Prometheus increment below is additive; correct only on a fresh-zero
@@ -160,6 +177,11 @@ pub fn set_tombstone_bytes(total: u64) {
          Prometheus counter would double-count"
     );
     metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(total);
+    // Absolute re-baseline of the decrementable gauge — no additive-race
+    // hazard here since `.set` (unlike the counter's `.increment`) overwrites
+    // rather than accumulates.
+    #[allow(clippy::cast_precision_loss)]
+    metrics::gauge!("topgun_ormap_tombstone_bytes").set(total as f64);
 }
 
 /// The startup warning for a detected legacy [`RecordValue::OrTombstones`] corpus,


### PR DESCRIPTION
## Summary

Resolves TODO-584 — makes the OR-Map tombstone prune both OBSERVABLE and EXERCISED by the soak, then re-promotes the byte-slope success-condition to a HARD gate, proven by live positive/negative/slow-leak controls.

The prune itself was already active in production (SPEC-342j wired the durable watermark). The two gaps that kept the soak from proving a plateau are closed here:

- **Decrementable gauge** — `sub_tombstone_bytes` is now called on every successful prune drop (`crdt.rs`); the exported `topgun_ormap_tombstone_bytes` metric reflects NET resident tombstone bytes, not cumulative creations. Previously additive-only → a plateau was invisible even when the prune fired.
- **Soak drives the LWM** — a tracked confirm-apply soak client (device_token + `ClientApplyAck`, cursor persisted across reconnect) advances the server's low-water-mark under churn, so epochs become prune-eligible and the prune actually fires during the soak. Previously the soak client never ACKed → LWM stayed 0 → nothing was prune-eligible.
- **Hard gate re-promoted** — the byte-slope is promoted from report-only to a hard gate, with pos/neg/slow-leak control modes; stale "dark until 342j" doc comments corrected.

## Live proof (the SPEC-342h lesson — no unit-test-only promotion)
- POSITIVE control (tracked+ACKing, 15 min): tombstone gate PASS, slope **−1707.5 B/h** (bytes decrease), gauge peaked 4284 → 2310, redb corpus bounded at 2856 bytes.
- NEGATIVE controls: FAIL at 742469 / 723579 B/h.
- Rust gate green; calibration + control modes pass.

## ⚠ Surfaced a separate pre-72h blocker (tracked, NOT this PR)
The positive control passed the tombstone gate but failed the run on the memory backstop: the **server child RSS grows ~390 MB/h** under sustained OR churn — orthogonal to tombstones (corpus is bounded/pruned, proven by the negative slope + independent redb key-scan). Pre-existing (SPEC-345 adds only an O(1) gauge). Tracked as **TODO-585**; the 72h G4b soak is re-gated on it.

## Follow-up
TODO-585 (server RSS leak) + a redb-corpus cross-check hardening (Review v1 Minor 4) before the unattended 72h run.