### PR TITLE
WAL replay merge-idempotency for LWW — a stale frame can no longer clobber a newer durable value [SPEC-353]

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -83,22 +83,34 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
 - **Discovered by:** SPEC-349 Audit v2 (three independent derivations).
 - **Status:** decided, **enforced**.
 
-### TG-WAL-006: WAL re-replay is NOT merge-idempotent today (known-false, tracked)
+### TG-WAL-006: WAL re-replay is merge-idempotent for `RecordValue::Lww` (enforced, LWW-scoped)
 
-- **Scope:** `WalRecovery::run` replay into `RedbDataStore`.
-- **Statement (negative):** `write_one` is a blind `table.insert` with no read-compare merge — a
-  replayed older frame CAN clobber a newer durable value written outside the replay window
-  (reproduced). Recovery safety currently rests ONLY on in-sequence-order replay +
-  last-frame-wins within the window.
-- **Maintaining code:** the truth is stated in the doc-contracts at `wal/mod.rs` (`replay_entry`,
-  `recover`) pointing at the tracker; `datastores/redb.rs:309` (`write_one`).
-- **Enforcing test:** the weaker (true) in-window property only, BY DESIGN ("don't ship the
-  loss as a test"): `prefix_watermark_proptest.rs::a_frame_written_after_the_partition_drains_is_still_replayed`
-  and `::a_mid_loop_remove_all_failure_still_replays_the_earlier_tombstones`.
-- **Violation consequence:** citing this branch for re-replay idempotency re-plants a false
-  invariant; timestamp regression on crash-recovery under out-of-order arrivals.
-- **Discovered by:** SPEC-350 execution (AC4(b) honest-unmet escalation).
-- **Status:** **open (TODO-598)** — flips to a positive merge-idempotency invariant when closed.
+- **Scope:** `WalRecovery::run` replay through `replay_entry`, for `RecordValue::Lww` values.
+- **Statement (positive):** re-replaying a WAL frame whose value is OLDER than the current durable
+  value MUST NOT change the durable value, for `RecordValue::Lww`: `replay_entry` reads the current
+  value and discards a modern Lww frame whose HLC timestamp is strictly lower (last-write-wins by
+  timestamp); ties and newer timestamps write through. `WalStorePayload::Legacy` frames (synthesized
+  always-merge timestamp), `RecordValue::OrMap`/`OrTombstones` frames, and a cross-kind (non-Lww
+  stored) value BYPASS the gate and keep the pre-existing blind replay. `write_one` stays a
+  CRDT-agnostic blind insert; the merge lives at the recovery boundary.
+- **Maintaining code:** `wal/mod.rs::replay_entry` (the `RecordValue::Lww` read-compare gate) +
+  `run` / call-site doc-contracts; `datastores/redb.rs` (`write_one` doc-comment records the
+  guarantee lives upstream).
+- **Enforcing test:** `wal/mod.rs::tests::replay_lww_gate_discards_older_frame_isolated` (older
+  discarded, ties/newer through, gate-off clobbers) and `::replay_or_crosskind_and_legacy_bypass_lww_gate`
+  (the bypass proof, since the harness model is LWW-only); the harness value-equality case
+  `wal_harness::cases::ac4_5_replay_clobber_caught_by_value_equality_oracle`.
+- **Superseded (still true, kept):** the weaker in-window proptests
+  `prefix_watermark_proptest.rs::a_frame_written_after_the_partition_drains_is_still_replayed`
+  and `::a_mid_loop_remove_all_failure_still_replays_the_earlier_tombstones` remain valid and are
+  subsumed by the stronger property above.
+- **OR residue (routed, NOT closed here):** OR-Map merge-idempotency as an independent property is
+  owned by `TG-OR-003` / SPEC-349b (tracked by TODO-608), where delta-fold-delegates-to-live-apply
+  answers it by construction; this invariant covers only the `RecordValue::Lww` case.
+- **Violation consequence:** timestamp regression on crash-recovery — a stale re-replayed frame
+  resurrects an older durable value.
+- **Discovered by:** SPEC-350 execution (AC4(b) honest-unmet escalation); closed by SPEC-353.
+- **Status:** decided, **enforced (LWW-scoped)**.
 
 ### TG-WAL-007: WAL write-path failures fail-stop through one abort-based mechanism
 

--- a/packages/server-rust/src/storage/datastores/redb.rs
+++ b/packages/server-rust/src/storage/datastores/redb.rs
@@ -306,6 +306,14 @@ impl RedbDataStore {
 /// tuple. Validates the map name, opens (or creates) the per-(map, `is_backup`)
 /// table inside one `WriteTransaction`, serializes the value via msgpack, and
 /// commits.
+///
+/// This is a deliberately CRDT-agnostic blind insert: it does NOT merge by
+/// timestamp. Last-write-wins ordering is upheld before the store is ever
+/// reached — by the CRDT service layer on the live path, and by the
+/// `RecordValue::Lww` read-compare gate in `WalRecovery::replay_entry` on the
+/// recovery path (TG-WAL-006). Keeping merge semantics out of the storage
+/// primitive avoids a layering inversion and a per-write read on the flush hot
+/// path.
 fn write_one(
     db: &redb::Database,
     map: &str,

--- a/packages/server-rust/src/storage/datastores/wal_harness/cases.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/cases.rs
@@ -640,6 +640,91 @@ fn ac4_c3_scalar_max_watermark_regression() {
 }
 
 // ---------------------------------------------------------------------------
+// AC4 / AC5 — TG-WAL-006 replay-clobber proof via the value_equality oracle
+// ---------------------------------------------------------------------------
+
+/// `DefectMode::ReplayClobberOlderFrame` (the pre-`TG-WAL-006` blind clobber) must
+/// be CAUGHT by the `value_equality` oracle as an `AckedValueMismatch` naming the
+/// key and the (expected, recovered) millis (AC4); and the identical case on the
+/// fixed path (`DefectMode::None`, gate on, no re-replay) must be GREEN under the
+/// same opt-in oracle (AC5 — the closing evidence SPEC-352's `OracleConfig`
+/// doc-comment names).
+///
+/// The case writes key 0 twice, timestamp-monotonic (ts=10 then ts=20). The FIRST
+/// write's flush is rejected (store unhealthy) so its sequence strands un-applied
+/// and holds the partition watermark back; the SECOND write flushes durably (ts=20)
+/// but its frame therefore ALSO stays un-applied. At recovery both frames replay
+/// in order (leaving ts=20 durable), then the seam re-replays the oldest (ts=10)
+/// frame over it — the older-frame-in-window condition the live `flush_key` path
+/// can produce but generated ops cannot manufacture (flush persists the watermark).
+/// Monotonic timestamps keep the last-arrival model and the LWW gate in agreement,
+/// so the oracle is sound.
+#[test]
+fn ac4_5_replay_clobber_caught_by_value_equality_oracle() {
+    let case: Case = vec![
+        Incarnation {
+            ops: vec![
+                WorkOp::Append { key: 0, millis: 10 },
+                WorkOp::SetStoreHealth { healthy: false },
+                WorkOp::FlushTick { advance_ms: 5_000 },
+                WorkOp::SetStoreHealth { healthy: true },
+                WorkOp::Append { key: 0, millis: 20 },
+                WorkOp::FlushTick { advance_ms: 5_000 },
+            ],
+            end: IncarnationEnd::Crash,
+        },
+        Incarnation {
+            ops: vec![WorkOp::Read { key: 0 }],
+            end: IncarnationEnd::CleanShutdown,
+        },
+    ];
+
+    let value_eq = OracleConfig {
+        value_equality: true,
+    };
+
+    // (a) defect present: the oracle catches the clobber, naming key/expected/recovered.
+    let defect_cfg = RunConfig {
+        defect: DefectMode::ReplayClobberOlderFrame,
+        oracle: value_eq,
+        ..RunConfig::baseline()
+    };
+    let defect_outcome = block_on_async(run_case(&case, &defect_cfg));
+    let mismatch = defect_outcome.violations.iter().find_map(|v| match v {
+        InvariantViolation::AckedValueMismatch {
+            key,
+            expected_millis,
+            recovered_millis,
+            ..
+        } => Some((*key, *expected_millis, *recovered_millis)),
+        _ => None,
+    });
+    assert_eq!(
+        mismatch,
+        Some((0, 20, 10)),
+        "AC4: value_equality must catch the replay clobber (key 0, expected 20, recovered 10); \
+         got violations {:?}",
+        defect_outcome.violations
+    );
+
+    // (b) discriminator: the fixed path is GREEN of any value mismatch (AC5).
+    let fixed_cfg = RunConfig {
+        defect: DefectMode::None,
+        oracle: value_eq,
+        ..RunConfig::baseline()
+    };
+    let fixed_outcome = block_on_async(run_case(&case, &fixed_cfg));
+    assert!(
+        !fixed_outcome
+            .violations
+            .iter()
+            .any(|v| matches!(v, InvariantViolation::AckedValueMismatch { .. })),
+        "AC5: the fixed path must report no AckedValueMismatch under value_equality; got {:?}",
+        fixed_outcome.violations
+    );
+}
+
+// ---------------------------------------------------------------------------
 // AC5 — C12 regression proof, with the cross-incarnation negative control
 // ---------------------------------------------------------------------------
 

--- a/packages/server-rust/src/storage/datastores/wal_harness/cases.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/cases.rs
@@ -548,9 +548,9 @@ fn ac14e_coverage_guard_discriminates_below_floor() {
 // AC11 — value-equality oracle stays off by default
 // ---------------------------------------------------------------------------
 
-/// The default oracle config keeps value equality OFF, so it cannot be silently
-/// flipped on and start firing REDs on the known-not-merge-idempotent replay
-/// behaviour (`TG-WAL-006` / `TODO-598`).
+/// The value-equality oracle stays OFF by default (opt-in per run): `TG-WAL-006`
+/// is enforced LWW-scoped, but the oracle is enabled explicitly only for the
+/// closing-evidence and regression runs, never silently for every case.
 #[test]
 fn ac11_value_equality_defaults_off() {
     assert!(!OracleConfig::default().value_equality);

--- a/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
@@ -1220,7 +1220,7 @@ thread_local! {
 ///
 /// Load-bearing for the `value_equality` oracle's soundness: value MUST stay a pure
 /// function of `millis`, and `counter`/`node_id` MUST stay constant. The oracle
-/// compares millis alone; if value stopped tracking millis, or counter/node_id
+/// compares `millis` alone; if value stopped tracking `millis`, or `counter`/`node_id`
 /// varied, an equal-millis different-value clobber would slip its strictly-older
 /// check (see the soundness-coupling note at the oracle in `evaluate_o1`).
 fn lww(millis: i64) -> RecordValue {

--- a/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
@@ -1112,14 +1112,21 @@ impl Driver {
             // writes for a key. Off by default; enabled explicitly for the
             // closing-evidence and regression runs.
             //
-            // Soundness coupling (do not break in `lww()`): comparing millis alone is
-            // sound ONLY because `lww(millis)` makes value a pure function of millis
-            // and fixes `counter:0`/`node_id:""`, so full-`Timestamp` order collapses
-            // to millis order and equal millis implies an identical value. A future
-            // generator that emits distinct values at equal millis, or varies
-            // counter/node_id, would let an equal-millis different-value clobber slip
-            // this strictly-older check — the oracle would then need the same
-            // full-`Timestamp` compare the gate uses.
+            // Soundness domain (two constraints, both currently satisfied):
+            //  1. Value coupling (do not break in `lww()`): comparing millis alone is
+            //     sound only because `lww(millis)` makes value a pure function of millis
+            //     and fixes `counter:0`/`node_id:""`, so full-`Timestamp` order collapses
+            //     to millis order and equal millis implies an identical value. A generator
+            //     that emitted distinct values at equal millis, or varied counter/node_id,
+            //     would let an equal-millis different-value clobber slip this check.
+            //  2. Reference point: `expected` is the model's LATEST-ARRIVAL millis, which
+            //     equals the true LWW winner (max timestamp) only when a key's writes are
+            //     MONOTONE in arrival order — as production HLC always is, and as the sole
+            //     `value_equality: true` case (`ac4_5_...`) is by construction. If a defect
+            //     run ever used a non-monotone key (arrival 20, 30, 10) a clobber landing in
+            //     `[latest_arrival, max_acked)` (e.g. recovered 20 vs latest-arrival 10)
+            //     would slip the strictly-older check. Making the oracle sound for
+            //     non-monotone defect runs needs a per-key max-live-millis reference.
             if self.config.oracle.value_equality {
                 if let (
                     ModelValue::Live { millis: expected },

--- a/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
@@ -736,7 +736,11 @@ impl Driver {
 
         // Apply the run's defect seams (R6).
         match self.config.defect {
-            DefectMode::None | DefectMode::UnlinkThenFsync => {}
+            // `ReplayClobberOlderFrame` is a recovery-side seam (see `recover`),
+            // so it installs nothing on the store.
+            DefectMode::None
+            | DefectMode::UnlinkThenFsync
+            | DefectMode::ReplayClobberOlderFrame => {}
             DefectMode::ScalarMaxWatermark => {
                 store.test_set_watermark_mode(WatermarkMode::ScalarMax);
             }
@@ -1086,13 +1090,8 @@ impl Driver {
                 continue;
             };
             let key_str = self.key_strings[usize::from(key) % self.key_strings.len()].clone();
-            let present = self
-                .inner
-                .load(TEST_MAP, &key_str)
-                .await
-                .ok()
-                .flatten()
-                .is_some();
+            let loaded = self.inner.load(TEST_MAP, &key_str).await.ok().flatten();
+            let present = loaded.is_some();
             let violated = match value {
                 ModelValue::Live { .. } => !present,
                 ModelValue::Tombstone => present,
@@ -1101,6 +1100,35 @@ impl Driver {
                 self.outcome
                     .violations
                     .push(InvariantViolation::AckedWriteLost { key, incarnation });
+            }
+
+            // value_equality oracle (opt-in, R5): a present acked-live value must
+            // NOT carry a timestamp OLDER than the model's latest acked HLC millis.
+            // A stale re-replay clobber resurrects an older durable value — the exact
+            // regression TG-WAL-006's fix prevents. Only a strictly-older recovered
+            // timestamp is flagged: a recovered value NEWER than the model's
+            // last-arrival is the LWW-by-timestamp winner (never data loss), so it
+            // must not false-positive when the generator emits out-of-timestamp-order
+            // writes for a key. Off by default; enabled explicitly for the
+            // closing-evidence and regression runs.
+            if self.config.oracle.value_equality {
+                if let (
+                    ModelValue::Live { millis: expected },
+                    Some(RecordValue::Lww { timestamp, .. }),
+                ) = (&value, &loaded)
+                {
+                    let recovered = i64::try_from(timestamp.millis).unwrap_or(i64::MAX);
+                    if recovered < *expected {
+                        self.outcome
+                            .violations
+                            .push(InvariantViolation::AckedValueMismatch {
+                                key,
+                                incarnation,
+                                expected_millis: *expected,
+                                recovered_millis: recovered,
+                            });
+                    }
+                }
             }
         }
     }
@@ -1140,7 +1168,15 @@ impl Driver {
     /// partition unresolved view to match the empty post-recovery pending map.
     /// `next_incarnation` is the index the loss surfaces at (for the O1 record).
     async fn recover(&mut self, next_incarnation: usize) {
-        let _ = WalRecovery::new(Arc::clone(&self.wal), vec![self.partition])
+        let mut recovery = WalRecovery::new(Arc::clone(&self.wal), vec![self.partition]);
+        // `ReplayClobberOlderFrame` reproduces the pre-`TG-WAL-006` blind clobber:
+        // disable the merge gate AND re-replay each partition's oldest un-applied
+        // frame over the newer durable value the in-order pass left behind.
+        if self.config.defect == DefectMode::ReplayClobberOlderFrame {
+            recovery.test_set_replay_merge_gate(false);
+            recovery.test_set_re_replay_oldest_frame(true);
+        }
+        let _ = recovery
             .run(Arc::clone(&self.inner) as Arc<dyn MapDataStore>)
             .await;
 

--- a/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
@@ -1111,6 +1111,15 @@ impl Driver {
             // must not false-positive when the generator emits out-of-timestamp-order
             // writes for a key. Off by default; enabled explicitly for the
             // closing-evidence and regression runs.
+            //
+            // Soundness coupling (do not break in `lww()`): comparing millis alone is
+            // sound ONLY because `lww(millis)` makes value a pure function of millis
+            // and fixes `counter:0`/`node_id:""`, so full-`Timestamp` order collapses
+            // to millis order and equal millis implies an identical value. A future
+            // generator that emits distinct values at equal millis, or varies
+            // counter/node_id, would let an equal-millis different-value clobber slip
+            // this strictly-older check — the oracle would then need the same
+            // full-`Timestamp` compare the gate uses.
             if self.config.oracle.value_equality {
                 if let (
                     ModelValue::Live { millis: expected },
@@ -1201,6 +1210,12 @@ thread_local! {
 }
 
 /// Builds an LWW record carrying `millis` as both the value and the timestamp.
+///
+/// Load-bearing for the `value_equality` oracle's soundness: value MUST stay a pure
+/// function of `millis`, and `counter`/`node_id` MUST stay constant. The oracle
+/// compares millis alone; if value stopped tracking millis, or counter/node_id
+/// varied, an equal-millis different-value clobber would slip its strictly-older
+/// check (see the soundness-coupling note at the oracle in `evaluate_o1`).
 fn lww(millis: i64) -> RecordValue {
     RecordValue::Lww {
         value: Value::Int(millis),

--- a/packages/server-rust/src/storage/datastores/wal_harness/mod.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/mod.rs
@@ -21,10 +21,9 @@
 //!
 //! The design admits both of the following as **cases on this harness**, not forks:
 //!
-//! - **Value-equality oracle.** `OracleConfig::value_equality` defaults to `false` because the
-//!   catalog records WAL re-replay as known-not-merge-idempotent today (`TODO-598`). Flipping the
-//!   flag to `true` — with the suite still green — is `TODO-598`'s own closing evidence; no driver
-//!   change is needed to exercise it.
+//! - **Value-equality oracle.** `OracleConfig::value_equality` defaults to `false` (opt-in per run);
+//!   `TG-WAL-006` is enforced (LWW-scoped), so a run with the flag on is green on the fixed path and
+//!   `DefectMode::ReplayClobberOlderFrame` is caught by it. No driver change is needed to exercise it.
 //! - **OR-Map delta-fold recovery across a restart.** This lands as an `OrDelta`-shaped variant
 //!   added to [`WorkOp`] plus an OR-shaped variant added to [`ModelValue`] — the OR-Map delta-fold
 //!   recovery proof lands as a case on this harness, rather than a fork of it. The driver's

--- a/packages/server-rust/src/storage/datastores/wal_harness/mod.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/mod.rs
@@ -166,6 +166,13 @@ pub(crate) enum DefectMode {
     /// Re-introduces the `TG-WAL-003` hazard via `wal/mod.rs`'s new
     /// `GcOrderMode::UnlinkThenFsync` seam.
     UnlinkThenFsync,
+    /// Re-introduces the pre-`TG-WAL-006` recovery clobber via `wal/mod.rs`'s
+    /// `WalRecovery` test seams: the `RecordValue::Lww` merge gate is disabled
+    /// (blind replay) AND each partition's oldest un-applied frame is re-replayed
+    /// once more after the in-order pass — reproducing "an older frame is
+    /// re-applied over a newer durable value". Caught by the `value_equality`
+    /// oracle as an `AckedValueMismatch`.
+    ReplayClobberOlderFrame,
 }
 
 /// `wal/mod.rs::mark_applied` crash-injection point (R7), fired between the sidecar write+fsync
@@ -191,12 +198,17 @@ pub(crate) enum BootSeedMode {
 
 /// Which oracles are active for a run (R5).
 ///
-/// `value_equality` gates a byte-for-byte equality check between the model's acked value and the
-/// recovered value, layered on top of O1/O2. It defaults to `false` because `TG-WAL-006` (open,
-/// tracked as `TODO-598`) records that `RedbDataStore::write_one` is a blind insert with no
-/// read-compare merge — WAL re-replay is NOT merge-idempotent today. Turning this on before
-/// `TODO-598` lands would fire REDs on known, tracked behaviour rather than new defects; flipping it
-/// to `true` (with the suite still green) IS `TODO-598`'s closing evidence.
+/// `value_equality` gates an equality check between the model's latest acked value (its HLC
+/// millis) and the recovered value's `RecordValue::Lww` timestamp, layered on top of O1/O2. When on,
+/// a recovered value whose timestamp does not match the model's latest acked write is reported as an
+/// `AckedValueMismatch` — the shape a stale re-replay clobber produces.
+///
+/// It defaults to `false` deliberately: the equality oracle is opt-in per run, and
+/// `ac11_value_equality_defaults_off` guards that `OracleConfig::default()` never silently enables
+/// it. `TG-WAL-006` is now enforced (LWW-scoped): `WalRecovery::replay_entry` discards a modern Lww
+/// frame older than the current durable value, so the baseline suite is GREEN with this flag turned
+/// on — that green run is the closing evidence the invariant refers to. `DefectMode::ReplayClobberOlderFrame`
+/// re-introduces the pre-fix blind clobber and IS caught by this oracle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) struct OracleConfig {
     pub value_equality: bool,
@@ -333,5 +345,17 @@ pub(crate) enum InvariantViolation {
     SegmentUnlinkedBeforeWatermarkFsync {
         partition: PartitionId,
         sequence: Sequence,
+    },
+
+    /// `TG-WAL-006`: the recovered `RecordValue::Lww` value for `key` carries a timestamp STRICTLY
+    /// OLDER than the model's latest acked HLC millis — a stale re-replayed frame clobbered a newer
+    /// durable value. Only reported when the `value_equality` oracle is enabled. A recovered value
+    /// newer than the model's last-arrival is the LWW winner and is NOT flagged. Carries the
+    /// incarnation the mismatch surfaced at, the model's expected millis, and the recovered millis.
+    AckedValueMismatch {
+        key: Key,
+        incarnation: usize,
+        expected_millis: i64,
+        recovered_millis: i64,
     },
 }

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -2449,7 +2449,11 @@ mod tests {
         WalRecovery::replay_entry(&store, &lww_frame("k", 30), 0, true)
             .await
             .unwrap();
-        assert_eq!(load_millis(&store, "k").await, Some(30), "ties write through");
+        assert_eq!(
+            load_millis(&store, "k").await,
+            Some(30),
+            "ties write through"
+        );
 
         // Gate OFF: the same older frame clobbers — the pre-fix blind replay.
         WalRecovery::replay_entry(&store, &lww_frame("k", 10), 0, false)

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -1628,16 +1628,33 @@ impl WalRecovery {
     /// Replays ONE entry through the inner store.
     ///
     /// Goes straight to the store rather than through the CRDT service layer, so
-    /// there is NO merge here.
+    /// the merge that upholds re-replay idempotency lives HERE, at the recovery
+    /// boundary, not in the store (`write_one` stays a CRDT-agnostic blind insert).
     ///
-    /// Re-replay safety today rests ONLY on in-sequence-order replay plus
-    /// last-frame-wins WITHIN the replayed window: the window's frames are applied
-    /// in ascending sequence order, so the newest frame in the window is the one
-    /// that survives. The store's `write_one` is a blind insert with NO
-    /// read-compare merge, so a stale replayed frame CAN clobber a newer durable
-    /// value written outside the window (reproduced; tracked as TODO-598).
+    /// Re-replay of a `RecordValue::Lww` frame is idempotent (TG-WAL-006): before
+    /// applying a modern Lww frame this reads the current durable value and, if the
+    /// incoming frame's HLC timestamp is strictly OLDER than the stored value's,
+    /// discards it (last-write-wins by timestamp). A stale replayed frame therefore
+    /// can no longer clobber a newer durable value written outside the replay window
+    /// (e.g. a frameless write-behind flush). Ties and newer timestamps write
+    /// through unchanged. The read-then-write is not atomic, which is safe because
+    /// recovery runs before the listener accepts connections — there are no
+    /// concurrent writers at boot.
     ///
-    /// Do NOT rely on re-replay idempotency until TODO-598 closes.
+    /// The gate is scoped to modern `WalStorePayload::Record(RecordValue::Lww)`
+    /// frames only:
+    /// - `WalStorePayload::Legacy` frames carry a SYNTHESIZED timestamp (zero-epoch
+    ///   when the WAL recorded none) whose intent is always-merge, so they BYPASS
+    ///   the gate and keep the pre-existing blind replay.
+    /// - `RecordValue::OrMap`/`OrTombstones` frames BYPASS the gate: their
+    ///   convergence is set-union of tags+tombstones, not a scalar timestamp max,
+    ///   and each per-key OR frame is a post-RMW full snapshot that is monotone in
+    ///   `wal_seq` order, so in-sequence replay converges to the newest snapshot
+    ///   regardless of re-replay. OR merge-idempotency as its own property is owned
+    ///   by `TG-OR-003` (SPEC-349b), not this path.
+    /// - A cross-kind case (stored value is not `Lww` while the incoming frame is)
+    ///   cannot be compared by timestamp, so it also BYPASSES the gate and writes
+    ///   through.
     async fn replay_entry(
         inner_store: &Arc<dyn MapDataStore>,
         entry: &WalEntry,
@@ -1667,6 +1684,30 @@ impl WalRecovery {
                         }
                     }
                 };
+
+                // Merge-idempotency gate (TG-WAL-006), scoped to modern Lww frames.
+                // Only a `Record`-payload `Lww` frame carries a real value timestamp
+                // to compare; if the current durable value is a strictly-newer Lww
+                // value, this frame is stale (it was superseded by a write outside
+                // the replay window) and must be discarded rather than clobber it.
+                // Legacy frames, OR frames, and a non-Lww stored value all fall
+                // through to the blind replay unchanged (see the doc-contract above).
+                if let WalStorePayload::Record(RecordValue::Lww {
+                    timestamp: incoming_ts,
+                    ..
+                }) = value
+                {
+                    if let Some(RecordValue::Lww {
+                        timestamp: stored_ts,
+                        ..
+                    }) = inner_store.load(&entry.map, &entry.key).await?
+                    {
+                        if *incoming_ts < stored_ts {
+                            return Ok(());
+                        }
+                    }
+                }
+
                 inner_store
                     .add(
                         &entry.map,
@@ -1707,12 +1748,14 @@ impl WalRecovery {
     /// own frame. Frames above the frontier stay in the replay window and are
     /// re-applied on a later boot.
     ///
-    /// That re-application is bounded, NOT idempotent. Its safety rests ONLY on
-    /// in-sequence-order replay plus last-frame-wins WITHIN the replayed window —
-    /// the inner store does NOT merge by timestamp: `write_one` is a blind insert
-    /// with no read-compare, so a stale replayed frame CAN clobber a newer durable
-    /// value written outside the window (reproduced; tracked as TODO-598). Do NOT
-    /// rely on re-replay idempotency until TODO-598 closes.
+    /// That re-application is idempotent for `RecordValue::Lww` (TG-WAL-006):
+    /// `replay_entry` reads the current durable value and discards a frame whose HLC
+    /// timestamp is strictly older, so a stale replayed frame can no longer clobber a
+    /// newer durable value written outside the window (e.g. a frameless write-behind
+    /// flush). `OrMap`/`OrTombstones` frames are idempotent by pre-existing
+    /// monotonicity (post-RMW full snapshots, monotone in `wal_seq` order), not by
+    /// this merge; their own merge-idempotency property is owned by `TG-OR-003`
+    /// (SPEC-349b). Legacy frames keep always-merge replay.
     ///
     /// A partition whose frontier stops below its highest enumerated frame raises
     /// the abandoned-write alarm here, at boot. Write-behind's watchdog cannot
@@ -1771,9 +1814,10 @@ impl WalRecovery {
                     Ok(()) => {
                         // Only a success that is still contiguous with the prefix
                         // may advance the frontier. Once an entry has failed, later
-                        // successes are kept (replay is idempotent, so re-running
-                        // them next boot is free) but they must NOT license GC of
-                        // the frame that failed.
+                        // successes are kept (replay is idempotent for Lww via the
+                        // read-compare in `replay_entry`, and for OR via snapshot
+                        // monotonicity, so re-running them next boot is free) but
+                        // they must NOT license GC of the frame that failed.
                         if first_failed.is_none() {
                             frontier = entry.sequence;
                         }

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -1597,6 +1597,17 @@ pub struct WalRecovery {
     wal: Arc<WalWriter>,
     /// Partition IDs to recover. If empty, all log files in `wal_dir` are used.
     partitions: Vec<u32>,
+    /// Whether the `RecordValue::Lww` merge-idempotency gate in `replay_entry` is
+    /// active. Always `true` in production; the harness flips it off to reproduce
+    /// the pre-`TG-WAL-006` blind clobber.
+    replay_merge_gate: bool,
+    /// Whether `run` re-replays each partition's oldest un-applied frame once more
+    /// after the in-order pass — a harness seam that manufactures the "older frame
+    /// re-applied over a newer durable value" condition the live `flush_key` path
+    /// produces but generated ops cannot. `#[cfg(test)]`-only: it does not exist in
+    /// a production build.
+    #[cfg(test)]
+    re_replay_oldest_frame: bool,
 }
 
 impl WalRecovery {
@@ -1604,7 +1615,28 @@ impl WalRecovery {
     /// partition IDs. Pass an empty slice to auto-discover partitions from the
     /// log files in `wal_dir`.
     pub fn new(wal: Arc<WalWriter>, partitions: Vec<u32>) -> Self {
-        Self { wal, partitions }
+        Self {
+            wal,
+            partitions,
+            replay_merge_gate: true,
+            #[cfg(test)]
+            re_replay_oldest_frame: false,
+        }
+    }
+
+    /// Test-only: disable (or re-enable) the `RecordValue::Lww` merge gate in
+    /// `replay_entry`. Disabling it reproduces the pre-`TG-WAL-006` blind replay.
+    #[cfg(test)]
+    pub(crate) fn test_set_replay_merge_gate(&mut self, enabled: bool) {
+        self.replay_merge_gate = enabled;
+    }
+
+    /// Test-only: after the in-order replay pass, re-replay each partition's oldest
+    /// un-applied frame once more — the harness seam that reproduces a stale
+    /// re-replay over a newer durable value.
+    #[cfg(test)]
+    pub(crate) fn test_set_re_replay_oldest_frame(&mut self, enabled: bool) {
+        self.re_replay_oldest_frame = enabled;
     }
 
     /// Discovers partition IDs by scanning `wal_dir` for segment files
@@ -1659,6 +1691,7 @@ impl WalRecovery {
         inner_store: &Arc<dyn MapDataStore>,
         entry: &WalEntry,
         now: i64,
+        merge_gate: bool,
     ) -> anyhow::Result<()> {
         match &entry.op {
             WalOp::Store {
@@ -1692,18 +1725,22 @@ impl WalRecovery {
                 // the replay window) and must be discarded rather than clobber it.
                 // Legacy frames, OR frames, and a non-Lww stored value all fall
                 // through to the blind replay unchanged (see the doc-contract above).
-                if let WalStorePayload::Record(RecordValue::Lww {
-                    timestamp: incoming_ts,
-                    ..
-                }) = value
-                {
-                    if let Some(RecordValue::Lww {
-                        timestamp: stored_ts,
+                // `merge_gate` is always `true` in production; the harness flips it
+                // off to reproduce the pre-fix blind clobber.
+                if merge_gate {
+                    if let WalStorePayload::Record(RecordValue::Lww {
+                        timestamp: incoming_ts,
                         ..
-                    }) = inner_store.load(&entry.map, &entry.key).await?
+                    }) = value
                     {
-                        if *incoming_ts < stored_ts {
-                            return Ok(());
+                        if let Some(RecordValue::Lww {
+                            timestamp: stored_ts,
+                            ..
+                        }) = inner_store.load(&entry.map, &entry.key).await?
+                        {
+                            if *incoming_ts < stored_ts {
+                                return Ok(());
+                            }
                         }
                     }
                 }
@@ -1810,7 +1847,7 @@ impl WalRecovery {
             let now = current_millis();
 
             for entry in &entries {
-                match Self::replay_entry(&inner_store, entry, now).await {
+                match Self::replay_entry(&inner_store, entry, now, self.replay_merge_gate).await {
                     Ok(()) => {
                         // Only a success that is still contiguous with the prefix
                         // may advance the frontier. Once an entry has failed, later
@@ -1837,6 +1874,22 @@ impl WalRecovery {
                         );
                         first_failed.get_or_insert(entry.sequence);
                     }
+                }
+            }
+
+            // Harness-only seam: re-replay the oldest un-applied frame once more,
+            // AFTER the in-order pass has left the newest value durable. This
+            // reproduces the stale re-replay the live `flush_key` path can cause
+            // (an older frame lingering in the replay window over a frameless newer
+            // durable write) — a condition generated ops cannot manufacture because
+            // in-order replay always ends on the newest frame. With the merge gate
+            // on (production) the re-replayed older frame is discarded; with it off
+            // it clobbers, which the `value_equality` oracle catches.
+            #[cfg(test)]
+            if self.re_replay_oldest_frame {
+                if let Some(oldest) = entries.first() {
+                    let _ =
+                        Self::replay_entry(&inner_store, oldest, now, self.replay_merge_gate).await;
                 }
             }
 
@@ -2186,6 +2239,311 @@ mod tests {
             timestamp: Some(timestamp),
             sequence: seq,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // TG-WAL-006 — replay merge-idempotency (LWW-scoped) direct unit tests
+    // -----------------------------------------------------------------------
+
+    /// A load-serving in-memory `MapDataStore`: unlike `ReplayStore` (records-only,
+    /// `load` returns `None`), this serves back what was last written so the
+    /// `replay_entry` merge gate can read the current durable value.
+    #[derive(Default)]
+    struct MergeProbeStore {
+        data: tokio::sync::Mutex<
+            std::collections::HashMap<(String, String), crate::storage::record::RecordValue>,
+        >,
+    }
+
+    #[async_trait]
+    impl MapDataStore for MergeProbeStore {
+        async fn add(
+            &self,
+            map: &str,
+            key: &str,
+            value: &crate::storage::record::RecordValue,
+            _exp: i64,
+            _now: i64,
+        ) -> anyhow::Result<()> {
+            self.data
+                .lock()
+                .await
+                .insert((map.to_string(), key.to_string()), value.clone());
+            Ok(())
+        }
+        async fn add_backup(
+            &self,
+            _map: &str,
+            _key: &str,
+            _value: &crate::storage::record::RecordValue,
+            _exp: i64,
+            _now: i64,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn remove(&self, map: &str, key: &str, _now: i64) -> anyhow::Result<()> {
+            self.data
+                .lock()
+                .await
+                .remove(&(map.to_string(), key.to_string()));
+            Ok(())
+        }
+        async fn remove_backup(&self, _map: &str, _key: &str, _now: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn load(
+            &self,
+            map: &str,
+            key: &str,
+        ) -> anyhow::Result<Option<crate::storage::record::RecordValue>> {
+            Ok(self
+                .data
+                .lock()
+                .await
+                .get(&(map.to_string(), key.to_string()))
+                .cloned())
+        }
+        async fn load_all(
+            &self,
+            _map: &str,
+            _keys: &[String],
+        ) -> anyhow::Result<Vec<(String, crate::storage::record::RecordValue)>> {
+            Ok(Vec::new())
+        }
+        async fn remove_all(&self, map: &str, keys: &[String]) -> anyhow::Result<()> {
+            for k in keys {
+                self.remove(map, k, 0).await?;
+            }
+            Ok(())
+        }
+        async fn enumerate_leaves(
+            &self,
+            _map: &str,
+            _is_backup: bool,
+            _sink: &mut dyn crate::storage::map_data_store::LeafSink,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn scan_values(
+            &self,
+            _map: &str,
+            _is_backup: bool,
+            _max_batch_cost: u64,
+        ) -> anyhow::Result<crate::storage::map_data_store::ScanBatch> {
+            Ok(crate::storage::map_data_store::ScanBatch::default())
+        }
+        async fn scan_values_batched(
+            &self,
+            _map: &str,
+            _is_backup: bool,
+            _cursor: crate::storage::map_data_store::ScanCursor,
+            _max_batch_cost: u64,
+        ) -> anyhow::Result<crate::storage::map_data_store::ScanBatch> {
+            Ok(crate::storage::map_data_store::ScanBatch::default())
+        }
+        fn is_loadable(&self, _key: &str) -> bool {
+            true
+        }
+        fn pending_operation_count(&self) -> u64 {
+            0
+        }
+        async fn soft_flush(&self) -> anyhow::Result<u64> {
+            Ok(0)
+        }
+        async fn hard_flush(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn flush_key(
+            &self,
+            _map: &str,
+            _key: &str,
+            _value: &crate::storage::record::RecordValue,
+            _backup: bool,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn reset(&self) {}
+        fn is_null(&self) -> bool {
+            false
+        }
+    }
+
+    fn ts(millis: u64) -> Timestamp {
+        Timestamp {
+            millis,
+            counter: 0,
+            node_id: "n".to_string(),
+        }
+    }
+
+    fn lww_frame(key: &str, millis: u64) -> WalEntry {
+        WalEntry {
+            map: "m".to_string(),
+            key: key.to_string(),
+            op: WalOp::Store {
+                value: WalStorePayload::Record(RecordValue::Lww {
+                    value: TgValue::Int(i64::try_from(millis).unwrap()),
+                    timestamp: ts(millis),
+                }),
+                expiration_time: None,
+            },
+            timestamp: None,
+            sequence: 1,
+        }
+    }
+
+    fn record_frame(key: &str, value: RecordValue) -> WalEntry {
+        WalEntry {
+            map: "m".to_string(),
+            key: key.to_string(),
+            op: WalOp::Store {
+                value: WalStorePayload::Record(value),
+                expiration_time: None,
+            },
+            timestamp: None,
+            sequence: 1,
+        }
+    }
+
+    async fn load_millis(store: &Arc<dyn MapDataStore>, key: &str) -> Option<u64> {
+        match store.load("m", key).await.unwrap() {
+            Some(RecordValue::Lww { timestamp, .. }) => Some(timestamp.millis),
+            _ => None,
+        }
+    }
+
+    /// TG-WAL-006: the `RecordValue::Lww` gate in `replay_entry` discards a frame
+    /// OLDER than the current durable value, writes through ties/newer, and — with
+    /// the gate off — reproduces the pre-fix blind clobber. This isolates the GATE
+    /// as the fix (independent of the harness's re-replay seam).
+    #[tokio::test]
+    async fn replay_lww_gate_discards_older_frame_isolated() {
+        let store: Arc<dyn MapDataStore> = Arc::new(MergeProbeStore::default());
+        let newer = RecordValue::Lww {
+            value: TgValue::Int(20),
+            timestamp: ts(20),
+        };
+
+        // Gate ON: an older (ts=10) frame over a newer (ts=20) durable value is discarded.
+        store.add("m", "k", &newer, 0, 0).await.unwrap();
+        WalRecovery::replay_entry(&store, &lww_frame("k", 10), 0, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            load_millis(&store, "k").await,
+            Some(20),
+            "gate ON must discard the older frame (no clobber)"
+        );
+
+        // Gate ON: a newer (ts=30) frame writes through.
+        WalRecovery::replay_entry(&store, &lww_frame("k", 30), 0, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            load_millis(&store, "k").await,
+            Some(30),
+            "gate ON must let a newer frame write through"
+        );
+
+        // Gate ON: an equal-timestamp frame writes through (ties, not strictly older).
+        WalRecovery::replay_entry(&store, &lww_frame("k", 30), 0, true)
+            .await
+            .unwrap();
+        assert_eq!(load_millis(&store, "k").await, Some(30), "ties write through");
+
+        // Gate OFF: the same older frame clobbers — the pre-fix blind replay.
+        WalRecovery::replay_entry(&store, &lww_frame("k", 10), 0, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            load_millis(&store, "k").await,
+            Some(10),
+            "gate OFF reproduces the blind clobber (the defect the fix closes)"
+        );
+    }
+
+    /// TG-WAL-006 scope: `OrMap`/`OrTombstones` frames and cross-kind (non-Lww
+    /// stored) frames BYPASS the Lww read-compare — proven directly, since the
+    /// harness `ModelValue` is LWW-only and cannot drive OR frames. Also proves a
+    /// `Legacy` frame keeps always-merge replay.
+    #[tokio::test]
+    async fn replay_or_crosskind_and_legacy_bypass_lww_gate() {
+        let store: Arc<dyn MapDataStore> = Arc::new(MergeProbeStore::default());
+
+        // (a) OR-over-OR: with the gate ON, an OR frame blind-overwrites the durable
+        // OR value — the Lww read-compare never intercepts an OR-valued frame.
+        let durable_or = RecordValue::OrMap {
+            records: vec![],
+            tombstones: vec!["B".to_string()],
+        };
+        store.add("m", "o", &durable_or, 0, 0).await.unwrap();
+        let or_frame = RecordValue::OrMap {
+            records: vec![],
+            tombstones: vec!["A".to_string()],
+        };
+        WalRecovery::replay_entry(&store, &record_frame("o", or_frame.clone()), 0, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.load("m", "o").await.unwrap(),
+            Some(or_frame),
+            "an OR frame must bypass the Lww gate and blind-overwrite (no timestamp compare)"
+        );
+
+        // (b) cross-kind: an OLDER Lww frame over a non-Lww (OR) stored value must
+        // write through — the gate's inner `Some(Lww)` match fails on an OR value.
+        WalRecovery::replay_entry(&store, &lww_frame("o", 1), 0, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            load_millis(&store, "o").await,
+            Some(1),
+            "a Lww frame over a non-Lww stored value writes through (cross-kind bypass)"
+        );
+
+        // (c) legacy: a `Legacy` payload has no real timestamp (synthesized
+        // zero-epoch) and must always-merge — bypass the gate even over a newer value.
+        let store2: Arc<dyn MapDataStore> = Arc::new(MergeProbeStore::default());
+        store2
+            .add(
+                "m",
+                "k",
+                &RecordValue::Lww {
+                    value: TgValue::Int(50),
+                    timestamp: ts(50),
+                },
+                0,
+                0,
+            )
+            .await
+            .unwrap();
+        let legacy = WalEntry {
+            map: "m".to_string(),
+            key: "k".to_string(),
+            op: WalOp::Store {
+                value: WalStorePayload::Legacy(TgValue::Int(1)),
+                expiration_time: None,
+            },
+            timestamp: None,
+            sequence: 1,
+        };
+        WalRecovery::replay_entry(&store2, &legacy, 0, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            store2.load("m", "k").await.unwrap(),
+            Some(RecordValue::Lww {
+                value: TgValue::Int(1),
+                // Legacy frames with no WAL timestamp reconstruct a zero-epoch HLC
+                // with an EMPTY node id (see `replay_entry`).
+                timestamp: Timestamp {
+                    millis: 0,
+                    counter: 0,
+                    node_id: String::new(),
+                },
+            }),
+            "a legacy frame must always-merge (bypass the gate) even over a newer value"
+        );
     }
 
     /// Manual measurement of the per-append fsync tax of each `WalFsyncPolicy`.
@@ -3156,7 +3514,9 @@ mod tests {
         let mut entry = make_wal_entry(1);
         entry.op = WalOp::TestNonSubsuming;
         assert!(
-            WalRecovery::replay_entry(&store, &entry, 0).await.is_err(),
+            WalRecovery::replay_entry(&store, &entry, 0, true)
+                .await
+                .is_err(),
             "a framing with no replay semantics must surface an error, never be \
              silently absorbed by a catch-all arm"
         );

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -1683,7 +1683,7 @@ impl WalRecovery {
     ///   and each per-key OR frame is a post-RMW full snapshot that is monotone in
     ///   `wal_seq` order, so in-sequence replay converges to the newest snapshot
     ///   regardless of re-replay. OR merge-idempotency as its own property is owned
-    ///   by `TG-OR-003` (SPEC-349b), not this path.
+    ///   by `TG-OR-003`, not this path.
     /// - A cross-kind case (stored value is not `Lww` while the incoming frame is)
     ///   cannot be compared by timestamp, so it also BYPASSES the gate and writes
     ///   through.
@@ -1791,8 +1791,8 @@ impl WalRecovery {
     /// newer durable value written outside the window (e.g. a frameless write-behind
     /// flush). `OrMap`/`OrTombstones` frames are idempotent by pre-existing
     /// monotonicity (post-RMW full snapshots, monotone in `wal_seq` order), not by
-    /// this merge; their own merge-idempotency property is owned by `TG-OR-003`
-    /// (SPEC-349b). Legacy frames keep always-merge replay.
+    /// this merge; their own merge-idempotency property is owned by `TG-OR-003`.
+    /// Legacy frames keep always-merge replay.
     ///
     /// A partition whose frontier stops below its highest enumerated frame raises
     /// the abandoned-write alarm here, at boot. Write-behind's watchdog cannot


### PR DESCRIPTION
## Summary

Roadmap step 5 (TODO-598): closes the replay-clobber defect SPEC-350 honestly escalated (AC4(b)) and flips **TG-WAL-006 from known-false to enforced (LWW-scoped)**.

- **The fix:** a `RecordValue::Lww`-gated read-compare merge in `wal/mod.rs::replay_entry` — recovery discards a modern Lww frame whose HLC timestamp is strictly older than the current durable value (ties and newer write through). `write_one` stays a CRDT-agnostic blind insert; the merge lives at the recovery boundary (option (ii), /xask-pinned: uses the existing `load`, no trait change).
- **Honest scoping:** `Legacy` / `OrMap` / `OrTombstones` / cross-kind frames BYPASS the gate — proven by a routing test. OR-Map merge-idempotency is NOT over-claimed: per-key OR snapshots are post-RMW under the writer lock (monotone in seq order), and the independent property is owned by TG-OR-003 / SPEC-349b (TODO-608).
- **Proof:** direct unit tests (older discarded / ties-newer through / gate-off clobbers / bypass routing) + the wal_harness `ReplayClobberOlderFrame` defect mode caught by the value-equality oracle (first combat use of the SPEC-352 harness).
- /xreview (glm-5.2): production fix confirmed on all axes; two verified-real instrument-genericity findings tracked as TODO-610 (oracle latest-arrival vs max-timestamp — zero current runs affected; correctness rests on the direct tests independently).

## Test evidence
`cargo test --release -p topgun-server` 1704+/0 · clippy `-D warnings` · fmt · `pnpm test:sim` 0 failed · `check-invariants.sh` 5 NAKED == baseline · audits ×2, review APPROVED (1 minor applied).

## Carried
TODO-608 (OR residue → SPEC-349b) · **TODO-609 (same-class `WalOp::Remove` clobber gap — /xask find; recommended next as a small spec before SPEC-349)** · TODO-610 (oracle genericity; rides with 349b's flush-standby reachability work; not 72h-gating).