### PR TITLE
Kill the OR-tombstone-gauge order-dependent test flake — task-local scoped sink [SPEC-351]

### DIFF
--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -3093,6 +3093,80 @@ mod tests {
         );
     }
 
+    /// The tombstone-bytes gauge is decremented by the REAL epoch-prune path.
+    ///
+    /// Reuses `ac4_prune_wired_into_or_write_path`'s eligibility recipe, but
+    /// asserts on the gauge rather than on stored contents: the production
+    /// `sub_tombstone_bytes` in the prune drain is otherwise reachable only
+    /// through a test-local mirror, which cannot detect its removal. Running
+    /// inside a private sink makes the net delta exact — three OR_REMOVE adds
+    /// minus the one tag the sweep drops — so a missing decrement cannot be
+    /// absorbed by ambient traffic.
+    #[tokio::test]
+    async fn or_prune_decrements_gauge_on_real_prune_path() {
+        let (svc, factory, frontier) = make_service_with_frontier();
+        let (t1, t2, t3) = ("T1", "T2", "T3");
+
+        let ((), net_delta) = crate::storage::tombstone_gauge::with_isolated_gauge(async {
+            // Add + remove T1 on k1 -> epoch 1; T2 on k2 -> epoch 2. Both stored.
+            for (key, val, tag) in [("k1", "v1", t1), ("k2", "v2", t2)] {
+                Arc::clone(&svc)
+                    .oneshot(or_add_op("m", key, val, tag))
+                    .await
+                    .unwrap();
+                Arc::clone(&svc)
+                    .oneshot(or_remove_op("m", key, tag))
+                    .await
+                    .unwrap();
+            }
+            assert_eq!(frontier.current_epoch(), 2, "epochs 1..=2 stamped");
+
+            // Raise the LWM strictly past epoch 1 (cursor 2 > 1) and open the
+            // durability watermark. Both are injected, so exactly which epoch is
+            // eligible is deterministic — no wall clock, no background sweeper.
+            let c: String = "a5:alice|dev-1".into();
+            frontier.set_delivered(ConnectionId(1), 100);
+            assert!(frontier.confirm_apply_ack(&c, 2, ConnectionId(1)).await);
+            assert_eq!(frontier.low_water_mark(), 2);
+            frontier.set_durable_epoch_watermark(1000);
+
+            // Fire the sweep via an OR_REMOVE on a THIRD key: epoch 3 (its own)
+            // and epoch 2 stay pinned, epoch 1's T1 is dropped and its bytes are
+            // returned to the gauge.
+            Arc::clone(&svc)
+                .oneshot(or_add_op("m", "k3", "v3", t3))
+                .await
+                .unwrap();
+            Arc::clone(&svc)
+                .oneshot(or_remove_op("m", "k3", t3))
+                .await
+                .unwrap();
+
+            // Pin the drop the decrement accounts for. Without this, a gauge
+            // delta alone could also be produced by a prune that never ran plus
+            // miscounted adds; pairing the two makes a failure attributable.
+            let (_, tombs_k1) = read_or_map(&factory, "m", "k1").await;
+            assert!(
+                !tombs_k1.contains(&t1.to_string()),
+                "epoch-1 tombstone pruned from storage via the OR write path"
+            );
+            let (_, tombs_k2) = read_or_map(&factory, "m", "k2").await;
+            assert!(
+                tombs_k2.contains(&t2.to_string()),
+                "epoch-2 tombstone still pinned (LWM 2 not strictly past epoch 2)"
+            );
+        })
+        .await;
+
+        // Derived from the tag lengths rather than hard-coded, so renaming a tag
+        // cannot silently invalidate the expectation.
+        let expected = (t1.len() + t2.len() + t3.len() - t1.len()) as u64;
+        assert_eq!(
+            net_delta, expected,
+            "three OR_REMOVE charges minus the single epoch-1 tag the prune drops"
+        );
+    }
+
     /// Op-path data-loss guard: the OR write path has NO forgotten-client gate,
     /// so a NOT-yet-ACKed (untracked) device's `CLIENT_OP` / `OP_BATCH` OR writes
     /// are APPLIED and acked even with tombstone protection active — never

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -3312,7 +3312,6 @@ mod tests {
     // practical here — this exercises the actual eviction blind-spot the gauge
     // exists to defend against, not a stand-in for it.
     #[tokio::test]
-    #[serial_test::serial(tombstone_gauge)]
     async fn or_remove_tombstone_gauge_survives_real_eviction_and_rehydration() {
         let dir = tempfile::tempdir().expect("tempdir");
         let redb_path = dir.path().join("gauge_residency.redb");
@@ -3334,21 +3333,15 @@ mod tests {
             Arc::new(SchemaService::new()),
         ));
 
-        // The gauge is a process-global static: the serial(tombstone_gauge) group
-        // serializes the gauge-asserting tests against each other, but UNMARKED
-        // parallel tests still mutate it via ordinary OR_REMOVE applies and prune
-        // drains. Exact-equality snapshots are therefore retried on a fresh map:
-        // ambient noise shifts between attempts, while a genuine double-count /
-        // dropped-gauge regression is deterministic and fails every attempt.
-        let mut attempt = 0usize;
-        'attempt: loop {
-            attempt += 1;
-            let map_name = &format!("gauge_residency_map_{attempt}");
-            let key = "item-1";
-            let tag = "tag-gauge-residency";
+        // The whole body runs against a private, zero-based gauge sink, so every
+        // snapshot below is this test's own contribution and nothing else's. No
+        // ambient OR_REMOVE traffic from parallel tests can reach it, which is
+        // what lets the three measurement points be exact equalities.
+        let map_name = "gauge_residency_map";
+        let key = "item-1";
+        let tag = "tag-gauge-residency";
 
-            let before_write = crate::storage::record::tombstone_bytes();
-
+        let ((), net_delta) = crate::storage::tombstone_gauge::with_isolated_gauge(async {
             svc.clone()
                 .oneshot(or_add_op(map_name, key, "payload", tag))
                 .await
@@ -3359,13 +3352,11 @@ mod tests {
                 .expect("or_remove must succeed");
 
             let after_write = crate::storage::record::tombstone_bytes();
-            if after_write - before_write != tag.len() as u64 {
-                assert!(
-                    attempt < 5,
-                    "gauge delta never settled to exactly the tag length across 5 quiet-window attempts                      (deterministic gauge regression, not parallel-test noise)"
-                );
-                continue 'attempt;
-            }
+            assert_eq!(
+                after_write,
+                tag.len() as u64,
+                "OR_REMOVE must charge the gauge exactly the tag's byte length"
+            );
 
             // Force the record non-resident via the real eviction primitive. The
             // OR_REMOVE above wrote through with `CallerProvenance::CrdtMerge` over a
@@ -3380,13 +3371,11 @@ mod tests {
             );
 
             let after_eviction = crate::storage::record::tombstone_bytes();
-            if after_eviction != after_write {
-                assert!(
-                    attempt < 5,
-                    "eviction kept moving the gauge across 5 attempts — a deterministic                      evict-drops-gauge regression, not parallel-test noise"
-                );
-                continue 'attempt;
-            }
+            assert_eq!(
+                after_eviction, after_write,
+                "evicting the record must not move the gauge — the accounting is \
+                 residency-independent"
+            );
 
             // Rehydrate: `get()` transparently reloads the non-resident record from
             // the datastore. Confirm the tombstone survived the round trip and the
@@ -3399,15 +3388,19 @@ mod tests {
             );
 
             let after_rehydration = crate::storage::record::tombstone_bytes();
-            if after_rehydration != after_write {
-                assert!(
-                    attempt < 5,
-                    "rehydration kept moving the gauge across 5 attempts — a deterministic                      double-count regression, not parallel-test noise"
-                );
-                continue 'attempt;
-            }
-            break 'attempt;
-        }
+            assert_eq!(
+                after_rehydration, after_write,
+                "rehydrating the record must not re-charge the gauge — a second \
+                 charge here is the double-count regression this test pins"
+            );
+        })
+        .await;
+
+        assert_eq!(
+            net_delta,
+            tag.len() as u64,
+            "net scoped delta across the write/evict/rehydrate cycle is one tag"
+        );
     }
 
     // AC1: add-wins — OR_REMOVE of one tag preserves concurrent survivors.

