### PR TITLE
OR-Map WAL/RSS growth (G1): mechanism measurement + OR-delta types/oracle [SPEC-346]

### DIFF
--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -1577,7 +1577,7 @@ fn build_mechanism_report(inp: &MechanismInputs) -> MechanismReport {
     };
 
     // Q4: the growth is the OR snapshot path iff the retained OR WAL bytes dwarf
-    // the bounded (SPEC-345, ~11KB pruned) tombstone corpus.
+    // the bounded (~11KB, pruned) tombstone corpus.
     let corpus = inp.tombstone_corpus_bytes.unwrap_or(0);
     let q4_is_or_not_tombstone = wal.or_bytes_total > corpus.saturating_mul(10).max(1_000_000);
 

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -103,6 +103,8 @@ use report::{
     append_progress, utc_timestamp_now, write_report, MemoryReport, ProgressSnapshot, SoakReport,
 };
 use topgun_server::storage::record::RecordValue;
+use topgun_server::storage::wal::format::{self, FrameDecodeResult};
+use topgun_server::storage::wal::{WalOp, WalStorePayload};
 
 /// Subject index used by the orchestrator's verifier connections. Far above the
 /// churn-client range so it never owns keys or collides with churn auth.
@@ -176,6 +178,14 @@ struct Config {
     /// This is the assertion mode that proves acked == durable on `kill -9` under
     /// load: it does NOT depend on a pre-kill flush masking a durability gap.
     no_pre_kill_drain: bool,
+    /// Opt-in measurement mode: after the run, scan the retained WAL segment
+    /// files and emit a structured mechanism report (Q1-Q4) attributing the
+    /// OR-churn WAL+RSS growth. REPORT-ONLY — never affects `passed`, so it
+    /// cannot false-RED the CI smoke; it exists so a LIVE 60-min OR-churn run
+    /// produces the numbers that pin the fix mechanism. Also snapshots the WAL
+    /// dir's on-disk size immediately before stop and immediately after the
+    /// shutdown drain so the Q2 drain-window burst can be attributed.
+    mechanism_report: bool,
     /// True once any soak-controlling flag is parsed. A bare invocation (or one
     /// carrying only foreign libtest args, as `cargo test --all-targets` passes)
     /// leaves this false so the harness prints usage and exits 0 instead of
@@ -222,6 +232,7 @@ impl Default for Config {
             no_ack: false,
             inject_slow_leak: false,
             no_pre_kill_drain: false,
+            mechanism_report: false,
             mode_requested: false,
         }
     }
@@ -731,12 +742,29 @@ async fn run_soak(config: &Config) -> i32 {
     }
 
     // --- Tear down ---
+    // Q2: bracket the shutdown-drain window by measuring the WAL dir on disk just
+    // before we stop and again after the drain completes, so the report can
+    // attribute the end-of-run WAL burst (Run B saw 84 -> 222 MB in the final
+    // ~60s). Gated on the opt-in measurement mode so a normal run pays nothing.
+    let wal_dir = data_dir.join("wal");
+    let wal_mb_before_drain = if config.mechanism_report {
+        sample_disk_mb(&wal_dir)
+    } else {
+        None
+    };
+
     stop.store(true, Ordering::SeqCst);
     paused.store(false, Ordering::SeqCst);
     for h in churn_handles {
         let _ = tokio::time::timeout(Duration::from_secs(5), h).await;
     }
     supervisor.shutdown().await;
+
+    let wal_mb_after_drain = if config.mechanism_report {
+        sample_disk_mb(&wal_dir)
+    } else {
+        None
+    };
 
     // Positive-control independent corpus assertion (R5): the server process
     // has just been reaped, so its redb handle is released and this scan can
