### PR TITLE
OR-Map resident-churn fix: in-place mutate seam + cheap estimated_cost [SPEC-347]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +562,21 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -1540,6 +1564,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +1944,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -2794,6 +2840,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
@@ -3754,6 +3806,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4707,6 +4765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4950,6 +5014,7 @@ dependencies = [
  "crc32c",
  "dashmap",
  "datafusion",
+ "dhat",
  "futures-util",
  "hdrhistogram",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,6 +4500,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stats_alloc"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5040,6 +5046,7 @@ dependencies = [
  "sha2",
  "sqlx",
  "static_assertions",
+ "stats_alloc",
  "subtle",
  "tantivy",
  "tempfile",

--- a/packages/server-rust/Cargo.toml
+++ b/packages/server-rust/Cargo.toml
@@ -19,10 +19,18 @@ swagger = ["dep:utoipa-swagger-ui"]
 # writes a heap profile on clean exit. Used to attribute in-process memory holders
 # during soak investigation; never enabled in production builds.
 dhat-heap = ["dep:dhat"]
+# Live-bytes counting allocator (off by default): wraps the System allocator via
+# stats_alloc (near-zero overhead, preserves libmalloc behavior) and tracks bytes
+# allocated-minus-freed, sampled with RSS to distinguish allocator retention (flat
+# live bytes, climbing RSS) from a real leak (climbing live bytes). Keeps the
+# high-throughput regime a full heap profiler would throttle. Mutually exclusive
+# with dhat-heap; never enabled in production builds.
+count-alloc = ["dep:stats_alloc"]
 
 [dependencies]
 topgun-core = { path = "../core-rust", features = ["arrow"] }
 dhat = { version = "0.3", optional = true }
+stats_alloc = { version = "0.1", optional = true }
 async-trait = "0.1"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }

--- a/packages/server-rust/Cargo.toml
+++ b/packages/server-rust/Cargo.toml
@@ -15,9 +15,14 @@ redb = ["dep:redb"]
 simulation = ["dep:madsim"]
 datafusion = ["dep:datafusion", "dep:arrow"]
 swagger = ["dep:utoipa-swagger-ui"]
+# Heap-profiling instrument (off by default): installs a dhat global allocator and
+# writes a heap profile on clean exit. Used to attribute in-process memory holders
+# during soak investigation; never enabled in production builds.
+dhat-heap = ["dep:dhat"]
 
 [dependencies]
 topgun-core = { path = "../core-rust", features = ["arrow"] }
+dhat = { version = "0.3", optional = true }
 async-trait = "0.1"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }

--- a/packages/server-rust/benches/soak_harness/process.rs
+++ b/packages/server-rust/benches/soak_harness/process.rs
@@ -289,8 +289,44 @@ impl ServerSupervisor {
     }
 
     /// Final teardown: SIGKILL without restart.
+    ///
+    /// When `TOPGUN_SOAK_GRACEFUL_SHUTDOWN=1`, send SIGTERM instead and give the
+    /// child up to 90s to exit cleanly (SIGKILL fallback). Graceful teardown lets
+    /// the server's `main` return normally so an end-of-run heap profiler (dhat)
+    /// can flush; the default SIGKILL path is unaffected for crash-recovery runs.
     pub async fn shutdown(&self) {
-        self.kill9().await;
+        if std::env::var("TOPGUN_SOAK_GRACEFUL_SHUTDOWN").as_deref() == Ok("1") {
+            self.graceful_shutdown().await;
+        } else {
+            self.kill9().await;
+        }
+    }
+
+    /// SIGTERM the child and wait (bounded) for a clean exit, falling back to
+    /// SIGKILL if it overruns. Marks the kill intentional so the exit watcher
+    /// stays quiet, mirroring `kill9`.
+    async fn graceful_shutdown(&self) {
+        self.intentional_kill.store(true, Ordering::SeqCst);
+        let pid = self.current_pid();
+        let child = self.child.lock().take();
+        if let Some(mut child) = child {
+            if let Some(pid) = pid {
+                // tokio's Child only exposes SIGKILL via start_kill; shell out to
+                // deliver the catchable SIGTERM the server drains on.
+                let _ = Command::new("kill")
+                    .arg("-TERM")
+                    .arg(pid.to_string())
+                    .status()
+                    .await;
+            }
+            match tokio::time::timeout(Duration::from_secs(90), child.wait()).await {
+                Ok(_) => {}
+                Err(_) => {
+                    let _ = child.start_kill();
+                    let _ = child.wait().await;
+                }
+            }
+        }
     }
 
     /// Spawn a task that reaps the current child and, if it died without an

--- a/packages/server-rust/benches/soak_harness/process.rs
+++ b/packages/server-rust/benches/soak_harness/process.rs
@@ -319,12 +319,12 @@ impl ServerSupervisor {
                     .status()
                     .await;
             }