--- a/packages/server-rust/src/storage/mod.rs
+++ b/packages/server-rust/src/storage/mod.rs
@@ -37,6 +37,7 @@ pub mod merkle_sync;
 pub mod mutation_observer;
 pub mod record;
 pub mod record_store;
+pub mod tombstone_gauge;
 pub mod wal;
 
 pub use datastores::*;

--- a/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
+++ b/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
@@ -16,17 +16,31 @@
 //! (the full-snapshot WAL write-through is unchanged, so crash recovery is
 //! byte-identical to before and is covered by the crash-safety proptests).
 //!
-//! It also proves the SPEC-345 tombstone-bytes gauge stays consistent under the
-//! in-place path (the gauge deltas route through `add_tombstone_bytes` /
+//! It also proves the tombstone-bytes gauge stays consistent under the in-place
+//! path (the gauge deltas route through `add_tombstone_bytes` /
 //! `sub_tombstone_bytes`, never bypassed), and that the cheap OrMap-arm
 //! `estimated_cost` estimate stays close to the true serialized size so the
 //! eviction water-mark is not skewed.
+//!
+//! # Scope of the gauge evidence in this file
+//!
+//! The gauge assertions here drive a **test-local `apply_inplace` mirror** that
+//! calls `add_tombstone_bytes` / `sub_tombstone_bytes` itself. They do NOT drive
+//! the production epoch-prune call site in the CRDT service. Deleting that
+//! production call would leave every test in this module green.
+//!
+//! These tests are therefore evidence for the **in-place mutation contract
+//! only**: that a mutation routed through `update_in_place` moves the gauge
+//! exactly once across a write-failure/retry, and that the net delta reconciles
+//! with the tombstones left resident. They must NOT be cited as evidence that
+//! any production call site is correctly wired — coverage of the production
+//! prune path lives with that path's own test.
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     use async_trait::async_trait;
     use proptest::prelude::*;