@@ -915,6 +943,51 @@ async fn run_soak(config: &Config) -> i32 {
     if let Some(path) = &config.json_output {
         write_report(path, &report);
         println!("wrote JSON report to {}", path.display());
+    }
+
+    // --- Mechanism report (R1: Q1-Q4, report-only) ---
+    // Built from the retained WAL frame scan plus the RSS/disk slopes and the
+    // independent tombstone corpus scan already computed above. REPORT-ONLY:
+    // it is printed (and serialized next to the JSON report when set) but never
+    // asserted into `passed`, so it cannot false-RED the bounded CI smoke.
+    if config.mechanism_report {
+        if let Some(wal) = scan_wal_frame_sizes(&wal_dir) {
+            let mechanism = build_mechanism_report(&MechanismInputs {
+                wal: &wal,
+                rss_samples: &mem_samples,
+                disk_samples: &disk_samples_snapshot,
+                rss_slope_mb_per_hour: mem.slope_mb_per_hour,
+                disk_slope_mb_per_hour: disk.slope_mb_per_hour,
+                tombstone_corpus_bytes: redb_tombstone_scan,
+                tombstone_gauge_bytes: tombstones.last_bytes,
+                wal_mb_before_drain,
+                wal_mb_after_drain,
+            });
+            print_mechanism_report(&mechanism);
+            if let Some(path) = &config.json_output {
+                let mech_path = path.with_extension("mechanism.json");
+                match std::fs::File::create(&mech_path) {
+                    Ok(f) => {
+                        if let Err(e) = serde_json::to_writer_pretty(f, &mechanism) {
+                            eprintln!("mechanism report write failed: {e}");
+                        } else {
+                            println!("wrote mechanism report to {}", mech_path.display());
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "mechanism report create failed for {}: {e}",
+                            mech_path.display()
+                        );
+                    }
+                }
+            }
+        } else {
+            eprintln!(
+                "mechanism report requested but WAL dir {} could not be scanned",
+                wal_dir.display()
+            );
+        }
     }
     // NOTE: neither the tombstone-byte nor the disk verdict is a field on
     // `SoakReport` (report.rs) — both are asserted into `passed`/`finished_reason`
@@ -1186,6 +1259,430 @@ fn scan_redb_tombstone_corpus(data_dir: &Path, map: &str) -> Option<u64> {
         }
     }
     Some(total_bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Mechanism report (R1: Q1-Q4 attribution of OR-churn WAL + RSS growth)
+// ---------------------------------------------------------------------------
+
+/// Per-op-kind WAL frame-size aggregates from a post-run scan of the retained
+/// segment files. The retained WAL is the acked-beyond-applied tail (GC has
+/// reclaimed everything at/below the applied watermark), so its highest
+/// sequences are the most-recently-appended frames — which lets a single
+/// end-of-run scan answer Q1 (does an OR op's frame size RISE over the run?) by
+/// bucketing OR frames by sequence into an early and a late half.
+struct WalFrameStats {
+    segment_files: usize,
+    or_frames: usize,
+    or_bytes_total: u64,
+    or_bytes_max: u64,
+    lww_frames: usize,
+    lww_bytes_total: u64,
+    lww_bytes_max: u64,
+    remove_frames: usize,
+    /// Mean OR frame bytes in the earliest / latest sequence half of the retained
+    /// corpus. `late > early` is the O(N)-per-op growth signature.
+    or_bytes_mean_early: f64,
+    or_bytes_mean_late: f64,
+    or_bytes_max_early: u64,
+    or_bytes_max_late: u64,
+    /// Frames whose sequence is in the top decile of the retained corpus (the
+    /// drain-window proxy) plus the largest OR frame among them: many small
+    /// frames points at a rotation/flush storm, a few large OR frames at a final
+    /// full-slot re-write.
+    top_decile_frames: usize,
+    top_decile_or_bytes_max: u64,
+}
+
+fn classify_frame(op: &WalOp) -> Option<bool> {
+    // Returns Some(true) for an OR frame, Some(false) for an LWW frame, None for
+    // a Remove/tombstone frame (counted separately). OR_ADD/OR_REMOVE both persist
+    // the full RecordValue::OrMap slot today; the legacy OrTombstones blob is also
+    // an OR-side snapshot. Legacy bare-Value frames replay as LWW.
+    match op {
+        WalOp::Remove => None,
+        WalOp::Store { value, .. } => match value {
+            WalStorePayload::Record(
+                RecordValue::OrMap { .. } | RecordValue::OrTombstones { .. },
+            ) => Some(true),
+            WalStorePayload::Record(RecordValue::Lww { .. }) | WalStorePayload::Legacy(_) => {
+                Some(false)
+            }
+        },
+    }
+}
+
+/// Scan every `*.log` WAL segment under `wal_dir`, decode intact frames, and
+/// aggregate per-op-kind frame sizes. Read-only and best-effort: a torn active
+/// tail decodes as its intact prefix (`TruncatedTail`), a corrupt/foreign file
+/// is skipped, and an exact on-disk frame size is recovered by re-encoding each
+/// decoded entry through the deterministic codec (the same trick WAL recovery
+/// uses to measure a segment's intact-prefix length). Returns `None` only if the
+/// directory cannot be read at all.
+fn scan_wal_frame_sizes(wal_dir: &Path) -> Option<WalFrameStats> {
+    let read_dir = std::fs::read_dir(wal_dir).ok()?;
+    // (sequence, frame_bytes) for every OR frame, and running LWW/Remove tallies.
+    let mut or_frames: Vec<(u64, u64)> = Vec::new();
+    let mut lww_bytes_total: u64 = 0;
+    let mut lww_bytes_max: u64 = 0;
+    let mut lww_frames: usize = 0;
+    let mut remove_frames: usize = 0;
+    let mut segment_files: usize = 0;
+    let mut max_seq: u64 = 0;
+
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("log") {
+            continue;
+        }
+        let Ok(data) = std::fs::read(&path) else {
+            continue;
+        };
+        segment_files += 1;
+        // A corrupt/foreign/empty file contributes no frames — skip it rather than
+        // abort the whole scan (this is a report-only instrument).
+        let (FrameDecodeResult::Complete(entries)
+        | FrameDecodeResult::TruncatedTail { complete: entries }) = format::decode_all(&data)
+        else {
+            continue;
+        };
+        for wal_entry in &entries {
+            let Ok(frame) = format::encode(wal_entry) else {
+                continue;
+            };
+            let bytes = frame.len() as u64;
+            max_seq = max_seq.max(wal_entry.sequence);
+            match classify_frame(&wal_entry.op) {
+                Some(true) => or_frames.push((wal_entry.sequence, bytes)),
+                Some(false) => {
+                    lww_frames += 1;
+                    lww_bytes_total += bytes;
+                    lww_bytes_max = lww_bytes_max.max(bytes);
+                }
+                None => remove_frames += 1,
+            }
+        }
+    }
+
+    or_frames.sort_by_key(|(seq, _)| *seq);
+    let or_count = or_frames.len();
+    let or_bytes_total: u64 = or_frames.iter().map(|(_, b)| *b).sum();
+    let or_bytes_max = or_frames.iter().map(|(_, b)| *b).max().unwrap_or(0);
+
+    let half = or_count / 2;
+    let (early, late) = or_frames.split_at(half);
+    let mean = |s: &[(u64, u64)]| -> f64 {
+        if s.is_empty() {
+            0.0
+        } else {
+            s.iter().map(|(_, b)| *b as f64).sum::<f64>() / s.len() as f64
+        }
+    };
+    let max_of = |s: &[(u64, u64)]| -> u64 { s.iter().map(|(_, b)| *b).max().unwrap_or(0) };
+
+    // Top-decile-by-sequence frames across BOTH kinds: the drain-window proxy.
+    let decile_floor = max_seq.saturating_sub(max_seq / 10);
+    let top_decile_frames = or_frames.iter().filter(|(s, _)| *s >= decile_floor).count();
+    let top_decile_or_bytes_max = or_frames
+        .iter()
+        .filter(|(s, _)| *s >= decile_floor)
+        .map(|(_, b)| *b)
+        .max()
+        .unwrap_or(0);
+
+    Some(WalFrameStats {
+        segment_files,
+        or_frames: or_count,
+        or_bytes_total,
+        or_bytes_max,
+        lww_frames,
+        lww_bytes_total,
+        lww_bytes_max,
+        remove_frames,
+        or_bytes_mean_early: mean(early),
+        or_bytes_mean_late: mean(late),
+        or_bytes_max_early: max_of(early),
+        or_bytes_max_late: max_of(late),
+        top_decile_frames,
+        top_decile_or_bytes_max,
+    })
+}
+
+/// Pearson correlation between the RSS and disk time series, matching each disk
+/// sample to the RSS sample nearest in elapsed time (both share `sampler_start`,
+/// but a skipped scrape can drop a point on either side). `None` if either
+/// series has fewer than two matched points or is degenerate (zero variance).
+fn rss_disk_correlation(rss: &[MemSample], disk: &[DiskSample]) -> Option<f64> {
+    if rss.len() < 2 || disk.len() < 2 {
+        return None;
+    }
+    let mut xs: Vec<f64> = Vec::new();
+    let mut ys: Vec<f64> = Vec::new();
+    for d in disk {
+        let nearest = rss.iter().min_by(|a, b| {
+            (a.elapsed_secs - d.elapsed_secs)
+                .abs()
+                .partial_cmp(&(b.elapsed_secs - d.elapsed_secs).abs())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })?;
+        xs.push(nearest.rss_mb);
+        ys.push(d.disk_mb);
+    }
+    let n = xs.len() as f64;
+    if n < 2.0 {
+        return None;
+    }
+    let mean_x = xs.iter().sum::<f64>() / n;
+    let mean_y = ys.iter().sum::<f64>() / n;
+    let mut cov = 0.0;
+    let mut var_x = 0.0;
+    let mut var_y = 0.0;
+    for (x, y) in xs.iter().zip(&ys) {
+        cov += (x - mean_x) * (y - mean_y);
+        var_x += (x - mean_x).powi(2);
+        var_y += (y - mean_y).powi(2);
+    }
+    if var_x <= f64::EPSILON || var_y <= f64::EPSILON {
+        return None;
+    }
+    Some(cov / (var_x.sqrt() * var_y.sqrt()))
+}
+
+/// Structured mechanism report answering Q1-Q4. REPORT-ONLY: serialized to the
+/// JSON output (when set) and printed to the console; never asserted into
+/// `passed`.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MechanismReport {
+    // Q1 — bytes per frame, OR vs LWW, and growth over the run.
+    q1_or_frame_bytes_mean_early: f64,
+    q1_or_frame_bytes_mean_late: f64,
+    q1_or_frame_bytes_max_early: u64,
+    q1_or_frame_bytes_max_late: u64,
+    q1_or_frame_bytes_max: u64,
+    q1_lww_frame_bytes_mean: f64,
+    q1_lww_frame_bytes_max: u64,
+    q1_or_frame_size_rises: bool,
+    q1_or_vs_lww_mean_ratio: f64,
+    // Q2 — the shutdown drain-window WAL burst.
+    q2_wal_mb_before_drain: Option<f64>,
+    q2_wal_mb_after_drain: Option<f64>,
+    q2_drain_delta_mb: Option<f64>,
+    q2_top_decile_frames: usize,
+    q2_top_decile_or_bytes_max: u64,
+    q2_attribution: String,
+    // Q3 — what holds RSS.
+    q3_rss_slope_mb_per_hour: f64,
+    q3_disk_slope_mb_per_hour: f64,
+    q3_rss_disk_correlation: Option<f64>,
+    q3_attribution: String,
+    // Q4 — NOT the tombstone index.
+    q4_tombstone_corpus_bytes: Option<u64>,
+    q4_tombstone_gauge_bytes: u64,
+    q4_or_wal_bytes_total: u64,
+    q4_growth_is_or_snapshot_not_tombstone: bool,
+    // Scan meta + verdict.
+    wal_segment_files: usize,
+    or_frames: usize,
+    lww_frames: usize,
+    remove_frames: usize,
+    conclusion: String,
+    sequencing_note: String,
+}
+
+/// Inputs the mechanism report is built from, bundled so the builder stays under
+/// the argument-count lint without an `#[allow]`.
+struct MechanismInputs<'a> {
+    wal: &'a WalFrameStats,
+    rss_samples: &'a [MemSample],
+    disk_samples: &'a [DiskSample],
+    rss_slope_mb_per_hour: f64,
+    disk_slope_mb_per_hour: f64,
+    tombstone_corpus_bytes: Option<u64>,
+    tombstone_gauge_bytes: u64,
+    wal_mb_before_drain: Option<f64>,
+    wal_mb_after_drain: Option<f64>,
+}
+
+fn build_mechanism_report(inp: &MechanismInputs) -> MechanismReport {
+    let wal = inp.wal;
+    let lww_mean = if wal.lww_frames == 0 {
+        0.0
+    } else {
+        wal.lww_bytes_total as f64 / wal.lww_frames as f64
+    };
+    // A 10% late-vs-early mean growth (with a non-trivial OR frame count) is the
+    // threshold for calling the O(N)-per-op frame growth confirmed.
+    let rises = wal.or_frames >= 20 && wal.or_bytes_mean_late > wal.or_bytes_mean_early * 1.10;
+    let or_vs_lww = if lww_mean <= f64::EPSILON {
+        0.0
+    } else {
+        (wal.or_bytes_mean_late.max(wal.or_bytes_mean_early)) / lww_mean
+    };
+
+    let drain_delta = match (inp.wal_mb_before_drain, inp.wal_mb_after_drain) {
+        (Some(before), Some(after)) => Some(after - before),
+        _ => None,
+    };
+    // Attribute the drain burst: a large delta carried by a few large OR frames in
+    // the top sequence decile points at a final full-slot re-write on drain; a
+    // large delta spread across many frames points at a rotation/flush storm.
+    let q2_attribution = match drain_delta {
+        Some(d) if d > 5.0 => {
+            if wal.top_decile_or_bytes_max > 4096 && wal.top_decile_frames < 512 {
+                format!(
+                    "drain grew WAL by {d:.1}MB carried by a few large OR frames \
+                     (top-decile max OR frame {}B across {} frames) — consistent with a \
+                     final full-slot re-write on drain, which delta-framing removes",
+                    wal.top_decile_or_bytes_max, wal.top_decile_frames
+                )
+            } else {
+                format!(
+                    "drain grew WAL by {d:.1}MB spread across {} top-decile frames — \
+                     consistent with a rotation/flush storm on shutdown drain",
+                    wal.top_decile_frames
+                )
+            }
+        }
+        Some(d) => format!("no significant drain burst (WAL delta {d:.1}MB)"),
+        None => {
+            "drain-window WAL size not captured (need --data-dir + --mechanism-report)".to_string()
+        }
+    };
+
+    let corr = rss_disk_correlation(inp.rss_samples, inp.disk_samples);
+    // Q3 branch (spec R2 rec 6): if RSS tracks disk in lockstep AND OR frames grow,
+    // the growing OR blobs sit in the write-behind queue / record cache and
+    // delta-framing shrinks BOTH. If RSS climbs while disk is flat, RSS is
+    // record-cache-driven and delta-framing would NOT reduce it — the fix would
+    // instead be compacting the resident representation.
+    let q3_attribution = match corr {
+        Some(c) if c > 0.8 && inp.disk_slope_mb_per_hour > 1.0 => format!(
+            "RSS tracks disk in lockstep (r={c:.2}); the growing OR blobs sit in the \
+             write-behind queue / record cache — delta-framing should reduce RSS too"
+        ),
+        Some(c) if inp.rss_slope_mb_per_hour > 1.0 && inp.disk_slope_mb_per_hour <= 1.0 => format!(
+            "RSS grows ({:.1}MB/h) while disk is ~flat (r={c:.2}); RSS is record-cache-driven \
+             — delta-framing alone would NOT bound RSS, compact the resident slot instead",
+            inp.rss_slope_mb_per_hour
+        ),
+        Some(c) => format!(
+            "RSS slope {:.1}MB/h, disk slope {:.1}MB/h, r={c:.2}",
+            inp.rss_slope_mb_per_hour, inp.disk_slope_mb_per_hour
+        ),
+        None => format!(
+            "RSS slope {:.1}MB/h, disk slope {:.1}MB/h (correlation unavailable)",
+            inp.rss_slope_mb_per_hour, inp.disk_slope_mb_per_hour
+        ),
+    };
+
+    // Q4: the growth is the OR snapshot path iff the retained OR WAL bytes dwarf
+    // the bounded (SPEC-345, ~11KB pruned) tombstone corpus.
+    let corpus = inp.tombstone_corpus_bytes.unwrap_or(0);
+    let q4_is_or_not_tombstone = wal.or_bytes_total > corpus.saturating_mul(10).max(1_000_000);
+
+    let conclusion = if rises && q4_is_or_not_tombstone {
+        "CONFIRMED: the OR write path appends the full per-key OR-Map snapshot per op, \
+         so an OR frame grows O(N) over the run while LWW frames stay flat, and the growth \
+         is the OR record/snapshot serialization path — NOT the bounded tombstone corpus. \
+         Fix surface: delta-frame the OR write path (append the mutation, fold on recovery)."
+            .to_string()
+    } else if !rises {
+        "REFUTED / INCONCLUSIVE: OR frame size did NOT rise late-vs-early over the retained \
+         corpus — the O(N)-per-op-frame hypothesis is not confirmed by this run. Inspect the \
+         acked-beyond-applied tail bound and write-behind retention before choosing the fix."
+            .to_string()
+    } else {
+        "PARTIAL: OR frames grow, but the retained OR WAL bytes do not clearly dwarf the \
+         tombstone corpus — re-check Q4 against the redb corpus scan before pinning the fix."
+            .to_string()
+    };
+
+    MechanismReport {
+        q1_or_frame_bytes_mean_early: wal.or_bytes_mean_early,
+        q1_or_frame_bytes_mean_late: wal.or_bytes_mean_late,
+        q1_or_frame_bytes_max_early: wal.or_bytes_max_early,
+        q1_or_frame_bytes_max_late: wal.or_bytes_max_late,
+        q1_or_frame_bytes_max: wal.or_bytes_max,
+        q1_lww_frame_bytes_mean: lww_mean,
+        q1_lww_frame_bytes_max: wal.lww_bytes_max,
+        q1_or_frame_size_rises: rises,
+        q1_or_vs_lww_mean_ratio: or_vs_lww,
+        q2_wal_mb_before_drain: inp.wal_mb_before_drain,
+        q2_wal_mb_after_drain: inp.wal_mb_after_drain,
+        q2_drain_delta_mb: drain_delta,
+        q2_top_decile_frames: wal.top_decile_frames,
+        q2_top_decile_or_bytes_max: wal.top_decile_or_bytes_max,
+        q2_attribution,
+        q3_rss_slope_mb_per_hour: inp.rss_slope_mb_per_hour,
+        q3_disk_slope_mb_per_hour: inp.disk_slope_mb_per_hour,
+        q3_rss_disk_correlation: corr,
+        q3_attribution,
+        q4_tombstone_corpus_bytes: inp.tombstone_corpus_bytes,
+        q4_tombstone_gauge_bytes: inp.tombstone_gauge_bytes,
+        q4_or_wal_bytes_total: wal.or_bytes_total,
+        q4_growth_is_or_snapshot_not_tombstone: q4_is_or_not_tombstone,
+        wal_segment_files: wal.segment_files,
+        or_frames: wal.or_frames,
+        lww_frames: wal.lww_frames,
+        remove_frames: wal.remove_frames,
+        conclusion,
+        sequencing_note: "Sequencing option for the R1 /xask gate: tail-bounding the \
+             acked-beyond-applied WAL is the lowest-risk FIRST containment (OOM/disk-full \
+             -> backpressure, zero recovery-path risk); delta-framing is the eventual \
+             O(1)-frame fix. If Q2 shows the drain burst is buffered O(N) frames, \
+             tail-bounding addresses it directly."
+            .to_string(),
+    }
+}
+
+fn print_mechanism_report(r: &MechanismReport) {
+    println!("\n=== OR-CHURN MECHANISM REPORT (report-only, Q1-Q4) ===");
+    println!(
+        "Q1 bytes/frame:    OR early(mean={:.0}B max={}B) late(mean={:.0}B max={}B) max={}B | \
+         LWW mean={:.0}B max={}B | OR/LWW={:.1}x | rises={}",
+        r.q1_or_frame_bytes_mean_early,
+        r.q1_or_frame_bytes_max_early,
+        r.q1_or_frame_bytes_mean_late,
+        r.q1_or_frame_bytes_max_late,
+        r.q1_or_frame_bytes_max,
+        r.q1_lww_frame_bytes_mean,
+        r.q1_lww_frame_bytes_max,
+        r.q1_or_vs_lww_mean_ratio,
+        r.q1_or_frame_size_rises,
+    );
+    println!(
+        "Q2 drain window:   before={} after={} delta={} | {}",
+        r.q2_wal_mb_before_drain
+            .map_or_else(|| "n/a".to_string(), |v| format!("{v:.1}MB")),
+        r.q2_wal_mb_after_drain
+            .map_or_else(|| "n/a".to_string(), |v| format!("{v:.1}MB")),
+        r.q2_drain_delta_mb
+            .map_or_else(|| "n/a".to_string(), |v| format!("{v:.1}MB")),
+        r.q2_attribution,
+    );
+    println!(
+        "Q3 RSS holder:     rss_slope={:.1}MB/h disk_slope={:.1}MB/h corr={} | {}",
+        r.q3_rss_slope_mb_per_hour,
+        r.q3_disk_slope_mb_per_hour,
+        r.q3_rss_disk_correlation
+            .map_or_else(|| "n/a".to_string(), |v| format!("{v:.2}")),
+        r.q3_attribution,
+    );
+    println!(
+        "Q4 not tombstone:  or_wal_bytes={} tombstone_corpus={} gauge={} | growth_is_or={}",
+        r.q4_or_wal_bytes_total,
+        r.q4_tombstone_corpus_bytes
+            .map_or_else(|| "n/a".to_string(), |v| v.to_string()),
+        r.q4_tombstone_gauge_bytes,
+        r.q4_growth_is_or_snapshot_not_tombstone,
+    );
+    println!(
+        "scan:              segments={} or_frames={} lww_frames={} remove_frames={}",
+        r.wal_segment_files, r.or_frames, r.lww_frames, r.remove_frames
+    );
+    println!("conclusion:        {}", r.conclusion);
+    println!("sequencing:        {}", r.sequencing_note);
 }
 
 // ---------------------------------------------------------------------------
