### PR TITLE
WAL Remove replay gate — REFUTED: structural proof + catalog enforcement, nil production delta [SPEC-354]

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -194,6 +194,12 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
   both `merge_gate` values — the discriminator vs the reverted gate) and the harness case
   `wal_harness::cases::ac1_ac6_stale_remove_clobber_caught_by_o1_oracle` (O1 `AckedWriteLost` catches
   the seam-injected out-of-order clobber; the `DefectMode::None` in-order run is green).
+  **Coverage note (deliberate narrowing):** the GENERATIVE baseline is not a second guard for the
+  gate-free property. `wal_harness`'s generator constrains arrival to a monotone-HLC domain (the O1
+  oracle's sound domain, `make_hlc_monotone`), which narrows it out of the range where a reintroduced
+  Remove gate would surface as `AckedWriteLost`. The isolated unit test above is therefore the SOLE
+  enforcing guard against gate reintroduction; oracle genericity over the non-monotone domain is owned
+  by TODO-610.
 - **Sibling invariant (DISTINCT):** `TG-WAL-006` owns the same re-replay-idempotency loss-class for
   `RecordValue::Lww` VALUES — there a gate IS correct because live-Store is HLC-conditional (LWW), so
   replay must mirror that compare. Remove is the counterpart whose live semantics are UNCONDITIONAL,
@@ -217,7 +223,17 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
   an older op on the same key — premise (c) of `TG-WAL-009`.
 - **Maintaining code:** `write_behind.rs` `next_wal_sequence` (atomic `fetch_add`) + `assign_wal_sequence`.
 - **Enforcing test:** `write_behind.rs::tests::wal_sequence_assignment_is_strictly_monotone_per_partition`
-  — 2000 concurrent assigns on ONE partition are all distinct and strictly increasing when sorted.
+  — 8 tasks on 8 DISTINCT partitions × 250 assigns each, asserting BOTH clauses: each partition's own
+  returns are strictly increasing in ARRIVAL order (per-partition monotonicity, the `M > N` step), and
+  all 2000 values are globally distinct (no reuse). Spreading across partitions is load-bearing for
+  discrimination, not incidental: `assign_wal_sequence` mints inside `with_partition`, i.e. under that
+  partition's OWN mutex, so a single-partition variant stays GREEN — and the whole lib suite with it —
+  when the `fetch_add` is replaced by a racy load/yield/store, because the lock serializes the bump and
+  hides whether the counter is atomic at all. Across 8 partitions the mutexes no longer overlap and the
+  same mutation goes RED on the ARRIVAL-ORDER assertion (observed: partition 0 returned `… 83, 75 …`,
+  i.e. the counter moved backwards), which aborts the test before the distinctness assertion is reached;
+  a distinctness-only variant of this test reports the same break as ~705 distinct values out of 2000.
+  Mutation-verified in both directions (green with `fetch_add`, red without).
 - **Violation consequence:** sequence reuse or non-monotone assignment breaks both the prefix-complete
   watermark and `TG-WAL-009`'s `M > N` step, admitting a stale-Remove clobber.
 - **Discovered by:** SPEC-354 Review v2 (cataloguing the gate-free warrant's premises).
@@ -234,8 +250,10 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
 - **Maintaining code:** `wal/mod.rs::WalWriter::unapplied` (the `all.sort_by_key(|e| e.sequence)`
   before the `applied_seq` filter) + `WalRecovery::run`'s in-order replay loop.
 - **Enforcing test:** `wal/mod.rs::tests::wal_recovery_replays_in_strictly_ascending_sequence_order`
-  — frames appended out of order (seq 3, 1, 2) are returned by `unapplied` and replayed 1, 2, 3;
-  removing the `sort_by_key` makes both assertions FAIL.
+  — frames appended out of order (seq 3, 1, 2) are returned by `unapplied` and replayed 1, 2, 3.
+  Mutation-verified: removing the `sort_by_key` fails the FIRST assertion (`unapplied`'s returned order,
+  `left: [3, 1, 2]` vs `right: [1, 2, 3]`), which aborts the test before the replay-order assertion is
+  reached — so the enforcement is real, but it is the enumeration-order assertion that discriminates.
 - **Violation consequence:** out-of-order replay would let a stale Remove delete a strictly-newer
   re-creation replayed before it, or miscompute the contiguous frontier — an acked-write loss.
 - **Discovered by:** SPEC-354 Review v2 (cataloguing the gate-free warrant's premises).

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -168,9 +168,20 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
   Remove, re-creating the value) or the Remove is the newest op for the key (deleting is
   live-correct). The stale-Remove-over-newer-frameless-value juxtaposition is reachable ONLY by
   re-applying an already-applied older frame after the in-order pass — the harness
-  `re_replay_oldest_frame` seam, never a production path. Both premises are themselves enforced here:
-  prefix-complete watermark (`TG-WB-001` / `TG-WAL-003`) and single-partition-per-key (`partition_for`
-  is deterministic).
+  `re_replay_oldest_frame` seam, never a production path. The chain rests on FOUR premises, EACH an
+  enforced invariant (not asserted prose):
+  - **(a) prefix-complete watermark** — `W = min(unresolved) - 1`, never at/above an unresolved
+    sequence, so `N > W` bounds the replay window: `TG-WAL-005` / `TG-WB-001` / `TG-WAL-003`.
+  - **(b) one sequence space per key** — `partition_for(map, key)` is deterministic, so a key's ops
+    are all sequenced in a single per-partition space (this is a SINGLE-SPACE claim, NOT itself an
+    ordering claim; the ordering is (c)/(d)): `partition_for` is a pure function.
+  - **(c) strictly-monotone per-partition sequence assignment** — a later arrival gets a strictly
+    HIGHER sequence, which is what makes the re-creation `M > N`: `TG-WAL-010`.
+  - **(d) strictly-ascending replay of the unapplied window** — a frame at `M > N` is replayed AFTER
+    the Remove at `N`, so the re-creation survives: `TG-WAL-011`.
+  Premises (c) and (d) carry the load-bearing `M > N` and replayed-after steps; (a) and (b) bound the
+  window and the sequence space. (b) alone is necessary-but-insufficient for the ordering — it is
+  (c)+(d) that order the space.
 - **Windowing residual (tracked, NOT closed by a gate):** the only genuine out-of-order hazard — a
   frameless `flush_key` durable write racing an un-resolved older Remove — is a WATERMARK/FRAMING
   concern, not a Remove-idempotency one, so it is routed to TODO-612 (SPEC-349/windowing), not
@@ -194,6 +205,41 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
   TODO-609); SPEC-354 Review v1 caught the unsound gate (an `AckedWriteLost` regression); closed by
   SPEC-354 via a pre-fix `/xask` + a structural non-reachability spike.
 - **Status:** decided, **enforced (Remove-scoped)**.
