### PR TITLE
CI-gated invariants catalog — INVARIANTS.md + check script [roadmap step 3]

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,18 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  invariants:
+    name: Invariants catalog gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      # INVARIANTS.md discipline: every entry either cites a test that still exists
+      # or carries an honest NAKED marker with a tracking TODO; the NAKED count may
+      # never grow silently. Pure bash — no toolchain needed.
+      - name: Check invariant-test mapping
+        run: ./scripts/check-invariants.sh
+
   check:
     name: Check & Lint
     runs-on: ubuntu-latest

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -1,0 +1,229 @@
+# TopGun Invariants Catalog
+
+Every durability/correctness invariant the system relies on, each mapped to the code that
+maintains it and the test that enforces it. **An invariant without an enforcing test is marked
+`NAKED` with a tracking TODO — visibly, on purpose.** CI (`scripts/check-invariants.sh`) verifies
+that every cited enforcing test still exists and that no new entry lands without either a test or
+an explicit `NAKED` marker; the gate is "the NAKED count never grows silently", not "zero NAKED".
+
+Conventions: IDs are `TG-<DOMAIN>-<NNN>` (domains: WAL, WB write-behind, OR, LWW, MRK merkle,
+EVI eviction, SYNC). Cite the ID verbatim in code comments and test names. Statuses:
+`decided` (holds by design) · `open (SPEC/TODO-nnn)` (not yet true / not yet wired) ·
+`aspirational`. Precedent: omnigraph `docs/invariants.md` (structure) — improved here with the
+CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
+
+---
+
+### TG-WAL-001: Acked writes are durable under `kill -9` when `WalFsyncPolicy::PerOp` is active
+
+- **Scope:** `WriteBehindDataStore` write path with a WAL bootstrap, `PerOp` policy.
+- **Statement:** every write acked `Ok(())` is present after `WalRecovery::run` replays a WAL that
+  survived an unclean shutdown (acked-before-crash ⊆ present-after-recovery). Under `PerOp`,
+  fsync completes before the append returns.
+- **Maintaining code:** `packages/server-rust/src/storage/wal/mod.rs` (PerOp arm, `sync_data`
+  before return); `write_behind.rs` append-before-ack path.
+- **Enforcing test:** `packages/server-rust/src/storage/crash_safety_proptest.rs` (the file's
+  stated oracle is exactly this invariant; real store + WAL, SIGKILL modeled by store drop).
+- **Violation consequence:** silently vanished acked writes after restart — worst CRDT-storage
+  class; client re-converges only if its own op-log survived.
+- **Discovered by:** SPEC-331/332/333 durability chain.
+- **Status:** decided (PerOp). Batched is deliberately weaker — see TG-WAL-002.
+
+### TG-WAL-002: `Batched` (default) fsync loss window is bounded to the group-commit window
+
+- **Scope:** `WalFsyncPolicy::Batched` (production default).
+- **Statement:** an unclean shutdown may lose acked writes appended since the last group-commit
+  fsync (~10 ms timer / 100 frames) — and NO MORE than that window. The gap is a documented
+  product trade-off (CLAUDE.md); its BOUND is the invariant.
+- **Maintaining code:** `wal/mod.rs` batched group-commit timer task.
+- **Enforcing test:** `NAKED — no test proves the loss window is bounded to
+  writes-since-last-sync and no wider (TODO-602)`. `crash_safety_proptest.rs` proves the PerOp
+  positive only.
+- **Violation consequence:** an unbounded loss window under the default policy — the documented
+  trade-off silently becomes a lie.
+- **Discovered by:** extraction pilot audit 2026-07-16; fsync-tier asymmetry noted vs TiKV.
+- **Status:** decided (gap intentional), **enforcement NAKED (TODO-602; harness TODO-597 is the
+  natural vehicle — a Batched-policy fault schedule)**.
+
+### TG-WAL-003: The applied watermark is durably fsynced before any sealed segment is unlinked
+
+- **Scope:** `mark_applied` → segment GC ordering, all policies.
+- **Statement:** the watermark sidecar write+fsync completes before any sealed-segment unlink it
+  licenses; a crash between them must not lose or corrupt data (GC is resumable, replay
+  idempotent under the watermark filter).
+- **Maintaining code:** `wal/mod.rs` `mark_applied` (fsync-before-unlink block + apply-time
+  re-validation before physical delete, SPEC-350).
+- **Enforcing test:** partially enforced —
+  `packages/server-rust/src/storage/datastores/prefix_watermark_proptest.rs` (SPEC-350) drives
+  GC gating + boot seeding across incarnations; the precise crash injection BETWEEN the sidecar
+  fsync and the unlink loop remains `NAKED (TODO-597 harness target)`.
+- **Violation consequence:** under-seeded `max_observed_sequence` on restart → sequence reuse →
+  recovery filter silently drops frames.
+- **Discovered by:** SPEC-330 era; hardened by SPEC-350.
+- **Status:** decided; enforcement partial (crash-point injection open).
+
+### TG-WAL-005: The per-partition applied watermark is prefix-complete across incarnations
+
+- **Scope:** `W(p)` tracker in `write_behind.rs` + `wal/mod.rs` (SPEC-350).
+- **Statement:** `W(p) = min(unresolved wal_seq) − 1`; W never advances past a frame that is
+  neither durably applied to the inner store nor superseded-by-carried-successor — including
+  across restarts (boot-seeded from `wal.unapplied(p)`); an unseeded partition refuses to
+  advance.
+- **Maintaining code:** the tracker bundled with `Arc<dyn Wal>` (one struct, cannot diverge);
+  boot seeding; unseeded-refuse guard.
+- **Enforcing test:** `prefix_watermark_proptest.rs` — restart-crossing proptest; both loss-guards
+  (unseeded-refuse, seed-retry) verified by revert during review (fail on pre-fix code).
+- **Violation consequence:** the SPEC-350 headline defect — acked writes of one key silently
+  dropped from replay because another key's flush advanced a scalar watermark past them.
+- **Discovered by:** SPEC-349 Audit v2 (three independent derivations).
+- **Status:** decided, **enforced**.
+
+### TG-WAL-006: WAL re-replay is NOT merge-idempotent today (known-false, tracked)
+
+- **Scope:** `WalRecovery::run` replay into `RedbDataStore`.
+- **Statement (negative):** `write_one` is a blind `table.insert` with no read-compare merge — a
+  replayed older frame CAN clobber a newer durable value written outside the replay window
+  (reproduced). Recovery safety currently rests ONLY on in-sequence-order replay +
+  last-frame-wins within the window.
+- **Maintaining code:** the truth is stated in the doc-contracts at `wal/mod.rs` (`replay_entry`,
+  `recover`) pointing at the tracker; `datastores/redb.rs:309` (`write_one`).
+- **Enforcing test:** the weaker (true) in-window property only, BY DESIGN ("don't ship the
+  loss as a test"): `prefix_watermark_proptest.rs::a_frame_written_after_the_partition_drains_is_still_replayed`
+  and `::a_mid_loop_remove_all_failure_still_replays_the_earlier_tombstones`.
+- **Violation consequence:** citing this branch for re-replay idempotency re-plants a false
+  invariant; timestamp regression on crash-recovery under out-of-order arrivals.
+- **Discovered by:** SPEC-350 execution (AC4(b) honest-unmet escalation).
+- **Status:** **open (TODO-598)** — flips to a positive merge-idempotency invariant when closed.
+
+### TG-WAL-007: WAL write-path failures fail-stop through one abort-based mechanism
+
+- **Scope:** `wal_fail_stop(tier, ctx) -> !`; Err taxonomy (P)/(A)/(B).
+- **Statement:** (P) sealed-target = programming bug → abort; (A) pre-frame errors (encode/open,
+  bytes provably not in segment) → rollback of the frameless seq only; (B) write/fsync errors
+  (frame possibly in segment) → abort, never retry the fsync (fsyncgate: PostgreSQL 2018, TiKV).
+  Discrimination is STRUCTURAL (pre-checks), never parsed from error content. Abort survives the
+  workspace's `panic = "abort"` prohibition and tokio unwind containment.
+- **Maintaining code:** `wal/mod.rs` pre-check seam + `wal_fail_stop` (`#[cfg(test)]` seam panics
+  for observability).
+- **Enforcing test:** `prefix_watermark_proptest.rs::a_pre_frame_append_failure_removes_only_the_frameless_sequence_from_add`
+  (+ `_from_remove` twin) and `::a_post_frame_append_failure_fail_stops_at_tier_b_without_rolling_back`
+  — the (c1)/(c2) inverted pair (frameless removed / frame-backed NOT removed, loss-class guard).
+- **Violation consequence:** continuing on a broken WAL (silent corruption) or rolling back
+  frame-backed seqs (the AC2(c2) resurrection defect).
+- **Discovered by:** SPEC-350 Audits v10–v12.
+- **Status:** decided, **enforced**.
+
+### TG-WAL-008: The stalled-watermark alarm classifies two ways and never fires on correct code
+
+- **Scope:** TrackerLeak vs AbandonedWrite classifier + two-sample confirmation.
+- **Statement:** `TrackerLeak` (code bug) fires only for a Live seq absent from BOTH queue and
+  in-flight registry on TWO independent samples separated by the derived re-confirm delay;
+  a hung store/disk classifies `AbandonedWrite`; a transient ownerless window (resolve between
+  samples) fires nothing.
+- **Maintaining code:** classifier in `write_behind.rs`; `max(bound/60, floor)` derived delay.
+- **Enforcing test:** `prefix_watermark_proptest.rs::a_hung_inner_store_is_an_abandoned_write_not_a_leak`
+  and `::a_boot_unreplayed_sequence_is_an_abandoned_write_not_a_leak` (classifier matrix by
+  scrape, commit `b3e0e89b`) incl. the transient-window negative control (AC3(a)(viii)).
+- **Violation consequence:** operator misdirection — a disk-full incident diagnosed as a code
+  bug, or a real leak suppressed.
+- **Discovered by:** SPEC-350 Audit v7 (two-class split), v10–v12 (races).
+- **Status:** decided, **enforced**.
+
+### TG-WB-001: The flushed watermark is prefix-complete — no mid-range hole
+
+- **Scope:** entry-ordering-space `pending_seqs` / `flushed_watermark()` (tombstone fence
+  consumer; INDEPENDENT of TG-WAL-005's wal_seq-space tracker).
+- **Statement:** `flushed_watermark()` never returns a value above a still-buffered sequence;
+  assign+track is atomic under one lock (the mid-range-hole guard).
+- **Maintaining code:** `write_behind.rs` `assign_tracked_sequence` + `resolve_pending`.
+- **Enforcing test:** `write_behind.rs::ac3c_flushed_watermark_prefix_complete_never_exposes_hole`
+  + surrounding block (coalesce-resolves-a-hole, prune-frontier-stall regression).
+- **Violation consequence:** a tombstone pruned while its bytes are still RAM-only → resurrection
+  after crash.
+- **Discovered by:** SPEC-330.
+- **Status:** decided, **enforced**.
+
+### TG-EVI-001: Never-evict-dirty — an unflushed write is never evicted from the resident cache
+
+- **Scope:** `evict_lru` in the record store.
+- **Statement:** a record whose latest write has not reached the durable backend is not evictable,
+  regardless of memory pressure.
+- **Maintaining code:** `storage/impls/default_record_store.rs` dirty-skip.
+- **Enforcing test:** `default_record_store.rs::evict_lru_skips_all_dirty_records` +
+  `::evict_lru_skips_dirty_in_mixed_snapshot` + assertion in `eviction_cost_test.rs`.
+- **Violation consequence:** eviction under pressure silently drops acked writes.
+- **Discovered by:** eviction design (pre-catalog).
+- **Status:** decided, **enforced**.
+
+### TG-OR-001: `update_in_place`'s mutate closure runs at most once per call
+
+- **Scope:** `RecordStore::update_in_place` seam (SPEC-347).
+- **Statement:** one call invokes `mutate` at most once (doc-contract, SPEC-347); gauge side
+  effects inside the closure must not double-count.
+- **Maintaining code:** doc-contract + DashMap shard-lock path.
+- **Enforcing test:** partial —
+  `or_inplace_mutate_proptest.rs::new_tombstone_counted_once_across_write_failure_and_retry`
+  proves no double-count across fail+retry; the literal call-counter assertion (`AtomicUsize
+  == 1` per call) is `NAKED (TODO-602)`.
+- **Violation consequence:** hidden internal retry double-applies CRDT mutations/gauge deltas.
+- **Discovered by:** SPEC-347 review minors.
+- **Status:** decided; enforcement partial.
+
+### TG-OR-002: OR observers receive the documented `old_value` contract (post-image)
+
+- **Scope:** observer fan-out on the in-place OR write path.
+- **Statement:** `update_in_place` passes the post-image as "old value" (documented, intentional);
+  no observer may silently depend on a pre-image.
+- **Maintaining code:** SPEC-347 doc-contracts.
+- **Enforcing test:** shape-only — the differential proptest matches notification COUNTS across
+  legacy/in-place paths; content assertion on `old_value` is `NAKED (TODO-602)`.
+- **Violation consequence:** a future observer reads `old_value`, silently gets wrong data.
+- **Discovered by:** extraction pilot audit.
+- **Status:** decided (scoped); enforcement shape-only.
+
+### TG-OR-003: OR delta-fold recovery is semantic-set-equivalent to the snapshot path
+
+- **Scope:** `OrDelta`/`OrDeltaFold` (SPEC-346 types; unwired until SPEC-349).
+- **Statement:** folding any op sequence through the delta path and the full-snapshot path yields
+  equal `or_map_semantic_view` (live set + tombstones + pruned), with the durable store as fold
+  base and snapshot frames as in-order absolute-set inputs.
+- **Maintaining code:** types + oracle landed (SPEC-346); fold delegates to the live apply path
+  (single-algebra rule, SPEC-349 R-mandate).
+- **Enforcing test:** `NAKED by the code's own admission — the doc names a differential recovery
+  test that does not exist yet (SPEC-349b + TODO-597 harness)`.
+- **Violation consequence:** silent post-crash divergence of OR state — the class the oracle was
+  built to kill.
+- **Discovered by:** SPEC-346 design.
+- **Status:** open (SPEC-349a/b).
+
+### TG-OR-004: The tombstone-bytes gauge tracks the REAL add and prune paths, test-isolatable
+
+- **Scope:** `ProcessGauge`/scoped sink (`storage/tombstone_gauge.rs`, SPEC-351).
+- **Statement:** `add_tombstone_bytes` fires on the real OR-remove path and `sub_tombstone_bytes`
+  on the real epoch-prune path (mutation-proven both directions); tests bind task-local isolated
+  gauges — no order-dependent global reads; negative controls never read a shared counter.
+- **Maintaining code:** `record.rs` fns delegating through the scoped sink resolver.
+- **Enforcing test:** SPEC-351 suite (9 tests) — real-prune-path coverage
+  (`crdt.rs:1394` mutation → deterministic RED), per-binding tripwire, private-counter foreign
+  traffic control.
+- **Violation consequence:** the SPEC-345 tombstone hard gate reads a fiction; the 72h soak's
+  primary instrument lies.
+- **Discovered by:** SPEC-351 audit C1 (the gauge was previously asserted only against a test
+  mirror — the discovered hole this entry closes).
+- **Status:** decided, **enforced**.
+
+### TG-MRK-001: The OR-Map Merkle leaf hash is set-canonical (order-independent)
+
+- **Scope:** `merkle_leaf_hash` (`map_data_store.rs`), mirrored by the TS client
+  (`packages/core/src/ORMapMerkleTree.ts`) — the granularity is a cross-language protocol
+  contract.
+- **Statement:** two OR-Map states with the same tag/tombstone SETS hash identically regardless
+  of insertion order (tags and tombstones sorted before hashing).
+- **Maintaining code:** the sort in `merkle_leaf_hash`.
+- **Enforcing test:** `NAKED for the order-independence claim (TODO-602)` — adjacent coverage
+  only (buffered-vs-flushed fixed-sequence equality; LWW-arm hash format).
+- **Violation consequence:** false Merkle mismatches → sync storms, or false matches → silent
+  divergence; breaks the SPEC-349 semantic-set recovery warrant.
+- **Discovered by:** extraction pilot audit; load-bearing for SPEC-346/349 (the /xask
+  Merkle-ordering caveat was refuted BY this sort — the sort itself deserves a test).
+- **Status:** decided (code sorts); enforcement NAKED.

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# CI gate for INVARIANTS.md — the machine-checkable layer the omnigraph precedent lacks.
+#
+# Checks:
+#   1. Every `### TG-<DOMAIN>-<NNN>:` entry has an `**Enforcing test:**` field.
+#   2. Every enforcing-test field either cites a test that still exists in the tree
+#      (function name greppable under packages/server-rust/src) or carries an explicit
+#      `NAKED` marker with a tracking reference (TODO-nnn / SPEC-nnn).
+#   3. The NAKED count does not grow silently: it is compared against the committed
+#      baseline in this script. Lowering it is celebrated (update the baseline);
+#      raising it fails CI unless the baseline is consciously raised in the same PR.
+#
+# The gate is NOT "zero NAKED" — that would incentivize deleting hard invariants
+# instead of writing hard tests. The failure mode being blocked is an invariant with
+# neither a test nor an honest marker.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+DOC="INVARIANTS.md"
+NAKED_BASELINE=6
+
+[ -f "$DOC" ] || { echo "FAIL: $DOC missing"; exit 1; }
+
+fail=0
+naked=0
+entries=0
+
+# Split the doc into entries and inspect each.
+ids=$(grep -E '^### TG-[A-Z]+-[0-9]{3}' "$DOC" | sed -E 's/^### (TG-[A-Z]+-[0-9]{3}).*/\1/')
+for id in $ids; do
+  entries=$((entries + 1))
+  # The entry body = lines from this heading to the next heading/EOF.
+  body=$(awk -v id="### $id" '
+    $0 ~ "^" id { grab=1 }
+    grab && $0 ~ /^### TG-/ && $0 !~ "^" id { exit }
+    grab { print }' "$DOC")
+
+  enforcing=$(printf '%s\n' "$body" | grep -A3 '\*\*Enforcing test:\*\*' || true)
+  if [ -z "$enforcing" ]; then
+    echo "FAIL: $id has no 'Enforcing test:' field"
+    fail=1
+    continue
+  fi
+
+  if printf '%s' "$enforcing" | grep -q 'NAKED'; then
+    naked=$((naked + 1))
+    if ! printf '%s' "$enforcing" | grep -qE '(TODO|SPEC)-[0-9]+'; then
+      echo "FAIL: $id is NAKED without a tracking TODO/SPEC reference"
+      fail=1
+    fi
+    continue
+  fi
+
+  # Extract candidate test function names (snake_case identifiers of length >= 12
+  # that look like test fns) and verify at least one still exists in the tree.
+  fns=$(printf '%s' "$enforcing" | grep -oE '[a-z][a-z0-9_]{11,}' | sort -u || true)
+  found=""
+  for fn in $fns; do
+    if grep -rq "fn $fn" packages/server-rust/src packages/server-rust/benches 2>/dev/null; then
+      found="$fn"
+      break
+    fi
+  done
+  # Fall back: a cited FILE that exists also counts (whole-file oracles like proptests).
+  if [ -z "$found" ]; then
+    files=$(printf '%s' "$enforcing" | grep -oE '[a-zA-Z0-9_/.-]+\.rs' | sort -u || true)
+    for f in $files; do
+      base=$(basename "$f")
+      if find packages/server-rust -name "$base" | grep -q .; then
+        found="$base"
+        break
+      fi
+    done
+  fi
+  if [ -z "$found" ]; then
+    echo "FAIL: $id cites an enforcing test, but no cited test fn/file exists in the tree"
+    fail=1
+  fi
+done
+
+echo "invariants: $entries entries, $naked NAKED (baseline $NAKED_BASELINE)"
+if [ "$naked" -gt "$NAKED_BASELINE" ]; then
+  echo "FAIL: NAKED count grew ($naked > $NAKED_BASELINE). Either add an enforcing test or"
+  echo "      consciously raise NAKED_BASELINE in scripts/check-invariants.sh in this PR."
+  fail=1
+elif [ "$naked" -lt "$NAKED_BASELINE" ]; then
+  echo "NOTE: NAKED count dropped to $naked — lower NAKED_BASELINE to lock in the progress."
+fi
+
+exit $fail


### PR DESCRIPTION
## Summary

Step 3 of the sequential pre-72h roadmap: a first-class **invariants catalog** with the machine-checkable layer its precedent (omnigraph's `docs/invariants.md`) lacks.

- **`INVARIANTS.md`** (repo root): 14 durability/correctness invariants, each with scope / falsifiable statement / maintaining code / **enforcing test or an honest `NAKED` marker with a tracking TODO** / violation consequence / discovery provenance. Includes the negative invariant TG-WAL-006 (re-replay is NOT merge-idempotent today — TODO-598) so nobody cites what does not hold.
- **`scripts/check-invariants.sh`** + a 5-min CI job: verifies every cited test fn/file still exists in the tree (catches silent un-enforcement via rename/delete), requires a TODO/SPEC reference on every NAKED marker, and fails if the NAKED count grows past the committed baseline (6). The gate is "NAKED never grows silently", not "zero NAKED" — deleting hard invariants must never be cheaper than writing hard tests.
- **TODO-602** filed: batches the four small NAKED closures (batched loss-window bound, literal at-most-once counter, observer old-value content, Merkle leaf order-independence); the other two NAKED entries are owned by TODO-597 (harness) and SPEC-349b.

Current tally: 8 enforced / 6 NAKED — three of the enforced rows were closed in the last two weeks (SPEC-350 watermark + fail-stop + classifier, SPEC-351 real-prune-path gauge), which is the catalog's point: the map now exists, and it shrinks visibly.

Script verified locally: `invariants: 14 entries, 6 NAKED (baseline 6)`, exit 0; citation-drift detection proven live (it caught three imprecise citations during authoring).