@@ -2012,6 +2509,7 @@ const KNOWN_FLAGS: &[&str] = &[
     "--no-ack",
     "--inject-slow-leak",
     "--no-pre-kill-drain",
+    "--mechanism-report",
     "--smoke",
 ];
 
@@ -2031,7 +2529,10 @@ fn print_usage() {
          \x20 soak_harness --inject-divergence\n\
          \x20 soak_harness --inject-panic\n\
          \x20 soak_harness --no-ack --duration 3600  # tombstone hard-gate must FAIL\n\
-         \x20 soak_harness --inject-slow-leak --duration 3600  # slope detection-floor calibration\n\n\
+         \x20 soak_harness --inject-slow-leak --duration 3600  # slope detection-floor calibration\n\
+         \x20 # OR-churn WAL/RSS growth mechanism report (Q1-Q4), report-only\n\
+         \x20 soak_harness --mechanism-report --or-churn true --or-keyspace 48 \\\n\
+         \x20              --crash-interval 0 --duration 3600 --data-dir ./soak-data\n\n\
          See packages/server-rust/benches/soak_harness/README.md for the full flag list\n\
          and the Hetzner 72h runner."
     );
@@ -2175,6 +2676,10 @@ fn parse_args() -> Config {
             }
             "--no-pre-kill-drain" => {
                 c.no_pre_kill_drain = true;
+                i += 1;
+            }
+            "--mechanism-report" => {
+                c.mechanism_report = true;
                 i += 1;
             }
             "--smoke" => {

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -1192,6 +1192,78 @@ fn read_or_map_state(value: Option<RecordValue>) -> (Vec<OrMapEntry>, Vec<String
     }
 }
 