+
+### TG-WAL-010: Per-partition WAL sequence assignment is strictly monotone
+
+- **Scope:** `WriteBehindDataStore::assign_wal_sequence` — the single mint point for a mutation's WAL
+  sequence — per partition.
+- **Statement:** every assigned WAL sequence is drawn from one process-global atomic counter
+  (`next_wal_sequence`, a `fetch_add`), so a partition's assigned sequences are a strictly-increasing
+  subsequence: no sequence is ever reused, and a later arrival gets a strictly HIGHER sequence than
+  an earlier op on the same partition. This is what makes a re-created value carry `M > N` relative to
+  an older op on the same key — premise (c) of `TG-WAL-009`.
+- **Maintaining code:** `write_behind.rs` `next_wal_sequence` (atomic `fetch_add`) + `assign_wal_sequence`.
+- **Enforcing test:** `write_behind.rs::tests::wal_sequence_assignment_is_strictly_monotone_per_partition`
+  — 2000 concurrent assigns on ONE partition are all distinct and strictly increasing when sorted.
+- **Violation consequence:** sequence reuse or non-monotone assignment breaks both the prefix-complete
+  watermark and `TG-WAL-009`'s `M > N` step, admitting a stale-Remove clobber.
+- **Discovered by:** SPEC-354 Review v2 (cataloguing the gate-free warrant's premises).
+- **Status:** decided, **enforced**.
+
+### TG-WAL-011: WAL recovery replays the unapplied window in strictly ascending sequence order
+
+- **Scope:** `Wal::unapplied` ordering contract + `WalRecovery::run` replay loop.
+- **Statement:** `Wal::unapplied` returns the unapplied window sorted strictly ascending by WAL
+  sequence — a defensive `sort_by_key(|e| e.sequence)` that holds REGARDLESS of the order frames were
+  appended or enumerated across segments — and `run` replays that Vec in order. A frame at sequence
+  `M > N` is therefore always replayed AFTER the frame at `N` (premise (d) of `TG-WAL-009`), and the
+  contiguous-success frontier the applied watermark advances to is well-defined by sequence.
+- **Maintaining code:** `wal/mod.rs::WalWriter::unapplied` (the `all.sort_by_key(|e| e.sequence)`
+  before the `applied_seq` filter) + `WalRecovery::run`'s in-order replay loop.
+- **Enforcing test:** `wal/mod.rs::tests::wal_recovery_replays_in_strictly_ascending_sequence_order`
+  — frames appended out of order (seq 3, 1, 2) are returned by `unapplied` and replayed 1, 2, 3;
+  removing the `sort_by_key` makes both assertions FAIL.
+- **Violation consequence:** out-of-order replay would let a stale Remove delete a strictly-newer
+  re-creation replayed before it, or miscompute the contiguous frontier — an acked-write loss.
+- **Discovered by:** SPEC-354 Review v2 (cataloguing the gate-free warrant's premises).
+- **Status:** decided, **enforced**.
 
 ### TG-WB-001: The flushed watermark is prefix-complete — no mid-range hole
 

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -146,6 +146,40 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
 - **Discovered by:** SPEC-350 Audit v7 (two-class split), v10–v12 (races).
 - **Status:** decided, **enforced**.
 
+### TG-WAL-009: WAL re-replay is idempotent for `WalOp::Remove` (enforced, Remove-scoped)
+
+- **Scope:** `WalRecovery::replay_entry` `WalOp::Remove` arm, for a frame carrying the removed
+  value's HLC in `entry.timestamp`.
+- **Statement (positive):** re-replaying a stale `WalOp::Remove` MUST NOT delete a durable value
+  re-created after it: `replay_entry` reads the current durable value and, when the frame carries a
+  REAL sourced HLC and the stored value is a `RecordValue::Lww` whose HLC is STRICTLY NEWER, discards
+  the Remove (last-write-wins by timestamp — the value was re-created after the Remove). Ties, an
+  older/absent target, and a non-`Lww` stored value all delete as before, so a legitimate deletion
+  is never suppressed. The zero-epoch sentinel `{0,0,""}` (stamped for an absent-key Remove, distinct
+  on the wire from legacy `None`) is a synthetic bottom, NOT a sound causal position, so the gate
+  does NOT skip on it — a sentinel Remove DELETES. This is required for soundness: an older un-durable
+  `Store` frame can replay just before a Remove in the same in-order pass, and skipping on a synthetic
+  bottom would resurrect a value the Remove is the last writer of. An absent-at-remove-time key needs
+  no sentinel protection because any re-creation is a fresh write carrying its own later WAL frame,
+  applied after the Remove. A legacy `None`-timestamp Remove (older server) likewise BYPASSES the
+  guard and always deletes, keeping the upgrade path over a pre-existing on-disk WAL intact.
+- **Maintaining code:** `wal/mod.rs::replay_entry` (the `WalOp::Remove` read-compare guard) + `run` /
+  `WalEntry` doc-contracts; `datastores/write_behind.rs::remove_frame_timestamp` populates the frame
+  HLC from the removed value at both `remove`/`remove_all` append sites.
+- **Enforcing test:** `wal/mod.rs::tests::replay_remove_gate_discards_stale_remove_isolated`
+  (strictly-older discarded, sentinel protects, tie/newer delete, gate-off clobbers) and
+  `::replay_legacy_remove_bypasses_gate` (the legacy-bypass proof); the harness case
+  `wal_harness::cases::ac1_ac6_stale_remove_clobber_caught_by_o1_oracle` (O1 `AckedWriteLost` catches
+  the clobber under the defect seam; the `DefectMode::None` run is green).
+- **Sibling invariant (DISTINCT):** `TG-WAL-006` owns the same re-replay-idempotency loss-class for
+  `RecordValue::Lww` VALUES; this invariant is the `WalOp::Remove` counterpart and is scoped strictly
+  to the Remove OP — the two share the recovery-boundary layering but not a comparison basis.
+- **Violation consequence:** acked-write loss on crash-recovery — a stale re-replayed Remove deletes
+  a value re-created after it (the durable re-creation vanishes).
+- **Discovered by:** SPEC-353 `/xask` (Review v1 flagged the Remove-clobber as the same loss-class,
+  routed to TODO-609); closed by SPEC-354.
+- **Status:** decided, **enforced (Remove-scoped)**.
+
 ### TG-WB-001: The flushed watermark is prefix-complete — no mid-range hole
 
 - **Scope:** entry-ordering-space `pending_seqs` / `flushed_watermark()` (tombstone fence

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -148,36 +148,51 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
 
 ### TG-WAL-009: WAL re-replay is idempotent for `WalOp::Remove` (enforced, Remove-scoped)
 
-- **Scope:** `WalRecovery::replay_entry` `WalOp::Remove` arm, for a frame carrying the removed
-  value's HLC in `entry.timestamp`.
-- **Statement (positive):** re-replaying a stale `WalOp::Remove` MUST NOT delete a durable value
-  re-created after it: `replay_entry` reads the current durable value and, when the frame carries a
-  REAL sourced HLC and the stored value is a `RecordValue::Lww` whose HLC is STRICTLY NEWER, discards
-  the Remove (last-write-wins by timestamp — the value was re-created after the Remove). Ties, an
-  older/absent target, and a non-`Lww` stored value all delete as before, so a legitimate deletion
-  is never suppressed. The zero-epoch sentinel `{0,0,""}` (stamped for an absent-key Remove, distinct
-  on the wire from legacy `None`) is a synthetic bottom, NOT a sound causal position, so the gate
-  does NOT skip on it — a sentinel Remove DELETES. This is required for soundness: an older un-durable
-  `Store` frame can replay just before a Remove in the same in-order pass, and skipping on a synthetic
-  bottom would resurrect a value the Remove is the last writer of. An absent-at-remove-time key needs
-  no sentinel protection because any re-creation is a fresh write carrying its own later WAL frame,
-  applied after the Remove. A legacy `None`-timestamp Remove (older server) likewise BYPASSES the
-  guard and always deletes, keeping the upgrade path over a pre-existing on-disk WAL intact.
-- **Maintaining code:** `wal/mod.rs::replay_entry` (the `WalOp::Remove` read-compare guard) + `run` /
-  `WalEntry` doc-contracts; `datastores/write_behind.rs::remove_frame_timestamp` populates the frame
-  HLC from the removed value at both `remove`/`remove_all` append sites.
-- **Enforcing test:** `wal/mod.rs::tests::replay_remove_gate_discards_stale_remove_isolated`
-  (strictly-older discarded, sentinel protects, tie/newer delete, gate-off clobbers) and
-  `::replay_legacy_remove_bypasses_gate` (the legacy-bypass proof); the harness case
+- **Scope:** `WalRecovery::replay_entry` `WalOp::Remove` arm. Modern Remove frames carry
+  `timestamp: None`; replay does not consult it.
+- **Statement (positive):** a `WalOp::Remove` replays UNCONDITIONALLY — a blind delete, identical to
+  the live remove path (`WriteBehindDataStore::remove`, which stages a pending-delete with no
+  timestamp compare). There is deliberately NO replay gate: the live path has no such condition, so a
+  gate would make `replay(Remove) != live(Remove)` and is itself unsound — an HLC-sourced gate
+  wrongly skipped a Remove whose sourced value-HLC was strictly older than the LWW survivor, losing
+  the acked delete (surfaced as `AckedWriteLost`). Idempotency is a property of the replay ORDER, not
+  a per-frame timestamp compare.
+- **Warrant (why no gate is NEEDED — structural non-reachability):** under prefix-complete, strictly
+  in-order replay of the unapplied window, a stale Remove can never delete a strictly-newer
+  re-creation. Let the Remove be at WAL sequence N and W the prefix-complete applied watermark
+  (`min(pending) - 1`, never at/above an unresolved sequence). For the Remove to be replayed, N > W.
+  A re-creation strictly newer than it has, by per-partition monotonic sequencing (= arrival order),
+  sequence M > N; for that re-creation to be durable-but-unframed (not re-enumerated after the
+  Remove) it must sit below the watermark, M <= W. Together: `M <= W < N < M` — a contradiction. So
+  either every strictly-newer re-creation's frame is also above W (enumerated and replayed AFTER the
+  Remove, re-creating the value) or the Remove is the newest op for the key (deleting is
+  live-correct). The stale-Remove-over-newer-frameless-value juxtaposition is reachable ONLY by
+  re-applying an already-applied older frame after the in-order pass — the harness
+  `re_replay_oldest_frame` seam, never a production path. Both premises are themselves enforced here:
+  prefix-complete watermark (`TG-WB-001` / `TG-WAL-003`) and single-partition-per-key (`partition_for`
+  is deterministic).
+- **Windowing residual (tracked, NOT closed by a gate):** the only genuine out-of-order hazard — a
+  frameless `flush_key` durable write racing an un-resolved older Remove — is a WATERMARK/FRAMING
+  concern, not a Remove-idempotency one, so it is routed to TODO-612 (SPEC-349/windowing), not
+  papered over with an unsound Remove-replay timestamp gate.
+- **Maintaining code:** `wal/mod.rs::replay_entry` (`WalOp::Remove` arm, unconditional) + `run` /
+  `WalEntry` doc-contracts; `datastores/write_behind.rs` `remove`/`remove_all` append Remove frames
+  with `timestamp: None`.
+- **Enforcing test:** `wal/mod.rs::tests::replay_remove_replays_unconditionally_isolated`
+  (strictly-older / tie / newer / sentinel / legacy-`None` Remove all delete unconditionally, under
+  both `merge_gate` values — the discriminator vs the reverted gate) and the harness case
   `wal_harness::cases::ac1_ac6_stale_remove_clobber_caught_by_o1_oracle` (O1 `AckedWriteLost` catches
-  the clobber under the defect seam; the `DefectMode::None` run is green).
+  the seam-injected out-of-order clobber; the `DefectMode::None` in-order run is green).
 - **Sibling invariant (DISTINCT):** `TG-WAL-006` owns the same re-replay-idempotency loss-class for
-  `RecordValue::Lww` VALUES; this invariant is the `WalOp::Remove` counterpart and is scoped strictly
-  to the Remove OP — the two share the recovery-boundary layering but not a comparison basis.
-- **Violation consequence:** acked-write loss on crash-recovery — a stale re-replayed Remove deletes
-  a value re-created after it (the durable re-creation vanishes).
-- **Discovered by:** SPEC-353 `/xask` (Review v1 flagged the Remove-clobber as the same loss-class,
-  routed to TODO-609); closed by SPEC-354.
+  `RecordValue::Lww` VALUES — there a gate IS correct because live-Store is HLC-conditional (LWW), so
+  replay must mirror that compare. Remove is the counterpart whose live semantics are UNCONDITIONAL,
+  so it needs no gate; the two share the recovery-boundary layering but not a comparison basis.
+- **Violation consequence:** acked-write loss on crash-recovery — either an unsound gate wrongly
+  skips a legitimate delete, or (if the windowing residual were left unhandled) a stale-Remove
+  clobbers a re-creation. Both surface as `AckedWriteLost`.
+- **Discovered by:** SPEC-353 `/xask` (Review v1 flagged the Remove-clobber loss-class, routed to
+  TODO-609); SPEC-354 Review v1 caught the unsound gate (an `AckedWriteLost` regression); closed by
+  SPEC-354 via a pre-fix `/xask` + a structural non-reachability spike.
 - **Status:** decided, **enforced (Remove-scoped)**.
 
 ### TG-WB-001: The flushed watermark is prefix-complete — no mid-range hole

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -168,8 +168,10 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
   Remove, re-creating the value) or the Remove is the newest op for the key (deleting is
   live-correct). The stale-Remove-over-newer-frameless-value juxtaposition is reachable ONLY by
   re-applying an already-applied older frame after the in-order pass — the harness
-  `re_replay_oldest_frame` seam, never a production path. The chain rests on FOUR premises, EACH an
-  enforced invariant (not asserted prose):
+  `re_replay_oldest_frame` seam, never a production path. The chain rests on FOUR premises, none of
+  them asserted prose — three are TEST-backed (each a catalogued enforced invariant with a real test:
+  (a), (c), (d)) and one is COMPILER/TYPE-backed ((b): a pure free function, which is why it cites no
+  invariant ID and needs no enforcing test):
   - **(a) prefix-complete watermark** — `W = min(unresolved) - 1`, never at/above an unresolved
     sequence, so `N > W` bounds the replay window: `TG-WAL-005` / `TG-WB-001` / `TG-WAL-003`.
   - **(b) one sequence space per key** — `partition_for(map, key)` is deterministic, so a key's ops

--- a/packages/server-rust/proptest-regressions/storage/datastores/wal_harness/cases.txt
+++ b/packages/server-rust/proptest-regressions/storage/datastores/wal_harness/cases.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc baf8de895b84866aacf8bf37cb701c834975ee82bbc2303b337d8fb8461a507d # shrinks to case = [Incarnation { ops: [RemoveAll { keys: [0] }, FlushTick { advance_ms: 0 }], end: Crash }]
+cc 340d7e254c74a17b5cfff223dd1b798306c2789f23618cc6b09588d756f6e663 # shrinks to case = [Incarnation { ops: [Append { key: 3, millis: 657772 }], end: Crash }, Incarnation { ops: [SetStoreHealth { healthy: false }, Append { key: 3, millis: 1 }], end: Crash }, Incarnation { ops: [Append { key: 0, millis: 1 }], end: Crash }]

--- a/packages/server-rust/src/storage/datastores/wal_harness/cases.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/cases.rs
@@ -197,16 +197,46 @@ fn incarnation_strategy(shape: &CaseShape) -> BoxedStrategy<Incarnation> {
         .boxed()
 }
 
+/// Rewrites every `Append`'s `millis` to a strictly-increasing, arrival-ordered
+/// value across the whole case, so each key's HLCs are MONOTONE in arrival order.
+///
+/// This is the O1/O2 LWW reference model's SOUND DOMAIN, and it matches production:
+/// a single node's HLC never goes backwards, so a key's WAL frames arrive in
+/// non-decreasing timestamp order. Under a NON-monotone arrival (a later frame with
+/// a lower HLC) the model's latest-arrival value diverges from the impl's max-HLC
+/// LWW winner: the impl's recovery discards the stale lower-HLC frame (advancing the
+/// watermark store-health-INDEPENDENTLY), while the health-gated reference model
+/// keeps it unresolved — producing false `WatermarkAboveUnresolved` / `AckedWriteLost`
+/// reports that are oracle artefacts, not real losses. Generating only monotone
+/// arrivals keeps the oracle inside its proven-sound domain; the non-monotone-arrival
+/// extension (a per-key max-live-millis reference) is owned by TODO-610, not this
+/// harness.
+fn make_hlc_monotone(mut case: Case) -> Case {
+    let mut next: i64 = 1;
+    for incarnation in &mut case {
+        for op in &mut incarnation.ops {
+            if let WorkOp::Append { millis, .. } = op {
+                *millis = next;
+                next += 1;
+            }
+        }
+    }
+    case
+}
+
 /// A whole case: `1..=max_incarnations` incarnations (R1). `force_single_incarnation`
 /// pins it to exactly one incarnation — AC5(c)'s negative control — so no crash and