@@ -42,10 +56,10 @@ mod tests {
     use crate::storage::map_data_store::{LeafSink, MapDataStore, ScanBatch, ScanCursor};
     use crate::storage::mutation_observer::{CompositeMutationObserver, MutationObserver};
     use crate::storage::record::{
-        add_tombstone_bytes, estimated_cost, sub_tombstone_bytes, tombstone_bytes, OrMapEntry,
-        Record, RecordValue,
+        add_tombstone_bytes, estimated_cost, sub_tombstone_bytes, OrMapEntry, Record, RecordValue,
     };
     use crate::storage::record_store::{CallerProvenance, ExpiryPolicy, RecordStore};
+    use crate::storage::tombstone_gauge::with_isolated_gauge;
 
     const MAP: &str = "omap";
     const KEY: &str = "k1";
@@ -67,12 +81,6 @@ mod tests {
         let _guard = handle.enter();
         block_in_place(|| Handle::current().block_on(fut))
     }
-
-    // The tombstone-bytes gauge is a single process-global static shared with
-    // every other test that touches OR removes/prunes. Serialize this module's
-    // gauge-measuring region so its own passes do not interleave; delta-based
-    // assertions keep it robust against unrelated modules' mutations.
-    static GAUGE_LOCK: Mutex<()> = Mutex::new(());
 
     // -----------------------------------------------------------------------
     // Counting mutation observer — proves the two paths fire identical fan-out
@@ -626,7 +634,6 @@ mod tests {
     /// bypassing them, so a boot `reconcile_tombstone_bytes` would agree.
     #[test]
     fn gauge_reconciles_with_resident_tombstones_under_inplace() {
-        let _serialize = GAUGE_LOCK.lock().unwrap();
         block_on_async(async {
             let h = make_harness();
 
@@ -650,11 +657,15 @@ mod tests {
                 OrOp::Prune { tag: "t9".into() },  // no-op prune (absent tag)
             ];
 
-            let baseline = tombstone_bytes();
-            for op in &ops {
-                apply_inplace(&h.store, op).await;
-            }
-            let net_delta = tombstone_bytes().saturating_sub(baseline);
+            // Exact equality, not a saturating delta: saturation would mask a
+            // negative net change, which is the underflow regression this test
+            // exists to catch.
+            let ((), net_delta) = with_isolated_gauge(async {
+                for op in &ops {
+                    apply_inplace(&h.store, op).await;
+                }
+            })
+            .await;
 
             let resident = h.store.get(KEY, false).await.unwrap().map(|r| r.value);
             let recomputed = resident_tombstone_bytes(resident.as_ref());
@@ -724,7 +735,6 @@ mod tests {
 
     #[test]
     fn legacy_ortombstones_upgrade_matches_get_build_put() {
-        let _serialize = GAUGE_LOCK.lock().unwrap();
         block_on_async(async {
             let inplace = make_harness();
             let legacy = make_harness();
@@ -810,7 +820,6 @@ mod tests {
 
     #[test]
     fn prune_reclaims_evicted_key_durable_tombstone() {
-        let _serialize = GAUGE_LOCK.lock().unwrap();
         block_on_async(async {
             let datastore = Arc::new(RetainingCountingStore::default());
 
@@ -865,7 +874,6 @@ mod tests {
 
     #[test]
     fn new_tombstone_counted_once_across_write_failure_and_retry() {
-        let _serialize = GAUGE_LOCK.lock().unwrap();
         block_on_async(async {
             let datastore = Arc::new(RetainingCountingStore::default());
             // Fail exactly the first write-through.
@@ -889,33 +897,37 @@ mod tests {
                 true
             };
 
-            let baseline = tombstone_bytes();
-            // First attempt: resident mutated + gauge incremented in-closure, then
-            // the durable write fails.
-            let r1 = store
-                .update_in_place(
-                    KEY,
-                    Some(empty_ormap()),
-                    ExpiryPolicy::NONE,
-                    CallerProvenance::CrdtMerge,
-                    &mut remove_once,
-                )
-                .await;
-            assert!(r1.is_err(), "first write-through must fail (injected)");
-            // Retry: the tag is already resident, so it is not re-counted; the
-            // durable write now succeeds.
-            let r2 = store
-                .update_in_place(
-                    KEY,
-                    Some(empty_ormap()),
-                    ExpiryPolicy::NONE,
-                    CallerProvenance::CrdtMerge,
-                    &mut remove_once,
-                )
-                .await;
-            assert!(r2.is_ok(), "retry write-through must succeed");
+            // Exact equality, not a saturating delta: saturation would mask a
+            // negative net change, which is the underflow regression this test
+            // exists to catch.
+            let ((), delta) = with_isolated_gauge(async {
+                // First attempt: resident mutated + gauge incremented
+                // in-closure, then the durable write fails.
+                let r1 = store
+                    .update_in_place(
+                        KEY,
+                        Some(empty_ormap()),
+                        ExpiryPolicy::NONE,
+                        CallerProvenance::CrdtMerge,
+                        &mut remove_once,
+                    )
+                    .await;
+                assert!(r1.is_err(), "first write-through must fail (injected)");
+                // Retry: the tag is already resident, so it is not re-counted;
+                // the durable write now succeeds.
+                let r2 = store
+                    .update_in_place(
+                        KEY,
+                        Some(empty_ormap()),
+                        ExpiryPolicy::NONE,
+                        CallerProvenance::CrdtMerge,
+                        &mut remove_once,
+                    )
+                    .await;
+                assert!(r2.is_ok(), "retry write-through must succeed");
+            })
+            .await;
 
-            let delta = tombstone_bytes().saturating_sub(baseline);
             assert_eq!(
                 delta,
                 tag.len() as u64,

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -465,85 +465,90 @@ pub struct Record {
 #[cfg(test)]
 mod tombstone_bytes_gauge_tests {
     use super::*;
-    use std::sync::Mutex;
+    use crate::storage::tombstone_gauge::with_isolated_gauge;
 
-    // Unscoped gauge calls resolve to a single process-global sink shared with
-    // every OR_REMOVE add and epoch-prune drop in the crate, and the Rust test
-    // harness runs tests concurrently on separate threads. A test-local mutex
-    // serializes only this module's tests against each other. Asserting a delta
-    // off a baseline confers NO isolation: a concurrent mutation from any other
-    // test module lands between the baseline read and the assertion and is
-    // indistinguishable from this test's own write. The only thing that makes a
-    // gauge assertion immune to that traffic is binding a private sink for the
-    // duration of the assertion.
-    static TEST_SERIALIZE: Mutex<()> = Mutex::new(());
+    // Every test here binds a private sink for the duration of its own future,
+    // so it observes only the writes it makes itself. `#[tokio::test]` is
+    // load-bearing rather than cosmetic: the override lives in a task-local, so
+    // a plain `#[test]` has no runtime to resolve it from, the resolver falls
+    // back to the process-global gauge, and the body would silently run on the
+    // shared counter every other OR-remove in the crate is also writing to —
+    // with nothing failing to compile to say so.
 
-    #[test]
-    fn add_tombstone_bytes_is_monotonic_and_visible_via_accessor() {
-        let _guard = TEST_SERIALIZE.lock().unwrap();
-        let baseline = tombstone_bytes();
+    #[tokio::test]
+    async fn add_tombstone_bytes_is_monotonic_and_visible_via_accessor() {
+        let ((), delta) = with_isolated_gauge(async {
+            add_tombstone_bytes(5);
+            assert_eq!(
+                tombstone_bytes(),
+                5,
+                "add_tombstone_bytes must increase the gauge by exactly n"
+            );
 
-        add_tombstone_bytes(5);
-        assert_eq!(
-            tombstone_bytes(),
-            baseline + 5,
-            "add_tombstone_bytes must increase the gauge by exactly n"
-        );
+            add_tombstone_bytes(3);
+            assert_eq!(
+                tombstone_bytes(),
+                8,
+                "successive adds must accumulate monotonically"
+            );
+        })
+        .await;
 
-        add_tombstone_bytes(3);
-        assert_eq!(
-            tombstone_bytes(),
-            baseline + 8,
-            "successive adds must accumulate monotonically"
-        );
+        assert_eq!(delta, 8, "the scope's net delta is the sum of its adds");
     }
 
-    #[test]
-    fn sub_tombstone_bytes_decrements_the_gauge() {
-        let _guard = TEST_SERIALIZE.lock().unwrap();
-        // Add first so the subtraction has headroom and cannot underflow
-        // relative to this test's own contribution, independent of whatever
-        // baseline other parallel tests have left in the global counter.
-        add_tombstone_bytes(10);
-        let after_add = tombstone_bytes();
+    #[tokio::test]
+    async fn sub_tombstone_bytes_decrements_the_gauge() {
+        // Add before subtracting so this exercises the add→sub pairing rather
+        // than an underflow off an empty sink.
+        let ((), delta) = with_isolated_gauge(async {
+            add_tombstone_bytes(10);
+            sub_tombstone_bytes(4);
+            assert_eq!(
+                tombstone_bytes(),
+                6,
+                "sub_tombstone_bytes must decrease the gauge by exactly n"
+            );
+        })
+        .await;
 
-        sub_tombstone_bytes(4);
-        assert_eq!(
-            tombstone_bytes(),
-            after_add - 4,
-            "sub_tombstone_bytes must decrease the gauge by exactly n"
-        );
+        assert_eq!(delta, 6, "add(10) then sub(4) nets to 6");
     }
 
     /// Serializing/deserializing an `OrMap` `RecordValue` must not touch the
     /// gauge — the gauge is updated only by explicit call sites at the
     /// `OR_REMOVE` tombstone-push / inbound-sync-union points (later task
     /// groups), never as a side effect of encoding.
-    #[test]
-    fn ormap_serde_round_trip_does_not_touch_gauge() {
-        let _guard = TEST_SERIALIZE.lock().unwrap();
-        let baseline = tombstone_bytes();
+    #[tokio::test]
+    async fn ormap_serde_round_trip_does_not_touch_gauge() {
+        let ((), delta) = with_isolated_gauge(async {
+            let value = RecordValue::OrMap {
+                records: vec![OrMapEntry {
+                    value: Value::String("hello".to_string()),
+                    tag: "tag-1".to_string(),
+                    timestamp: Timestamp {
+                        millis: 100,
+                        counter: 0,
+                        node_id: "node-a".to_string(),
+                    },
+                }],
+                tombstones: vec!["tag-removed".to_string()],
+            };
 
-        let value = RecordValue::OrMap {
-            records: vec![OrMapEntry {
-                value: Value::String("hello".to_string()),
-                tag: "tag-1".to_string(),
-                timestamp: Timestamp {
-                    millis: 100,
-                    counter: 0,
-                    node_id: "node-a".to_string(),
-                },
-            }],
-            tombstones: vec!["tag-removed".to_string()],
-        };
+            let bytes = rmp_serde::to_vec_named(&value).expect("serialize OrMap");
+            let _decoded: RecordValue = rmp_serde::from_slice(&bytes).expect("deserialize OrMap");
 
-        let bytes = rmp_serde::to_vec_named(&value).expect("serialize OrMap");
-        let _decoded: RecordValue = rmp_serde::from_slice(&bytes).expect("deserialize OrMap");
+            assert_eq!(
+                tombstone_bytes(),
+                0,
+                "serde round-trip must not mutate the tombstone-bytes gauge"
+            );
+        })
+        .await;
 
         assert_eq!(
-            tombstone_bytes(),
-            baseline,
-            "serde round-trip must not mutate the tombstone-bytes gauge"
+            delta, 0,
+            "a serde round-trip contributes nothing to the scope"
         );
     }
 }

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -3,11 +3,13 @@
 //! Defines the core data structures stored in [`StorageEngine`](super::StorageEngine):
 //! [`Record`], [`RecordMetadata`], [`RecordValue`], and [`OrMapEntry`].
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 use topgun_core::hlc::Timestamp;
 use topgun_core::types::Value;
+
+use super::tombstone_gauge::with_sink;
 
 /// Process-monotonic counter for minting per-write identity tokens.
 ///
@@ -18,39 +20,6 @@ use topgun_core::types::Value;
 /// `Relaxed` ordering is sufficient because token publication is already
 /// synchronized by the `DashMap` shard lock at `get_mut`/put.
 static WRITE_TOKEN: AtomicU64 = AtomicU64::new(1);
-
-/// Process-global running total of OR-Map tombstone bytes (sum of removed
-/// tags' UTF-8 byte lengths currently tracked across all `OrMap.tombstones`
-/// sets).
-///
-/// This is the in-process source of truth behind [`add_tombstone_bytes`],
-/// [`sub_tombstone_bytes`], and [`tombstone_bytes`]. It exists to give the
-/// unbounded-tombstone-growth soak monitor (and the `/metrics` Prometheus
-/// surface) a cheap, lock-free signal of how much tombstone data has
-/// accumulated, without walking every resident `OrMap` record on each check.
-/// `Relaxed` ordering is sufficient: this is a monitoring counter, not a
-/// correctness-critical value guarding any invariant, so no other memory
-/// operation needs to be ordered against it.
-static OR_TOMBSTONE_BYTES: AtomicU64 = AtomicU64::new(0);
-
-/// Fail-loud tripwire recording whether [`add_tombstone_bytes`] has fired in
-/// this process.
-///
-/// [`set_tombstone_bytes`] pairs an **absolute** `AtomicU64` store with an
-/// **additive** Prometheus `increment`. The one-time boot seed is only correct
-/// on a fresh recorder: if any `add_tombstone_bytes` landed between recorder
-/// install and the boot seed, the `AtomicU64` would still self-correct (it is a
-/// store), but the Prometheus counter — the sink the soak harness scrapes —
-/// would silently double-count (it is additive). No `add_tombstone_bytes` call
-/// site is reachable before `set_ready()` today, so the boot seed is the sole
-/// gauge mutator in the recovery→ready window; this flag turns a future refactor
-/// that violates that ordering into a loud failure — a `tracing::error!` in every
-/// build (the soak harness and production run release, where `debug_assert!` is a
-/// no-op) plus a hard `debug_assert!` in debug/test — rather than a silent
-/// double-count of the Prometheus counter the harness scrapes. Written with
-/// `Release` / read with `Acquire` so the boot seed reliably observes a prior arm
-/// even if the two ever run on different threads.
-static TOMBSTONE_ADD_FIRED: AtomicBool = AtomicBool::new(false);
 
 /// Adds `n` bytes to the process-global OR-Map tombstone-bytes gauge and
 /// emits the same delta to both exported Prometheus series: the
@@ -67,17 +36,7 @@ static TOMBSTONE_ADD_FIRED: AtomicBool = AtomicBool::new(false);
 /// this gauge exists to expose, and a constant per-entry factor only scales
 /// it without changing what it reveals.
 pub fn add_tombstone_bytes(n: u64) {
-    // Arm the tripwire that makes the boot-seed dual-write asymmetry fail loud
-    // (see TOMBSTONE_ADD_FIRED). A single store on the write path is negligible
-    // next to the map mutation that precedes it; `Release` pairs with the boot
-    // seed's `Acquire` load so the seed reliably observes this arm cross-thread.
-    TOMBSTONE_ADD_FIRED.store(true, Ordering::Release);
-    OR_TOMBSTONE_BYTES.fetch_add(n, Ordering::Relaxed);
-    metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(n);
-    // Precision loss only above 2^53 bytes of tombstone data on one process —
-    // not a real-world concern for this monitoring signal.
-    #[allow(clippy::cast_precision_loss)]
-    metrics::gauge!("topgun_ormap_tombstone_bytes").increment(n as f64);
+    with_sink(|s| s.add(n));
 }
 
 /// Subtracts `n` bytes from the process-global OR-Map tombstone-bytes gauge,
@@ -103,11 +62,7 @@ pub fn add_tombstone_bytes(n: u64) {
 /// underflow in practice, but `fetch_sub` wraps on underflow rather than
 /// panicking — acceptable for a monitoring counter.
 pub fn sub_tombstone_bytes(n: u64) {
-    OR_TOMBSTONE_BYTES.fetch_sub(n, Ordering::Relaxed);
-    // Precision loss only above 2^53 bytes of tombstone data on one process —
-    // not a real-world concern for this monitoring signal.
-    #[allow(clippy::cast_precision_loss)]
-    metrics::gauge!("topgun_ormap_tombstone_bytes").decrement(n as f64);
+    with_sink(|s| s.sub(n));
 }
 
 /// Reads the current value of the process-global OR-Map tombstone-bytes gauge.
@@ -116,8 +71,13 @@ pub fn sub_tombstone_bytes(n: u64) {
 /// [`sub_tombstone_bytes`] Prometheus-divergence note above, and by the
 /// soak-test monitor that watches for unbounded tombstone growth.
 #[must_use]
+// The closure is redundant only in the release arm, where the resolver hands
+// over a concrete `&ProcessGauge`. Test builds receive a `&dyn
+// TombstoneGaugeSink`, and a bare method path cannot satisfy that
+// higher-ranked bound. The closure is the one form that compiles in both.
+#[allow(clippy::redundant_closure_for_method_calls)]
 pub fn tombstone_bytes() -> u64 {
-    OR_TOMBSTONE_BYTES.load(Ordering::Relaxed)
+    with_sink(|s| s.read())
 }
 
 /// Re-baselines the OR-Map tombstone-bytes gauge to an absolute `total`.
@@ -125,7 +85,7 @@ pub fn tombstone_bytes() -> u64 {
 /// This is the **only** absolute-set path for the gauge. It exists exclusively
 /// for the one-time startup reconciliation that runs after WAL recovery
 /// completes (see `bin/topgun_server.rs`): the process-local
-/// [`OR_TOMBSTONE_BYTES`] atomic and both exported Prometheus series
+/// [`ProcessGauge`](super::tombstone_gauge::ProcessGauge) atomic and both exported Prometheus series
 /// (`topgun_ormap_tombstone_bytes_total` and `topgun_ormap_tombstone_bytes`)
 /// reset to zero/absent on every process start and never re-count rehydrated
 /// (redb-persisted) tombstones, so without this boot seed the scraped series
@@ -138,7 +98,7 @@ pub fn tombstone_bytes() -> u64 {
 /// connections.
 ///
 /// It performs THREE writes, in order, because they are **separate sinks**:
-///  1. `OR_TOMBSTONE_BYTES.store(total)` re-baselines the in-process `AtomicU64`
+///  1. `bytes.store(total)` re-baselines the in-process `AtomicU64`
 ///     — an absolute store, never `fetch_add`: a per-rehydration increment would
 ///     reintroduce the eviction double-count the gauge's cardinal rule forbids.
 ///  2. `metrics::counter!(...).increment(total)` seeds the monotonic
@@ -154,34 +114,7 @@ pub fn tombstone_bytes() -> u64 {
 ///     double-count risk and can be called safely even if this boot seed ever
 ///     ran more than once.
 pub fn set_tombstone_bytes(total: u64) {
-    OR_TOMBSTONE_BYTES.store(total, Ordering::Relaxed);
-    // The Prometheus increment below is additive; correct only on a fresh-zero
-    // recorder. No add_tombstone_bytes site is reachable before this boot seed,
-    // so the tripwire must still be un-armed here — otherwise the counter the
-    // harness scrapes would silently double-count. Fail loud in EVERY build: the
-    // soak harness and production run release, where `debug_assert!` alone is a
-    // no-op, so an error log carries the signal there while the debug_assert hard
-    // -fails tests.
-    let armed = TOMBSTONE_ADD_FIRED.load(Ordering::Acquire);
-    if armed {
-        tracing::error!(
-            target: "topgun_server::bootstrap",
-            "set_tombstone_bytes boot seed ran after add_tombstone_bytes — the additive \
-             Prometheus counter will double-count; the recovery→ready gauge-window invariant \
-             was violated by a reachable pre-set_ready write path"
-        );
-    }
-    debug_assert!(
-        !armed,
-        "set_tombstone_bytes boot seed ran after add_tombstone_bytes — the additive \
-         Prometheus counter would double-count"
-    );
-    metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(total);
-    // Absolute re-baseline of the decrementable gauge — no additive-race
-    // hazard here since `.set` (unlike the counter's `.increment`) overwrites
-    // rather than accumulates.
-    #[allow(clippy::cast_precision_loss)]
-    metrics::gauge!("topgun_ormap_tombstone_bytes").set(total as f64);
+    with_sink(|s| s.set(total));
 }
 
 /// The startup warning for a detected legacy [`RecordValue::OrTombstones`] corpus,
@@ -534,15 +467,15 @@ mod tombstone_bytes_gauge_tests {
     use super::*;
     use std::sync::Mutex;
 
-    // `OR_TOMBSTONE_BYTES` is a single process-global static. The production
-    // writers are the OR_REMOVE add path and the epoch-prune drop path (which
-    // decrements on a successful tombstone drop), so these tests are not the
-    // only mutators — and the Rust test harness runs tests concurrently on
-    // separate threads, where a delta-based assertion in one test can still
-    // observe an in-flight mutation from another. A test-local mutex serializes
-    // just this module's tests against each other; asserting deltas (rather
-    // than absolute values) additionally keeps these tests robust against
-    // concurrent mutation from other test modules.
+    // Unscoped gauge calls resolve to a single process-global sink shared with
+    // every OR_REMOVE add and epoch-prune drop in the crate, and the Rust test
+    // harness runs tests concurrently on separate threads. A test-local mutex
+    // serializes only this module's tests against each other. Asserting a delta
+    // off a baseline confers NO isolation: a concurrent mutation from any other
+    // test module lands between the baseline read and the assertion and is
+    // indistinguishable from this test's own write. The only thing that makes a
+    // gauge assertion immune to that traffic is binding a private sink for the
+    // duration of the assertion.
     static TEST_SERIALIZE: Mutex<()> = Mutex::new(());
 
     #[test]

--- a/packages/server-rust/src/storage/tombstone_gauge.rs
+++ b/packages/server-rust/src/storage/tombstone_gauge.rs
@@ -373,6 +373,7 @@ mod tests {
         with_gauge_sink, with_isolated_gauge, with_sink, IsolatedGauge, ProcessGauge,
         TombstoneGaugeSink,
     };
+    use crate::storage::record::{add_tombstone_bytes, tombstone_bytes};
     use std::sync::Arc;
 
     #[tokio::test]
@@ -405,6 +406,90 @@ mod tests {
 
         assert_eq!(observer.read(), 3);
         assert!(observer.armed(), "an add arms the receiving instance");
+    }
+
+    /// Adversarial proof that a scoped assertion is immune to concurrent
+    /// foreign traffic, with an in-band negative control proving the foreign
+    /// traffic was real.
+    ///
+    /// The foreign writes go through `tokio::spawn`, which the task-local
+    /// override deliberately does not cross, so they land on the process gauge —
+    /// exactly the contention a gauge assertion has to survive. They are joined
+    /// *inside* the scope so they are guaranteed to have landed before it
+    /// closes; an un-joined spawn would let the test pass while proving nothing.
+    ///
+    /// The process-gauge readings are taken **outside** the scope on purpose:
+    /// inside it, `tombstone_bytes()` resolves to the isolated sink, so a
+    /// reading there would measure the wrong sink and collapse (b) into a
+    /// restatement of (a). And (b) is a lower bound, never an equality — the
+    /// process gauge is shared with the whole crate, so pinning it exactly would
+    /// re-create the order-dependence this seam exists to remove.
+    #[tokio::test]
+    async fn a_scope_ignores_concurrent_foreign_traffic_on_the_process_gauge() {
+        const FOREIGN_TASKS: u64 = 4;
+        const FOREIGN_PER_TASK: u64 = 25;
+        const FOREIGN_TOTAL: u64 = FOREIGN_TASKS * FOREIGN_PER_TASK;
+        const OWN: u64 = 11;
+
+        let before = tombstone_bytes();
+
+        let ((), delta) = with_isolated_gauge(async {
+            let foreign: Vec<_> = (0..FOREIGN_TASKS)
+                .map(|_| tokio::spawn(async { add_tombstone_bytes(FOREIGN_PER_TASK) }))
+                .collect();
+
+            add_tombstone_bytes(OWN);
+
+            for task in foreign {
+                task.await.expect("foreign gauge task must not panic");
+            }
+        })
+        .await;
+
+        let after = tombstone_bytes();
+
+        assert_eq!(
+            delta, OWN,
+            "the scoped delta must count only the scope's own writes"
+        );
+        // Phrased as an addition rather than `after - before` so a concurrent
+        // prune elsewhere in the suite cannot underflow the subtraction into a
+        // panic before the assertion gets to report anything.
+        assert!(
+            after >= before.saturating_add(FOREIGN_TOTAL),
+            "the foreign traffic must have landed on the process gauge \
+             (before {before}, after {after}, expected a rise of at least {FOREIGN_TOTAL})"
+        );
+    }
+
+    /// The boot-seed tripwire still arms when an add reaches the gauge through
+    /// `record.rs`'s public API.
+    ///
+    /// Both reads are taken on a private `ProcessGauge` bound for this scope
+    /// alone, never on the process singleton: every unmarked OR-remove in the
+    /// crate arms that one, so a global read would be order-dependent by
+    /// construction. `set()` is never called here — on an armed instance it
+    /// trips the boot-seed `debug_assert!`.
+    #[tokio::test]
+    async fn an_add_through_the_public_api_arms_its_own_gauge_s_tripwire() {
+        let sink = Arc::new(ProcessGauge::new());
+        let observer = Arc::clone(&sink);
+
+        assert!(
+            !observer.armed(),
+            "a freshly-constructed gauge must start un-armed"
+        );
+
+        with_gauge_sink(sink, async {
+            add_tombstone_bytes(6);
+        })
+        .await;
+
+        assert_eq!(observer.read(), 6, "the bound instance received the add");
+        assert!(
+            observer.armed(),
+            "an add routed through the public API must arm the receiving instance"
+        );
     }
 
     #[test]

--- a/packages/server-rust/src/storage/tombstone_gauge.rs
+++ b/packages/server-rust/src/storage/tombstone_gauge.rs
@@ -250,7 +250,7 @@ impl TombstoneGaugeSink for ProcessGauge {
 }
 
 /// The one gauge production ever writes to.
-pub static PROCESS_GAUGE: ProcessGauge = ProcessGauge::new();
+pub(crate) static PROCESS_GAUGE: ProcessGauge = ProcessGauge::new();
 
 /// A private, test-only sink: a bare counter with no Prometheus emission.
 ///
@@ -312,7 +312,7 @@ tokio::task_local! {
 /// monomorphises and inlines down to the same atomic operation it has always
 /// performed — no branch, no vtable.
 #[cfg(not(test))]
-pub fn with_sink<R>(f: impl FnOnce(&ProcessGauge) -> R) -> R {
+pub(crate) fn with_sink<R>(f: impl FnOnce(&ProcessGauge) -> R) -> R {
     f(&PROCESS_GAUGE)
 }
 
@@ -327,7 +327,7 @@ pub fn with_sink<R>(f: impl FnOnce(&ProcessGauge) -> R) -> R {
 /// the process gauge is the designed behaviour — it is exactly what makes a
 /// scoped assertion immune to it.
 #[cfg(test)]
-pub fn with_sink<R>(f: impl FnOnce(&dyn TombstoneGaugeSink) -> R) -> R {
+pub(crate) fn with_sink<R>(f: impl FnOnce(&dyn TombstoneGaugeSink) -> R) -> R {
     match GAUGE_SINK.try_with(Arc::clone) {
         Ok(sink) => f(&*sink),
         Err(_) => f(&PROCESS_GAUGE),

--- a/packages/server-rust/src/storage/tombstone_gauge.rs
+++ b/packages/server-rust/src/storage/tombstone_gauge.rs
@@ -373,7 +373,8 @@ mod tests {
         with_gauge_sink, with_isolated_gauge, with_sink, IsolatedGauge, ProcessGauge,
         TombstoneGaugeSink,
     };
-    use crate::storage::record::{add_tombstone_bytes, tombstone_bytes};
+    use crate::storage::record::add_tombstone_bytes;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
 
     #[tokio::test]
@@ -452,12 +453,27 @@ mod tests {
     /// *inside* the scope so they are guaranteed to have landed before it
     /// closes; an un-joined spawn would let the test pass while proving nothing.
     ///
-    /// The process-gauge readings are taken **outside** the scope on purpose:
-    /// inside it, `tombstone_bytes()` resolves to the isolated sink, so a
-    /// reading there would measure the wrong sink and collapse (b) into a
-    /// restatement of (a). And (b) is a lower bound, never an equality — the
-    /// process gauge is shared with the whole crate, so pinning it exactly would
-    /// re-create the order-dependence this seam exists to remove.
+    /// The two assertions divide the claim:
+    ///
+    ///  - (a) `delta == OWN` is the isolation claim itself, and it alone
+    ///    discriminates the spawn-propagation property: were the task-local to
+    ///    cross `tokio::spawn`, the foreign adds would land on the isolated sink
+    ///    and this would read `OWN + FOREIGN_TOTAL`.
+    ///  - (b) is the negative control that keeps (a) from passing vacuously —
+    ///    it proves each spawned task really executed its add rather than being
+    ///    skipped or optimised into a no-op.
+    ///
+    /// (b) accounts the foreign work on a **counter private to this test**
+    /// rather than diffing the shared process gauge. A before/after diff of that
+    /// gauge is not deterministic: the whole crate writes to it, and correctly
+    /// unscoped subtractions elsewhere in the suite can land inside the live
+    /// window and outpace the foreign additions, reddening the assertion on
+    /// perfectly correct behaviour. That is the very order-dependent
+    /// shared-counter flake this seam exists to remove, so the control must not
+    /// reintroduce it. Proving the adds landed *specifically* on the process
+    /// gauge is not part of the isolation claim — (a) already establishes they
+    /// did not land on the scope — and asserting it was the sole source of the
+    /// race.
     #[tokio::test]
     async fn a_scope_ignores_concurrent_foreign_traffic_on_the_process_gauge() {
         const FOREIGN_TASKS: u64 = 4;
@@ -465,11 +481,19 @@ mod tests {
         const FOREIGN_TOTAL: u64 = FOREIGN_TASKS * FOREIGN_PER_TASK;
         const OWN: u64 = 11;
 
-        let before = tombstone_bytes();
+        // Private to this test: nothing else in the crate can write to it, so
+        // its final value is exact by construction.
+        let accounted = Arc::new(AtomicU64::new(0));
 
         let ((), delta) = with_isolated_gauge(async {
             let foreign: Vec<_> = (0..FOREIGN_TASKS)
-                .map(|_| tokio::spawn(async { add_tombstone_bytes(FOREIGN_PER_TASK) }))
+                .map(|_| {
+                    let accounted = Arc::clone(&accounted);
+                    tokio::spawn(async move {
+                        add_tombstone_bytes(FOREIGN_PER_TASK);
+                        accounted.fetch_add(FOREIGN_PER_TASK, Ordering::Relaxed);
+                    })
+                })
                 .collect();
 
             add_tombstone_bytes(OWN);
@@ -480,19 +504,15 @@ mod tests {
         })
         .await;
 
-        let after = tombstone_bytes();
-
         assert_eq!(
             delta, OWN,
             "the scoped delta must count only the scope's own writes"
         );
-        // Phrased as an addition rather than `after - before` so a concurrent
-        // prune elsewhere in the suite cannot underflow the subtraction into a
-        // panic before the assertion gets to report anything.
-        assert!(
-            after >= before.saturating_add(FOREIGN_TOTAL),
-            "the foreign traffic must have landed on the process gauge \
-             (before {before}, after {after}, expected a rise of at least {FOREIGN_TOTAL})"
+        assert_eq!(
+            accounted.load(Ordering::Relaxed),
+            FOREIGN_TOTAL,
+            "every foreign task must have executed its add, so the isolation \
+             claim above is asserted against real concurrent traffic"
         );
     }
 

--- a/packages/server-rust/src/storage/tombstone_gauge.rs
+++ b/packages/server-rust/src/storage/tombstone_gauge.rs
@@ -389,6 +389,40 @@ mod tests {
         assert_eq!(delta, 5, "the scope's final value is its net delta");
     }
 
+    /// Enforces the pure-delegation invariant the trait impl documents, rather
+    /// than leaving it to a comment nobody re-checks.
+    ///
+    /// Release resolves `s.add(n)` to the inherent method and test builds
+    /// resolve it to the trait method, so the two builds agree only while the
+    /// trait impl delegates verbatim. Tests exercise the trait arm exclusively,
+    /// which means a divergence introduced here would be invisible to every
+    /// other test in the crate — including the ones this module exists to make
+    /// trustworthy. Driving both arms over identical instances and comparing
+    /// the observable state turns that silent divergence into a red test.
+    #[test]
+    fn the_trait_impl_delegates_verbatim_to_the_inherent_methods() {
+        let inherent = ProcessGauge::new();
+        let via_trait = ProcessGauge::new();
+        let dynamic: &dyn TombstoneGaugeSink = &via_trait;
+
+        // Same op sequence, one arm per dispatch form.
+        inherent.add(9);
+        dynamic.add(9);
+        ProcessGauge::sub(&inherent, 4);
+        dynamic.sub(4);
+
+        assert_eq!(
+            ProcessGauge::read(&inherent),
+            dynamic.read(),
+            "inherent and trait dispatch must leave identical byte counts"
+        );
+        assert_eq!(
+            inherent.armed(),
+            via_trait.armed(),
+            "inherent and trait dispatch must arm the tripwire identically"
+        );
+    }
+
     /// Pins the binding helper itself: a caller-supplied sink receives the
     /// scope's writes, and its tripwire is observable on that instance alone —
     /// never through a process-global read that every unmarked OR-remove in the

--- a/packages/server-rust/src/storage/tombstone_gauge.rs
+++ b/packages/server-rust/src/storage/tombstone_gauge.rs
@@ -1,0 +1,418 @@
+//! Resolvable sink behind the OR-Map tombstone-bytes gauge.
+//!
+//! The gauge is a process-global monitoring signal written from every OR-remove
+//! and inbound-sync union in the process. That is correct for production — there
+//! is exactly one process and exactly one number to export — but it makes any
+//! test that asserts on the gauge observe the whole crate's concurrent traffic,
+//! not its own. This module puts a resolvable sink between the gauge's public
+//! API and its storage, so a test can bind a private sink for the duration of
+//! its own future and read a delta nothing else can perturb.
+//!
+//! Production resolves to the one process gauge through a `cfg`-split resolver, so a
+//! release build carries neither a branch nor a vtable: it calls the same
+//! atomics and emits the same two Prometheus series it always has.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+#[cfg(test)]
+use std::future::Future;
+#[cfg(test)]
+use std::sync::Arc;
+
+/// A destination for OR-Map tombstone-byte accounting.
+///
+/// `Send + Sync` is required because the gauge is reachable from any tokio
+/// worker thread: the write path runs wherever the task happens to be scheduled.
+pub trait TombstoneGaugeSink: Send + Sync {
+    /// Adds `n` bytes to the gauge.
+    fn add(&self, n: u64);
+    /// Subtracts `n` bytes from the gauge.
+    fn sub(&self, n: u64);
+    /// Reads the gauge's current value.
+    fn read(&self) -> u64;
+    /// Re-baselines the gauge to an absolute `total`.
+    fn set(&self, total: u64);
+}
+
+/// The production sink: an `AtomicU64` plus the exported Prometheus series.
+///
+/// Instantiable rather than a bag of free statics so a test can bind a fresh,
+/// private instance and observe *its* tripwire, instead of reading a
+/// process-global flag that every unmarked OR-remove in the crate arms.
+/// Production reaches the gauge only through the single process instance, so
+/// this changes nothing about how the process behaves.
+pub struct ProcessGauge {
+    /// Running total of OR-Map tombstone bytes (sum of removed tags' UTF-8 byte
+    /// lengths currently tracked across all `OrMap.tombstones` sets).
+    ///
+    /// This is the in-process source of truth the unbounded-tombstone-growth
+    /// soak monitor (and the `/metrics` Prometheus surface) reads, giving them a
+    /// cheap, lock-free signal of how much tombstone data has accumulated
+    /// without walking every resident `OrMap` record on each check. `Relaxed`
+    /// ordering is sufficient: this is a monitoring counter, not a
+    /// correctness-critical value guarding any invariant, so no other memory
+    /// operation needs to be ordered against it.
+    bytes: AtomicU64,
+
+    /// Fail-loud tripwire recording whether [`ProcessGauge::add`] has fired on
+    /// this instance.
+    ///
+    /// [`ProcessGauge::set`] pairs an **absolute** `AtomicU64` store with an
+    /// **additive** Prometheus `increment`. The one-time boot seed is only
+    /// correct on a fresh recorder: if any add landed between recorder install
+    /// and the boot seed, the `AtomicU64` would still self-correct (it is a
+    /// store), but the Prometheus counter — the sink the soak harness scrapes —
+    /// would silently double-count (it is additive). No add call site is
+    /// reachable before `set_ready()` today, so the boot seed is the sole gauge
+    /// mutator in the recovery→ready window; this flag turns a future refactor
+    /// that violates that ordering into a loud failure — a `tracing::error!` in
+    /// every build (the soak harness and production run release, where
+    /// `debug_assert!` is a no-op) plus a hard `debug_assert!` in debug/test —
+    /// rather than a silent double-count of the Prometheus counter the harness
+    /// scrapes. Written with `Release` / read with `Acquire` so the boot seed
+    /// reliably observes a prior arm even if the two ever run on different
+    /// threads.
+    add_fired: AtomicBool,
+}
+
+impl ProcessGauge {
+    /// Creates a zeroed, un-armed gauge.
+    ///
+    /// `const` so the process instance is a plain static initialiser with no
+    /// `OnceLock` or lazy machinery on the read path.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            bytes: AtomicU64::new(0),
+            add_fired: AtomicBool::new(false),
+        }
+    }
+
+    /// Adds `n` bytes to the gauge and emits the same delta to both exported
+    /// Prometheus series: the `topgun_ormap_tombstone_bytes_total` monotonic
+    /// creation-rate counter (mirrors the `topgun_operations_total` emit pattern
+    /// in `service/middleware/metrics.rs`), and the
+    /// `topgun_ormap_tombstone_bytes` gauge — the decrementable series a prune
+    /// path can move back down, and the one the soak monitor's plateau/slope fit
+    /// reads over `GET /metrics`.
+    pub fn add(&self, n: u64) {
+        // Arm the tripwire that makes the boot-seed dual-write asymmetry fail
+        // loud (see `add_fired`). A single store on the write path is negligible
+        // next to the map mutation that precedes it; `Release` pairs with the
+        // boot seed's `Acquire` load so the seed reliably observes this arm
+        // cross-thread.
+        self.add_fired.store(true, Ordering::Release);
+        self.bytes.fetch_add(n, Ordering::Relaxed);
+        metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(n);
+        // Precision loss only above 2^53 bytes of tombstone data on one process
+        // — not a real-world concern for this monitoring signal.
+        #[allow(clippy::cast_precision_loss)]
+        metrics::gauge!("topgun_ormap_tombstone_bytes").increment(n as f64);
+    }
+
+    /// Subtracts `n` bytes from the gauge and mirrors the same decrement onto
+    /// the exported `topgun_ormap_tombstone_bytes` Prometheus gauge — the
+    /// byte-for-byte counterpart of [`ProcessGauge::add`]'s increment.
+    ///
+    /// Unlike the `topgun_ormap_tombstone_bytes_total` counter (which follows
+    /// the `_total` *monotonic* convention and therefore cannot legally
+    /// decrease), `topgun_ormap_tombstone_bytes` has no such constraint: it is a
+    /// plain Prometheus gauge, so this decrement is externally visible over
+    /// `GET /metrics` without needing the in-process accessor — the surface an
+    /// out-of-process soak monitor actually scrapes.
+    ///
+    /// `fetch_sub` wraps on underflow rather than panicking — acceptable for a
+    /// monitoring counter, and it keeps an underflow regression observable
+    /// rather than masking it behind saturation.
+    pub fn sub(&self, n: u64) {
+        self.bytes.fetch_sub(n, Ordering::Relaxed);
+        // Precision loss only above 2^53 bytes of tombstone data on one process
+        // — not a real-world concern for this monitoring signal.
+        #[allow(clippy::cast_precision_loss)]
+        metrics::gauge!("topgun_ormap_tombstone_bytes").decrement(n as f64);
+    }
+
+    /// Reads the gauge's current value.
+    #[must_use]
+    pub fn read(&self) -> u64 {
+        self.bytes.load(Ordering::Relaxed)
+    }
+
+    /// Re-baselines the gauge to an absolute `total`.
+    ///
+    /// This is the **only** absolute-set path for the gauge. It exists
+    /// exclusively for the one-time startup reconciliation that runs after WAL
+    /// recovery completes (see `bin/topgun_server.rs`): the process-local atomic
+    /// and both exported Prometheus series
+    /// (`topgun_ormap_tombstone_bytes_total` and `topgun_ormap_tombstone_bytes`)
+    /// reset to zero/absent on every process start and never re-count rehydrated
+    /// (redb-persisted) tombstones, so without this boot seed the scraped series
+    /// sawtooths back to 0 on every `kill -9` restart and the cross-restart leak
+    /// becomes invisible. Seeding from the true reconciled corpus (rather than a
+    /// literal `0`) means a genuine leak still shows as net upward drift from a
+    /// real starting point, and a monitor that only trusts non-zero samples sees
+    /// one from the first scrape after boot. It MUST NEVER be called on the hot
+    /// read/write path — only once, at boot, before the listener accepts
+    /// connections.
+    ///
+    /// It performs THREE writes, in order, because they are **separate sinks**:
+    ///  1. `bytes.store(total)` re-baselines the in-process `AtomicU64` — an
+    ///     absolute store, never `fetch_add`: a per-rehydration increment would
+    ///     reintroduce the eviction double-count the gauge's cardinal rule
+    ///     forbids.
+    ///  2. `metrics::counter!(...).increment(total)` seeds the monotonic
+    ///     `_total` Prometheus counter, a *different* sink living in the process
+    ///     `PrometheusHandle` recorder; on a fresh process it starts at
+    ///     0/absent, so a single `increment(total)` from zero lands the exported
+    ///     series at `total` while staying a legal monotonic-from-zero counter (a
+    ///     Prometheus counter has no `.set`/`.store`).
+    ///  3. `metrics::gauge!(...).set(total)` re-baselines the decrementable
+    ///     `topgun_ormap_tombstone_bytes` gauge — the series the soak monitor's
+    ///     plateau/slope fit actually scrapes over `GET /metrics`. Unlike the
+    ///     counter this is a plain absolute `.set`, so it carries no additive
+    ///     double-count risk and can be called safely even if this boot seed ever
+    ///     ran more than once.
+    pub fn set(&self, total: u64) {
+        self.bytes.store(total, Ordering::Relaxed);
+        // The Prometheus increment below is additive; correct only on a
+        // fresh-zero recorder. No add call site is reachable before this boot
+        // seed, so the tripwire must still be un-armed here — otherwise the
+        // counter the harness scrapes would silently double-count. Fail loud in
+        // EVERY build: the soak harness and production run release, where
+        // `debug_assert!` alone is a no-op, so an error log carries the signal
+        // there while the debug_assert hard-fails tests.
+        let armed = self.add_fired.load(Ordering::Acquire);
+        if armed {
+            tracing::error!(
+                target: "topgun_server::bootstrap",
+                "set_tombstone_bytes boot seed ran after add_tombstone_bytes — the additive \
+                 Prometheus counter will double-count; the recovery→ready gauge-window invariant \
+                 was violated by a reachable pre-set_ready write path"
+            );
+        }
+        debug_assert!(
+            !armed,
+            "set_tombstone_bytes boot seed ran after add_tombstone_bytes — the additive \
+             Prometheus counter would double-count"
+        );
+        metrics::counter!("topgun_ormap_tombstone_bytes_total").increment(total);
+        // Absolute re-baseline of the decrementable gauge — no additive-race
+        // hazard here since `.set` (unlike the counter's `.increment`)
+        // overwrites rather than accumulates.
+        #[allow(clippy::cast_precision_loss)]
+        metrics::gauge!("topgun_ormap_tombstone_bytes").set(total as f64);
+    }
+
+    /// Reports whether an add has fired on **this instance**.
+    ///
+    /// Instance-scoped by construction: it can only ever report on its receiver,
+    /// so a test binding a private gauge observes a tripwire no other test can
+    /// influence.
+    #[cfg(test)]
+    pub(crate) fn armed(&self) -> bool {
+        self.add_fired.load(Ordering::Acquire)
+    }
+}
+
+impl Default for ProcessGauge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Every method here MUST stay a one-line delegation to the inherent method,
+/// with no added logic.
+///
+/// The resolver is `cfg`-split: in release it hands the closure a
+/// `&ProcessGauge`, where an inherent method always wins method resolution; in
+/// test builds it hands over a `&dyn TombstoneGaugeSink`, where only these trait
+/// methods are visible. The two builds therefore call *different* methods, and
+/// stay behaviourally identical only for as long as this impl is a pure
+/// delegation. Anything added here — an extra emit, a counter, a debug assert —
+/// would apply in test builds and not in release, and no test in this crate
+/// could observe the divergence, because tests only ever exercise the test arm.
+impl TombstoneGaugeSink for ProcessGauge {
+    fn add(&self, n: u64) {
+        Self::add(self, n);
+    }
+
+    fn sub(&self, n: u64) {
+        Self::sub(self, n);
+    }
+
+    fn read(&self) -> u64 {
+        Self::read(self)
+    }
+
+    fn set(&self, total: u64) {
+        Self::set(self, total);
+    }
+}
+
+/// The one gauge production ever writes to.
+pub static PROCESS_GAUGE: ProcessGauge = ProcessGauge::new();
+
+/// A private, test-only sink: a bare counter with no Prometheus emission.
+///
+/// It carries **no tripwire field at all**, which makes "an isolated add cannot
+/// arm a tripwire" a property the compiler checks rather than an assertion some
+/// test has to make about global state.
+#[cfg(test)]
+pub(crate) struct IsolatedGauge {
+    bytes: AtomicU64,
+}
+
+#[cfg(test)]
+impl IsolatedGauge {
+    /// Creates a zeroed isolated sink.
+    pub(crate) const fn new() -> Self {
+        Self {
+            bytes: AtomicU64::new(0),
+        }
+    }
+}
+
+#[cfg(test)]
+impl TombstoneGaugeSink for IsolatedGauge {
+    fn add(&self, n: u64) {
+        self.bytes.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// `fetch_sub` rather than a saturating subtraction, matching production, so
+    /// an underflow regression stays observable instead of being masked.
+    fn sub(&self, n: u64) {
+        self.bytes.fetch_sub(n, Ordering::Relaxed);
+    }
+
+    fn read(&self) -> u64 {
+        self.bytes.load(Ordering::Relaxed)
+    }
+
+    fn set(&self, total: u64) {
+        self.bytes.store(total, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+tokio::task_local! {
+    /// Ambient sink override for the current task and everything it awaits
+    /// inline.
+    ///
+    /// A `tokio::task_local` rather than a `std::thread_local`: `#[tokio::test]`
+    /// and the proptest bridge run on multi-thread runtimes that may move a task
+    /// to a different worker at every `.await`, so a thread-local override would
+    /// be silently dropped mid-test — and silence is precisely the failure mode
+    /// this seam exists to remove.
+    static GAUGE_SINK: Arc<dyn TombstoneGaugeSink>;
+}
+
+/// Resolves the gauge sink for the current context and hands it to `f`.
+///
+/// Release builds resolve statically to [`PROCESS_GAUGE`], so the call
+/// monomorphises and inlines down to the same atomic operation it has always
+/// performed — no branch, no vtable.
+#[cfg(not(test))]
+pub fn with_sink<R>(f: impl FnOnce(&ProcessGauge) -> R) -> R {
+    f(&PROCESS_GAUGE)
+}
+
+/// Resolves the gauge sink for the current context and hands it to `f`.
+///
+/// Prefers a task-local override when one is bound, else [`PROCESS_GAUGE`].
+///
+/// A missing override is **not** an error and must never panic: the gauge is
+/// reachable from synchronous, runtime-less contexts (`evict_lru`, the boot
+/// seed), and the overwhelming majority of this crate's tests perform OR-removes
+/// or inbound syncs with no gauge scope at all. Routing that unscoped traffic to
+/// the process gauge is the designed behaviour — it is exactly what makes a
+/// scoped assertion immune to it.
+#[cfg(test)]
+pub fn with_sink<R>(f: impl FnOnce(&dyn TombstoneGaugeSink) -> R) -> R {
+    match GAUGE_SINK.try_with(Arc::clone) {
+        Ok(sink) => f(&*sink),
+        Err(_) => f(&PROCESS_GAUGE),
+    }
+}
+
+/// Runs `f` with `sink` bound as the ambient gauge sink.
+///
+/// The override propagates to everything awaited **inline on the same task**. It
+/// does **NOT** propagate across `tokio::spawn`: a write driven through a spawned
+/// task observes the process gauge instead, and a scoped read of it would come
+/// back as 0. Any future test that drives a gauge write through a spawned task
+/// must account for that rather than assume the scope reaches it.
+#[cfg(test)]
+pub(crate) async fn with_gauge_sink<F, R>(sink: Arc<dyn TombstoneGaugeSink>, f: F) -> R
+where
+    F: Future<Output = R>,
+{
+    GAUGE_SINK.scope(sink, f).await
+}
+
+/// Runs `f` against a fresh [`IsolatedGauge`], returning its output alongside
+/// the sink's final value.
+///
+/// The sink starts at zero, so the returned value **is** the net delta of every
+/// gauge write made inside the scope — and only those. The same inline-only
+/// propagation contract as [`with_gauge_sink`] applies: writes made on a
+/// `tokio::spawn`ed task land on the process gauge and are not counted here.
+#[cfg(test)]
+pub(crate) async fn with_isolated_gauge<F, R>(f: F) -> (R, u64)
+where
+    F: Future<Output = R>,
+{
+    let sink = Arc::new(IsolatedGauge::new());
+    let observer = Arc::clone(&sink);
+    let out = with_gauge_sink(sink, f).await;
+    (out, observer.read())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        with_gauge_sink, with_isolated_gauge, with_sink, IsolatedGauge, ProcessGauge,
+        TombstoneGaugeSink,
+    };
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn isolated_scope_reports_its_own_net_delta() {
+        let (out, delta) = with_isolated_gauge(async {
+            with_sink(|s| s.add(7));
+            with_sink(|s| s.sub(2));
+            with_sink(|s| s.read())
+        })
+        .await;
+
+        assert_eq!(out, 5, "a scoped read must observe the scoped sink");
+        assert_eq!(delta, 5, "the scope's final value is its net delta");
+    }
+
+    /// Pins the binding helper itself: a caller-supplied sink receives the
+    /// scope's writes, and its tripwire is observable on that instance alone —
+    /// never through a process-global read that every unmarked OR-remove in the
+    /// crate would arm.
+    #[tokio::test]
+    async fn an_explicitly_bound_sink_receives_the_scope_s_writes() {
+        let sink = Arc::new(ProcessGauge::new());
+        let observer = Arc::clone(&sink);
+        assert!(!observer.armed(), "a fresh gauge starts un-armed");
+
+        with_gauge_sink(sink, async {
+            with_sink(|s| s.add(3));
+        })
+        .await;
+
+        assert_eq!(observer.read(), 3);
+        assert!(observer.armed(), "an add arms the receiving instance");
+    }
+
+    #[test]
+    fn an_isolated_sub_wraps_rather_than_saturating() {
+        // Wrapping keeps an underflow regression observable instead of hiding it
+        // behind a floor of zero.
+        let sink = IsolatedGauge::new();
+        sink.sub(1);
+        assert_eq!(sink.read(), u64::MAX);
+    }
+}


### PR DESCRIPTION
## Summary

Eliminates TODO-600 (the `OR_TOMBSTONE_BYTES` process-global counter flake) **structurally, not by suppression**: `record.rs`'s four gauge fns now delegate through a task-local scoped sink resolver — tests bind a private `IsolatedGauge`, production resolves to the shared `ProcessGauge`, signatures unchanged, no hot-path branch in release.

- Gauge tests 6 → 9; **the real epoch-prune decrement path (`crdt.rs` `sub_tombstone_bytes`) is covered for the first time** (the audit discovered no test anywhere asserted the gauge against the real prune path — the prior proptest drove a test-local mirror).
- Both mutation proofs re-verified by the reviewer by actual mutation (RED on deleted add/sub calls, restored byte-identical).
- Review v1 caught the isolation-proof test itself being flaky (diffing the live shared gauge, 2/80); redesigned to a **test-private foreign-traffic counter** — deterministic by construction. Recorded pattern: negative controls must never read a shared counter; even a monotone ≥ recreates the flake class.
- /xreview (glm-5.2, 1213-line diff): 2 HIGH refuted on evidence, 1 MED adopted, 1 MED by-design, 1 LOW declined.

## Test evidence
Suite 1683/0 (lib), fmt + clippy `-D warnings` clean, soak_tombstone_retain + sim green; audit ×2, review ×2 (v2 APPROVED). Carried: TODO-601 (14 rustdoc intra-doc links across 7 unrelated files — out of the 5-file budget).

Roadmap: step 2 of the sequential pre-72h chain (reliable CI) — next: INVARIANTS.md → cross-incarnation harness (TODO-597) → replay-clobber fix (TODO-598) → OR delta-framing (SPEC-349a/b).