+/// Order-independent semantic view of an OR-Map slot: the live `(tag, value)`
+/// set and the tombstone set, each canonicalized by sorting, so two slots that
+/// hold the same CRDT state but in a different `Vec` order compare equal.
+///
+/// This is the equivalence oracle for the planned delta-fold recovery path (see
+/// [`crate::storage::wal::OrDeltaFold`]): the G2 differential recovery test folds
+/// a random OR op sequence through BOTH the delta path and the full-snapshot path
+/// and asserts their views are equal under this type.
+// `Value` is only `PartialEq` (it can hold a float), so the view is `PartialEq`
+// too; the equivalence test compares views with `assert_eq!`, which needs only
+// `PartialEq`.
+#[derive(Debug, Clone, PartialEq)]
+#[allow(
+    dead_code,
+    reason = "recovery-equivalence oracle for the delta-fold seam; the G2 differential \
+              recovery test is the first consumer — defined here in Wave 1 as the \
+              interface, not yet wired to a recovery path"
+)]
+pub(crate) struct OrMapSemanticView {
+    /// Live entries as `(tag, value)` pairs, sorted by tag then value-debug for a
+    /// canonical, order-independent comparison. The HLC timestamp is excluded: a
+    /// tag is unique per add, so `(tag, value)` already identifies a survivor, and
+    /// the fold must reproduce the same survivors regardless of insertion order.
+    pub live: Vec<(String, Value)>,
+    /// Observed-remove tombstone tags, sorted.
+    pub tombstones: Vec<String>,
+}
+
+/// Extract the [`OrMapSemanticView`] equivalence key from any OR-carrying
+/// `RecordValue`.
+///
+/// ## Recovery-equivalence invariant decision: SEMANTIC-SET (not byte-for-byte)
+///
+/// The resident `RecordValue::OrMap` is NOT canonically ordered. Evidence from
+/// the OR write path in this file:
+///
+/// - OR_ADD builds `records` with `records.retain(|e| e.tag != new_entry.tag)`
+///   then `records.push(new_entry)` — the vector is in **operation-insertion
+///   order**, never sorted.
+/// - OR_REMOVE appends with `tombstones.push(tag.clone())` — also insertion order.
+/// - The prune path (`prune_epoch_tombstones`) `retain`s in place, preserving
+///   whatever order was there.
+/// - `storage/record.rs` declares `records: Vec<OrMapEntry>` / `tombstones:
+///   Vec<String>` with no ordering invariant, and OR-Map cross-node convergence
+///   is set-based (add-wins / remove-wins), so no canonical byte ordering is
+///   required or guaranteed anywhere.
+///
+/// A delta-fold could therefore reconstruct a semantically-identical slot whose
+/// `Vec` order differs from the full-snapshot slot, so **byte-for-byte equality
+/// would be a false-positive "data loss" signal** and is rejected as the
+/// invariant. The testable invariant the G2 differential test asserts is
+/// semantic-set equivalence: same live `(tag, value)` set, same tombstone set
+/// (and, for a prune, the same pruned-tag set — observable as the removed
+/// tombstones). Byte-for-byte would only be defensible if a canonical ordering
+/// were imposed on the resident representation, which today it is not.
+#[allow(
+    dead_code,
+    reason = "equivalence oracle for the delta-fold seam; first consumed by the G2 \
+              differential recovery test — Wave 1 defines the interface only"
+)]
+pub(crate) fn or_map_semantic_view(value: Option<RecordValue>) -> OrMapSemanticView {
+    let (records, mut tombstones) = read_or_map_state(value);
+    let mut live: Vec<(String, Value)> =
+        records.into_iter().map(|e| (e.tag, e.value)).collect();
+    live.sort_by(|a, b| {
+        a.0.cmp(&b.0)
+            .then_with(|| format!("{:?}", a.1).cmp(&format!("{:?}", b.1)))
+    });
+    tombstones.sort();
+    OrMapSemanticView { live, tombstones }
+}
+
 /// Run the wholesale epoch-drop prune over the storage backing `factory`.
 ///
 /// Drains every currently prune-eligible epoch's tombstone refs out of the

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -1197,7 +1197,7 @@ fn read_or_map_state(value: Option<RecordValue>) -> (Vec<OrMapEntry>, Vec<String
 /// hold the same CRDT state but in a different `Vec` order compare equal.
 ///
 /// This is the equivalence oracle for the planned delta-fold recovery path (see
-/// [`crate::storage::wal::OrDeltaFold`]): the G2 differential recovery test folds
+/// [`crate::storage::wal::OrDeltaFold`]): the differential recovery test folds
 /// a random OR op sequence through BOTH the delta path and the full-snapshot path
 /// and asserts their views are equal under this type.
 // `Value` is only `PartialEq` (it can hold a float), so the view is `PartialEq`
@@ -1206,8 +1206,8 @@ fn read_or_map_state(value: Option<RecordValue>) -> (Vec<OrMapEntry>, Vec<String
 #[derive(Debug, Clone, PartialEq)]
 #[allow(
     dead_code,
-    reason = "recovery-equivalence oracle for the delta-fold seam; the G2 differential \
-              recovery test is the first consumer — defined here in Wave 1 as the \
+    reason = "recovery-equivalence oracle for the delta-fold seam; the differential \
+              recovery test is the first consumer — defined here as the \
               interface, not yet wired to a recovery path"
 )]
 pub(crate) struct OrMapSemanticView {
@@ -1242,15 +1242,15 @@ pub(crate) struct OrMapSemanticView {
 /// A delta-fold could therefore reconstruct a semantically-identical slot whose
 /// `Vec` order differs from the full-snapshot slot, so **byte-for-byte equality
 /// would be a false-positive "data loss" signal** and is rejected as the
-/// invariant. The testable invariant the G2 differential test asserts is
+/// invariant. The testable invariant the differential test asserts is
 /// semantic-set equivalence: same live `(tag, value)` set, same tombstone set
 /// (and, for a prune, the same pruned-tag set — observable as the removed
 /// tombstones). Byte-for-byte would only be defensible if a canonical ordering
 /// were imposed on the resident representation, which today it is not.
 #[allow(
     dead_code,
-    reason = "equivalence oracle for the delta-fold seam; first consumed by the G2 \
-              differential recovery test — Wave 1 defines the interface only"
+    reason = "equivalence oracle for the delta-fold seam; first consumed by the \
+              differential recovery test — the interface is defined here only"
 )]
 pub(crate) fn or_map_semantic_view(value: Option<RecordValue>) -> OrMapSemanticView {
     let (records, mut tombstones) = read_or_map_state(value);

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -1200,10 +1200,18 @@ fn read_or_map_state(value: Option<RecordValue>) -> (Vec<OrMapEntry>, Vec<String
 /// [`crate::storage::wal::OrDeltaFold`]): the differential recovery test folds
 /// a random OR op sequence through BOTH the delta path and the full-snapshot path
 /// and asserts their views are equal under this type.
-// `Value` is only `PartialEq` (it can hold a float), so the view is `PartialEq`
-// too; the equivalence test compares views with `assert_eq!`, which needs only
-// `PartialEq`.
-#[derive(Debug, Clone, PartialEq)]
+///
+/// Values are canonicalized to their `{:?}` debug string rather than kept as
+/// `Value`, so equality on the view is a **total, reflexive** relation. A raw
+/// `Value` is only `PartialEq`, and a float `NaN` is not equal to itself — a view
+/// holding a `NaN`-valued entry would then compare unequal to its own recovery,
+/// producing a false-positive "data loss" signal in the differential test.
+/// Debug-string canonicalization removes that hole (`NaN` maps to the same
+/// string as itself). This relies on `Value::Debug` being injective across live
+/// variants (distinct values → distinct strings), which holds for the current
+/// `Value` enum; if a future variant summarizes or truncates in `Debug`, the
+/// oracle must switch to a dedicated canonical key on `Value` instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(
     dead_code,
     reason = "recovery-equivalence oracle for the delta-fold seam; the differential \
@@ -1211,11 +1219,13 @@ fn read_or_map_state(value: Option<RecordValue>) -> (Vec<OrMapEntry>, Vec<String
               interface, not yet wired to a recovery path"
 )]
 pub(crate) struct OrMapSemanticView {
-    /// Live entries as `(tag, value)` pairs, sorted by tag then value-debug for a
-    /// canonical, order-independent comparison. The HLC timestamp is excluded: a
-    /// tag is unique per add, so `(tag, value)` already identifies a survivor, and
-    /// the fold must reproduce the same survivors regardless of insertion order.
-    pub live: Vec<(String, Value)>,
+    /// Live entries as `(tag, canonical-value-string)` pairs, sorted, for a
+    /// canonical, order-independent comparison. The value is its `{:?}` string so
+    /// the relation stays reflexive under float `NaN` (see the type doc). The HLC
+    /// timestamp is excluded: a tag is unique per add, so `(tag, value)` already
+    /// identifies a survivor, and the fold must reproduce the same survivors
+    /// regardless of insertion order.
+    pub live: Vec<(String, String)>,
     /// Observed-remove tombstone tags, sorted.
     pub tombstones: Vec<String>,
 }