-/// therefore no recovery can occur.
+/// therefore no recovery can occur. Generated HLCs are made monotone in arrival order
+/// (see `make_hlc_monotone`) so the run stays in the oracle's sound domain.
 fn case_strategy(shape: &CaseShape) -> BoxedStrategy<Case> {
     let max_inc = if shape.force_single_incarnation {
         1
     } else {
         shape.max_incarnations
     };
-    proptest::collection::vec(incarnation_strategy(shape), 1..=max_inc).boxed()
+    proptest::collection::vec(incarnation_strategy(shape), 1..=max_inc)
+        .prop_map(make_hlc_monotone)
+        .boxed()
 }
 
 // ---------------------------------------------------------------------------
@@ -734,22 +764,26 @@ fn ac4_5_replay_clobber_caught_by_value_equality_oracle() {
 /// the fixed path (`DefectMode::None`, gate on, no re-replay) must be GREEN (AC1/AC6
 /// — the fix holds).
 ///
-/// The case makes the stale Remove the OLDEST un-applied frame over a newer durable
-/// re-creation — the condition the live `flush_key` path can produce but generated
-/// ops cannot manufacture:
+/// The case arranges a stale Remove as the OLDEST un-applied frame over a newer
+/// durable re-creation, then relies on the harness `re_replay_oldest_frame` seam to
+/// re-apply that Remove OUT OF ORDER — the only way to fabricate the clobber, since
+/// in-order replay always ends on the newest frame (production can never manufacture
+/// it — see TG-WAL-009's non-reachability argument):
 ///  1. Append key 0 (ts=5) and flush it durably — its frame is applied, advancing
 ///     the watermark past it, so it drops OUT of the replay window.
-///  2. Remove key 0 — write-behind sources the removed value's HLC (ts=5) onto the
-///     frame; its flush is REJECTED (store unhealthy), so the Remove frame strands
-///     un-applied and holds the watermark back. It is now the oldest un-applied frame.
+///  2. Remove key 0 (frame carries no timestamp); its flush is REJECTED (store
+///     unhealthy), so the Remove frame strands un-applied and holds the watermark
+///     back. It is now the oldest un-applied frame.
 ///  3. Re-create key 0 (ts=20) and flush it durably — its frame stays un-applied
 ///     because the stranded Remove blocks the contiguous frontier.
 ///
-/// At recovery the in-order pass leaves ts=20 durable (the gate skips the stale
-/// Remove), then the seam re-replays the oldest frame — the Remove. With the gate
-/// off (defect) it blind-deletes the re-creation; the model's acked value for key 0
-/// is `Live{20}`, so O1 reports `AckedWriteLost`. With the gate on (`None`) the
-/// re-replayed Remove is discarded and the run is GREEN.
+/// At recovery the in-order pass replays the Remove THEN the ts=20 re-creation, so
+/// key 0 ends `Live{20}` — matching the model. Under `DefectMode::None` there is no
+/// re-replay, so the run is GREEN (AC1/AC6 — replay is correct without a gate). The
+/// defect then re-replays the OLDEST frame (the Remove) after the in-order pass;
+/// replay-remove is unconditional (identical to live), so it blind-deletes the
+/// re-creation, and O1 reports `AckedWriteLost` for key 0 (AC5 — the seam-injected
+/// out-of-order clobber is detected).
 #[test]
 fn ac1_ac6_stale_remove_clobber_caught_by_o1_oracle() {
     let case: Case = vec![

--- a/packages/server-rust/src/storage/datastores/wal_harness/cases.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/cases.rs
@@ -725,6 +725,84 @@ fn ac4_5_replay_clobber_caught_by_value_equality_oracle() {
 }
 
 // ---------------------------------------------------------------------------
+// AC1 / AC5 / AC6 — TG-WAL-009 stale-Remove-clobber proof via the O1 oracle
+// ---------------------------------------------------------------------------
+
+/// `DefectMode::ReplayStaleRemoveOverNewerValue` (the pre-`TG-WAL-009` blind Remove
+/// clobber) must be CAUGHT by the O1 `AckedWriteLost` oracle naming the deleted key
+/// (AC5 — defect-present detection, NO model/oracle fork); and the identical case on
+/// the fixed path (`DefectMode::None`, gate on, no re-replay) must be GREEN (AC1/AC6
+/// — the fix holds).
+///
+/// The case makes the stale Remove the OLDEST un-applied frame over a newer durable
+/// re-creation — the condition the live `flush_key` path can produce but generated
+/// ops cannot manufacture:
+///  1. Append key 0 (ts=5) and flush it durably — its frame is applied, advancing
+///     the watermark past it, so it drops OUT of the replay window.
+///  2. Remove key 0 — write-behind sources the removed value's HLC (ts=5) onto the
+///     frame; its flush is REJECTED (store unhealthy), so the Remove frame strands
+///     un-applied and holds the watermark back. It is now the oldest un-applied frame.
+///  3. Re-create key 0 (ts=20) and flush it durably — its frame stays un-applied
+///     because the stranded Remove blocks the contiguous frontier.
+///
+/// At recovery the in-order pass leaves ts=20 durable (the gate skips the stale
+/// Remove), then the seam re-replays the oldest frame — the Remove. With the gate
+/// off (defect) it blind-deletes the re-creation; the model's acked value for key 0
+/// is `Live{20}`, so O1 reports `AckedWriteLost`. With the gate on (`None`) the
+/// re-replayed Remove is discarded and the run is GREEN.
+#[test]
+fn ac1_ac6_stale_remove_clobber_caught_by_o1_oracle() {
+    let case: Case = vec![
+        Incarnation {
+            ops: vec![
+                WorkOp::Append { key: 0, millis: 5 },
+                WorkOp::FlushTick { advance_ms: 5_000 },
+                WorkOp::Remove { key: 0 },
+                WorkOp::SetStoreHealth { healthy: false },
+                WorkOp::FlushTick { advance_ms: 5_000 },
+                WorkOp::SetStoreHealth { healthy: true },
+                WorkOp::Append { key: 0, millis: 20 },
+                WorkOp::FlushTick { advance_ms: 5_000 },
+            ],
+            end: IncarnationEnd::Crash,
+        },
+        Incarnation {
+            ops: vec![WorkOp::Read { key: 0 }],
+            end: IncarnationEnd::CleanShutdown,
+        },
+    ];
+
+    // (a) defect present: the O1 oracle catches the stale-Remove clobber of key 0.
+    let defect_cfg = RunConfig {
+        defect: DefectMode::ReplayStaleRemoveOverNewerValue,
+        ..RunConfig::baseline()
+    };
+    let defect_outcome = block_on_async(run_case(&case, &defect_cfg));
+    let lost = defect_outcome
+        .violations
+        .iter()
+        .any(|v| matches!(v, InvariantViolation::AckedWriteLost { key: 0, .. }));
+    assert!(
+        lost,
+        "AC5: the stale-Remove clobber must surface as AckedWriteLost naming key 0; \
+         got violations {:?}",
+        defect_outcome.violations
+    );
+
+    // (b) discriminator: the fixed path clobbers nothing (AC1/AC6).
+    let fixed_cfg = RunConfig {
+        defect: DefectMode::None,
+        ..RunConfig::baseline()
+    };
+    let fixed_outcome = block_on_async(run_case(&case, &fixed_cfg));
+    assert!(
+        fixed_outcome.violations.is_empty(),
+        "AC6: the fixed path must report zero violations for the identical run; got {:?}",
+        fixed_outcome.violations
+    );
+}
+
+// ---------------------------------------------------------------------------
 // AC5 — C12 regression proof, with the cross-incarnation negative control
 // ---------------------------------------------------------------------------
 

--- a/packages/server-rust/src/storage/datastores/wal_harness/cases.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/cases.rs
@@ -677,8 +677,8 @@ fn ac4_c3_scalar_max_watermark_regression() {
 /// be CAUGHT by the `value_equality` oracle as an `AckedValueMismatch` naming the
 /// key and the (expected, recovered) millis (AC4); and the identical case on the
 /// fixed path (`DefectMode::None`, gate on, no re-replay) must be GREEN under the
-/// same opt-in oracle (AC5 — the closing evidence SPEC-352's `OracleConfig`
-/// doc-comment names).
+/// same opt-in oracle (AC5 — the closing evidence the `OracleConfig` doc-comment
+/// names).
 ///
 /// The case writes key 0 twice, timestamp-monotonic (ts=10 then ts=20). The FIRST
 /// write's flush is rejected (store unhealthy) so its sequence strands un-applied

--- a/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
@@ -736,11 +736,12 @@ impl Driver {
 
         // Apply the run's defect seams (R6).
         match self.config.defect {
-            // `ReplayClobberOlderFrame` is a recovery-side seam (see `recover`),
-            // so it installs nothing on the store.
+            // Both replay-clobber defects are recovery-side seams (see `recover`),
+            // so they install nothing on the store.
             DefectMode::None
             | DefectMode::UnlinkThenFsync
-            | DefectMode::ReplayClobberOlderFrame => {}
+            | DefectMode::ReplayClobberOlderFrame
+            | DefectMode::ReplayStaleRemoveOverNewerValue => {}
             DefectMode::ScalarMaxWatermark => {
                 store.test_set_watermark_mode(WatermarkMode::ScalarMax);
             }
@@ -1185,10 +1186,17 @@ impl Driver {
     /// `next_incarnation` is the index the loss surfaces at (for the O1 record).
     async fn recover(&mut self, next_incarnation: usize) {
         let mut recovery = WalRecovery::new(Arc::clone(&self.wal), vec![self.partition]);
-        // `ReplayClobberOlderFrame` reproduces the pre-`TG-WAL-006` blind clobber:
-        // disable the merge gate AND re-replay each partition's oldest un-applied
-        // frame over the newer durable value the in-order pass left behind.
-        if self.config.defect == DefectMode::ReplayClobberOlderFrame {
+        // Both replay-clobber defects reproduce the pre-fix blind re-replay with the
+        // SAME two seams: disable the merge gate AND re-replay each partition's
+        // oldest un-applied frame over the newer durable value the in-order pass
+        // left behind. `ReplayClobberOlderFrame` (TG-WAL-006) arranges that oldest
+        // frame to be a stale Lww Store; `ReplayStaleRemoveOverNewerValue`
+        // (TG-WAL-009) arranges it to be a stale `WalOp::Remove` — the guard and the
+        // clobber differ, the seam does not.
+        if matches!(
+            self.config.defect,
+            DefectMode::ReplayClobberOlderFrame | DefectMode::ReplayStaleRemoveOverNewerValue
+        ) {
             recovery.test_set_replay_merge_gate(false);
             recovery.test_set_re_replay_oldest_frame(true);
         }

--- a/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/driver.rs
@@ -1186,13 +1186,15 @@ impl Driver {
     /// `next_incarnation` is the index the loss surfaces at (for the O1 record).
     async fn recover(&mut self, next_incarnation: usize) {
         let mut recovery = WalRecovery::new(Arc::clone(&self.wal), vec![self.partition]);
-        // Both replay-clobber defects reproduce the pre-fix blind re-replay with the
-        // SAME two seams: disable the merge gate AND re-replay each partition's
-        // oldest un-applied frame over the newer durable value the in-order pass
-        // left behind. `ReplayClobberOlderFrame` (TG-WAL-006) arranges that oldest
-        // frame to be a stale Lww Store; `ReplayStaleRemoveOverNewerValue`
-        // (TG-WAL-009) arranges it to be a stale `WalOp::Remove` — the guard and the
-        // clobber differ, the seam does not.
+        // Both replay-clobber defects re-replay each partition's oldest un-applied
+        // frame over the newer durable value the in-order pass left behind.
+        // `ReplayClobberOlderFrame` (TG-WAL-006) arranges that oldest frame to be a
+        // stale Lww Store and ALSO disables the Lww merge gate (which live-Store's
+        // LWW semantics require replay to mirror); `ReplayStaleRemoveOverNewerValue`
+        // (TG-WAL-009) arranges it to be a stale `WalOp::Remove`, whose replay is
+        // unconditional (no gate to disable — the `merge_gate=false` below is a
+        // vestigial no-op for the Remove arm). The out-of-order re-replay seam is
+        // what produces the clobber; in-order replay never does.
         if matches!(
             self.config.defect,
             DefectMode::ReplayClobberOlderFrame | DefectMode::ReplayStaleRemoveOverNewerValue

--- a/packages/server-rust/src/storage/datastores/wal_harness/mod.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/mod.rs
@@ -172,6 +172,14 @@ pub(crate) enum DefectMode {
     /// re-applied over a newer durable value". Caught by the `value_equality`
     /// oracle as an `AckedValueMismatch`.
     ReplayClobberOlderFrame,
+    /// Re-introduces the pre-`TG-WAL-009` Remove clobber via the SAME `WalRecovery`
+    /// test seams: the replay gate is disabled AND each partition's oldest
+    /// un-applied frame is re-replayed once more. When a case arranges that oldest
+    /// frame to be a stale `WalOp::Remove` sitting in the replay window over a
+    /// key re-created with a newer durable value, the blind re-replay deletes the
+    /// re-creation. Caught by the O1 `AckedWriteLost` oracle (expected Live, got
+    /// absent) — NO new oracle needed.
+    ReplayStaleRemoveOverNewerValue,
 }
 
 /// `wal/mod.rs::mark_applied` crash-injection point (R7), fired between the sidecar write+fsync

--- a/packages/server-rust/src/storage/datastores/wal_harness/mod.rs
+++ b/packages/server-rust/src/storage/datastores/wal_harness/mod.rs
@@ -172,12 +172,14 @@ pub(crate) enum DefectMode {
     /// re-applied over a newer durable value". Caught by the `value_equality`
     /// oracle as an `AckedValueMismatch`.
     ReplayClobberOlderFrame,
-    /// Re-introduces the pre-`TG-WAL-009` Remove clobber via the SAME `WalRecovery`
-    /// test seams: the replay gate is disabled AND each partition's oldest
-    /// un-applied frame is re-replayed once more. When a case arranges that oldest
-    /// frame to be a stale `WalOp::Remove` sitting in the replay window over a
-    /// key re-created with a newer durable value, the blind re-replay deletes the
-    /// re-creation. Caught by the O1 `AckedWriteLost` oracle (expected Live, got
+    /// Fabricates a stale-Remove clobber via `wal/mod.rs`'s `re_replay_oldest_frame`
+    /// seam: each partition's oldest un-applied frame is re-replayed once more AFTER
+    /// the in-order pass. Replay-remove is UNCONDITIONAL (identical to live, TG-WAL-009
+    /// — there is no Remove gate to disable), so when a case arranges that oldest
+    /// frame to be a `WalOp::Remove` over a key re-created with a newer durable value,
+    /// the out-of-order re-replay deletes the re-creation. This state is unreachable
+    /// under in-order replay (which always ends on the newest frame) — only the seam
+    /// manufactures it. Caught by the O1 `AckedWriteLost` oracle (expected Live, got
     /// absent) — NO new oracle needed.
     ReplayStaleRemoveOverNewerValue,
 }

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -2627,13 +2627,13 @@ impl MapDataStore for WriteBehindDataStore {
         // discovered even when not resident.
         let mut names = self.inner.list_maps().await?;
 
-        // Union in maps whose only write is still buffered in staging. Before
-        // SPEC-323 clean-marking, a buffered record was necessarily also
-        // resident, so the durable catalog covered it. R6 makes a buffered
-        // record evictable, so a map whose sole write is buffered-and-evicted is
-        // now reachable only via staging — it must be surfaced here or the
-        // residency-independent seed would miss it. A map present in staging
-        // only via pending deletes (None) contributes nothing.
+        // Union in maps whose only write is still buffered in staging. A buffered
+        // record used to be necessarily resident too, so the durable catalog
+        // covered it; clean-marking made a buffered record evictable, so a map
+        // whose sole write is buffered-and-evicted is now reachable only via
+        // staging — it must be surfaced here or the residency-independent seed
+        // would miss it. A map present in staging only via pending deletes
+        // (None) contributes nothing.
         let mut staging_only: Vec<String> = self
             .staging
             .iter()
@@ -4294,15 +4294,25 @@ mod tests {
         assert_eq!(appended[0].1.key, "k1");
     }
 
-    /// TG-WAL-010: per-partition WAL-sequence assignment is strictly monotone —
-    /// concurrent `assign_wal_sequence` calls on ONE partition never hand out the
-    /// same sequence twice. This is premise (c) of the TG-WAL-009 gate-free
-    /// warrant (a strictly-newer re-creation of a key gets a strictly HIGHER WAL
-    /// sequence than an older op on the same key, so `M > N` holds).
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    /// TG-WAL-010: WAL-sequence assignment is strictly monotone per partition and
+    /// never reuses a sequence globally. This is premise (c) of the TG-WAL-009
+    /// gate-free warrant (a strictly-newer re-creation of a key gets a strictly
+    /// HIGHER WAL sequence than an older op on the same key, so `M > N` holds).
+    ///
+    /// The assigns MUST be spread across distinct partitions. `assign_wal_sequence`
+    /// mints inside `with_partition`, i.e. under that partition's OWN mutex, so
+    /// pinning every task to one partition lets the lock serialize the counter bump
+    /// and hides whether the counter itself is atomic: with all tasks on a single
+    /// partition, replacing the `fetch_add` with a racy load/store keeps this test
+    /// (and the whole suite) green. Spread over 8 partitions the mutexes no longer
+    /// overlap and the same mutation goes RED on the arrival-order assertion (the
+    /// counter is observed moving backwards within one partition). One task per
+    /// partition is what makes that arrival order observable at all.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn wal_sequence_assignment_is_strictly_monotone_per_partition() {
-        const PARTITION: u32 = 7;
-        const TASKS: usize = 8;
+        // Eight DISTINCT partitions, named explicitly so the test needs no
+        // usize/u32 casts.
+        const PARTITIONS: [u32; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
         const PER_TASK: usize = 250;
 
         let wal = InMemoryTestWal::new();
@@ -4317,22 +4327,39 @@ mod tests {
             }),
         );
 
+        // One task per partition: distinct partitions => distinct tracking mutexes,
+        // so the only thing ordering these assigns is the counter itself.
         let mut handles = Vec::new();
-        for _ in 0..TASKS {
+        for partition in PARTITIONS {
             let store = Arc::clone(&store);
             handles.push(tokio::spawn(async move {
-                (0..PER_TASK)
-                    .map(|_| store.assign_wal_sequence(PARTITION))
-                    .collect::<Vec<u64>>()
+                (
+                    partition,
+                    (0..PER_TASK)
+                        .map(|_| store.assign_wal_sequence(partition))
+                        .collect::<Vec<u64>>(),
+                )
             }));
         }
 
         let mut all = Vec::new();
         for h in handles {
-            all.extend(h.await.unwrap());
+            let (partition, assigned) = h.await.unwrap();
+
+            // Per-partition monotonicity, in ARRIVAL order (not sorted): a later
+            // arrival on a partition gets a strictly higher sequence. This is the
+            // `M > N` step of the TG-WAL-009 warrant.
+            assert!(
+                assigned.windows(2).all(|w| w[0] < w[1]),
+                "partition {partition} assignments must be strictly increasing in \
+                 arrival order, got {assigned:?}"
+            );
+            all.extend(assigned);
         }
 
-        let total = TASKS * PER_TASK;
+        // Global no-reuse: one process-global counter feeds every partition, so no
+        // sequence may be handed out twice across partitions either.
+        let total = PARTITIONS.len() * PER_TASK;
         let unique: std::collections::HashSet<u64> = all.iter().copied().collect();
         assert_eq!(
             unique.len(),
@@ -4340,14 +4367,6 @@ mod tests {
             "a strictly-monotone counter never reuses a sequence under concurrency \
              ({total} concurrent assigns produced {} distinct values)",
             unique.len()
-        );
-
-        // Distinct integers are strictly increasing once sorted — the observable
-        // monotonicity of the assignment.
-        all.sort_unstable();
-        assert!(
-            all.windows(2).all(|w| w[0] < w[1]),
-            "sorted per-partition assignments must be strictly increasing"
         );
     }
 

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -4294,6 +4294,63 @@ mod tests {
         assert_eq!(appended[0].1.key, "k1");
     }
 
+    /// TG-WAL-010: per-partition WAL-sequence assignment is strictly monotone —
+    /// concurrent `assign_wal_sequence` calls on ONE partition never hand out the
+    /// same sequence twice. This is premise (c) of the TG-WAL-009 gate-free
+    /// warrant (a strictly-newer re-creation of a key gets a strictly HIGHER WAL
+    /// sequence than an older op on the same key, so `M > N` holds).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn wal_sequence_assignment_is_strictly_monotone_per_partition() {
+        const PARTITION: u32 = 7;
+        const TASKS: usize = 8;
+        const PER_TASK: usize = 250;
+
+        let wal = InMemoryTestWal::new();
+        let wal_arc: Arc<dyn Wal> = Arc::clone(&wal) as Arc<dyn Wal>;
+        let inner: Arc<dyn MapDataStore> = Arc::new(SpyDataStore::new());
+        let store = WriteBehindDataStore::new_with_wal(
+            inner,
+            WriteBehindConfig::default(),
+            Some(WalBootstrap {
+                wal: wal_arc,
+                sequence_start: 1,
+            }),
+        );
+
+        let mut handles = Vec::new();
+        for _ in 0..TASKS {
+            let store = Arc::clone(&store);
+            handles.push(tokio::spawn(async move {
+                (0..PER_TASK)
+                    .map(|_| store.assign_wal_sequence(PARTITION))
+                    .collect::<Vec<u64>>()
+            }));
+        }
+
+        let mut all = Vec::new();
+        for h in handles {
+            all.extend(h.await.unwrap());
+        }
+
+        let total = TASKS * PER_TASK;
+        let unique: std::collections::HashSet<u64> = all.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            total,
+            "a strictly-monotone counter never reuses a sequence under concurrency \
+             ({total} concurrent assigns produced {} distinct values)",
+            unique.len()
+        );
+
+        // Distinct integers are strictly increasing once sorted — the observable
+        // monotonicity of the assignment.
+        all.sort_unstable();
+        assert!(
+            all.windows(2).all(|w| w[0] < w[1]),
+            "sorted per-partition assignments must be strictly increasing"
+        );
+    }
+
     // AC1: WAL entry is appended before remove() returns Ok(())
     #[tokio::test]
     async fn wal_append_happens_before_remove_returns() {

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use tokio::sync::{watch, Notify};
+use topgun_core::hlc::Timestamp;
 use topgun_core::{fnv1a_hash, PARTITION_COUNT};
 use tracing::{error, warn};
 
@@ -1679,6 +1680,30 @@ impl WriteBehindDataStore {
     /// winner's freshly-appended live frame, so its install must not reach the
     /// map. Sequences are inserted without displacing existing entries for the
     /// same reason: a seed must never overwrite what a live write recorded.
+    /// HLC to stamp on a `WalOp::Remove` frame so crash recovery can guard the
+    /// replay against deleting a NEWER re-creation of the same key.
+    ///
+    /// The frame carries the HLC of the value being removed (read through the
+    /// staging→inner overlay). At `replay_entry` recovery compares it to the
+    /// currently-stored value's HLC under LWW's total order: a stale re-replayed
+    /// Remove whose HLC is strictly older than the stored value is discarded, so a
+    /// value re-created after this Remove survives. When the key has no `Lww` value
+    /// to source an HLC from — absent, a pending-delete, or a non-`Lww` value — the
+    /// **zero-epoch sentinel** `{0,0,""}` is stamped: any real re-creation has an
+    /// HLC `> 0`, so the same guard protects it, while an absent-key Remove that
+    /// meets an older-or-tie value still deletes. This is distinct from a legacy
+    /// `None` frame (older servers), which bypasses the guard and always deletes.
+    async fn remove_frame_timestamp(&self, map: &str, key: &str) -> anyhow::Result<Timestamp> {
+        match self.load(map, key).await? {
+            Some(RecordValue::Lww { timestamp, .. }) => Ok(timestamp),
+            _ => Ok(Timestamp {
+                millis: 0,
+                counter: 0,
+                node_id: String::new(),
+            }),
+        }
+    }
+
     async fn ensure_wal_seeded(&self, partition: u32) {
         let Some(tracking) = &self.wal else {
             return;
@@ -2388,6 +2413,11 @@ impl MapDataStore for WriteBehindDataStore {
         // watermark this write eventually advances already accounts for whatever
         // a prior incarnation left un-applied.
         self.ensure_wal_seeded(partition_id).await;
+
+        // Source the removed value's HLC BEFORE assigning a sequence so the frame
+        // carries the idempotency key recovery needs (see `remove_frame_timestamp`).
+        let remove_hlc = self.remove_frame_timestamp(map, key).await?;
+
         let wal_seq = self.assign_wal_sequence(partition_id);
 
         // Append to WAL before updating in-memory state so crash recovery can
@@ -2396,7 +2426,7 @@ impl MapDataStore for WriteBehindDataStore {
             map: map.to_string(),
             key: key.to_string(),
             op: WalOp::Remove,
-            timestamp: None,
+            timestamp: Some(remove_hlc),
             sequence: wal_seq,
         };
         // Evaluated on the SURVIVOR — this write — never on what it displaces.
@@ -2537,6 +2567,11 @@ impl MapDataStore for WriteBehindDataStore {
             // the watermark this write eventually advances already accounts for
             // whatever a prior incarnation left un-applied.
             self.ensure_wal_seeded(partition_id).await;
+
+            // One HLC source per key — the frame carries the removed value's HLC so
+            // recovery guards each key's Remove replay (see `remove_frame_timestamp`).
+            let remove_hlc = self.remove_frame_timestamp(map, key).await?;
+
             let wal_seq = self.assign_wal_sequence(partition_id);
 
             // Append each tombstone to the WAL before queuing so crash recovery
@@ -2545,7 +2580,7 @@ impl MapDataStore for WriteBehindDataStore {
                 map: map.to_string(),
                 key: key.clone(),
                 op: WalOp::Remove,
-                timestamp: None,
+                timestamp: Some(remove_hlc),
                 sequence: wal_seq,
             };
             // Evaluated on the SURVIVOR — this key's write — never on what it

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -1686,13 +1686,15 @@ impl WriteBehindDataStore {
     /// The frame carries the HLC of the value being removed (read through the
     /// staging→inner overlay). At `replay_entry` recovery compares it to the
     /// currently-stored value's HLC under LWW's total order: a stale re-replayed
-    /// Remove whose HLC is strictly older than the stored value is discarded, so a
-    /// value re-created after this Remove survives. When the key has no `Lww` value
-    /// to source an HLC from — absent, a pending-delete, or a non-`Lww` value — the
-    /// **zero-epoch sentinel** `{0,0,""}` is stamped: any real re-creation has an
-    /// HLC `> 0`, so the same guard protects it, while an absent-key Remove that
-    /// meets an older-or-tie value still deletes. This is distinct from a legacy
-    /// `None` frame (older servers), which bypasses the guard and always deletes.
+    /// Remove whose REAL HLC is strictly older than the stored value is discarded,
+    /// so a value re-created after this Remove survives. When the key has no `Lww`
+    /// value to source an HLC from — absent, a pending-delete, or a non-`Lww`
+    /// value — the **zero-epoch sentinel** `{0,0,""}` is stamped (distinct on the
+    /// wire from a legacy `None` frame). The sentinel is a synthetic bottom, not a
+    /// causal position, so recovery does NOT gate on it — a sentinel Remove deletes.
+    /// An absent-at-remove-time key needs no gate protection: any re-creation is a
+    /// fresh write carrying its own later WAL frame, which in-order replay applies
+    /// after this Remove.
     async fn remove_frame_timestamp(&self, map: &str, key: &str) -> anyhow::Result<Timestamp> {
         match self.load(map, key).await? {
             Some(RecordValue::Lww { timestamp, .. }) => Ok(timestamp),

--- a/packages/server-rust/src/storage/datastores/write_behind.rs
+++ b/packages/server-rust/src/storage/datastores/write_behind.rs
@@ -12,7 +12,6 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use tokio::sync::{watch, Notify};
-use topgun_core::hlc::Timestamp;
 use topgun_core::{fnv1a_hash, PARTITION_COUNT};
 use tracing::{error, warn};
 
@@ -1680,32 +1679,6 @@ impl WriteBehindDataStore {
     /// winner's freshly-appended live frame, so its install must not reach the
     /// map. Sequences are inserted without displacing existing entries for the
     /// same reason: a seed must never overwrite what a live write recorded.
-    /// HLC to stamp on a `WalOp::Remove` frame so crash recovery can guard the
-    /// replay against deleting a NEWER re-creation of the same key.
-    ///
-    /// The frame carries the HLC of the value being removed (read through the
-    /// staging→inner overlay). At `replay_entry` recovery compares it to the
-    /// currently-stored value's HLC under LWW's total order: a stale re-replayed
-    /// Remove whose REAL HLC is strictly older than the stored value is discarded,
-    /// so a value re-created after this Remove survives. When the key has no `Lww`
-    /// value to source an HLC from — absent, a pending-delete, or a non-`Lww`
-    /// value — the **zero-epoch sentinel** `{0,0,""}` is stamped (distinct on the
-    /// wire from a legacy `None` frame). The sentinel is a synthetic bottom, not a
-    /// causal position, so recovery does NOT gate on it — a sentinel Remove deletes.
-    /// An absent-at-remove-time key needs no gate protection: any re-creation is a
-    /// fresh write carrying its own later WAL frame, which in-order replay applies
-    /// after this Remove.
-    async fn remove_frame_timestamp(&self, map: &str, key: &str) -> anyhow::Result<Timestamp> {
-        match self.load(map, key).await? {
-            Some(RecordValue::Lww { timestamp, .. }) => Ok(timestamp),
-            _ => Ok(Timestamp {
-                millis: 0,
-                counter: 0,
-                node_id: String::new(),
-            }),
-        }
-    }
-
     async fn ensure_wal_seeded(&self, partition: u32) {
         let Some(tracking) = &self.wal else {
             return;
@@ -2416,19 +2389,17 @@ impl MapDataStore for WriteBehindDataStore {
         // a prior incarnation left un-applied.
         self.ensure_wal_seeded(partition_id).await;
 
-        // Source the removed value's HLC BEFORE assigning a sequence so the frame
-        // carries the idempotency key recovery needs (see `remove_frame_timestamp`).
-        let remove_hlc = self.remove_frame_timestamp(map, key).await?;
-
         let wal_seq = self.assign_wal_sequence(partition_id);
 
         // Append to WAL before updating in-memory state so crash recovery can
-        // replay the tombstone if the process dies after ack but before flush.
+        // replay the tombstone if the process dies after ack but before flush. A
+        // Remove frame carries no timestamp: replay deletes unconditionally, exactly
+        // as this live path does (see `WalRecovery::replay_entry`, TG-WAL-009).
         let wal_entry = WalEntry {
             map: map.to_string(),
             key: key.to_string(),
             op: WalOp::Remove,
-            timestamp: Some(remove_hlc),
+            timestamp: None,
             sequence: wal_seq,
         };
         // Evaluated on the SURVIVOR — this write — never on what it displaces.
@@ -2570,19 +2541,17 @@ impl MapDataStore for WriteBehindDataStore {
             // whatever a prior incarnation left un-applied.
             self.ensure_wal_seeded(partition_id).await;
 
-            // One HLC source per key — the frame carries the removed value's HLC so
-            // recovery guards each key's Remove replay (see `remove_frame_timestamp`).
-            let remove_hlc = self.remove_frame_timestamp(map, key).await?;
-
             let wal_seq = self.assign_wal_sequence(partition_id);
 
             // Append each tombstone to the WAL before queuing so crash recovery
-            // can replay every individual key deletion, not just the batch call.
+            // can replay every individual key deletion, not just the batch call. A
+            // Remove frame carries no timestamp: replay deletes unconditionally, as
+            // this live path does (see `WalRecovery::replay_entry`, TG-WAL-009).
             let wal_entry = WalEntry {
                 map: map.to_string(),
                 key: key.clone(),
                 op: WalOp::Remove,
-                timestamp: Some(remove_hlc),
+                timestamp: None,
                 sequence: wal_seq,
             };
             // Evaluated on the SURVIVOR — this key's write — never on what it

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -1882,6 +1882,13 @@ impl WalRecovery {
                 continue;
             }
 
+            // `entries` is strictly ascending by WAL sequence: `Wal::unapplied`
+            // sorts defensively (see its impl), and the loop below replays in that
+            // order. Both the contiguous-frontier watermark logic AND the gate-free
+            // Remove-idempotency non-reachability argument (TG-WAL-009's premise
+            // that a stale Remove is replayed only when every strictly-newer frame
+            // for the key is replayed AFTER it) rely on this ascending order
+            // (TG-WAL-011).
             tracing::info!(
                 partition = partition_id,
                 count = entries.len(),
@@ -2304,6 +2311,9 @@ mod tests {
         data: tokio::sync::Mutex<
             std::collections::HashMap<(String, String), crate::storage::record::RecordValue>,
         >,
+        /// The key of every `add`/`remove` in call order, so a recovery test can
+        /// assert the REPLAY ORDER (TG-WAL-011), not just the final state.
+        replay_order: tokio::sync::Mutex<Vec<String>>,
     }
 
     #[async_trait]
@@ -2316,6 +2326,7 @@ mod tests {
             _exp: i64,
             _now: i64,
         ) -> anyhow::Result<()> {
+            self.replay_order.lock().await.push(key.to_string());
             self.data
                 .lock()
                 .await
@@ -2333,6 +2344,7 @@ mod tests {
             Ok(())
         }
         async fn remove(&self, map: &str, key: &str, _now: i64) -> anyhow::Result<()> {
+            self.replay_order.lock().await.push(key.to_string());
             self.data
                 .lock()
                 .await
@@ -2681,6 +2693,61 @@ mod tests {
                 "every Remove deletes unconditionally regardless of its timestamp: {frame:?}"
             );
         }
+    }
+
+    /// TG-WAL-011: recovery replays the unapplied window in strictly ASCENDING
+    /// WAL-sequence order — `Wal::unapplied` sorts frames by sequence regardless of
+    /// the order they were appended (its defensive `sort_by_key`), and `run`
+    /// replays them in that order. This is premise (d) of the TG-WAL-009 gate-free
+    /// warrant — the "a strictly-newer re-creation is replayed AFTER the stale
+    /// Remove" step. Frames appended OUT OF ORDER (seq 3, 1, 2) come back — and
+    /// replay — 1, 2, 3. Removing the `sort_by_key` in `unapplied` makes both
+    /// assertions FAIL — the discriminator for the ordering contract.
+    #[tokio::test]
+    async fn wal_recovery_replays_in_strictly_ascending_sequence_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal = WalWriter::new(dir.path().to_path_buf(), WalFsyncPolicy::None).unwrap();
+
+        // Append out of sequence order (all > 0; seq 0 is the reserved sentinel
+        // `unapplied` filters). Each key carries its sequence so the probe records
+        // the replay order back.
+        for seq in [3u64, 1, 2] {
+            let entry = WalEntry {
+                map: "m".to_string(),
+                key: seq.to_string(),
+                op: WalOp::Remove,
+                timestamp: None,
+                sequence: seq,
+            };
+            wal.append(0, &entry).await.unwrap();
+        }
+        // `unapplied` sorts the shuffled appends into strictly ascending sequence
+        // order — the contract `run`'s in-order replay (and TG-WAL-009) depends on.
+        let enumerated: Vec<u64> = wal
+            .unapplied(0)
+            .await
+            .unwrap()
+            .iter()
+            .map(|e| e.sequence)
+            .collect();
+        assert_eq!(
+            enumerated,
+            vec![1, 2, 3],
+            "unapplied must return strictly ascending sequence order regardless of append order"
+        );
+
+        let store = Arc::new(MergeProbeStore::default());
+        WalRecovery::new(Arc::clone(&wal), vec![0])
+            .run(Arc::clone(&store) as Arc<dyn MapDataStore>)
+            .await
+            .unwrap();
+
+        let order = store.replay_order.lock().await.clone();
+        assert_eq!(
+            order,
+            vec!["1".to_string(), "2".to_string(), "3".to_string()],
+            "recovery must replay in ascending sequence order (got {order:?})"
+        );
     }
 
     /// Manual measurement of the per-append fsync tax of each `WalFsyncPolicy`.

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -379,7 +379,12 @@ pub struct WalEntry {
     pub op: WalOp,
     /// HLC timestamp from the originating write. Used as the idempotency key:
     /// during recovery, a replayed entry whose timestamp is older than the
-    /// current in-memory value is a no-op.
+    /// current in-memory value is a no-op. For a `WalOp::Store` `Lww` frame this
+    /// is the value's own HLC; for a modern `WalOp::Remove` frame it is the HLC of
+    /// the value being removed (the zero-epoch sentinel `{0,0,""}` when the key had
+    /// no `Lww` value to source one) — the idempotency key that lets recovery guard
+    /// a stale Remove against a newer re-creation. `None` is reserved for legacy
+    /// frames written by older servers, which bypass the replay gate.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub timestamp: Option<Timestamp>,
     /// Monotonically increasing counter assigned at append time. Establishes
@@ -1687,6 +1692,18 @@ impl WalRecovery {
     /// - A cross-kind case (stored value is not `Lww` while the incoming frame is)
     ///   cannot be compared by timestamp, so it also BYPASSES the gate and writes
     ///   through.
+    ///
+    /// Re-replay of a `WalOp::Remove` frame is ALSO idempotent, under a DISTINCT
+    /// invariant (`TG-WAL-009`, Remove-scoped — not the `TG-WAL-006` value claim
+    /// above). A modern Remove frame carries the removed value's HLC in
+    /// `entry.timestamp`; before deleting, this reads the current durable value and,
+    /// if it is a `RecordValue::Lww` whose HLC is STRICTLY NEWER than the Remove's,
+    /// discards the Remove (the value was re-created after it). Ties, an
+    /// older/absent target, and a non-`Lww` stored value all delete as before, so a
+    /// legitimate deletion is never suppressed. The zero-epoch sentinel `{0,0,""}`
+    /// (stamped for an absent-key Remove) flows through the same compare and skips
+    /// any real (`> 0`) value. A legacy `None`-timestamp Remove (older server)
+    /// BYPASSES the guard and always deletes, keeping the upgrade path intact.
     async fn replay_entry(
         inner_store: &Arc<dyn MapDataStore>,
         entry: &WalEntry,
@@ -1755,7 +1772,37 @@ impl WalRecovery {
                     )
                     .await
             }
-            WalOp::Remove => inner_store.remove(&entry.map, &entry.key, now).await,
+            WalOp::Remove => {
+                // Remove-idempotency gate (TG-WAL-009), DISTINCT from the LWW-value
+                // gate above (TG-WAL-006). A modern Remove frame carries the removed
+                // value's HLC in `entry.timestamp`; recovery must not let a STALE
+                // re-replayed Remove delete a value re-created after it (a frameless
+                // durable write outside the replay window). When the frame carries a
+                // real HLC and the current durable value is a strictly-NEWER `Lww`,
+                // the value was re-created after this Remove, so the Remove is stale
+                // and is skipped. Ties, older/absent targets, and a non-`Lww` stored
+                // value all delete as before. The zero-epoch sentinel `{0,0,""}`
+                // (absent-key remove) flows through this same `Some(hlc)` path and
+                // correctly skips any real (`> 0`) stored value — no special-casing.
+                // A legacy `None`-timestamp frame BYPASSES the guard and always
+                // deletes, preserving the upgrade path over a pre-existing on-disk
+                // WAL. `merge_gate` is always `true` in production; the harness flips
+                // it off to reproduce the pre-fix blind clobber.
+                if merge_gate {
+                    if let Some(remove_hlc) = &entry.timestamp {
+                        if let Some(RecordValue::Lww {
+                            timestamp: stored_ts,
+                            ..
+                        }) = inner_store.load(&entry.map, &entry.key).await?
+                        {
+                            if stored_ts > *remove_hlc {
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+                inner_store.remove(&entry.map, &entry.key, now).await
+            }
             // An explicit arm rather than a `_` catch-all: the exhaustiveness is
             // what forces a future framing to declare its replay semantics here
             // instead of inheriting someone else's. This variant is never
@@ -1793,6 +1840,12 @@ impl WalRecovery {
     /// monotonicity (post-RMW full snapshots, monotone in `wal_seq` order), not by
     /// this merge; their own merge-idempotency property is owned by `TG-OR-003`.
     /// Legacy frames keep always-merge replay.
+    ///
+    /// `WalOp::Remove` re-replay is idempotent under a DISTINCT invariant
+    /// (`TG-WAL-009`): a modern Remove frame carries the removed value's HLC, and
+    /// `replay_entry` discards a strictly-older Remove over a re-created newer
+    /// durable value; ties/newer/absent/non-`Lww`-stored targets delete, and a
+    /// legacy `None`-timestamp Remove bypasses the guard and always deletes.
     ///
     /// A partition whose frontier stops below its highest enumerated frame raises
     /// the abandoned-write alarm here, at boot. Write-behind's watchdog cannot

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -377,16 +377,15 @@ pub struct WalEntry {
     pub key: String,
     /// The operation to replay on recovery.
     pub op: WalOp,
-    /// HLC timestamp from the originating write. Used as the idempotency key:
-    /// during recovery, a replayed entry whose timestamp is older than the
-    /// current in-memory value is a no-op. For a `WalOp::Store` `Lww` frame this
-    /// is the value's own HLC; for a modern `WalOp::Remove` frame it is the HLC of
-    /// the value being removed — the idempotency key that lets recovery guard a
-    /// stale Remove against a newer re-creation. When the key had no `Lww` value to
-    /// source one, the zero-epoch sentinel `{0,0,""}` is stamped (distinct from
-    /// legacy `None` on the wire); it is NOT a sound gate basis, so recovery does
-    /// not skip on it. `None` is reserved for legacy frames written by older
-    /// servers, which bypass the replay gate.
+    /// HLC timestamp from the originating write. It is the idempotency key for
+    /// `WalOp::Store` `Lww` frames ONLY: during recovery a replayed Store whose
+    /// timestamp is older than the current durable value is a no-op (TG-WAL-006).
+    /// `WalOp::Remove` frames carry `None` — a Remove replays UNCONDITIONALLY,
+    /// exactly as the live remove path deletes unconditionally (no timestamp
+    /// compare), so recovery never consults a Remove's timestamp (TG-WAL-009). A
+    /// Remove gate would be unsound: live-remove has no such condition, and under
+    /// prefix-complete in-order replay a stale Remove can never be juxtaposed over
+    /// a strictly-newer re-creation (proof recorded in INVARIANTS.md TG-WAL-009).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub timestamp: Option<Timestamp>,
     /// Monotonically increasing counter assigned at append time. Establishes
@@ -1695,20 +1694,24 @@ impl WalRecovery {
     ///   cannot be compared by timestamp, so it also BYPASSES the gate and writes
     ///   through.
     ///
-    /// Re-replay of a `WalOp::Remove` frame is ALSO idempotent, under a DISTINCT
-    /// invariant (`TG-WAL-009`, Remove-scoped — not the `TG-WAL-006` value claim
-    /// above). A modern Remove frame carries the removed value's HLC in
-    /// `entry.timestamp`; before deleting, this reads the current durable value and,
-    /// if it is a `RecordValue::Lww` whose HLC is STRICTLY NEWER than the Remove's
-    /// REAL sourced HLC, discards the Remove (the value was re-created after it).
-    /// Ties, an older/absent target, and a non-`Lww` stored value all delete as
-    /// before, so a legitimate deletion is never suppressed. The zero-epoch sentinel
-    /// `{0,0,""}` (stamped for an absent-key Remove) is NOT a sound gate basis — it
-    /// is a synthetic bottom, not a causal position — so a sentinel Remove DELETES
-    /// as before; an absent-at-remove-time key needs no protection because any
-    /// re-creation carries its own later frame that in-order replay applies after
-    /// the Remove. A legacy `None`-timestamp Remove (older server) likewise BYPASSES
-    /// the guard and always deletes, keeping the upgrade path intact.
+    /// Re-replay of a `WalOp::Remove` frame is idempotent WITHOUT a gate, under a
+    /// DISTINCT invariant (`TG-WAL-009`, Remove-scoped — not the `TG-WAL-006` value
+    /// claim above). A Remove replays UNCONDITIONALLY, identical to the live remove
+    /// path (a blind delete with no timestamp compare): `entry.timestamp` is not
+    /// consulted. This is single-algebra-correct — a gate the live path does not
+    /// have would make `replay(Remove) != live(Remove)` and would itself lose acked
+    /// deletes (a Remove whose sourced value-HLC is strictly older than the LWW
+    /// survivor would be wrongly skipped). No gate is NEEDED either: under
+    /// prefix-complete, in-order replay of the unapplied window, a stale Remove at
+    /// sequence N is replayed only when N is above the watermark, in which case
+    /// every higher-sequence frame — including any strictly-newer re-creation — is
+    /// also above the watermark and replayed AFTER it, so the re-creation survives;
+    /// and the only way a re-creation is durable-but-unframed is that its sequence
+    /// is below the watermark, i.e. OLDER than the replayed Remove, so deleting it
+    /// is live-correct. The `stale-Remove-over-newer-frameless-value` juxtaposition
+    /// is unreachable except by re-applying an already-applied older frame — the
+    /// harness `re_replay_oldest_frame` seam, never a production path (see
+    /// INVARIANTS.md TG-WAL-009 for the full state-machine argument).
     async fn replay_entry(
         inner_store: &Arc<dyn MapDataStore>,
         entry: &WalEntry,
@@ -1778,48 +1781,18 @@ impl WalRecovery {
                     .await
             }
             WalOp::Remove => {
-                // Remove-idempotency gate (TG-WAL-009), DISTINCT from the LWW-value
-                // gate above (TG-WAL-006). A modern Remove frame carries the removed
-                // value's HLC in `entry.timestamp`; recovery must not let a STALE
-                // re-replayed Remove delete a value re-created after it (a frameless
-                // durable write outside the replay window). When the frame carries a
-                // REAL sourced HLC and the current durable value is a strictly-NEWER
-                // `Lww`, the value was re-created after this Remove, so the Remove is
-                // stale and is skipped. Ties, older/absent targets, and a non-`Lww`
-                // stored value all delete as before.
-                //
-                // The zero-epoch sentinel `{0,0,""}` (stamped when the key had no
-                // `Lww` value at remove time) is NOT a real causal position, so it is
-                // an UNSOUND basis to skip: comparing it against a real value's HLC
-                // (every real value is `> 0`) would always skip, and an older
-                // un-durable `Store` frame can legitimately replay JUST BEFORE this
-                // Remove in the same in-order pass — skipping would then resurrect a
-                // value the Remove is the last writer of. An absent-at-remove-time
-                // key needs no sentinel protection anyway: any re-creation of it is a
-                // fresh write carrying its OWN later frame (higher `wal_seq`), which
-                // in-order replay applies AFTER this Remove. So a sentinel Remove
-                // deletes as before — only a REAL HLC gates. A legacy `None`
-                // timestamp frame likewise BYPASSES the guard and always deletes
-                // (upgrade path). `merge_gate` is always `true` in production; the
-                // harness flips it off to reproduce the pre-fix blind clobber.
-                if merge_gate {
-                    if let Some(remove_hlc) = &entry.timestamp {
-                        let is_sentinel = remove_hlc.millis == 0
-                            && remove_hlc.counter == 0
-                            && remove_hlc.node_id.is_empty();
-                        if !is_sentinel {
-                            if let Some(RecordValue::Lww {
-                                timestamp: stored_ts,
-                                ..
-                            }) = inner_store.load(&entry.map, &entry.key).await?
-                            {
-                                if stored_ts > *remove_hlc {
-                                    return Ok(());
-                                }
-                            }
-                        }
-                    }
-                }
+                // Replay a Remove UNCONDITIONALLY (TG-WAL-009) — identical to the
+                // live remove path, which is a blind delete with no timestamp
+                // compare. `entry.timestamp` is deliberately NOT consulted and
+                // `merge_gate` is ignored for this arm: a gate the live path does not
+                // have would make `replay(Remove) != live(Remove)` and would itself
+                // lose acked deletes (the exact regression an HLC-sourced gate
+                // produced). No gate is needed — under prefix-complete in-order
+                // replay a stale Remove can never be juxtaposed over a strictly-newer
+                // re-creation (see `run`'s doc-contract and INVARIANTS.md TG-WAL-009
+                // for the state-machine argument). The harness reproduces the
+                // synthetic out-of-order clobber via its `re_replay_oldest_frame`
+                // seam, not through this arm.
                 inner_store.remove(&entry.map, &entry.key, now).await
             }
             // An explicit arm rather than a `_` catch-all: the exhaustiveness is
@@ -1861,12 +1834,16 @@ impl WalRecovery {
     /// Legacy frames keep always-merge replay.
     ///
     /// `WalOp::Remove` re-replay is idempotent under a DISTINCT invariant
-    /// (`TG-WAL-009`): a modern Remove frame carries the removed value's REAL HLC,
-    /// and `replay_entry` discards a strictly-older Remove over a re-created newer
-    /// durable value; ties/newer/absent/non-`Lww`-stored targets delete. An
-    /// absent-key Remove carries the zero-epoch sentinel, which does NOT gate (no
-    /// sound causal HLC), so it deletes; a legacy `None`-timestamp Remove likewise
-    /// bypasses the guard and always deletes.
+    /// (`TG-WAL-009`) WITHOUT a gate: a Remove replays UNCONDITIONALLY, identical to
+    /// the live remove path (blind delete). Because this pass is prefix-complete and
+    /// strictly in-order, a stale Remove at sequence N is replayed only when N sits
+    /// above the applied watermark, which forces every higher-sequence frame —
+    /// including any strictly-newer re-creation — above the watermark too, so the
+    /// re-creation replays AFTER the Remove and survives; and a re-creation that is
+    /// durable-but-unframed necessarily sits below the watermark (older than the
+    /// replayed Remove), so deleting it is live-correct. The out-of-order
+    /// stale-Remove-over-newer-value state is unreachable here and is fabricated
+    /// only by the harness `re_replay_oldest_frame` seam.
     ///
     /// A partition whose frontier stops below its highest enumerated frame raises
     /// the abandoned-write alarm here, at boot. Write-behind's watchdog cannot
@@ -2634,37 +2611,20 @@ mod tests {
         }
     }
 
-    /// TG-WAL-009: the `WalOp::Remove` gate in `replay_entry` discards a Remove
-    /// whose REAL HLC is STRICTLY OLDER than the current durable value (the value
-    /// was re-created after the Remove), lets a tie/newer Remove delete, and — with
-    /// the gate off — reproduces the pre-fix blind clobber. Also proves the
-    /// zero-epoch sentinel Remove (absent-key path) is NOT a sound gate basis and so
-    /// DELETES a present real value rather than resurrecting it. This isolates the
-    /// GATE as the fix (independent of the harness's re-replay seam).
+    /// TG-WAL-009: `replay_entry` replays a `WalOp::Remove` UNCONDITIONALLY —
+    /// identical to the live remove path (a blind delete). It NEVER consults the
+    /// frame's timestamp and NEVER resurrects a value via a gate. The strictly-older
+    /// case is the discriminator: an HLC-sourced gate (the reverted regression)
+    /// would have SKIPPED a Remove whose sourced HLC is older than the durable
+    /// value, losing the acked delete; unconditional replay deletes it, matching
+    /// live. This isolates the SEMANTICS (independent of the harness re-replay seam),
+    /// and `merge_gate` is proven irrelevant to the Remove arm.
     #[tokio::test]
-    async fn replay_remove_gate_discards_stale_remove_isolated() {
-        let store: Arc<dyn MapDataStore> = Arc::new(MergeProbeStore::default());
+    async fn replay_remove_replays_unconditionally_isolated() {
         let newer = RecordValue::Lww {
             value: TgValue::Int(20),
             timestamp: ts(20),
         };
-
-        // Gate ON: a stale Remove (real hlc=10) over a newer (ts=20) re-created
-        // value is discarded — the value survives.
-        store.add("m", "k", &newer, 0, 0).await.unwrap();
-        WalRecovery::replay_entry(&store, &remove_frame("k", 10), 0, true)
-            .await
-            .unwrap();
-        assert_eq!(
-            load_millis(&store, "k").await,
-            Some(20),
-            "gate ON must discard a strictly-older Remove (no clobber of the re-creation)"
-        );
-
-        // Gate ON: the zero-epoch sentinel Remove (absent-key remove) is a synthetic
-        // bottom, NOT a sound causal HLC, so it does not gate — it DELETES the
-        // present value. (In production an absent-key re-creation carries its own
-        // later frame, so nothing legitimate is lost.)
         let sentinel_remove = WalEntry {
             map: "m".to_string(),
             key: "k".to_string(),
@@ -2676,85 +2636,51 @@ mod tests {
             }),
             sequence: 1,
         };
-        WalRecovery::replay_entry(&store, &sentinel_remove, 0, true)
-            .await
-            .unwrap();
-        assert_eq!(
-            store.load("m", "k").await.unwrap(),
-            None,
-            "gate ON: the zero-epoch sentinel Remove must delete (not resurrect) a present value"
-        );
 
-        // Gate ON: a tie Remove (hlc=20) deletes — the guard only discards STRICTLY
-        // older Removes, so it never suppresses a legitimate deletion.
-        store.add("m", "k", &newer, 0, 0).await.unwrap();
-        WalRecovery::replay_entry(&store, &remove_frame("k", 20), 0, true)
-            .await
-            .unwrap();
-        assert_eq!(
-            store.load("m", "k").await.unwrap(),
-            None,
-            "gate ON: a tie Remove (hlc == stored) still deletes"
-        );
+        // The discriminator: a Remove whose sourced HLC (10) is STRICTLY OLDER than
+        // a newer durable value (20) STILL deletes. The reverted gate would have
+        // skipped this (resurrecting the value and losing the acked delete); live
+        // remove deletes unconditionally, so replay must too. Proven under BOTH
+        // `merge_gate` values — the Remove arm ignores the flag entirely.
+        for merge_gate in [true, false] {
+            let store: Arc<dyn MapDataStore> = Arc::new(MergeProbeStore::default());
+            store.add("m", "k", &newer, 0, 0).await.unwrap();
+            WalRecovery::replay_entry(&store, &remove_frame("k", 10), 0, merge_gate)
+                .await
+                .unwrap();
+            assert_eq!(
+                store.load("m", "k").await.unwrap(),
+                None,
+                "a strictly-older Remove still deletes (unconditional replay = live), \
+                 merge_gate={merge_gate}"
+            );
+        }
 
-        // Gate ON: a newer Remove over an older value deletes.
-        store.add("m", "k", &newer, 0, 0).await.unwrap();
-        WalRecovery::replay_entry(&store, &remove_frame("k", 30), 0, true)
-            .await
-            .unwrap();
-        assert_eq!(
-            store.load("m", "k").await.unwrap(),
-            None,
-            "gate ON: a newer Remove over an older value deletes"
-        );
-
-        // Gate OFF: a stale Remove clobbers the newer value — the pre-fix blind replay.
-        store.add("m", "k", &newer, 0, 0).await.unwrap();
-        WalRecovery::replay_entry(&store, &remove_frame("k", 10), 0, false)
-            .await
-            .unwrap();
-        assert_eq!(
-            store.load("m", "k").await.unwrap(),
-            None,
-            "gate OFF reproduces the blind Remove clobber (the defect the fix closes)"
-        );
-    }
-
-    /// TG-WAL-009 legacy bypass: a Remove frame with `timestamp: None` (written by
-    /// an older server) BYPASSES the guard and always deletes, even over a newer
-    /// durable value — the upgrade path over a pre-existing on-disk WAL must never
-    /// silently stop deleting (mirrors the LWW legacy bypass).
-    #[tokio::test]
-    async fn replay_legacy_remove_bypasses_gate() {
-        let store: Arc<dyn MapDataStore> = Arc::new(MergeProbeStore::default());
-        store
-            .add(
-                "m",
-                "k",
-                &RecordValue::Lww {
-                    value: TgValue::Int(50),
-                    timestamp: ts(50),
-                },
-                0,
-                0,
-            )
-            .await
-            .unwrap();
-        let legacy = WalEntry {
-            map: "m".to_string(),
-            key: "k".to_string(),
-            op: WalOp::Remove,
-            timestamp: None,
-            sequence: 1,
-        };
-        WalRecovery::replay_entry(&store, &legacy, 0, true)
-            .await
-            .unwrap();
-        assert_eq!(
-            store.load("m", "k").await.unwrap(),
-            None,
-            "a legacy None-timestamp Remove must always delete (bypass the gate)"
-        );
+        // A tie, a newer, a sentinel, and a legacy `None` Remove all delete too —
+        // there is no timestamp condition on the Remove arm at all.
+        for frame in [
+            remove_frame("k", 20),
+            remove_frame("k", 30),
+            sentinel_remove,
+            WalEntry {
+                map: "m".to_string(),
+                key: "k".to_string(),
+                op: WalOp::Remove,
+                timestamp: None,
+                sequence: 1,
+            },
+        ] {
+            let store: Arc<dyn MapDataStore> = Arc::new(MergeProbeStore::default());
+            store.add("m", "k", &newer, 0, 0).await.unwrap();
+            WalRecovery::replay_entry(&store, &frame, 0, true)
+                .await
+                .unwrap();
+            assert_eq!(
+                store.load("m", "k").await.unwrap(),
+                None,
+                "every Remove deletes unconditionally regardless of its timestamp: {frame:?}"
+            );
+        }
     }
 
     /// Manual measurement of the per-append fsync tax of each `WalFsyncPolicy`.

--- a/packages/server-rust/src/storage/wal/mod.rs
+++ b/packages/server-rust/src/storage/wal/mod.rs
@@ -381,10 +381,12 @@ pub struct WalEntry {
     /// during recovery, a replayed entry whose timestamp is older than the
     /// current in-memory value is a no-op. For a `WalOp::Store` `Lww` frame this
     /// is the value's own HLC; for a modern `WalOp::Remove` frame it is the HLC of
-    /// the value being removed (the zero-epoch sentinel `{0,0,""}` when the key had
-    /// no `Lww` value to source one) — the idempotency key that lets recovery guard
-    /// a stale Remove against a newer re-creation. `None` is reserved for legacy
-    /// frames written by older servers, which bypass the replay gate.
+    /// the value being removed — the idempotency key that lets recovery guard a
+    /// stale Remove against a newer re-creation. When the key had no `Lww` value to
+    /// source one, the zero-epoch sentinel `{0,0,""}` is stamped (distinct from
+    /// legacy `None` on the wire); it is NOT a sound gate basis, so recovery does
+    /// not skip on it. `None` is reserved for legacy frames written by older
+    /// servers, which bypass the replay gate.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub timestamp: Option<Timestamp>,
     /// Monotonically increasing counter assigned at append time. Establishes
@@ -1697,13 +1699,16 @@ impl WalRecovery {
     /// invariant (`TG-WAL-009`, Remove-scoped — not the `TG-WAL-006` value claim
     /// above). A modern Remove frame carries the removed value's HLC in
     /// `entry.timestamp`; before deleting, this reads the current durable value and,
-    /// if it is a `RecordValue::Lww` whose HLC is STRICTLY NEWER than the Remove's,
-    /// discards the Remove (the value was re-created after it). Ties, an
-    /// older/absent target, and a non-`Lww` stored value all delete as before, so a
-    /// legitimate deletion is never suppressed. The zero-epoch sentinel `{0,0,""}`
-    /// (stamped for an absent-key Remove) flows through the same compare and skips
-    /// any real (`> 0`) value. A legacy `None`-timestamp Remove (older server)
-    /// BYPASSES the guard and always deletes, keeping the upgrade path intact.
+    /// if it is a `RecordValue::Lww` whose HLC is STRICTLY NEWER than the Remove's
+    /// REAL sourced HLC, discards the Remove (the value was re-created after it).
+    /// Ties, an older/absent target, and a non-`Lww` stored value all delete as
+    /// before, so a legitimate deletion is never suppressed. The zero-epoch sentinel
+    /// `{0,0,""}` (stamped for an absent-key Remove) is NOT a sound gate basis — it
+    /// is a synthetic bottom, not a causal position — so a sentinel Remove DELETES
+    /// as before; an absent-at-remove-time key needs no protection because any
+    /// re-creation carries its own later frame that in-order replay applies after
+    /// the Remove. A legacy `None`-timestamp Remove (older server) likewise BYPASSES
+    /// the guard and always deletes, keeping the upgrade path intact.
     async fn replay_entry(
         inner_store: &Arc<dyn MapDataStore>,
         entry: &WalEntry,
@@ -1778,25 +1783,39 @@ impl WalRecovery {
                 // value's HLC in `entry.timestamp`; recovery must not let a STALE
                 // re-replayed Remove delete a value re-created after it (a frameless
                 // durable write outside the replay window). When the frame carries a
-                // real HLC and the current durable value is a strictly-NEWER `Lww`,
-                // the value was re-created after this Remove, so the Remove is stale
-                // and is skipped. Ties, older/absent targets, and a non-`Lww` stored
-                // value all delete as before. The zero-epoch sentinel `{0,0,""}`
-                // (absent-key remove) flows through this same `Some(hlc)` path and
-                // correctly skips any real (`> 0`) stored value — no special-casing.
-                // A legacy `None`-timestamp frame BYPASSES the guard and always
-                // deletes, preserving the upgrade path over a pre-existing on-disk
-                // WAL. `merge_gate` is always `true` in production; the harness flips
-                // it off to reproduce the pre-fix blind clobber.
+                // REAL sourced HLC and the current durable value is a strictly-NEWER
+                // `Lww`, the value was re-created after this Remove, so the Remove is
+                // stale and is skipped. Ties, older/absent targets, and a non-`Lww`
+                // stored value all delete as before.
+                //
+                // The zero-epoch sentinel `{0,0,""}` (stamped when the key had no
+                // `Lww` value at remove time) is NOT a real causal position, so it is
+                // an UNSOUND basis to skip: comparing it against a real value's HLC
+                // (every real value is `> 0`) would always skip, and an older
+                // un-durable `Store` frame can legitimately replay JUST BEFORE this
+                // Remove in the same in-order pass — skipping would then resurrect a
+                // value the Remove is the last writer of. An absent-at-remove-time
+                // key needs no sentinel protection anyway: any re-creation of it is a
+                // fresh write carrying its OWN later frame (higher `wal_seq`), which
+                // in-order replay applies AFTER this Remove. So a sentinel Remove
+                // deletes as before — only a REAL HLC gates. A legacy `None`
+                // timestamp frame likewise BYPASSES the guard and always deletes
+                // (upgrade path). `merge_gate` is always `true` in production; the
+                // harness flips it off to reproduce the pre-fix blind clobber.
                 if merge_gate {
                     if let Some(remove_hlc) = &entry.timestamp {
-                        if let Some(RecordValue::Lww {
-                            timestamp: stored_ts,
-                            ..
-                        }) = inner_store.load(&entry.map, &entry.key).await?
-                        {
-                            if stored_ts > *remove_hlc {
-                                return Ok(());
+                        let is_sentinel = remove_hlc.millis == 0
+                            && remove_hlc.counter == 0
+                            && remove_hlc.node_id.is_empty();
+                        if !is_sentinel {
+                            if let Some(RecordValue::Lww {
+                                timestamp: stored_ts,
+                                ..
+                            }) = inner_store.load(&entry.map, &entry.key).await?
+                            {
+                                if stored_ts > *remove_hlc {
+                                    return Ok(());
+                                }
                             }
                         }
                     }
@@ -1842,10 +1861,12 @@ impl WalRecovery {
     /// Legacy frames keep always-merge replay.
     ///
     /// `WalOp::Remove` re-replay is idempotent under a DISTINCT invariant
-    /// (`TG-WAL-009`): a modern Remove frame carries the removed value's HLC, and
-    /// `replay_entry` discards a strictly-older Remove over a re-created newer
-    /// durable value; ties/newer/absent/non-`Lww`-stored targets delete, and a
-    /// legacy `None`-timestamp Remove bypasses the guard and always deletes.
+    /// (`TG-WAL-009`): a modern Remove frame carries the removed value's REAL HLC,
+    /// and `replay_entry` discards a strictly-older Remove over a re-created newer
+    /// durable value; ties/newer/absent/non-`Lww`-stored targets delete. An
+    /// absent-key Remove carries the zero-epoch sentinel, which does NOT gate (no
+    /// sound causal HLC), so it deletes; a legacy `None`-timestamp Remove likewise
+    /// bypasses the guard and always deletes.
     ///
     /// A partition whose frontier stops below its highest enumerated frame raises
     /// the abandoned-write alarm here, at boot. Write-behind's watchdog cannot
@@ -2600,6 +2621,139 @@ mod tests {
                 },
             }),
             "a legacy frame must always-merge (bypass the gate) even over a newer value"
+        );
+    }
+
+    fn remove_frame(key: &str, millis: u64) -> WalEntry {
+        WalEntry {
+            map: "m".to_string(),
+            key: key.to_string(),
+            op: WalOp::Remove,
+            timestamp: Some(ts(millis)),
+            sequence: 1,
+        }
+    }
+
+    /// TG-WAL-009: the `WalOp::Remove` gate in `replay_entry` discards a Remove
+    /// whose REAL HLC is STRICTLY OLDER than the current durable value (the value
+    /// was re-created after the Remove), lets a tie/newer Remove delete, and — with
+    /// the gate off — reproduces the pre-fix blind clobber. Also proves the
+    /// zero-epoch sentinel Remove (absent-key path) is NOT a sound gate basis and so
+    /// DELETES a present real value rather than resurrecting it. This isolates the
+    /// GATE as the fix (independent of the harness's re-replay seam).
+    #[tokio::test]
+    async fn replay_remove_gate_discards_stale_remove_isolated() {
+        let store: Arc<dyn MapDataStore> = Arc::new(MergeProbeStore::default());
+        let newer = RecordValue::Lww {
+            value: TgValue::Int(20),
+            timestamp: ts(20),
+        };
+
+        // Gate ON: a stale Remove (real hlc=10) over a newer (ts=20) re-created
+        // value is discarded — the value survives.
+        store.add("m", "k", &newer, 0, 0).await.unwrap();
+        WalRecovery::replay_entry(&store, &remove_frame("k", 10), 0, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            load_millis(&store, "k").await,
+            Some(20),
+            "gate ON must discard a strictly-older Remove (no clobber of the re-creation)"
+        );
+
+        // Gate ON: the zero-epoch sentinel Remove (absent-key remove) is a synthetic
+        // bottom, NOT a sound causal HLC, so it does not gate — it DELETES the
+        // present value. (In production an absent-key re-creation carries its own
+        // later frame, so nothing legitimate is lost.)
+        let sentinel_remove = WalEntry {
+            map: "m".to_string(),
+            key: "k".to_string(),
+            op: WalOp::Remove,
+            timestamp: Some(Timestamp {
+                millis: 0,
+                counter: 0,
+                node_id: String::new(),
+            }),
+            sequence: 1,
+        };
+        WalRecovery::replay_entry(&store, &sentinel_remove, 0, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.load("m", "k").await.unwrap(),
+            None,
+            "gate ON: the zero-epoch sentinel Remove must delete (not resurrect) a present value"
+        );
+
+        // Gate ON: a tie Remove (hlc=20) deletes — the guard only discards STRICTLY
+        // older Removes, so it never suppresses a legitimate deletion.
+        store.add("m", "k", &newer, 0, 0).await.unwrap();
+        WalRecovery::replay_entry(&store, &remove_frame("k", 20), 0, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.load("m", "k").await.unwrap(),
+            None,
+            "gate ON: a tie Remove (hlc == stored) still deletes"
+        );
+
+        // Gate ON: a newer Remove over an older value deletes.
+        store.add("m", "k", &newer, 0, 0).await.unwrap();
+        WalRecovery::replay_entry(&store, &remove_frame("k", 30), 0, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.load("m", "k").await.unwrap(),
+            None,
+            "gate ON: a newer Remove over an older value deletes"
+        );
+
+        // Gate OFF: a stale Remove clobbers the newer value — the pre-fix blind replay.
+        store.add("m", "k", &newer, 0, 0).await.unwrap();
+        WalRecovery::replay_entry(&store, &remove_frame("k", 10), 0, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.load("m", "k").await.unwrap(),
+            None,
+            "gate OFF reproduces the blind Remove clobber (the defect the fix closes)"
+        );
+    }
+
+    /// TG-WAL-009 legacy bypass: a Remove frame with `timestamp: None` (written by
+    /// an older server) BYPASSES the guard and always deletes, even over a newer
+    /// durable value — the upgrade path over a pre-existing on-disk WAL must never
+    /// silently stop deleting (mirrors the LWW legacy bypass).
+    #[tokio::test]
+    async fn replay_legacy_remove_bypasses_gate() {
+        let store: Arc<dyn MapDataStore> = Arc::new(MergeProbeStore::default());
+        store
+            .add(
+                "m",
+                "k",
+                &RecordValue::Lww {
+                    value: TgValue::Int(50),
+                    timestamp: ts(50),
+                },
+                0,
+                0,
+            )
+            .await
+            .unwrap();
+        let legacy = WalEntry {
+            map: "m".to_string(),
+            key: "k".to_string(),
+            op: WalOp::Remove,
+            timestamp: None,
+            sequence: 1,
+        };
+        WalRecovery::replay_entry(&store, &legacy, 0, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.load("m", "k").await.unwrap(),
+            None,
+            "a legacy None-timestamp Remove must always delete (bypass the gate)"
         );
     }
 


### PR DESCRIPTION
## Summary

A **refutation outcome** (planned as a bugfix, delivered as a proof): the hypothesized Remove replay gate (TODO-609) was built, then **disproven by the spec's own generative baseline** — the gate lost acked deletes that the live path would perform (live-remove is unconditional; any HLC gate makes replay ≠ live, violating single-algebra). The gate was deleted; **net production behavior delta vs main is NIL** (verified line-by-line in review + /xreview).

What shipped instead:
- **TG-WAL-009**: the gate-free Remove-idempotency warrant — a structural non-reachability proof (`M ≤ W < N < M` contradiction: a stale-Remove-over-newer-re-creation cannot occur under prefix-complete in-order replay), all four premises machine-backed and catalogued.
- **Two new enforced invariants**: TG-WAL-010 (per-partition wal_seq strictly monotone + global no-reuse — mutation-verified across 8 partitions) and TG-WAL-011 (recovery replays the unapplied window in ascending seq order — mutation-verified by sort deletion).
- **Anti-regression discriminator**: reintroducing the rejected gate goes RED (verified by actual gate restoration during review).
- Oracle sound-domain constraint (`make_hlc_monotone`) — the non-monotone domain stays honestly owned by TODO-610.
- Catalog 16 → 18 entries, NAKED stays 5 == baseline.

Residuals routed: TODO-610 (oracle non-monotone domain, rides SPEC-349b), TODO-611 (pre-existing O2), **TODO-612 (frameless flush_key windowing residual — PRE-SOAK gate, owned by SPEC-349)**.

## Test evidence
5 review cycles (v1 caught a loss-class regression by clean-main worktree provenance proof; v4 ran mutation experiments; v5 APPROVED) · full `cargo test --release` 1790/0 · clippy `-D warnings` · fmt · sim · `check-invariants.sh` 18 entries, 5 NAKED == baseline · /xreview: 0 findings ("cannot break it"), NIL-delta independently confirmed.