-            match tokio::time::timeout(Duration::from_secs(90), child.wait()).await {
-                Ok(_) => {}
-                Err(_) => {
-                    let _ = child.start_kill();
-                    let _ = child.wait().await;
-                }
+            if tokio::time::timeout(Duration::from_secs(90), child.wait())
+                .await
+                .is_err()
+            {
+                let _ = child.start_kill();
+                let _ = child.wait().await;
             }
         }
     }

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -448,9 +448,26 @@ impl ClusterService for ClusterStateAdapter {
 // Entry point
 // ---------------------------------------------------------------------------
 
+// Heap-profiling allocator, compiled in only under the `dhat-heap` feature. The
+// profile is written when the `Profiler` guard in `main` is dropped, which only
+// happens on a clean return — so a profiled run must be stopped with SIGTERM
+// (graceful shutdown), never SIGKILL.
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 #[tokio::main]
 #[allow(clippy::too_many_lines)]
 async fn main() -> anyhow::Result<()> {
+    // Hold the dhat heap profiler for the whole process lifetime; dropping it on
+    // a clean `main` return flushes the profile to `DHAT_OUT` (default
+    // `dhat-heap.json`). No-op unless built with `--features dhat-heap`.
+    #[cfg(feature = "dhat-heap")]
+    let _dhat_profiler = {
+        let out = std::env::var("DHAT_OUT").unwrap_or_else(|_| "dhat-heap.json".to_string());
+        dhat::Profiler::builder().file_name(out).build()
+    };
+
     // Initialize tracing AND install the global Prometheus recorder in one call.
     // Without this the `/metrics` endpoint renders an empty body (no recorder is
     // installed), so counters like `topgun_ormap_tombstone_bytes_total` are

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -451,10 +451,22 @@ impl ClusterService for ClusterStateAdapter {
 // Heap-profiling allocator, compiled in only under the `dhat-heap` feature. The
 // profile is written when the `Profiler` guard in `main` is dropped, which only
 // happens on a clean return — so a profiled run must be stopped with SIGTERM
-// (graceful shutdown), never SIGKILL.
-#[cfg(feature = "dhat-heap")]
+// (graceful shutdown), never SIGKILL. Mutually exclusive with `count-alloc`.
+#[cfg(all(feature = "dhat-heap", not(feature = "count-alloc")))]
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
+
+// Live-bytes counting allocator, compiled in only under the `count-alloc` feature.
+// `stats_alloc` wraps the System allocator (preserving libmalloc/glibc behavior —
+// so the current allocator regime is measured, not changed) and tracks cumulative
+// bytes allocated/deallocated with near-zero overhead, so it does NOT throttle
+// throughput the way a full heap profiler does. Paired with the RSS sampler it
+// distinguishes allocator page-retention/fragmentation (live bytes FLAT while RSS
+// climbs) from a real reference leak (live bytes climbing WITH RSS). Off by default;
+// the workspace forbids hand-written unsafe, so the wrapper lives in the crate.
+#[cfg(feature = "count-alloc")]
+#[global_allocator]
+static ALLOC: &stats_alloc::StatsAlloc<std::alloc::System> = &stats_alloc::INSTRUMENTED_SYSTEM;
 
 #[tokio::main]
 #[allow(clippy::too_many_lines)]
@@ -467,6 +479,34 @@ async fn main() -> anyhow::Result<()> {
         let out = std::env::var("DHAT_OUT").unwrap_or_else(|_| "dhat-heap.json".to_string());
         dhat::Profiler::builder().file_name(out).build()
     };
+
+    // Sample the live-bytes counter alongside the harness's per-30s RSS sampler so
+    // the two series can be correlated post-run. Emitted on stderr (mirrored by the
+    // soak harness under SOAK_SERVER_LOG_PASSTHROUGH). No-op unless built with
+    // `--features count-alloc`.
+    #[cfg(feature = "count-alloc")]
+    tokio::spawn(async move {
+        let start = std::time::Instant::now();
+        let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
+        loop {
+            tick.tick().await;
+            let s = ALLOC.stats();
+            // Net live bytes = cumulative allocated − cumulative deallocated.
+            let allocated = i64::try_from(s.bytes_allocated).unwrap_or(i64::MAX);
+            let deallocated = i64::try_from(s.bytes_deallocated).unwrap_or(i64::MAX);
+            let live = allocated - deallocated;
+            #[allow(clippy::cast_precision_loss)]
+            let live_mb = live as f64 / 1_048_576.0;
+            eprintln!(
+                "alloc_probe elapsed_s={} live_bytes={} live_mb={:.1} allocs={} deallocs={}",
+                start.elapsed().as_secs(),
+                live,
+                live_mb,
+                s.allocations,
+                s.deallocations
+            );
+        }
+    });
 
     // Initialize tracing AND install the global Prometheus recorder in one call.
     // Without this the `/metrics` endpoint renders an empty body (no recorder is

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -560,6 +560,11 @@ impl CrdtService {
             // closure runs exactly once (per key, under the writer lock above).
             let mut new_entry_opt = Some(new_entry);
             let mut merge_add = move |value: &mut RecordValue| {
+                // Upgrade a legacy non-OrMap resident slot (an OrTombstones blob
+                // from an older server) to the unified OrMap shape first, matching
+                // the prior get -> read_or_map_state -> put path — otherwise the add
+                // is dropped and the legacy blob re-persisted unchanged.
+                normalize_to_or_map(value);
                 if let RecordValue::OrMap {
                     records,
                     tombstones,
@@ -631,6 +636,9 @@ impl CrdtService {
             let mut stamped_new_tombstone = false;
             {
                 let mut apply_remove = |value: &mut RecordValue| {
+                    // Upgrade a legacy OrTombstones blob to OrMap first (see OR_ADD);
+                    // otherwise the tombstone append is dropped on the upgrade path.
+                    normalize_to_or_map(value);
                     if let RecordValue::OrMap {
                         records,
                         tombstones,
@@ -641,6 +649,14 @@ impl CrdtService {
                         // Only a genuinely-new tag is counted and epoch-stamped.
                         if !tombstones.contains(tag) {
                             tombstones.push(tag.clone());
+                            // Feeds the residency-independent soak leak gauge. Counted
+                            // here, atomically with the resident push (under the engine's
+                            // per-key lock) rather than after the durable write, so a
+                            // failed write + client retry counts the tag exactly once
+                            // (the retry sees it already resident): a post-write
+                            // increment would miss it on retry and later underflow the
+                            // gauge on prune. Eviction/rehydration never move this number.
+                            crate::storage::record::add_tombstone_bytes(tag.len() as u64);
                             stamped_new_tombstone = true;
                         }
                     }
@@ -661,13 +677,6 @@ impl CrdtService {
                     )
                     .await
                     .map_err(OperationError::Internal)?;
-            }
-
-            if stamped_new_tombstone {
-                // Feeds the residency-independent soak leak gauge: counted here on
-                // the write path (once per genuinely-new tag) so eviction and
-                // rehydration of the record never move this number.
-                crate::storage::record::add_tombstone_bytes(tag.len() as u64);
             }
 
             // Stamp the genuinely-new tombstone with the current server epoch —
@@ -1205,6 +1214,29 @@ fn read_or_map_state(value: Option<RecordValue>) -> (Vec<OrMapEntry>, Vec<String
     }
 }
 
+/// Normalize a resident slot to the unified `OrMap` shape in place before an
+/// in-place OR merge. A legacy `OrTombstones` blob persisted by an older server
+/// is converted to `OrMap { records: [], tombstones: tags }`, exactly as the
+/// prior get -> `read_or_map_state` -> put path did; a slot that is already
+/// `OrMap` is left untouched. Without this the in-place merge closure would fail
+/// its `OrMap` pattern match, silently drop the mutation, and re-persist the
+/// legacy blob unchanged — losing an acked write on the upgrade path.
+fn normalize_to_or_map(value: &mut RecordValue) {
+    if !matches!(value, RecordValue::OrMap { .. }) {
+        let (records, tombstones) = read_or_map_state(Some(std::mem::replace(
+            value,
+            RecordValue::OrMap {
+                records: Vec::new(),
+                tombstones: Vec::new(),
+            },
+        )));
+        *value = RecordValue::OrMap {
+            records,
+            tombstones,
+        };
+    }
+}
+
 /// Order-independent semantic view of an OR-Map slot: the live `(tag, value)`
 /// set and the tombstone set, each canonicalized by sorting, so two slots that
 /// hold the same CRDT state but in a different `Vec` order compare equal.
@@ -1315,9 +1347,24 @@ pub(crate) async fn prune_epoch_tombstones(
         let store = factory.get_or_create(&r.map, hash_to_partition(&r.key));
         // Serialize the drop against concurrent OR writes on this key.
         let _guard = key_writer.acquire(&r.map, &r.key).await;
-        // Drop the tag from the resident tombstone set IN PLACE (init=None →
-        // mutate only if the record is present, never create one), owing a durable
-        // write only when a tombstone was actually removed.
+        // Ensure the key is resident before the in-place drop: init=None only mutates
+        // an already-resident slot, so an evicted key's durable tombstone would
+        // otherwise never be reclaimed and its frontier ref would be consumed without
+        // retry. Hydrating first (as the prior get -> put path did) also reclaims
+        // evicted keys and surfaces a backend read error so the ref can be re-indexed.
+        match store.get(&r.key, false).await {
+            Ok(Some(_)) => {}
+            // Truly gone (no resident and no durable record): nothing to reclaim.
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::warn!(map = %r.map, key = %r.key, epoch, "prune read failed, re-indexing tombstone for retry: {e}");
+                frontier.restore_tombstone_ref(epoch, r);
+                continue;
+            }
+        }
+        // Drop the tag from the now-resident tombstone set IN PLACE (init=None →
+        // mutate only the present record, never create one), owing a durable write
+        // only when a tombstone was actually removed.
         let mut dropped = false;
         let result = {
             let mut drop_tag = |value: &mut RecordValue| {

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -546,44 +546,49 @@ impl CrdtService {
             // does NOT cover the OR_REMOVE RMW below (342b's responsibility).
             let key_guard = self.key_writer.acquire(&op.map_name, &op.key).await;
 
-            // Read existing OR-Map state so the new entry is merged in rather than replacing.
-            // OR-Map add-wins semantics require all concurrent additions to be preserved,
-            // while observed-remove semantics require an already-tombstoned tag to stay
-            // suppressed (remove-wins: no resurrection). Inlined here rather than wiring
-            // core-rust ORMap because that primitive owns its own HLC + Merkle and is keyed
-            // map-wide; constructing one to mutate a single per-key storage slot would cost
-            // more than the set algebra it replaces. The algebra below matches core-rust
-            // ORMap (retain survivors, skip tombstoned re-adds) exactly.
-            let record_value = {
-                let existing = store
-                    .get(&op.key, false)
-                    .await
-                    .map_err(OperationError::Internal)?;
-                let (mut records, tombstones) = read_or_map_state(existing.map(|r| r.value));
-
-                // Remove-wins: a tag already observed-removed is never resurrected.
-                if tombstones.contains(&new_entry.tag) {
-                    RecordValue::OrMap {
-                        records,
-                        tombstones,
-                    }
-                } else {
-                    // Remove any existing entry with the same tag (idempotent re-add).
-                    records.retain(|e| e.tag != new_entry.tag);
-                    records.push(new_entry);
-                    RecordValue::OrMap {
-                        records,
-                        tombstones,
+            // Merge the new entry into the resident OR-Map slot IN PLACE rather
+            // than reading a full clone, rebuilding, and re-putting the whole
+            // ~130 KB snapshot every op. OR-Map add-wins semantics require all
+            // concurrent additions to be preserved, while observed-remove
+            // semantics require an already-tombstoned tag to stay suppressed
+            // (remove-wins: no resurrection). The algebra below matches core-rust
+            // ORMap (retain survivors, skip tombstoned re-adds) exactly; it is
+            // inlined here rather than wiring core-rust ORMap because that
+            // primitive owns its own HLC + Merkle and is keyed map-wide.
+            //
+            // `Option::take` moves the entry into the closure without a clone; the
+            // closure runs exactly once (per key, under the writer lock above).
+            let mut new_entry_opt = Some(new_entry);
+            let mut merge_add = move |value: &mut RecordValue| {
+                if let RecordValue::OrMap {
+                    records,
+                    tombstones,
+                } = value
+                {
+                    let entry = new_entry_opt
+                        .take()
+                        .expect("OR_ADD merge closure runs exactly once");
+                    // Remove-wins: a tag already observed-removed is never resurrected.
+                    if !tombstones.contains(&entry.tag) {
+                        // Remove any existing entry with the same tag (idempotent re-add).
+                        records.retain(|e| e.tag != entry.tag);
+                        records.push(entry);
                     }
                 }
+                // Match the prior path, which always re-persisted the slot even
+                // when remove-wins suppressed the add.
+                true
             };
-
             store
-                .put(
+                .update_in_place(
                     &op.key,
-                    record_value,
+                    Some(RecordValue::OrMap {
+                        records: Vec::new(),
+                        tombstones: Vec::new(),
+                    }),
                     ExpiryPolicy::NONE,
                     CallerProvenance::CrdtMerge,
+                    &mut merge_add,
                 )
                 .await
                 .map_err(OperationError::Internal)?;
@@ -617,45 +622,53 @@ impl CrdtService {
             // tombstone-set monotonicity (no pruned tag flickering back in mid-window).
             let key_guard = self.key_writer.acquire(&op.map_name, &op.key).await;
 
-            // Read-modify-write over the unified OrMap shape: drop only the matched tag
-            // from records (preserving every concurrent survivor) and append the removed
-            // tag to the tombstone set. Writing the legacy destructive OrTombstones blob
-            // here would clobber all concurrent records, which is the data-loss bug.
-            let (record_value, stamped_new_tombstone) = {
-                let existing = store
-                    .get(&op.key, false)
-                    .await
-                    .map_err(OperationError::Internal)?;
-                let (mut records, mut tombstones) = read_or_map_state(existing.map(|r| r.value));
-
-                records.retain(|e| e.tag != *tag);
-                // Dedup: a re-issued remove must not duplicate the tombstone. Only a
-                // genuinely-new tag is counted and epoch-stamped.
-                let is_new = !tombstones.contains(tag);
-                if is_new {
-                    tombstones.push(tag.clone());
-                    // Feeds the residency-independent soak leak gauge: counted here
-                    // on the write path (once per genuinely-new tag) so eviction and
-                    // rehydration of the record never move this number.
-                    crate::storage::record::add_tombstone_bytes(tag.len() as u64);
-                }
-                (
-                    RecordValue::OrMap {
+            // Read-modify-write over the unified OrMap shape IN PLACE: drop only the
+            // matched tag from records (preserving every concurrent survivor) and
+            // append the removed tag to the tombstone set, mutating the resident
+            // slot rather than cloning + rebuilding + re-putting the whole snapshot.
+            // Writing the legacy destructive OrTombstones blob here would clobber
+            // all concurrent records, which is the data-loss bug.
+            let mut stamped_new_tombstone = false;
+            {
+                let mut apply_remove = |value: &mut RecordValue| {
+                    if let RecordValue::OrMap {
                         records,
                         tombstones,
-                    },
-                    is_new,
-                )
-            };
-            store
-                .put(
-                    &op.key,
-                    record_value,
-                    ExpiryPolicy::NONE,
-                    CallerProvenance::CrdtMerge,
-                )
-                .await
-                .map_err(OperationError::Internal)?;
+                    } = value
+                    {
+                        records.retain(|e| e.tag != *tag);
+                        // Dedup: a re-issued remove must not duplicate the tombstone.
+                        // Only a genuinely-new tag is counted and epoch-stamped.
+                        if !tombstones.contains(tag) {
+                            tombstones.push(tag.clone());
+                            stamped_new_tombstone = true;
+                        }
+                    }
+                    // Match the prior path, which always re-persisted the slot even
+                    // for a duplicate (already-tombstoned) remove.
+                    true
+                };
+                store
+                    .update_in_place(
+                        &op.key,
+                        Some(RecordValue::OrMap {
+                            records: Vec::new(),
+                            tombstones: Vec::new(),
+                        }),
+                        ExpiryPolicy::NONE,
+                        CallerProvenance::CrdtMerge,
+                        &mut apply_remove,
+                    )
+                    .await
+                    .map_err(OperationError::Internal)?;
+            }
+
+            if stamped_new_tombstone {
+                // Feeds the residency-independent soak leak gauge: counted here on
+                // the write path (once per genuinely-new tag) so eviction and
+                // rehydration of the record never move this number.
+                crate::storage::record::add_tombstone_bytes(tag.len() as u64);
+            }
 
             // Stamp the genuinely-new tombstone with the current server epoch —
             // server-authoritative, derived from the epoch counter, NEVER from the
@@ -1302,40 +1315,43 @@ pub(crate) async fn prune_epoch_tombstones(
         let store = factory.get_or_create(&r.map, hash_to_partition(&r.key));
         // Serialize the drop against concurrent OR writes on this key.
         let _guard = key_writer.acquire(&r.map, &r.key).await;
-        let existing = match store.get(&r.key, false).await {
-            Ok(v) => v,
+        // Drop the tag from the resident tombstone set IN PLACE (init=None →
+        // mutate only if the record is present, never create one), owing a durable
+        // write only when a tombstone was actually removed.
+        let mut dropped = false;
+        let result = {
+            let mut drop_tag = |value: &mut RecordValue| {
+                if let RecordValue::OrMap { tombstones, .. } = value {
+                    let before = tombstones.len();
+                    tombstones.retain(|t| t != &r.tag);
+                    dropped = tombstones.len() != before;
+                }
+                dropped
+            };
+            store
+                .update_in_place(
+                    &r.key,
+                    None,
+                    ExpiryPolicy::NONE,
+                    CallerProvenance::CrdtMerge,
+                    &mut drop_tag,
+                )
+                .await
+        };
+        match result {
+            // The tag is durably gone from storage only once the write-through
+            // succeeds — decrement here so the gauge tracks bytes actually
+            // resident, not bytes merely removed from an in-memory copy.
+            Ok(_) => {
+                if dropped {
+                    crate::storage::record::sub_tombstone_bytes(r.tag.len() as u64);
+                }
+            }
             Err(e) => {
                 // Operator-visible: a swallowed storage error on the prune path
                 // would silently stall tombstone reclamation.
-                tracing::warn!(map = %r.map, key = %r.key, epoch, "prune read failed, re-indexing tombstone for retry: {e}");
+                tracing::warn!(map = %r.map, key = %r.key, epoch, "prune update failed, re-indexing tombstone for retry: {e}");
                 frontier.restore_tombstone_ref(epoch, r);
-                continue;
-            }
-        };
-        let (records, mut tombstones) = read_or_map_state(existing.map(|rec| rec.value));
-        let before = tombstones.len();
-        tombstones.retain(|t| t != &r.tag);
-        if tombstones.len() != before {
-            match store
-                .put(
-                    &r.key,
-                    RecordValue::OrMap {
-                        records,
-                        tombstones,
-                    },
-                    ExpiryPolicy::NONE,
-                    CallerProvenance::CrdtMerge,
-                )
-                .await
-            {
-                // The tag is durably gone from storage only once `put` succeeds —
-                // decrement here so the gauge tracks bytes actually resident, not
-                // bytes merely removed from an in-memory copy that never landed.
-                Ok(_) => crate::storage::record::sub_tombstone_bytes(r.tag.len() as u64),
-                Err(e) => {
-                    tracing::warn!(map = %r.map, key = %r.key, epoch, "prune put failed, re-indexing tombstone for retry: {e}");
-                    frontier.restore_tombstone_ref(epoch, r);
-                }
             }
         }
     }

--- a/packages/server-rust/src/sim/mod.rs
+++ b/packages/server-rust/src/sim/mod.rs
@@ -46,4 +46,10 @@ pub use madsim::rand;
 
 pub mod cluster;
 pub mod network;
+
+/// OR-Map churn convergence under a network-partition fault, exercising the
+/// in-place mutate write path.
+#[cfg(test)]
+mod or_churn_inplace;
+
 pub mod tombstone_gc_proof;

--- a/packages/server-rust/src/sim/or_churn_inplace.rs
+++ b/packages/server-rust/src/sim/or_churn_inplace.rs
@@ -18,9 +18,7 @@ mod tests {
     /// Live entry tags in an OR-Map value.
     fn live_tags(value: &RecordValue) -> Vec<String> {
         match value {
-            RecordValue::OrMap { records, .. } => {
-                records.iter().map(|e| e.tag.clone()).collect()
-            }
+            RecordValue::OrMap { records, .. } => records.iter().map(|e| e.tag.clone()).collect(),
             _ => Vec::new(),
         }
     }
@@ -30,7 +28,7 @@ mod tests {
         match value {
             RecordValue::OrMap { tombstones, .. } => tombstones.clone(),
             RecordValue::OrTombstones { tags } => tags.clone(),
-            _ => Vec::new(),
+            RecordValue::Lww { .. } => Vec::new(),
         }
     }
 

--- a/packages/server-rust/src/sim/or_churn_inplace.rs
+++ b/packages/server-rust/src/sim/or_churn_inplace.rs
@@ -1,0 +1,128 @@
+//! OR-Map churn convergence under a network-partition fault, exercising the
+//! in-place mutate write path.
+//!
+//! The OR write path now mutates the resident `RecordValue::OrMap` in place
+//! (`RecordStore::update_in_place`) instead of cloning + rebuilding + re-putting
+//! the whole per-key snapshot. This simulation drives real OR_ADD / OR_REMOVE
+//! ops through the full `CrdtService` op path on both sides of a network
+//! partition, then heals and Merkle-syncs, and asserts the cluster converges
+//! with add-wins (every concurrently-added tag survives) and remove-wins (a
+//! tag removed on one side does not resurrect on the other) — the invariants
+//! the in-place mutation must preserve under the partition-then-merge fault.
+
+#[cfg(test)]
+mod tests {
+    use crate::sim::cluster::SimCluster;
+    use crate::storage::record::RecordValue;
+
+    /// Live entry tags in an OR-Map value.
+    fn live_tags(value: &RecordValue) -> Vec<String> {
+        match value {
+            RecordValue::OrMap { records, .. } => {
+                records.iter().map(|e| e.tag.clone()).collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    /// Observed-remove tombstone tags in an OR-Map value.
+    fn tombstone_tags(value: &RecordValue) -> Vec<String> {
+        match value {
+            RecordValue::OrMap { tombstones, .. } => tombstones.clone(),
+            RecordValue::OrTombstones { tags } => tags.clone(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// Fault scenario: two nodes churn OR adds/removes in isolation across a
+    /// network partition, then heal + Merkle-sync. The in-place OR write path
+    /// must converge both nodes to the same value, keeping every concurrently
+    /// added tag (add-wins) and suppressing the tag removed on node 0
+    /// (remove-wins — no resurrection).
+    #[tokio::test]
+    async fn or_churn_across_partition_converges_inplace() {
+        let mut cluster = SimCluster::new(2, 4747);
+        cluster.start().expect("cluster should start");
+
+        let (map, key) = ("ormap", "doc");
+
+        // Partition the two nodes so neither sees the other's churn.
+        cluster.inject_partition(&[0], &[1]);
+
+        // Churn: each isolated side adds its own five uniquely-tagged entries.
+        for i in 0..5 {
+            cluster
+                .or_write(
+                    0,
+                    map,
+                    key,
+                    format!("a{i}"),
+                    rmpv::Value::String(format!("va{i}").into()),
+                )
+                .await
+                .expect("or_write on partitioned node 0 should succeed");
+            cluster
+                .or_write(
+                    1,
+                    map,
+                    key,
+                    format!("b{i}"),
+                    rmpv::Value::String(format!("vb{i}").into()),
+                )
+                .await
+                .expect("or_write on partitioned node 1 should succeed");
+        }
+
+        // Node 0 removes one of its own tags while still partitioned — its
+        // tombstone must cross the merge and keep the tag suppressed on node 1.
+        cluster
+            .or_remove(0, map, key, "a2")
+            .await
+            .expect("or_remove on partitioned node 0 should succeed");
+
+        // Heal and Merkle-sync both directions to carry every entry + tombstone.
+        cluster.heal_partition();
+        cluster
+            .merkle_sync_pair(0, 1, map)
+            .await
+            .expect("merkle sync 0→1 after heal should succeed");
+        cluster
+            .merkle_sync_pair(1, 0, map)
+            .await
+            .expect("merkle sync 1→0 after heal should succeed");
+
+        let converged = cluster
+            .assert_converged(map, key)
+            .await
+            .expect("assert_converged should not error")
+            .expect("both nodes should hold a value after convergence");
+
+        let live = live_tags(&converged);
+        let tombs = tombstone_tags(&converged);
+
+        // Add-wins: every un-removed tag from BOTH partitioned sides survives.
+        for i in 0..5 {
+            if i != 2 {
+                assert!(
+                    live.contains(&format!("a{i}")),
+                    "add-wins: node 0's tag a{i} must survive the merge (live={live:?})"
+                );
+            }
+            assert!(
+                live.contains(&format!("b{i}")),
+                "add-wins: node 1's tag b{i} must survive the merge (live={live:?})"
+            );
+        }
+
+        // Remove-wins: the tag removed on node 0 is absent from the live set and
+        // recorded as a tombstone — no resurrection through the in-place merge.
+        assert!(
+            !live.contains(&"a2".to_string()),
+            "remove-wins: removed tag a2 must not resurrect (live={live:?})"
+        );
+        assert!(
+            tombs.contains(&"a2".to_string()),
+            "remove-wins: removed tag a2 must be recorded as a tombstone (tombstones={tombs:?})"
+        );
+    }
+}

--- a/packages/server-rust/src/storage/engine.rs
+++ b/packages/server-rust/src/storage/engine.rs
@@ -120,6 +120,11 @@ pub trait StorageEngine: Send + Sync + 'static {
     /// value — returning `false` after a change would leave a resident mutation
     /// that never reaches the durable backend (data loss on eviction).
     ///
+    /// Implementations MUST invoke `mutate` **at most once** per call. Callers may
+    /// rely on single invocation (e.g. the `OR_ADD` merge closure moves its entry in
+    /// via `Option::take` and would panic on a second call); an engine that retries
+    /// the closure would break that contract.
+    ///
     /// On a `true` return the engine stamps `on_update(now)` (bumping version and
     /// minting a fresh per-write token) and recomputes `metadata.cost` via
     /// `cost_of` over the mutated value, all under the same lock, then returns a

--- a/packages/server-rust/src/storage/engine.rs
+++ b/packages/server-rust/src/storage/engine.rs
@@ -4,7 +4,7 @@
 //! Hazelcast's `Storage<K,R>`). Implementations provide in-memory key-value
 //! storage with cursor-based iteration support.
 
-use super::record::Record;
+use super::record::{Record, RecordValue};
 
 /// Opaque cursor for resumable iteration over storage entries.
 ///
@@ -38,6 +38,36 @@ pub struct FetchResult<T> {
     pub items: Vec<T>,
     /// Updated cursor for the next fetch call.
     pub next_cursor: IterationCursor,
+}
+
+/// Outcome of an in-place record mutation via [`StorageEngine::update_in_place`].
+///
+/// Distinguishes the three terminal states so the caller (a
+/// [`RecordStore`](super::RecordStore)) can fire the correct observer
+/// notification and decide whether a durable write-through is owed, WITHOUT a
+/// full get→clone→put round trip.
+pub enum UpdateInPlaceOutcome {
+    /// The key was absent and no `init` value was supplied, so nothing was
+    /// mutated. No observer notification and no write-through are owed.
+    Absent,
+    /// The mutation closure ran but reported no durable change was needed
+    /// (returned `false`), so the resident metadata was left untouched. No
+    /// observer notification and no write-through are owed. Used by the prune
+    /// sweep when the target tag was already gone from the tombstone set.
+    Unchanged,
+    /// The record was created or updated in place. `record` is a clone of the
+    /// mutated resident record (for the caller's post-lock observer fan-out and
+    /// async write-through); `inserted` is `true` when the key was absent and a
+    /// fresh record was created (fire `on_put`), `false` when an existing
+    /// resident record was mutated (fire `on_update`).
+    Written {
+        /// Clone of the mutated resident record — the single owned copy the
+        /// caller hands to the async write-through and observer fan-out.
+        record: Record,
+        /// `true` if a fresh record was inserted (key was absent), `false` if
+        /// an existing resident record was mutated in place.
+        inserted: bool,
+    },
 }
 
 /// Low-level typed key-value storage with cursor-based iteration.
@@ -79,6 +109,34 @@ pub trait StorageEngine: Send + Sync + 'static {
     /// the key is absent or the resident record is a different write (token
     /// mismatch — a newer write owns the slot).
     fn mark_stored(&self, key: &str, now: i64, token: u64) -> bool;
+
+    /// Mutate a resident record's value in place under the engine's per-key
+    /// write lock, avoiding the full get→clone→put round trip.
+    ///
+    /// `mutate` runs synchronously while the shard write lock is held, receiving
+    /// `&mut RecordValue` for the resident slot, and returns `true` if it made a
+    /// change that must be persisted (a durable write is owed) or `false` if the
+    /// call is a no-op. The closure MUST return `true` whenever it altered the
+    /// value — returning `false` after a change would leave a resident mutation
+    /// that never reaches the durable backend (data loss on eviction).
+    ///
+    /// On a `true` return the engine stamps `on_update(now)` (bumping version and
+    /// minting a fresh per-write token) and recomputes `metadata.cost` via
+    /// `cost_of` over the mutated value, all under the same lock, then returns a
+    /// clone of the mutated record in [`UpdateInPlaceOutcome::Written`].
+    ///
+    /// If the key is absent: when `init` is `Some`, the value is created from it,
+    /// `mutate` is applied, and (on a `true` return) the fresh record is inserted
+    /// with metadata minted via `RecordMetadata::new`; when `init` is `None`, the
+    /// call is a no-op returning [`UpdateInPlaceOutcome::Absent`].
+    fn update_in_place(
+        &self,
+        key: &str,
+        now: i64,
+        init: Option<RecordValue>,
+        mutate: &mut dyn FnMut(&mut RecordValue) -> bool,
+        cost_of: &dyn Fn(&RecordValue) -> u64,
+    ) -> UpdateInPlaceOutcome;
 
     /// Remove a record by key, returning the removed record.
     fn remove(&self, key: &str) -> Option<Record>;

--- a/packages/server-rust/src/storage/engines/hashmap.rs
+++ b/packages/server-rust/src/storage/engines/hashmap.rs
@@ -4,11 +4,12 @@
 //! Suitable for development, testing, and production workloads where
 //! all data fits in memory.
 
+use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use rand::Rng;
 
-use crate::storage::engine::{FetchResult, IterationCursor, StorageEngine};
-use crate::storage::record::Record;
+use crate::storage::engine::{FetchResult, IterationCursor, StorageEngine, UpdateInPlaceOutcome};
+use crate::storage::record::{Record, RecordMetadata, RecordValue};
 
 /// In-memory storage backed by [`DashMap`] for concurrent read access.
 ///
@@ -77,6 +78,56 @@ impl StorageEngine for HashMapStorage {
             }
         }
         false
+    }
+
+    fn update_in_place(
+        &self,
+        key: &str,
+        now: i64,
+        init: Option<RecordValue>,
+        mutate: &mut dyn FnMut(&mut RecordValue) -> bool,
+        cost_of: &dyn Fn(&RecordValue) -> u64,
+    ) -> UpdateInPlaceOutcome {
+        // `entry` holds the shard write lock across the match, so the
+        // check-mutate-or-insert is atomic against any other engine op on this
+        // key — there is no get()+put() window a concurrent writer could tear.
+        // The one owned-key allocation on the occupied path (bytes) is trivial
+        // next to the per-op resident-snapshot churn this seam exists to remove.
+        match self.entries.entry(key.to_string()) {
+            Entry::Occupied(mut occ) => {
+                let record = occ.get_mut();
+                if !mutate(&mut record.value) {
+                    return UpdateInPlaceOutcome::Unchanged;
+                }
+                // Mint a fresh write token and bump version/last_update in place,
+                // then re-cost from the mutated value — no full-snapshot rebuild.
+                record.metadata.on_update(now);
+                record.metadata.cost = cost_of(&record.value);
+                UpdateInPlaceOutcome::Written {
+                    record: record.clone(),
+                    inserted: false,
+                }
+            }
+            Entry::Vacant(vac) => {
+                let Some(mut value) = init else {
+                    return UpdateInPlaceOutcome::Absent;
+                };
+                if !mutate(&mut value) {
+                    return UpdateInPlaceOutcome::Absent;
+                }
+                let cost = cost_of(&value);
+                let record = Record {
+                    value,
+                    metadata: RecordMetadata::new(now, cost),
+                };
+                let clone = record.clone();
+                vac.insert(record);
+                UpdateInPlaceOutcome::Written {
+                    record: clone,
+                    inserted: true,
+                }
+            }
+        }
     }
 
     fn remove(&self, key: &str) -> Option<Record> {

--- a/packages/server-rust/src/storage/impls/default_record_store.rs
+++ b/packages/server-rust/src/storage/impls/default_record_store.rs
@@ -273,6 +273,12 @@ impl RecordStore for DefaultRecordStore {
         // Lww; merkle/query use the new value), so the new value is passed as the
         // old value rather than re-cloning the resident slot this seam exists to
         // stop churning.
+        //
+        // CONTRACT: any observer added later that reads `old_value` for an OrMap
+        // record would receive the post-image here, not the true pre-image. That
+        // is only safe because this seam is OrMap-only; if a future observer needs
+        // the OrMap pre-image, capture a pre-mutation clone in the engine's
+        // Occupied arm and thread it through instead of reusing the new value.
         if inserted {
             self.observer.on_put(key, &record, None, false);
         } else {

--- a/packages/server-rust/src/storage/impls/default_record_store.rs
+++ b/packages/server-rust/src/storage/impls/default_record_store.rs
@@ -254,9 +254,9 @@ impl RecordStore for DefaultRecordStore {
         // the engine seam expects. The wrapper is only ever called synchronously
         // inside update_in_place (before any await), so it needs no Send bound.
         let mut engine_mutate = |value: &mut RecordValue| mutate(value);
-        let outcome =
-            self.engine
-                .update_in_place(key, now, init, &mut engine_mutate, &cost_of);
+        let outcome = self
+            .engine
+            .update_in_place(key, now, init, &mut engine_mutate, &cost_of);
 
         let (record, inserted) = match outcome {
             UpdateInPlaceOutcome::Absent | UpdateInPlaceOutcome::Unchanged => return Ok(false),

--- a/packages/server-rust/src/storage/impls/default_record_store.rs
+++ b/packages/server-rust/src/storage/impls/default_record_store.rs
@@ -233,6 +233,77 @@ impl RecordStore for DefaultRecordStore {
         Ok(old_record.map(|r| r.value))
     }
 
+    async fn update_in_place(
+        &self,
+        key: &str,
+        init: Option<RecordValue>,
+        expiry: ExpiryPolicy,
+        provenance: CallerProvenance,
+        mutate: &mut (dyn for<'a> FnMut(&'a mut RecordValue) -> bool + Send),
+    ) -> anyhow::Result<bool> {
+        use crate::storage::engine::UpdateInPlaceOutcome;
+
+        let now = now_millis();
+        // Cost estimate mirrors put(): value bytes + the key string's heap
+        // contribution. For the OrMap arm this is now a cheap structural
+        // estimate (no per-op full serialize).
+        let cost_of =
+            |value: &RecordValue| crate::storage::record::estimated_cost(value) + key.len() as u64;
+
+        // Re-borrow the `&mut (dyn FnMut + Send)` as the plain `&mut dyn FnMut`
+        // the engine seam expects. The wrapper is only ever called synchronously
+        // inside update_in_place (before any await), so it needs no Send bound.
+        let mut engine_mutate = |value: &mut RecordValue| mutate(value);
+        let outcome =
+            self.engine
+                .update_in_place(key, now, init, &mut engine_mutate, &cost_of);
+
+        let (record, inserted) = match outcome {
+            UpdateInPlaceOutcome::Absent | UpdateInPlaceOutcome::Unchanged => return Ok(false),
+            UpdateInPlaceOutcome::Written { record, inserted } => (record, inserted),
+        };
+
+        // Capture the token off the record just written, before any concurrent
+        // writer can replace the slot — the exact-identity key for mark_stored.
+        let write_token = record.metadata.write_token;
+
+        // Fire observer notifications matching put(): on_put for a fresh insert,
+        // on_update for an existing record. The OR observers never read the
+        // pre-image (the index observer skips OrMap; search/embedding handle only
+        // Lww; merkle/query use the new value), so the new value is passed as the
+        // old value rather than re-cloning the resident slot this seam exists to
+        // stop churning.
+        if inserted {
+            self.observer.on_put(key, &record, None, false);
+        } else {
+            self.observer
+                .on_update(key, &record, &record.value, &record.value, false);
+        }
+
+        // Write-through for Client or CrdtMerge provenance — byte-identical to
+        // put()'s full-snapshot durable write, so crash recovery is unchanged.
+        if matches!(
+            provenance,
+            CallerProvenance::Client | CallerProvenance::CrdtMerge
+        ) {
+            let expiration_time = self.compute_expiration_time(&expiry, now);
+            self.data_store
+                .add(&self.name, key, &record.value, expiration_time, now)
+                .await?;
+
+            // Mark clean in place under the engine's per-key lock only when the
+            // resident record is still the exact write we persisted (token match).
+            if !self.data_store.is_null() && !self.engine.mark_stored(key, now, write_token) {
+                tracing::trace!(
+                    key,
+                    "mark_stored found no eligible record after in-place persist (evicted or superseded)"
+                );
+            }
+        }
+
+        Ok(true)
+    }
+
     async fn remove(
         &self,
         key: &str,

--- a/packages/server-rust/src/storage/mod.rs
+++ b/packages/server-rust/src/storage/mod.rs
@@ -19,6 +19,11 @@ mod crash_safety_proptest;
 #[cfg(test)]
 mod eviction_cost_test;
 
+/// Differential resident-state equivalence proof for the OR-Map in-place mutate
+/// write path vs the historical get→build→put path.
+#[cfg(test)]
+mod or_inplace_mutate_proptest;
+
 pub mod datastores;
 pub mod durable_merkle;
 pub mod engine;

--- a/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
+++ b/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
@@ -127,6 +127,9 @@ mod tests {
     struct RetainingCountingStore {
         data: AsyncMutex<HashMap<(String, String), RecordValue>>,
         adds: AtomicUsize,
+        // Number of upcoming add() calls to fail with an error, for the
+        // write-failure + retry gauge test. Zero (the default) never fails.
+        fail_adds: AtomicUsize,
     }
 
     #[async_trait]
@@ -139,6 +142,10 @@ mod tests {
             _exp: i64,
             _now: i64,
         ) -> anyhow::Result<()> {
+            if self.fail_adds.load(Ordering::Relaxed) > 0 {
+                self.fail_adds.fetch_sub(1, Ordering::Relaxed);
+                return Err(anyhow::anyhow!("injected write-through failure"));
+            }
             self.adds.fetch_add(1, Ordering::Relaxed);
             self.data
                 .lock()
@@ -299,6 +306,18 @@ mod tests {
         }
     }
 
+    /// Mirror of the private `normalize_to_or_map` in `crdt.rs`: upgrade a legacy
+    /// non-`OrMap` slot to the unified `OrMap` shape in place before an in-place merge.
+    fn normalize(value: &mut RecordValue) {
+        if !matches!(value, RecordValue::OrMap { .. }) {
+            let (records, tombstones) = read_state(Some(std::mem::replace(value, empty_ormap())));
+            *value = RecordValue::OrMap {
+                records,
+                tombstones,
+            };
+        }
+    }
+
     struct Harness {
         store: DefaultRecordStore,
         observer: Arc<CountingObserver>,
@@ -338,6 +357,7 @@ mod tests {
                 };
                 let mut entry_opt = Some(entry);
                 let mut merge = move |value: &mut RecordValue| {
+                    normalize(value);
                     if let RecordValue::OrMap {
                         records,
                         tombstones,
@@ -363,38 +383,41 @@ mod tests {
                     .unwrap();
             }
             OrOp::Remove { tag } => {
-                let mut is_new = false;
-                {
-                    let mut apply = |value: &mut RecordValue| {
-                        if let RecordValue::OrMap {
-                            records,
-                            tombstones,
-                        } = value
-                        {
-                            records.retain(|e| e.tag != *tag);
-                            if !tombstones.contains(tag) {
-                                tombstones.push(tag.clone());
-                                is_new = true;
-                            }
+                let mut apply = |value: &mut RecordValue| {
+                    normalize(value);
+                    if let RecordValue::OrMap {
+                        records,
+                        tombstones,
+                    } = value
+                    {
+                        records.retain(|e| e.tag != *tag);
+                        if !tombstones.contains(tag) {
+                            tombstones.push(tag.clone());
+                            // Mirror production: count atomically with the resident
+                            // push (inside the closure), so a failed write + retry
+                            // counts the tag exactly once.
+                            add_tombstone_bytes(tag.len() as u64);
                         }
-                        true
-                    };
-                    store
-                        .update_in_place(
-                            KEY,
-                            Some(empty_ormap()),
-                            ExpiryPolicy::NONE,
-                            CallerProvenance::CrdtMerge,
-                            &mut apply,
-                        )
-                        .await
-                        .unwrap();
-                }
-                if is_new {
-                    add_tombstone_bytes(tag.len() as u64);
-                }
+                    }
+                    true
+                };
+                store
+                    .update_in_place(
+                        KEY,
+                        Some(empty_ormap()),
+                        ExpiryPolicy::NONE,
+                        CallerProvenance::CrdtMerge,
+                        &mut apply,
+                    )
+                    .await
+                    .unwrap();
             }
             OrOp::Prune { tag } => {
+                // Mirror production: hydrate first so an evicted key's durable
+                // tombstone is reclaimed too (init=None only mutates a resident slot).
+                if store.get(KEY, false).await.unwrap().is_none() {
+                    return;
+                }
                 let mut dropped = false;
                 {
                     let mut drop_tag = |value: &mut RecordValue| {
@@ -689,5 +712,215 @@ mod tests {
                 .map(|i| format!("{}:{}:node-1", 1_600_000_000_000_u64 + i as u64, i))
                 .collect(),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // HIGH-1 regression: a legacy OrTombstones resident slot (persisted by an
+    // older server; never emitted by the current write path) is UPGRADED to
+    // OrMap by the in-place path, not silently dropped — matching the old
+    // get -> read_or_map_state -> put path. Without normalization the in-place
+    // OrMap pattern match fails and the add/remove is lost on the upgrade path.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn legacy_ortombstones_upgrade_matches_get_build_put() {
+        let _serialize = GAUGE_LOCK.lock().unwrap();
+        block_on_async(async {
+            let inplace = make_harness();
+            let legacy = make_harness();
+
+            for h in [&inplace, &legacy] {
+                h.store
+                    .put(
+                        KEY,
+                        RecordValue::OrTombstones {
+                            tags: vec!["t0".into(), "t1".into()],
+                        },
+                        ExpiryPolicy::NONE,
+                        CallerProvenance::CrdtMerge,
+                    )
+                    .await
+                    .unwrap();
+            }
+
+            let ops = vec![
+                OrOp::Add {
+                    tag: "t2".into(),
+                    val: 7,
+                }, // fresh add survives
+                OrOp::Add {
+                    tag: "t0".into(),
+                    val: 9,
+                }, // remove-wins: suppressed by the legacy tombstone
+                OrOp::Remove { tag: "t3".into() }, // new tombstone appended
+                OrOp::Add {
+                    tag: "t4".into(),
+                    val: 11,
+                },
+            ];
+            for op in &ops {
+                apply_inplace(&inplace.store, op).await;
+                apply_legacy(&legacy.store, op).await;
+            }
+
+            let a = inplace
+                .store
+                .get(KEY, false)
+                .await
+                .unwrap()
+                .map(|r| r.value);
+            let b = legacy.store.get(KEY, false).await.unwrap().map(|r| r.value);
+            assert_eq!(
+                a, b,
+                "in-place must upgrade the legacy OrTombstones blob exactly like get->build->put"
+            );
+            assert!(
+                matches!(a, Some(RecordValue::OrMap { .. })),
+                "legacy blob must be upgraded to OrMap, not left as OrTombstones with adds dropped"
+            );
+            assert_eq!(
+                or_map_semantic_view(a),
+                or_map_semantic_view(b),
+                "semantic view must match after the legacy upgrade"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // MED-2 regression: prune reclaims an EVICTED key's durable tombstone by
+    // hydrating first — init=None alone only mutates a resident slot, so a
+    // non-resident key's durable tombstone would leak and its frontier ref be
+    // consumed without retry. Mirrors prune_epoch_tombstones (hydrate-then-drop).
+    // -----------------------------------------------------------------------
+
+    fn store_sharing(datastore: &Arc<RetainingCountingStore>) -> DefaultRecordStore {
+        let observer = Arc::new(CountingObserver::default());
+        let composite = Arc::new(CompositeMutationObserver::new(vec![
+            Arc::clone(&observer) as Arc<dyn MutationObserver>
+        ]));
+        DefaultRecordStore::new(
+            MAP.to_string(),
+            0,
+            Box::new(HashMapStorage::new()),
+            Arc::clone(datastore) as Arc<dyn MapDataStore>,
+            composite,
+            StorageConfig::default(),
+        )
+    }
+
+    #[test]
+    fn prune_reclaims_evicted_key_durable_tombstone() {
+        let _serialize = GAUGE_LOCK.lock().unwrap();
+        block_on_async(async {
+            let datastore = Arc::new(RetainingCountingStore::default());
+
+            // store1 creates a durable tombstone for t0.
+            let store1 = store_sharing(&datastore);
+            apply_inplace(
+                &store1,
+                &OrOp::Add {
+                    tag: "t0".into(),
+                    val: 1,
+                },
+            )
+            .await;
+            apply_inplace(&store1, &OrOp::Remove { tag: "t0".into() }).await;
+            let durable = datastore
+                .data
+                .lock()
+                .await
+                .get(&(MAP.to_string(), KEY.to_string()))
+                .cloned();
+            assert!(
+                matches!(&durable, Some(RecordValue::OrMap { tombstones, .. }) if tombstones.contains(&"t0".to_string())),
+                "precondition: t0 tombstone must be durable, got {durable:?}"
+            );
+
+            // store2 shares the datastore but has an empty engine — the key is
+            // NON-RESIDENT there (models eviction). Prune must still reclaim it.
+            let store2 = store_sharing(&datastore);
+            apply_inplace(&store2, &OrOp::Prune { tag: "t0".into() }).await;
+
+            let durable_after = datastore
+                .data
+                .lock()
+                .await
+                .get(&(MAP.to_string(), KEY.to_string()))
+                .cloned();
+            assert!(
+                matches!(&durable_after, Some(RecordValue::OrMap { tombstones, .. }) if !tombstones.contains(&"t0".to_string())),
+                "prune must reclaim the evicted key's durable tombstone (hydrate-then-drop), got {durable_after:?}"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // MED-1 regression: a new tombstone is counted in the gauge EXACTLY ONCE
+    // even when the durable write fails and the client retries. The increment is
+    // atomic with the resident push, so the retry (which finds it already
+    // resident) does not double-count, and the failed first attempt does not skip
+    // it — a post-write increment would skip it on retry and later underflow the
+    // non-saturating gauge on prune.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn new_tombstone_counted_once_across_write_failure_and_retry() {
+        let _serialize = GAUGE_LOCK.lock().unwrap();
+        block_on_async(async {
+            let datastore = Arc::new(RetainingCountingStore::default());
+            // Fail exactly the first write-through.
+            datastore.fail_adds.store(1, Ordering::Relaxed);
+            let store = store_sharing(&datastore);
+
+            let tag = "tX";
+            let mut remove_once = |value: &mut RecordValue| {
+                normalize(value);
+                if let RecordValue::OrMap {
+                    records,
+                    tombstones,
+                } = value
+                {
+                    records.retain(|e| e.tag != tag);
+                    if !tombstones.iter().any(|t| t == tag) {
+                        tombstones.push(tag.to_string());
+                        add_tombstone_bytes(tag.len() as u64);
+                    }
+                }
+                true
+            };
+
+            let baseline = tombstone_bytes();
+            // First attempt: resident mutated + gauge incremented in-closure, then
+            // the durable write fails.
+            let r1 = store
+                .update_in_place(
+                    KEY,
+                    Some(empty_ormap()),
+                    ExpiryPolicy::NONE,
+                    CallerProvenance::CrdtMerge,
+                    &mut remove_once,
+                )
+                .await;
+            assert!(r1.is_err(), "first write-through must fail (injected)");
+            // Retry: the tag is already resident, so it is not re-counted; the
+            // durable write now succeeds.
+            let r2 = store
+                .update_in_place(
+                    KEY,
+                    Some(empty_ormap()),
+                    ExpiryPolicy::NONE,
+                    CallerProvenance::CrdtMerge,
+                    &mut remove_once,
+                )
+                .await;
+            assert!(r2.is_ok(), "retry write-through must succeed");
+
+            let delta = tombstone_bytes().saturating_sub(baseline);
+            assert_eq!(
+                delta,
+                tag.len() as u64,
+                "a new tombstone must be counted exactly once across write-failure + retry"
+            );
+        });
     }
 }

--- a/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
+++ b/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
@@ -241,7 +241,13 @@ mod tests {
             Ok(())
         }
 
-        async fn flush_key(&self, _: &str, _: &str, _: &RecordValue, _: bool) -> anyhow::Result<()> {
+        async fn flush_key(
+            &self,
+            _: &str,
+            _: &str,
+            _: &RecordValue,
+            _: bool,
+        ) -> anyhow::Result<()> {
             Ok(())
         }
 
@@ -495,7 +501,7 @@ mod tests {
 
     /// Sum of every resident tombstone tag's UTF-8 byte length — the same
     /// `tag.len()` accounting `reconcile_tombstone_bytes` recomputes at boot.
-    fn resident_tombstone_bytes(value: &Option<RecordValue>) -> u64 {
+    fn resident_tombstone_bytes(value: Option<&RecordValue>) -> u64 {
         match value {
             Some(RecordValue::OrMap { tombstones, .. }) => {
                 tombstones.iter().map(|t| t.len() as u64).sum()
@@ -617,8 +623,8 @@ mod tests {
                     tag: "t0".into(),
                     val: 3,
                 }, // remove-wins: suppressed, tombstone stays
-                OrOp::Prune { tag: "t2".into() }, // drop one tombstone
-                OrOp::Prune { tag: "t9".into() }, // no-op prune (absent tag)
+                OrOp::Prune { tag: "t2".into() },  // drop one tombstone
+                OrOp::Prune { tag: "t9".into() },  // no-op prune (absent tag)
             ];
 
             let baseline = tombstone_bytes();
@@ -628,7 +634,7 @@ mod tests {
             let net_delta = tombstone_bytes().saturating_sub(baseline);
 
             let resident = h.store.get(KEY, false).await.unwrap().map(|r| r.value);
-            let recomputed = resident_tombstone_bytes(&resident);
+            let recomputed = resident_tombstone_bytes(resident.as_ref());
 
             assert_eq!(
                 net_delta, recomputed,
@@ -642,11 +648,12 @@ mod tests {
     // AC6 (Rec 3): cheap OrMap estimated_cost stays close to the true size
     // -----------------------------------------------------------------------
 
-    /// The structural OrMap-arm cost estimate feeds the `TOPGUN_MAX_RAM_MB`
+    /// The structural `OrMap`-arm cost estimate feeds the `TOPGUN_MAX_RAM_MB`
     /// eviction water-mark, so it must not materially diverge from the true
     /// `rmp_serde` serialized size. Assert it stays within 1.5× in both
-    /// directions for representative OrMap slots.
+    /// directions for representative `OrMap` slots.
     #[test]
+    #[allow(clippy::cast_precision_loss)]
     fn estimated_cost_ormap_fidelity_within_1_5x() {
         let slots = [
             build_slot(1, 0),
@@ -668,6 +675,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::cast_possible_wrap)]
     fn build_slot(records: usize, tombstones: usize) -> RecordValue {
         RecordValue::OrMap {
             records: (0..records)

--- a/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
+++ b/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
@@ -1,0 +1,685 @@
+//! Differential resident-state equivalence proof for the OR-Map in-place mutate
+//! write path.
+//!
+//! The OR write path used to read-modify-write by cloning the whole per-key
+//! `RecordValue::OrMap` snapshot, rebuilding it, and re-putting it on every op.
+//! It now mutates the resident slot IN PLACE via
+//! [`RecordStore::update_in_place`](crate::storage::RecordStore::update_in_place).
+//! These tests prove the switch changed only *how* the slot is written, not
+//! *what* ends up resident: a random OR op sequence applied via BOTH paths
+//! yields a byte-identical resident `OrMap` (same records order, same tombstone
+//! order — and, canonically, the same [`or_map_semantic_view`] live/tombstone
+//! sets), fires the SAME observer notifications, and performs the SAME durable
+//! write-through.
+//!
+//! This is a LIVE-PATH equivalence proof: no `kill -9`, no WAL recovery fold
+//! (the full-snapshot WAL write-through is unchanged, so crash recovery is
+//! byte-identical to before and is covered by the crash-safety proptests).
+//!
+//! It also proves the SPEC-345 tombstone-bytes gauge stays consistent under the
+//! in-place path (the gauge deltas route through `add_tombstone_bytes` /
+//! `sub_tombstone_bytes`, never bypassed), and that the cheap OrMap-arm
+//! `estimated_cost` estimate stays close to the true serialized size so the
+//! eviction water-mark is not skewed.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use proptest::prelude::*;
+    use tokio::runtime::Handle;
+    use tokio::sync::Mutex as AsyncMutex;
+    use tokio::task::block_in_place;
+    use topgun_core::hlc::Timestamp;
+    use topgun_core::types::Value;
+
+    use crate::service::domain::crdt::or_map_semantic_view;
+    use crate::storage::engines::HashMapStorage;
+    use crate::storage::impls::{DefaultRecordStore, StorageConfig};
+    use crate::storage::map_data_store::{LeafSink, MapDataStore, ScanBatch, ScanCursor};
+    use crate::storage::mutation_observer::{CompositeMutationObserver, MutationObserver};
+    use crate::storage::record::{
+        add_tombstone_bytes, estimated_cost, sub_tombstone_bytes, tombstone_bytes, OrMapEntry,
+        Record, RecordValue,
+    };
+    use crate::storage::record_store::{CallerProvenance, ExpiryPolicy, RecordStore};
+
+    const MAP: &str = "omap";
+    const KEY: &str = "k1";
+
+    // -----------------------------------------------------------------------
+    // Async-bridge runtime (CLAUDE.md §Proptest Async Bridge)
+    // -----------------------------------------------------------------------
+
+    static PROPTEST_RUNTIME: std::sync::LazyLock<tokio::runtime::Runtime> =
+        std::sync::LazyLock::new(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("build multi-thread runtime for proptest async bridge")
+        });
+
+    fn block_on_async<F: std::future::Future>(fut: F) -> F::Output {
+        let handle = PROPTEST_RUNTIME.handle().clone();
+        let _guard = handle.enter();
+        block_in_place(|| Handle::current().block_on(fut))
+    }
+
+    // The tombstone-bytes gauge is a single process-global static shared with
+    // every other test that touches OR removes/prunes. Serialize this module's
+    // gauge-measuring region so its own passes do not interleave; delta-based
+    // assertions keep it robust against unrelated modules' mutations.
+    static GAUGE_LOCK: Mutex<()> = Mutex::new(());
+
+    // -----------------------------------------------------------------------
+    // Counting mutation observer — proves the two paths fire identical fan-out
+    // -----------------------------------------------------------------------
+
+    #[derive(Default)]
+    struct CountingObserver {
+        put: AtomicUsize,
+        update: AtomicUsize,
+        remove: AtomicUsize,
+        load: AtomicUsize,
+    }
+
+    impl CountingObserver {
+        fn snapshot(&self) -> (usize, usize, usize, usize) {
+            (
+                self.put.load(Ordering::Relaxed),
+                self.update.load(Ordering::Relaxed),
+                self.remove.load(Ordering::Relaxed),
+                self.load.load(Ordering::Relaxed),
+            )
+        }
+    }
+
+    impl MutationObserver for CountingObserver {
+        fn on_put(&self, _: &str, _: &Record, _: Option<&RecordValue>, _: bool) {
+            self.put.fetch_add(1, Ordering::Relaxed);
+        }
+        fn on_update(&self, _: &str, _: &Record, _: &RecordValue, _: &RecordValue, _: bool) {
+            self.update.fetch_add(1, Ordering::Relaxed);
+        }
+        fn on_remove(&self, _: &str, _: &Record, _: bool) {
+            self.remove.fetch_add(1, Ordering::Relaxed);
+        }
+        fn on_evict(&self, _: &str, _: &Record, _: bool) {}
+        fn on_load(&self, _: &str, _: &Record, _: bool) {
+            self.load.fetch_add(1, Ordering::Relaxed);
+        }
+        fn on_replication_put(&self, _: &str, _: &Record, _: bool) {}
+        fn on_clear(&self) {}
+        fn on_reset(&self) {}
+        fn on_destroy(&self, _: bool) {}
+    }
+
+    // -----------------------------------------------------------------------
+    // Retaining + add-counting data store — proves the two paths write through
+    // the SAME durable content the same number of times. `is_null()` is false
+    // so the full write-through + mark_stored discipline runs.
+    // -----------------------------------------------------------------------
+
+    #[derive(Default)]
+    struct RetainingCountingStore {
+        data: AsyncMutex<HashMap<(String, String), RecordValue>>,
+        adds: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl MapDataStore for RetainingCountingStore {
+        async fn add(
+            &self,
+            map: &str,
+            key: &str,
+            value: &RecordValue,
+            _exp: i64,
+            _now: i64,
+        ) -> anyhow::Result<()> {
+            self.adds.fetch_add(1, Ordering::Relaxed);
+            self.data
+                .lock()
+                .await
+                .insert((map.to_string(), key.to_string()), value.clone());
+            Ok(())
+        }
+
+        async fn add_backup(
+            &self,
+            _: &str,
+            _: &str,
+            _: &RecordValue,
+            _: i64,
+            _: i64,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn remove(&self, map: &str, key: &str, _now: i64) -> anyhow::Result<()> {
+            self.data
+                .lock()
+                .await
+                .remove(&(map.to_string(), key.to_string()));
+            Ok(())
+        }
+
+        async fn remove_backup(&self, _: &str, _: &str, _: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn load(&self, map: &str, key: &str) -> anyhow::Result<Option<RecordValue>> {
+            Ok(self
+                .data
+                .lock()
+                .await
+                .get(&(map.to_string(), key.to_string()))
+                .cloned())
+        }
+
+        async fn load_all(
+            &self,
+            map: &str,
+            keys: &[String],
+        ) -> anyhow::Result<Vec<(String, RecordValue)>> {
+            let guard = self.data.lock().await;
+            let mut out = Vec::new();
+            for key in keys {
+                if let Some(value) = guard.get(&(map.to_string(), key.clone())) {
+                    out.push((key.clone(), value.clone()));
+                }
+            }
+            Ok(out)
+        }
+
+        async fn remove_all(&self, map: &str, keys: &[String]) -> anyhow::Result<()> {
+            let mut guard = self.data.lock().await;
+            for key in keys {
+                guard.remove(&(map.to_string(), key.clone()));
+            }
+            Ok(())
+        }
+
+        async fn enumerate_leaves(
+            &self,
+            _: &str,
+            _: bool,
+            _: &mut dyn LeafSink,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn scan_values(&self, _: &str, _: bool, _: u64) -> anyhow::Result<ScanBatch> {
+            Ok(ScanBatch::default())
+        }
+
+        async fn scan_values_batched(
+            &self,
+            _: &str,
+            _: bool,
+            _: ScanCursor,
+            _: u64,
+        ) -> anyhow::Result<ScanBatch> {
+            Ok(ScanBatch::default())
+        }
+
+        fn is_loadable(&self, _: &str) -> bool {
+            true
+        }
+
+        fn pending_operation_count(&self) -> u64 {
+            0
+        }
+
+        async fn soft_flush(&self) -> anyhow::Result<u64> {
+            Ok(0)
+        }
+
+        async fn hard_flush(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn flush_key(&self, _: &str, _: &str, _: &RecordValue, _: bool) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn reset(&self) {}
+
+        // A real (non-null) backend so the full write-through + mark_stored path
+        // exercises exactly what production does.
+        fn is_null(&self) -> bool {
+            false
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Op model + shared helpers
+    // -----------------------------------------------------------------------
+
+    #[derive(Debug, Clone)]
+    enum OrOp {
+        Add { tag: String, val: i64 },
+        Remove { tag: String },
+        Prune { tag: String },
+    }
+
+    fn ts(millis: u64) -> Timestamp {
+        Timestamp {
+            millis,
+            counter: 0,
+            node_id: "node-1".to_string(),
+        }
+    }
+
+    fn empty_ormap() -> RecordValue {
+        RecordValue::OrMap {
+            records: Vec::new(),
+            tombstones: Vec::new(),
+        }
+    }
+
+    /// Mirror of the private `read_or_map_state` in `crdt.rs`, so the legacy
+    /// comparison path reproduces the exact old get→build→put behavior.
+    fn read_state(value: Option<RecordValue>) -> (Vec<OrMapEntry>, Vec<String>) {
+        match value {
+            Some(RecordValue::OrMap {
+                records,
+                tombstones,
+            }) => (records, tombstones),
+            Some(RecordValue::OrTombstones { tags }) => (Vec::new(), tags),
+            _ => (Vec::new(), Vec::new()),
+        }
+    }
+
+    struct Harness {
+        store: DefaultRecordStore,
+        observer: Arc<CountingObserver>,
+        datastore: Arc<RetainingCountingStore>,
+    }
+
+    fn make_harness() -> Harness {
+        let observer = Arc::new(CountingObserver::default());
+        let datastore = Arc::new(RetainingCountingStore::default());
+        let composite = Arc::new(CompositeMutationObserver::new(vec![
+            Arc::clone(&observer) as Arc<dyn MutationObserver>
+        ]));
+        let store = DefaultRecordStore::new(
+            MAP.to_string(),
+            0,
+            Box::new(HashMapStorage::new()),
+            Arc::clone(&datastore) as Arc<dyn MapDataStore>,
+            composite,
+            StorageConfig::default(),
+        );
+        Harness {
+            store,
+            observer,
+            datastore,
+        }
+    }
+
+    /// Apply an op through the NEW in-place mutate path — mirrors the production
+    /// `crdt.rs` OR write path exactly (same mutate closures, same gauge calls).
+    async fn apply_inplace(store: &DefaultRecordStore, op: &OrOp) {
+        match op {
+            OrOp::Add { tag, val } => {
+                let entry = OrMapEntry {
+                    value: Value::Int(*val),
+                    tag: tag.clone(),
+                    timestamp: ts(u64::try_from(val.rem_euclid(1_000_000)).unwrap_or(0)),
+                };
+                let mut entry_opt = Some(entry);
+                let mut merge = move |value: &mut RecordValue| {
+                    if let RecordValue::OrMap {
+                        records,
+                        tombstones,
+                    } = value
+                    {
+                        let e = entry_opt.take().expect("runs once");
+                        if !tombstones.contains(&e.tag) {
+                            records.retain(|r| r.tag != e.tag);
+                            records.push(e);
+                        }
+                    }
+                    true
+                };
+                store
+                    .update_in_place(
+                        KEY,
+                        Some(empty_ormap()),
+                        ExpiryPolicy::NONE,
+                        CallerProvenance::CrdtMerge,
+                        &mut merge,
+                    )
+                    .await
+                    .unwrap();
+            }
+            OrOp::Remove { tag } => {
+                let mut is_new = false;
+                {
+                    let mut apply = |value: &mut RecordValue| {
+                        if let RecordValue::OrMap {
+                            records,
+                            tombstones,
+                        } = value
+                        {
+                            records.retain(|e| e.tag != *tag);
+                            if !tombstones.contains(tag) {
+                                tombstones.push(tag.clone());
+                                is_new = true;
+                            }
+                        }
+                        true
+                    };
+                    store
+                        .update_in_place(
+                            KEY,
+                            Some(empty_ormap()),
+                            ExpiryPolicy::NONE,
+                            CallerProvenance::CrdtMerge,
+                            &mut apply,
+                        )
+                        .await
+                        .unwrap();
+                }
+                if is_new {
+                    add_tombstone_bytes(tag.len() as u64);
+                }
+            }
+            OrOp::Prune { tag } => {
+                let mut dropped = false;
+                {
+                    let mut drop_tag = |value: &mut RecordValue| {
+                        if let RecordValue::OrMap { tombstones, .. } = value {
+                            let before = tombstones.len();
+                            tombstones.retain(|t| t != tag);
+                            dropped = tombstones.len() != before;
+                        }
+                        dropped
+                    };
+                    store
+                        .update_in_place(
+                            KEY,
+                            None,
+                            ExpiryPolicy::NONE,
+                            CallerProvenance::CrdtMerge,
+                            &mut drop_tag,
+                        )
+                        .await
+                        .unwrap();
+                }
+                if dropped {
+                    sub_tombstone_bytes(tag.len() as u64);
+                }
+            }
+        }
+    }
+
+    /// Apply an op through the OLD get→build→put path — the historical
+    /// `crdt.rs` OR write path this fix replaced.
+    async fn apply_legacy(store: &DefaultRecordStore, op: &OrOp) {
+        match op {
+            OrOp::Add { tag, val } => {
+                let entry = OrMapEntry {
+                    value: Value::Int(*val),
+                    tag: tag.clone(),
+                    timestamp: ts(u64::try_from(val.rem_euclid(1_000_000)).unwrap_or(0)),
+                };
+                let existing = store.get(KEY, false).await.unwrap();
+                let (mut records, tombstones) = read_state(existing.map(|r| r.value));
+                let rv = if tombstones.contains(&entry.tag) {
+                    RecordValue::OrMap {
+                        records,
+                        tombstones,
+                    }
+                } else {
+                    records.retain(|e| e.tag != entry.tag);
+                    records.push(entry);
+                    RecordValue::OrMap {
+                        records,
+                        tombstones,
+                    }
+                };
+                store
+                    .put(KEY, rv, ExpiryPolicy::NONE, CallerProvenance::CrdtMerge)
+                    .await
+                    .unwrap();
+            }
+            OrOp::Remove { tag } => {
+                let existing = store.get(KEY, false).await.unwrap();
+                let (mut records, mut tombstones) = read_state(existing.map(|r| r.value));
+                records.retain(|e| e.tag != *tag);
+                let is_new = !tombstones.contains(tag);
+                if is_new {
+                    tombstones.push(tag.clone());
+                    add_tombstone_bytes(tag.len() as u64);
+                }
+                store
+                    .put(
+                        KEY,
+                        RecordValue::OrMap {
+                            records,
+                            tombstones,
+                        },
+                        ExpiryPolicy::NONE,
+                        CallerProvenance::CrdtMerge,
+                    )
+                    .await
+                    .unwrap();
+            }
+            OrOp::Prune { tag } => {
+                let existing = store.get(KEY, false).await.unwrap();
+                let (records, mut tombstones) = read_state(existing.map(|r| r.value));
+                let before = tombstones.len();
+                tombstones.retain(|t| t != tag);
+                if tombstones.len() != before {
+                    store
+                        .put(
+                            KEY,
+                            RecordValue::OrMap {
+                                records,
+                                tombstones,
+                            },
+                            ExpiryPolicy::NONE,
+                            CallerProvenance::CrdtMerge,
+                        )
+                        .await
+                        .unwrap();
+                    sub_tombstone_bytes(tag.len() as u64);
+                }
+            }
+        }
+    }
+
+    /// Sum of every resident tombstone tag's UTF-8 byte length — the same
+    /// `tag.len()` accounting `reconcile_tombstone_bytes` recomputes at boot.
+    fn resident_tombstone_bytes(value: &Option<RecordValue>) -> u64 {
+        match value {
+            Some(RecordValue::OrMap { tombstones, .. }) => {
+                tombstones.iter().map(|t| t.len() as u64).sum()
+            }
+            _ => 0,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Strategies
+    // -----------------------------------------------------------------------
+
+    /// Small tag space so adds/removes/prunes overlap on the same tags
+    /// (interleaved add/remove on the same tag, removes of non-existent tags,
+    /// prunes racing removes).
+    fn or_op() -> impl Strategy<Value = OrOp> {
+        prop_oneof![
+            (0u8..6, any::<i32>()).prop_map(|(t, v)| OrOp::Add {
+                tag: format!("t{t}"),
+                val: i64::from(v),
+            }),
+            (0u8..6).prop_map(|t| OrOp::Remove {
+                tag: format!("t{t}"),
+            }),
+            (0u8..6).prop_map(|t| OrOp::Prune {
+                tag: format!("t{t}"),
+            }),
+        ]
+    }
+
+    // -----------------------------------------------------------------------
+    // AC6: resident-state + observer + write-through differential equivalence
+    // -----------------------------------------------------------------------
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+        /// The in-place path and the get→build→put path leave a byte-identical
+        /// resident `OrMap` (records order + tombstones order), the same canonical
+        /// [`or_map_semantic_view`], the same observer fan-out counts, and the same
+        /// durable write-through content and add count.
+        #[test]
+        fn inplace_matches_get_build_put(ops in prop::collection::vec(or_op(), 1..40)) {
+            block_on_async(async {
+                let inplace = make_harness();
+                let legacy = make_harness();
+
+                for op in &ops {
+                    apply_inplace(&inplace.store, op).await;
+                    apply_legacy(&legacy.store, op).await;
+                }
+
+                let a = inplace.store.get(KEY, false).await.unwrap().map(|r| r.value);
+                let b = legacy.store.get(KEY, false).await.unwrap().map(|r| r.value);
+
+                // Byte-for-byte resident equality (records order + tombstones order),
+                // the HARD resident-state-equivalence invariant.
+                prop_assert_eq!(&a, &b, "resident OrMap must be byte-identical across the two write paths");
+
+                // Canonical set-based oracle (order-independent) as a second check.
+                prop_assert_eq!(
+                    or_map_semantic_view(a.clone()),
+                    or_map_semantic_view(b.clone()),
+                    "semantic view (live + tombstone sets) must match"
+                );
+
+                // Identical observer fan-out (on_put for a fresh key, on_update for
+                // an existing one — the ENTER/UPDATE distinction search relies on).
+                prop_assert_eq!(
+                    inplace.observer.snapshot(),
+                    legacy.observer.snapshot(),
+                    "observer notification counts must match across the two write paths"
+                );
+
+                // Identical durable write-through: same persisted content, same
+                // number of add() calls.
+                let da = inplace.datastore.data.lock().await.get(&(MAP.to_string(), KEY.to_string())).cloned();
+                let db = legacy.datastore.data.lock().await.get(&(MAP.to_string(), KEY.to_string())).cloned();
+                prop_assert_eq!(da, db, "durable write-through content must match");
+                prop_assert_eq!(
+                    inplace.datastore.adds.load(Ordering::Relaxed),
+                    legacy.datastore.adds.load(Ordering::Relaxed),
+                    "write-through must fire the same number of times"
+                );
+
+                Ok(())
+            })?;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AC6: SPEC-345 gauge reconciliation under the in-place path
+    // -----------------------------------------------------------------------
+
+    /// After a mixed add/remove/dup-remove/prune sequence via the in-place path,
+    /// the net tombstone-bytes gauge change equals the tombstone-byte sum
+    /// recomputed from the resident slot — i.e. the in-place path routes gauge
+    /// deltas through `add_tombstone_bytes` / `sub_tombstone_bytes`, never
+    /// bypassing them, so a boot `reconcile_tombstone_bytes` would agree.
+    #[test]
+    fn gauge_reconciles_with_resident_tombstones_under_inplace() {
+        let _serialize = GAUGE_LOCK.lock().unwrap();
+        block_on_async(async {
+            let h = make_harness();
+
+            let ops = vec![
+                OrOp::Add {
+                    tag: "t0".into(),
+                    val: 1,
+                },
+                OrOp::Add {
+                    tag: "t1".into(),
+                    val: 2,
+                },
+                OrOp::Remove { tag: "t0".into() }, // new tombstone
+                OrOp::Remove { tag: "t0".into() }, // duplicate — must NOT re-count
+                OrOp::Remove { tag: "t2".into() }, // tombstone for a never-added tag
+                OrOp::Add {
+                    tag: "t0".into(),
+                    val: 3,
+                }, // remove-wins: suppressed, tombstone stays
+                OrOp::Prune { tag: "t2".into() }, // drop one tombstone
+                OrOp::Prune { tag: "t9".into() }, // no-op prune (absent tag)
+            ];
+
+            let baseline = tombstone_bytes();
+            for op in &ops {
+                apply_inplace(&h.store, op).await;
+            }
+            let net_delta = tombstone_bytes().saturating_sub(baseline);
+
+            let resident = h.store.get(KEY, false).await.unwrap().map(|r| r.value);
+            let recomputed = resident_tombstone_bytes(&resident);
+
+            assert_eq!(
+                net_delta, recomputed,
+                "in-place gauge delta ({net_delta}) must equal the resident tombstone-byte \
+                 sum ({recomputed}) — the gauge must not be bypassed"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // AC6 (Rec 3): cheap OrMap estimated_cost stays close to the true size
+    // -----------------------------------------------------------------------
+
+    /// The structural OrMap-arm cost estimate feeds the `TOPGUN_MAX_RAM_MB`
+    /// eviction water-mark, so it must not materially diverge from the true
+    /// `rmp_serde` serialized size. Assert it stays within 1.5× in both
+    /// directions for representative OrMap slots.
+    #[test]
+    fn estimated_cost_ormap_fidelity_within_1_5x() {
+        let slots = [
+            build_slot(1, 0),
+            build_slot(10, 3),
+            build_slot(48, 12),
+            build_slot(100, 40),
+        ];
+        for value in &slots {
+            let cheap = estimated_cost(value);
+            let true_bytes = rmp_serde::to_vec_named(value).unwrap().len() as u64;
+            let cheap_f = cheap as f64;
+            let true_f = true_bytes as f64;
+            assert!(
+                cheap_f <= true_f * 1.5 && true_f <= cheap_f * 1.5,
+                "estimated_cost {cheap} must be within 1.5x of true serialized size \
+                 {true_bytes} (ratio {:.3})",
+                cheap_f / true_f
+            );
+        }
+    }
+
+    fn build_slot(records: usize, tombstones: usize) -> RecordValue {
+        RecordValue::OrMap {
+            records: (0..records)
+                .map(|i| OrMapEntry {
+                    value: Value::Int(i as i64 * 7 + 1),
+                    tag: format!("{}:{}:node-1", 1_700_000_000_000_u64 + i as u64, i),
+                    timestamp: ts(1_700_000_000_000 + i as u64),
+                })
+                .collect(),
+            tombstones: (0..tombstones)
+                .map(|i| format!("{}:{}:node-1", 1_600_000_000_000_u64 + i as u64, i))
+                .collect(),
+        }
+    }
+}

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -349,7 +349,7 @@ pub const COST_ESTIMATE_FALLBACK: u64 = 4096;
 
 /// Per-`OrMapEntry` structural framing constant (bytes).
 ///
-/// Approximates the fixed MsgPack overhead of one `OrMapEntry` map — the map
+/// Approximates the fixed `MsgPack` overhead of one `OrMapEntry` map — the map
 /// header plus the `value`/`tag`/`timestamp` field-name strings and the nested
 /// `Timestamp` map's `millis`/`counter`/`nodeId` keys, headers, and fixed-width
 /// numeric fields — everything except the variable `value`, `tag`, and
@@ -358,11 +358,11 @@ pub const COST_ESTIMATE_FALLBACK: u64 = 4096;
 /// `rmp_serde::to_vec_named` size for representative OR entries.
 const OR_ENTRY_FRAMING_BYTES: u64 = 61;
 
-/// Fixed MsgPack framing (bytes) for the outer `OrMap` map itself (the map
+/// Fixed `MsgPack` framing (bytes) for the outer `OrMap` map itself (the map
 /// header + `records`/`tombstones` field names + array headers).
 const OR_MAP_FRAMING_BYTES: u64 = 12;
 
-/// Structural byte-size estimate of a [`Value`], approximating its MsgPack
+/// Structural byte-size estimate of a [`Value`], approximating its `MsgPack`
 /// encoding without serializing.
 ///
 /// `Value` is an externally-tagged enum, so each variant carries a small

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -347,21 +347,84 @@ impl RecordMetadata {
 /// is the `tracing::warn!` emitted alongside it.
 pub const COST_ESTIMATE_FALLBACK: u64 = 4096;
 
+/// Per-`OrMapEntry` structural framing constant (bytes).
+///
+/// Approximates the fixed MsgPack overhead of one `OrMapEntry` map — the map
+/// header plus the `value`/`tag`/`timestamp` field-name strings and the nested
+/// `Timestamp` map's `millis`/`counter`/`nodeId` keys, headers, and fixed-width
+/// numeric fields — everything except the variable `value`, `tag`, and
+/// `node_id` byte lengths, which are added separately. Chosen so the cheap
+/// structural estimate lands close to (within ~1.5× of) the true
+/// `rmp_serde::to_vec_named` size for representative OR entries.
+const OR_ENTRY_FRAMING_BYTES: u64 = 61;
+
+/// Fixed MsgPack framing (bytes) for the outer `OrMap` map itself (the map
+/// header + `records`/`tombstones` field names + array headers).
+const OR_MAP_FRAMING_BYTES: u64 = 12;
+
+/// Structural byte-size estimate of a [`Value`], approximating its MsgPack
+/// encoding without serializing.
+///
+/// `Value` is an externally-tagged enum, so each variant carries a small
+/// map/variant-name framing overhead in addition to its payload bytes; the
+/// per-variant constants below fold that in. This is a monitoring/eviction size
+/// signal, not an exact wire measurement.
+fn value_byte_estimate(value: &Value) -> u64 {
+    match value {
+        Value::Null => 5,
+        Value::Bool(_) => 7,
+        Value::Int(_) => 14,
+        Value::Float(_) => 16,
+        Value::String(s) => 10 + s.len() as u64,
+        Value::Bytes(b) => 9 + b.len() as u64,
+        Value::Array(items) => 8 + items.iter().map(value_byte_estimate).sum::<u64>(),
+        Value::Map(entries) => {
+            6 + entries
+                .iter()
+                .map(|(k, v)| k.len() as u64 + 3 + value_byte_estimate(v))
+                .sum::<u64>()
+        }
+    }
+}
+
+/// Cheap structural byte-size estimate of an `OrMap` slot — the sum of each
+/// record's value/tag/timestamp byte lengths plus fixed framing, and each
+/// tombstone tag's UTF-8 byte length — WITHOUT serializing the whole snapshot.
+///
+/// This reuses the same `tag.len()` accounting the SPEC-345 tombstone gauge
+/// uses. It replaces the former per-put `rmp_serde::to_vec_named` of the entire
+/// (often ~130 KB) OR snapshot, which was a dominant source of per-op allocator
+/// churn on the OR write path.
+fn or_map_estimated_cost(records: &[OrMapEntry], tombstones: &[String]) -> u64 {
+    let records_bytes: u64 = records
+        .iter()
+        .map(|e| {
+            OR_ENTRY_FRAMING_BYTES
+                + value_byte_estimate(&e.value)
+                + e.tag.len() as u64
+                + e.timestamp.node_id.len() as u64
+        })
+        .sum();
+    let tombstones_bytes: u64 = tombstones.iter().map(|t| t.len() as u64 + 2).sum();
+    OR_MAP_FRAMING_BYTES + records_bytes + tombstones_bytes
+}
+
 /// Returns the estimated heap cost of a [`RecordValue`] in bytes.
 ///
-/// Serializes the value via `rmp_serde::to_vec_named` (the same encoding used
-/// by the persistence layer) and returns the byte length, floored to `≥ 1`.
-/// The floor prevents empty/`Null` values from contributing zero cost, which
-/// would leave the eviction orchestrator blind to maps of empty values.
+/// For the [`RecordValue::OrMap`] arm this is a cheap structural size estimate
+/// (see [`or_map_estimated_cost`]) — the sum of the records' value/tag/timestamp
+/// byte lengths plus the tombstone tag byte lengths — so the write path never
+/// serializes the whole (often ~130 KB) OR snapshot just to size it. Every
+/// other arm serializes via `rmp_serde::to_vec_named` (the same encoding used by
+/// the persistence layer) and returns the byte length. The result is floored to
+/// `≥ 1` so empty/`Null` values still contribute non-zero cost, keeping the
+/// eviction orchestrator from going blind to maps of empty values.
 ///
-/// This is a deliberate *second* serialization of the value — the persistence
-/// path (`MapDataStore::add`) encodes it again to write it. Reusing the
+/// The non-OrMap serialize is a deliberate *second* encode — the persistence
+/// path (`MapDataStore::add`) encodes the value again to write it. Reusing the
 /// persisted bytes would require threading the encoded length back out through
 /// the datastore trait (every backend impl), so the estimate stays
-/// self-contained here. The extra encode is bounded by the value size already
-/// paid for the durable write and runs only on the write path (not per eviction
-/// tick), so the cost is acceptable; folding the two encodes into one is a
-/// tracked follow-up optimization.
+/// self-contained here. It runs only on the write path (not per eviction tick).
 ///
 /// On serialization failure the fallback is [`COST_ESTIMATE_FALLBACK`] plus a
 /// `tracing::warn!` — never a silent `1`, which would blind the orchestrator to
@@ -372,6 +435,14 @@ pub const COST_ESTIMATE_FALLBACK: u64 = 4096;
 /// callers retain the key in scope without the helper needing to take ownership.
 #[must_use]
 pub fn estimated_cost(value: &RecordValue) -> u64 {
+    if let RecordValue::OrMap {
+        records,
+        tombstones,
+    } = value
+    {
+        return or_map_estimated_cost(records, tombstones).max(1);
+    }
+
     match rmp_serde::to_vec_named(value) {
         Ok(bytes) => (bytes.len() as u64).max(1),
         Err(e) => {

--- a/packages/server-rust/src/storage/record_store.rs
+++ b/packages/server-rust/src/storage/record_store.rs
@@ -118,7 +118,8 @@ pub trait RecordStore: Send + Sync {
     /// `mutate` runs synchronously under the engine's per-key write lock and
     /// returns `true` if it made a change that must be persisted, or `false`
     /// for a no-op (e.g. a prune whose target tag was already gone). It MUST
-    /// return `true` whenever it altered the value.
+    /// return `true` whenever it altered the value, and is invoked **at most
+    /// once** per call — callers may rely on single invocation.
     ///
     /// If the key is absent: when `init` is `Some`, a fresh record is created
     /// from it, `mutate` is applied, and (on a `true` return) `on_put` fires;

--- a/packages/server-rust/src/storage/record_store.rs
+++ b/packages/server-rust/src/storage/record_store.rs
@@ -111,6 +111,50 @@ pub trait RecordStore: Send + Sync {
         provenance: CallerProvenance,
     ) -> anyhow::Result<Option<RecordValue>>;
 
+    /// Mutate a resident record's value in place, firing the same observer
+    /// notifications and durable write-through as [`put`](RecordStore::put)
+    /// WITHOUT a full get→build→put round trip.
+    ///
+    /// `mutate` runs synchronously under the engine's per-key write lock and
+    /// returns `true` if it made a change that must be persisted, or `false`
+    /// for a no-op (e.g. a prune whose target tag was already gone). It MUST
+    /// return `true` whenever it altered the value.
+    ///
+    /// If the key is absent: when `init` is `Some`, a fresh record is created
+    /// from it, `mutate` is applied, and (on a `true` return) `on_put` fires;
+    /// when `init` is `None`, the call is a no-op. Returns `true` when a record
+    /// was created or updated (a write-through was owed), `false` otherwise.
+    ///
+    /// This exists for the OR-Map write path, whose per-op read-modify-write
+    /// otherwise cloned the whole ~130 KB resident snapshot on every op. The OR
+    /// observers ignore the pre-image, so no old value is materialized.
+    ///
+    /// The default implementation falls back to a get→mutate→put round trip so
+    /// non-optimized stores remain correct; [`DefaultRecordStore`] overrides it
+    /// with the true in-place seam.
+    async fn update_in_place(
+        &self,
+        key: &str,
+        init: Option<RecordValue>,
+        expiry: ExpiryPolicy,
+        provenance: CallerProvenance,
+        mutate: &mut (dyn for<'a> FnMut(&'a mut RecordValue) -> bool + Send),
+    ) -> anyhow::Result<bool> {
+        let existing = self.get(key, false).await?;
+        let mut value = match existing {
+            Some(record) => record.value,
+            None => match init {
+                Some(v) => v,
+                None => return Ok(false),
+            },
+        };
+        if !mutate(&mut value) {
+            return Ok(false);
+        }
+        self.put(key, value, expiry, provenance).await?;
+        Ok(true)
+    }
+
     /// Remove a record, returning the old value.
     async fn remove(
         &self,


### PR DESCRIPTION
## Summary

Kills ~42% of the per-op full-snapshot resident churn on the OR-Map write path (TODO-585 umbrella):

- **`update_in_place` seam** (StorageEngine → RecordStore → engine) — the OR RMW now mutates the resident `RecordValue::OrMap` slot in place under the per-key writer lock (DashMap shard-lock invariant — no torn reads, verified in review) instead of get → clone → build → put. Removes dhat holder #4.
- **Cheap structural `estimated_cost`** for the OrMap arm — replaces the full `rmp_serde::to_vec_named` serialize-to-count-bytes per op (dhat holder #2, `record.rs:374`).
- Proven **byte-identical** to the legacy get→build→put path: 926-line differential resident-state equivalence proptest + OR-churn-under-partition sim test + gauge-reconciliation + `estimated_cost` fidelity tests.
- **/xreview (glm-5.2): 3 real divergences fixed** — legacy-`OrTombstones` dropped-write, tombstone-gauge undercount on write-fail+retry, prune skipping evicted keys — each with a regression test that fails on pre-fix code; 2 findings rejected with verified reasoning.

## Honest scope note (AC3)
The 60-min batched positive control proved this fix alone does NOT plateau RSS (retention-dominant allocator behavior + `write_behind` per-key clones tracking the resident live-set — full 9-run diagnosis in the archived spec). The plateau is re-planned: **SPEC-349** (delta-framing, now RSS-load-bearing) + TODO-590 (allocator eval) / 591 (kill observer `record.clone()`) / 592 (redb cache cap) / 593 (resident live-set root) / 594 (prune error-path ref-restore). This PR is the correct, groundwork-quality churn reduction — not the finish line.

## Test evidence
`cargo clippy --all-targets --all-features -D warnings` + `fmt` clean; 1626 lib tests green; sim test green; audit v4 APPROVED; review v1 APPROVED (0 crit / 0 major); count-alloc + dhat diagnostic scaffolding feature-gated off by default.

72h soak (TODO-484) remains gated on SPEC-349 → SPEC-348 (+TODO-586).