@@ -1254,11 +1264,11 @@ pub(crate) struct OrMapSemanticView {
 )]
 pub(crate) fn or_map_semantic_view(value: Option<RecordValue>) -> OrMapSemanticView {
     let (records, mut tombstones) = read_or_map_state(value);
-    let mut live: Vec<(String, Value)> = records.into_iter().map(|e| (e.tag, e.value)).collect();
-    live.sort_by(|a, b| {
-        a.0.cmp(&b.0)
-            .then_with(|| format!("{:?}", a.1).cmp(&format!("{:?}", b.1)))
-    });
+    let mut live: Vec<(String, String)> = records
+        .into_iter()
+        .map(|e| (e.tag, format!("{:?}", e.value)))
+        .collect();
+    live.sort();
     tombstones.sort();
     OrMapSemanticView { live, tombstones }
 }
@@ -1416,6 +1426,67 @@ mod tests {
             counter: 1,
             node_id: "test-node".to_string(),
         }
+    }
+
+    #[test]
+    fn or_map_semantic_view_order_independent_and_reflexive_under_nan() {
+        let ts = make_timestamp();
+        let entry = |tag: &str, v: Value| OrMapEntry {
+            value: v,
+            tag: tag.to_string(),
+            timestamp: ts.clone(),
+        };
+
+        // Same live set + tombstone set, opposite Vec order → equal views. This is
+        // the order-independence the delta-fold path relies on (the resident slot
+        // is in operation-insertion order, never canonically sorted).
+        let a = RecordValue::OrMap {
+            records: vec![
+                entry("t1", Value::Int(1)),
+                entry("t2", Value::String("x".into())),
+            ],
+            tombstones: vec!["z".to_string(), "a".to_string()],
+        };
+        let b = RecordValue::OrMap {
+            records: vec![
+                entry("t2", Value::String("x".into())),
+                entry("t1", Value::Int(1)),
+            ],
+            tombstones: vec!["a".to_string(), "z".to_string()],
+        };
+        assert_eq!(
+            or_map_semantic_view(Some(a)),
+            or_map_semantic_view(Some(b)),
+            "order-differing but set-equal OR-Map slots must compare equal"
+        );
+
+        // A NaN-valued slot must equal ITSELF: a derived PartialEq that delegated
+        // to Value would break reflexivity (NaN != NaN) and report a slot as
+        // unequal to its own recovery. Debug-string canonicalization fixes it.
+        let nan = RecordValue::OrMap {
+            records: vec![entry("t1", Value::Float(f64::NAN))],
+            tombstones: vec![],
+        };
+        assert_eq!(
+            or_map_semantic_view(Some(nan.clone())),
+            or_map_semantic_view(Some(nan)),
+            "the equivalence oracle must be reflexive even for NaN float values"
+        );
+
+        // A genuine live-value difference must still be detected (non-vacuous).
+        let c = RecordValue::OrMap {
+            records: vec![entry("t1", Value::Int(1))],
+            tombstones: vec![],
+        };
+        let d = RecordValue::OrMap {
+            records: vec![entry("t1", Value::Int(2))],
+            tombstones: vec![],
+        };
+        assert_ne!(
+            or_map_semantic_view(Some(c)),
+            or_map_semantic_view(Some(d)),
+            "distinct survivor values must produce distinct views"
+        );
     }
 
     fn make_ctx() -> OperationContext {

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -1228,10 +1228,10 @@ pub(crate) struct OrMapSemanticView {
 /// The resident `RecordValue::OrMap` is NOT canonically ordered. Evidence from
 /// the OR write path in this file:
 ///
-/// - OR_ADD builds `records` with `records.retain(|e| e.tag != new_entry.tag)`
+/// - `OR_ADD` builds `records` with `records.retain(|e| e.tag != new_entry.tag)`
 ///   then `records.push(new_entry)` — the vector is in **operation-insertion
 ///   order**, never sorted.
-/// - OR_REMOVE appends with `tombstones.push(tag.clone())` — also insertion order.
+/// - `OR_REMOVE` appends with `tombstones.push(tag.clone())` — also insertion order.
 /// - The prune path (`prune_epoch_tombstones`) `retain`s in place, preserving
 ///   whatever order was there.
 /// - `storage/record.rs` declares `records: Vec<OrMapEntry>` / `tombstones:
@@ -1254,8 +1254,7 @@ pub(crate) struct OrMapSemanticView {
 )]
 pub(crate) fn or_map_semantic_view(value: Option<RecordValue>) -> OrMapSemanticView {
     let (records, mut tombstones) = read_or_map_state(value);
-    let mut live: Vec<(String, Value)> =
-        records.into_iter().map(|e| (e.tag, e.value)).collect();
+    let mut live: Vec<(String, Value)> = records.into_iter().map(|e| (e.tag, e.value)).collect();
     live.sort_by(|a, b| {
         a.0.cmp(&b.0)
             .then_with(|| format!("{:?}", a.1).cmp(&format!("{:?}", b.1)))

--- a/packages/server-rust/src/storage/wal/format.rs
+++ b/packages/server-rust/src/storage/wal/format.rs
@@ -42,6 +42,18 @@ pub const FRAME_MAGIC: u32 = 0x54_47_57_4C;
 /// Bumped whenever the frame layout changes in a backward-incompatible way so
 /// recovery can refuse to read frames written by a newer binary rather than
 /// silently mis-interpreting them as corruption.
+///
+/// Version-discipline note for the planned OR-delta frame (see
+/// [`crate::storage::wal::OrDelta`]): appending a per-op OR mutation instead of a
+/// full snapshot is carried as a new `WalOp` payload inside the same frame
+/// envelope, which is an additive MsgPack-named change — it does NOT alter the
+/// header layout. A legacy binary that meets a delta frame fails `WalEntry`
+/// deserialization, which `decode_all` reports as `Corruption` (a fail-closed
+/// refusal to start, never a silent mis-read), so mixed old/new recovery is
+/// already safe WITHOUT a version bump. Bumping this byte when the delta frame
+/// lands is therefore an explicit-signal choice rather than a safety requirement;
+/// either way the CRC32C + length-bound + exhaustive-`FrameDecodeResult` envelope
+/// below is preserved.
 pub const FRAME_VERSION: u8 = 1;
 
 /// Total header bytes: 4 (magic) + 1 (version) + 4 (length) + 4 (crc32c).

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -222,7 +222,9 @@ pub enum OrDelta {
     /// low-water-mark has passed their epoch. Fold: remove these tags from
     /// `tombstones`.
     Prune {
-        /// Tombstone tags being reclaimed.
+        /// Tombstone tags being reclaimed. An empty `tags` is a representable
+        /// no-op (a fold over it changes nothing); the write path MUST NOT emit
+        /// one — an empty-prune delta only inflates the WAL without effect.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         tags: Vec<String>,
     },
@@ -268,18 +270,20 @@ impl OrDeltaCheckpointPolicy {
         }
     }
 
-    /// Whether an op that is the `ops_since_checkpoint`-th delta carrying
-    /// `bytes_since_checkpoint` accumulated bytes must be materialized as a full
-    /// snapshot instead of a delta under this policy.
+    /// Whether the current op must be materialized as a full snapshot instead of a
+    /// delta under this policy.
+    ///
+    /// `delta_index` is **1-indexed**: the first delta after a checkpoint is
+    /// `delta_index = 1` (NOT `0` — passing the pre-op count is an off-by-one that
+    /// would make `full_snapshot_only()` fold the first op of every window instead
+    /// of snapshotting it). `window_bytes` is the delta bytes accumulated in the
+    /// current checkpoint window including this op. With `snapshot_every_ops = K`,
+    /// the op snapshots when `delta_index >= K`, so the K=1 `full_snapshot_only()`
+    /// policy snapshots on `delta_index = 1` — every op — and never folds a delta.
     #[must_use]
-    pub const fn should_checkpoint(
-        &self,
-        ops_since_checkpoint: u32,
-        bytes_since_checkpoint: u64,
-    ) -> bool {
-        ops_since_checkpoint >= self.snapshot_every_ops
-            || (self.snapshot_every_bytes > 0
-                && bytes_since_checkpoint >= self.snapshot_every_bytes)
+    pub const fn should_checkpoint(&self, delta_index: u32, window_bytes: u64) -> bool {
+        delta_index >= self.snapshot_every_ops
+            || (self.snapshot_every_bytes > 0 && window_bytes >= self.snapshot_every_bytes)
     }
 }
 
@@ -1215,6 +1219,43 @@ mod tests {
     use super::*;
     use std::sync::Arc;
     use topgun_core::types::Value as TgValue;
+
+    // -----------------------------------------------------------------------
+    // OrDeltaCheckpointPolicy — the delta-fold depth bound (types-only seam)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_snapshot_only_snapshots_every_op() {
+        // The K=1 fallback must snapshot on the FIRST delta of every window
+        // (delta_index is 1-indexed), so recovery never folds a delta. A 0-indexed
+        // read of should_checkpoint would silently fold the first op instead.
+        let p = OrDeltaCheckpointPolicy::full_snapshot_only();
+        assert!(p.should_checkpoint(1, 0));
+        assert!(p.should_checkpoint(1, u64::MAX));
+    }
+
+    #[test]
+    fn should_checkpoint_honors_k_and_b_independently() {
+        let p = OrDeltaCheckpointPolicy {
+            snapshot_every_ops: 4,
+            snapshot_every_bytes: 1000,
+        };
+        // Below both thresholds → fold as a delta.
+        assert!(!p.should_checkpoint(1, 0));
+        assert!(!p.should_checkpoint(3, 999));
+        // K trips at the K-th delta.
+        assert!(p.should_checkpoint(4, 0));
+        // B trips independently of op count.
+        assert!(p.should_checkpoint(1, 1000));
+
+        // snapshot_every_bytes == 0 disables the byte trigger entirely.
+        let no_b = OrDeltaCheckpointPolicy {
+            snapshot_every_ops: 4,
+            snapshot_every_bytes: 0,
+        };
+        assert!(!no_b.should_checkpoint(1, u64::MAX));
+        assert!(no_b.should_checkpoint(4, 0));
+    }
 
     // -----------------------------------------------------------------------
     // Helper types for behavioral tests

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -23,7 +23,7 @@ use topgun_core::hlc::Timestamp;
 use topgun_core::types::Value;
 
 use crate::storage::map_data_store::MapDataStore;
-use crate::storage::record::RecordValue;
+use crate::storage::record::{OrMapEntry, RecordValue};
 
 // ---------------------------------------------------------------------------
 // WalFsyncPolicy
@@ -149,6 +149,167 @@ pub enum WalStorePayload {
     Record(RecordValue),
     /// Bare value written by older servers; replayed as an LWW record.
     Legacy(Value),
+}
+
+// ---------------------------------------------------------------------------
+// OrDelta — per-op OR-Map mutation seam (interface only; not yet wired)
+// ---------------------------------------------------------------------------
+
+/// The minimal per-op OR-Map mutation an OR write would append **instead of** a
+/// full [`RecordValue::OrMap`] snapshot.
+///
+/// Today every OR_ADD / OR_REMOVE persists the *entire* per-key OR-Map slot
+/// (`records: Vec<OrMapEntry>` + `tombstones: Vec<String>`) on every op, so the
+/// Nth op on a key appends an O(N) frame and the retained WAL grows without
+/// bound under sustained churn. Appending only the mutation makes the durable
+/// append O(1) per op; recovery folds the deltas back onto the resident slot
+/// (see [`OrDeltaFold`]).
+///
+/// This models the spec's candidate shape
+/// `{ added: Option<OrMapEntry>, removed_tag: Option<String>, pruned_tags: Vec<String> }`
+/// as an **enum discriminant** rather than a bag of `Option`s: a single OR op is
+/// exactly one of add / remove, and an epoch-GC sweep is a prune — an enum makes
+/// the illegal "both added and removed set" state unrepresentable and satisfies
+/// the op-kind-discriminant type-mapping rule (serde owns the tag; there is no
+/// `r#type` field). The set-algebra a fold must apply matches the resident CRDT
+/// exactly: add-wins (retain concurrent survivors, an already-tombstoned tag is
+/// never resurrected), remove-wins (drop the matched tag from records, record its
+/// tombstone), prune (drop the given tombstone tags once the low-water-mark has
+/// passed their epoch).
+///
+/// ## Codec-safety envelope (design contract for the G2 wiring)
+///
+/// An `OrDelta` is carried inside a [`WalEntry`] and encoded through the SAME
+/// [`format::encode`] path as every other frame, so it inherits the frame codec
+/// invariants unchanged and MUST NOT weaken them:
+///
+/// - **CRC32C**: the frame stays length-prefixed and Castagnoli-checksummed; a
+///   bit-flip in a delta frame is caught exactly as it is for a Store frame.
+/// - **Length bound**: a delta payload is far smaller than a full snapshot, so it
+///   is trivially within [`format::MAX_FRAME_PAYLOAD_LEN`]; the bound still
+///   applies and rejects a corrupt/bloated declared length before allocating.
+/// - **Exhaustive decode**: recovery MUST continue to pattern-match every
+///   [`format::FrameDecodeResult`] variant and NEVER panic on malformed input —
+///   folding a decoded delta happens only on the `Complete` / tolerated
+///   `TruncatedTail` arms, exactly like the current Store replay.
+/// - **Version discipline**: introducing an `OrDelta`-carrying `WalOp` variant is
+///   an additive MsgPack-named change. A legacy binary reading a new delta frame
+///   fails `WalEntry` deserialization, which `decode_all` already classifies as
+///   `Corruption` (a *refusal to start*, never a silent mis-read) — so mixed
+///   old/new recovery fails closed. Whether G2 also bumps
+///   [`format::FRAME_VERSION`] for an explicit signal (rather than relying on the
+///   deserialize-refusal) is the version-discipline decision to settle when the
+///   delta frame lands; the safety floor (fail-closed, no silent corruption) holds
+///   either way.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum OrDelta {
+    /// OR_ADD: a tagged entry was added. Fold: remove any existing entry with the
+    /// same tag (idempotent re-add), then append this one — UNLESS the tag is
+    /// already tombstoned, in which case the add is suppressed (remove-wins).
+    Add {
+        /// The added entry (value + unique tag + HLC timestamp).
+        entry: OrMapEntry,
+    },
+    /// OR_REMOVE: a tag was observed-removed. Fold: drop the matched tag from
+    /// `records` (preserving every concurrent survivor) and append it to
+    /// `tombstones` if genuinely new.
+    Remove {
+        /// The observed-removed tag.
+        tag: String,
+    },
+    /// Epoch-GC prune: the given tombstone tags are dropped once the fleet-wide
+    /// low-water-mark has passed their epoch. Fold: remove these tags from
+    /// `tombstones`.
+    Prune {
+        /// Tombstone tags being reclaimed.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        tags: Vec<String>,
+    },
+}
+
+/// Checkpoint policy that bounds delta-fold depth (the PRIMARY delta design:
+/// checkpoint + bounded-deltas, not an unbounded fold chain).
+///
+/// A pure "fold every delta since key creation" chain is unbounded → slow
+/// recovery and fragile (one lost/corrupt delta breaks all subsequent state).
+/// Instead, a full-snapshot frame (the existing `WalOp::Store` of the whole
+/// `RecordValue::OrMap`) is emitted every `snapshot_every_ops` (K) ops **or**
+/// `snapshot_every_bytes` (B) accumulated delta bytes per key, whichever trips
+/// first; recovery folds only the deltas since that key's last checkpoint. This
+/// bounds recovery cost, localizes corruption blast-radius to one checkpoint
+/// window, still yields the ~100× WAL reduction, and degrades naturally to a
+/// **K=1 full-snapshot-only fallback** (see [`Self::full_snapshot_only`]) the
+/// recovery path can drop to on ANY fold anomaly.
+///
+/// The concrete K / B values are a deliberately-unset design parameter: they are
+/// resolved at the R1 `/xask` design gate with the live measurement in hand, not
+/// guessed here without data. Counts are integers (ops, bytes) — never `f64`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OrDeltaCheckpointPolicy {
+    /// K: emit a full-snapshot frame after this many deltas on a key. `1` means
+    /// "snapshot every op" — the full-snapshot-only fallback.
+    pub snapshot_every_ops: u32,
+    /// B: emit a full-snapshot frame once accumulated delta bytes on a key reach
+    /// this threshold, independent of op count.
+    pub snapshot_every_bytes: u64,
+}
+
+impl OrDeltaCheckpointPolicy {
+    /// The K=1 fallback: every OR op emits a full snapshot, so recovery never
+    /// folds a delta. This is the behaviourally-identical-to-today mode the
+    /// recovery path drops to whenever a fold anomaly is detected, and the
+    /// baseline the differential recovery test exercises.
+    #[must_use]
+    pub const fn full_snapshot_only() -> Self {
+        Self {
+            snapshot_every_ops: 1,
+            snapshot_every_bytes: 0,
+        }
+    }
+
+    /// Whether an op that is the `ops_since_checkpoint`-th delta carrying
+    /// `bytes_since_checkpoint` accumulated bytes must be materialized as a full
+    /// snapshot instead of a delta under this policy.
+    #[must_use]
+    pub const fn should_checkpoint(
+        &self,
+        ops_since_checkpoint: u32,
+        bytes_since_checkpoint: u64,
+    ) -> bool {
+        ops_since_checkpoint >= self.snapshot_every_ops
+            || (self.snapshot_every_bytes > 0
+                && bytes_since_checkpoint >= self.snapshot_every_bytes)
+    }
+}
+
+/// Recovery-fold interface: replays a bounded run of [`OrDelta`]s onto a resident
+/// OR-Map slot to reconstruct the value the full-snapshot path would have
+/// produced.
+///
+/// **Interface only — the production recovery path is NOT wired to this in Wave
+/// 1.** `base` is the resident slot as of the key's last full-snapshot checkpoint
+/// (`None` for a key whose first frame in the replay window is itself a
+/// checkpoint, i.e. an empty starting slot); `deltas` are the checkpoint-window
+/// deltas in WAL sequence order. The returned value is a `RecordValue::OrMap`.
+///
+/// ## Recovery-equivalence invariant (SEMANTIC-SET, not byte-for-byte)
+///
+/// The reconstructed slot is required to be **semantic-set equivalent** to the
+/// full-snapshot path's slot — the same live `(tag, value)` set, the same
+/// tombstone set, and the same pruned-tag set — NOT byte-for-byte identical. The
+/// resident `RecordValue::OrMap` stores `records`/`tombstones` in
+/// **operation-insertion order** (the CRDT write path does `retain(tag != ...)`
+/// then `push(...)`; it never canonically sorts), and cross-node OR-Map
+/// convergence is set-based, so no canonical byte ordering exists to make
+/// bit-equality a robust invariant. The G2 differential recovery test asserts
+/// this semantic-set equivalence (via the equivalence oracle defined alongside
+/// the OR write path), including the K=1 full-snapshot-only fallback.
+pub trait OrDeltaFold {
+    /// Fold `deltas` (checkpoint-window, in sequence order) onto `base`,
+    /// returning the reconstructed `RecordValue::OrMap`. Must apply the exact
+    /// add-wins / remove-wins / prune algebra the resident CRDT slot uses.
+    fn fold(&self, base: Option<RecordValue>, deltas: &[OrDelta]) -> RecordValue;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -177,7 +177,7 @@ pub enum WalStorePayload {
 /// tombstone), prune (drop the given tombstone tags once the low-water-mark has
 /// passed their epoch).
 ///
-/// ## Codec-safety envelope (design contract for the G2 wiring)
+/// ## Codec-safety envelope (design contract for the write-path wiring)
 ///
 /// An `OrDelta` is carried inside a [`WalEntry`] and encoded through the SAME
 /// [`format::encode`] path as every other frame, so it inherits the frame codec
@@ -196,7 +196,7 @@ pub enum WalStorePayload {
 ///   an additive MsgPack-named change. A legacy binary reading a new delta frame
 ///   fails `WalEntry` deserialization, which `decode_all` already classifies as
 ///   `Corruption` (a *refusal to start*, never a silent mis-read) — so mixed
-///   old/new recovery fails closed. Whether G2 also bumps
+///   old/new recovery fails closed. Whether the wiring step also bumps
 ///   [`format::FRAME_VERSION`] for an explicit signal (rather than relying on the
 ///   deserialize-refusal) is the version-discipline decision to settle when the
 ///   delta frame lands; the safety floor (fail-closed, no silent corruption) holds
@@ -302,7 +302,7 @@ impl OrDeltaCheckpointPolicy {
 /// **operation-insertion order** (the CRDT write path does `retain(tag != ...)`
 /// then `push(...)`; it never canonically sorts), and cross-node OR-Map
 /// convergence is set-based, so no canonical byte ordering exists to make
-/// bit-equality a robust invariant. The G2 differential recovery test asserts
+/// bit-equality a robust invariant. The differential recovery test asserts
 /// this semantic-set equivalence (via the equivalence oracle defined alongside
 /// the OR write path), including the K=1 full-snapshot-only fallback.
 pub trait OrDeltaFold {

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -158,7 +158,7 @@ pub enum WalStorePayload {
 /// The minimal per-op OR-Map mutation an OR write would append **instead of** a
 /// full [`RecordValue::OrMap`] snapshot.
 ///
-/// Today every OR_ADD / OR_REMOVE persists the *entire* per-key OR-Map slot
+/// Today every `OR_ADD` / `OR_REMOVE` persists the *entire* per-key OR-Map slot
 /// (`records: Vec<OrMapEntry>` + `tombstones: Vec<String>`) on every op, so the
 /// Nth op on a key appends an O(N) frame and the retained WAL grows without
 /// bound under sustained churn. Appending only the mutation makes the durable
@@ -204,14 +204,14 @@ pub enum WalStorePayload {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum OrDelta {
-    /// OR_ADD: a tagged entry was added. Fold: remove any existing entry with the
+    /// `OR_ADD`: a tagged entry was added. Fold: remove any existing entry with the
     /// same tag (idempotent re-add), then append this one — UNLESS the tag is
     /// already tombstoned, in which case the add is suppressed (remove-wins).
     Add {
         /// The added entry (value + unique tag + HLC timestamp).
         entry: OrMapEntry,
     },
-    /// OR_REMOVE: a tag was observed-removed. Fold: drop the matched tag from
+    /// `OR_REMOVE`: a tag was observed-removed. Fold: drop the matched tag from
     /// `records` (preserving every concurrent survivor) and append it to
     /// `tombstones` if genuinely new.
     Remove {


### PR DESCRIPTION
## Summary

G1 of the OR-write-path WAL/RSS growth fix (TODO-585). **Measurement + interface only — the production write path is untouched** (crdt.rs +71 additive lines, 0 deletions; `WalOp` enum unchanged; format.rs change is a doc-comment).

- **`--mechanism-report` soak-harness mode (Q1–Q4)** — pinned the mechanism by live 60-min release measurement: the OR write path appends a **full per-key `RecordValue::OrMap` snapshot on EVERY op, mean ~128 KB = 585× an LWW frame**, huge-but-FLAT over the run (`rises=false` — the resident snapshot saturates early; SPEC-345's prune bounds it). Reframe: **write-amplification × retention-window**, not a per-key leak. RSS tracks disk r=0.89 (blobs in the write-behind queue). Growth is 100% OR-path (LWW-only control: RSS plateau 43 MB, disk 3.8 MB flat).
- **`OrDelta` WAL type + `OrDeltaFold` recovery-fold interface** (types only; wiring the `WalOp` variant is G2's job — it forces a `WalRecovery::run` match arm). A `format.rs` doc-note records the version-discipline: a legacy binary meeting a delta frame fails deserialization → `Corruption` → fail-closed refusal, never a silent mis-read.
- **`or_map_semantic_view` equivalence oracle** — the semantic-set invariant SPEC-347's delta-fold recovery proof will assert against (`merkle_leaf_hash` sorts tags+tombstones, so set-equivalence is sufficient for sync — verified against the /xask Merkle-ordering caveat, which was false). /xreview hardened the oracle (NaN reflexivity) + the checkpoint-policy K=1 index contract.

## Fix fork → SPEC-347 (not this PR)
(a) delta-framing (lean) vs (c) per-(key,tag) layout normalization (fallback) vs (b) tail-bounding (contingent on the R0 apply-lag investigation). Resolved in SPEC-347's /sf:discuss + /xask design phase.

## Test evidence
fmt + clippy `--all-targets --all-features -D warnings` clean; oracle + checkpoint-policy unit tests green; mechanism report from a live 60-min release soak; audit 1×APPROVED, review 1×APPROVED (+/xreview 2 seam fixes).

72h soak (TODO-484) remains gated on SPEC-347 + TODO-586.