### PR TITLE
OR-delta apply seam + gauge-reconcile lib seam + prune error-path hardening [SPEC-349a, 1/3]

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -368,7 +368,9 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
   counter call sites in `crdt.rs`: `add_tombstone_bytes` inside the OR_REMOVE mutate closure's
   new-tombstone guard, and `sub_tombstone_bytes` in `crdt.rs::prune_epoch_tombstones`'s post-write
   `Ok(_)` arm behind `dropped`. Both deliberately sit OUTSIDE the extracted pure apply
-  (`crdt.rs::apply_or_delta`, which is counter-free by contract — TG-OR-003). That purity rule is NOT
+  (`crdt.rs::apply_or_delta`, whose counter-freeness is itself asserted, behaviourally by
+  `crdt.rs::or_apply_moves_no_tombstone_bytes_on_any_arm` and structurally by
+  `::or_apply_body_names_no_tombstone_byte_counter`). That purity rule is NOT
   permission to move them into it: the decrement in particular must fire only after the durable write
   succeeds, because the gauge tracks bytes actually resident, not bytes removed from an in-memory copy.
   Citations are kept line-number-free on purpose — the SPEC-349 extraction relocated the surrounding

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -311,13 +311,20 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
 - **Statement:** one call invokes `mutate` at most once (doc-contract, SPEC-347); gauge side
   effects inside the closure must not double-count.
 - **Maintaining code:** doc-contract + DashMap shard-lock path.
-- **Enforcing test:** partial —
-  `or_inplace_mutate_proptest.rs::new_tombstone_counted_once_across_write_failure_and_retry`
-  proves no double-count across fail+retry; the literal call-counter assertion (`AtomicUsize
-  == 1` per call) is `NAKED (TODO-602)`.
+- **Enforcing test:** the literal call-counter assertion now exists —
+  `or_inplace_mutate_proptest.rs::update_in_place_invokes_the_mutate_closure_exactly_once_per_call`
+  counts invocations per call (`AtomicUsize`) on the insert, occupied and failed-write-through
+  paths, and `::update_in_place_admits_the_take_once_shape_the_or_add_path_uses` pins the OR_ADD
+  `Option::take` shape; both are mutation-proven RED against a second `mutate` call in either
+  `engines/hashmap.rs` arm.
+  `::new_tombstone_counted_once_across_write_failure_and_retry` covers the gauge half (no
+  double-count across fail+retry).
+  Scope of that evidence, stated honestly: it counts the production pair the record-store factory
+  builds (`DefaultRecordStore` + `HashMapStorage`). Other `RecordStore` impls, including the trait's
+  own default fallback, are not counted.
 - **Violation consequence:** hidden internal retry double-applies CRDT mutations/gauge deltas.
 - **Discovered by:** SPEC-347 review minors.
-- **Status:** decided; enforcement partial.
+- **Status:** decided, **enforced** for the production store/engine pair.
 
 ### TG-OR-002: OR observers receive the documented `old_value` contract (post-image)
 

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -345,7 +345,11 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
   equal `or_map_semantic_view` (live set + tombstones + pruned), with the durable store as fold
   base and snapshot frames as in-order absolute-set inputs.
 - **Maintaining code:** types + oracle landed (SPEC-346); fold delegates to the live apply path
-  (single-algebra rule, SPEC-349 R-mandate).
+  (single-algebra rule, SPEC-349 R-mandate). That path now has a named anchor: `crdt.rs::apply_or_delta`
+  — the ONE extracted pure apply of the add-wins / remove-wins / prune algebra, which the live OR_ADD,
+  OR_REMOVE and epoch-prune call sites all route through (SPEC-349a). The delta fold must delegate to
+  that symbol rather than re-implement the algebra; a second hand-written copy is what this invariant
+  forbids, and the symbol is what SPEC-349b's delegation is checked against.
 - **Enforcing test:** `NAKED — the OR delta-fold differential recovery proof does not exist yet.
   It lands as a case on the cross-incarnation harness
   (packages/server-rust/src/storage/datastores/wal_harness/), driven by SPEC-349b — not a fork`.
@@ -360,10 +364,18 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
 - **Statement:** `add_tombstone_bytes` fires on the real OR-remove path and `sub_tombstone_bytes`
   on the real epoch-prune path (mutation-proven both directions); tests bind task-local isolated
   gauges — no order-dependent global reads; negative controls never read a shared counter.
-- **Maintaining code:** `record.rs` fns delegating through the scoped sink resolver.
-- **Enforcing test:** SPEC-351 suite (9 tests) — real-prune-path coverage
-  (`crdt.rs:1394` mutation → deterministic RED), per-binding tripwire, private-counter foreign
-  traffic control.
+- **Maintaining code:** `record.rs` fns delegating through the scoped sink resolver, plus the two
+  counter call sites in `crdt.rs`: `add_tombstone_bytes` inside the OR_REMOVE mutate closure's
+  new-tombstone guard, and `sub_tombstone_bytes` in `crdt.rs::prune_epoch_tombstones`'s post-write
+  `Ok(_)` arm behind `dropped`. Both deliberately sit OUTSIDE the extracted pure apply
+  (`crdt.rs::apply_or_delta`, which is counter-free by contract — TG-OR-003). That purity rule is NOT
+  permission to move them into it: the decrement in particular must fire only after the durable write
+  succeeds, because the gauge tracks bytes actually resident, not bytes removed from an in-memory copy.
+  Citations are kept line-number-free on purpose — the SPEC-349 extraction relocated the surrounding
+  code, and a line citation would have drifted silently.
+- **Enforcing test:** SPEC-351 suite (9 tests) — real-prune-path coverage at
+  `crdt.rs::prune_epoch_tombstones`, post-write `Ok(_)` arm (mutating that `sub_tombstone_bytes` call
+  → deterministic RED), per-binding tripwire, private-counter foreign traffic control.
 - **Violation consequence:** the SPEC-345 tombstone hard gate reads a fiction; the 72h soak's
   primary instrument lies.
 - **Discovered by:** SPEC-351 audit C1 (the gauge was previously asserted only against a test

--- a/packages/server-rust/src/bin/topgun_server.rs
+++ b/packages/server-rust/src/bin/topgun_server.rs
@@ -95,7 +95,7 @@ use topgun_server::storage::impls::StorageConfig;
 use topgun_server::storage::map_data_store::MapDataStore;
 use topgun_server::storage::merkle_sync::{MerkleObserverFactory, MerkleSyncManager};
 use topgun_server::storage::mutation_observer::MutationObserver;
-use topgun_server::storage::record::{legacy_tombstone_warning, set_tombstone_bytes, RecordValue};
+use topgun_server::storage::record::reconcile_tombstone_bytes;
 use topgun_server::storage::wal::{Wal, WalFsyncPolicy, WalRecovery, WalWriter};
 
 // ---------------------------------------------------------------------------
@@ -162,124 +162,6 @@ async fn select_datastore() -> anyhow::Result<(Arc<dyn MapDataStore>, StorageBac
         other => anyhow::bail!(
             "Unknown STORAGE_BACKEND='{other}' (expected: redb, postgres, null)"
         ),
-    }
-}
-
-/// One-time startup reconciliation of the OR-Map tombstone-bytes gauge.
-///
-/// Runs exactly once, after WAL recovery completes and strictly before the
-/// listener accepts connections, for durable backends only. Walks the full
-/// persisted primary keyspace via the cursor-batched scan surface, sums
-/// `tag.len()` over every tombstone string in every persisted `OrMap` record,
-/// and re-baselines the gauge to that absolute total via [`set_tombstone_bytes`].
-/// This makes the scraped `topgun_ormap_tombstone_bytes_total` series survive a
-/// `kill -9` restart — the gauge otherwise resets to 0 on every process start
-/// and never re-counts rehydrated (redb-persisted) tombstones.
-///
-/// Never runs on any read/write/rehydration path — boot-only, exactly-once. On
-/// scan failure it logs a WARN and leaves the process-local gauge at its default
-/// (0): reconciliation is a monitoring-accuracy improvement, not a durability
-/// invariant, so a failed reconcile degrades to today's process-local behavior
-/// rather than aborting startup.
-///
-/// Legacy `RecordValue::OrTombstones { tags }` blobs are deliberately excluded
-/// from the sum. The live `add_tombstone_bytes` gauge never counts them either:
-/// the read path folds their tags into the unified `OrMap.tombstones` view
-/// WITHOUT emitting to the gauge, so summing them here would over-count relative
-/// to the live gauge this seed re-baselines.
-///
-/// `list_maps` on the redb backend enumerates primary partitions only, so backup
-/// tombstones are excluded — correct for the single-node soak/demo tier this
-/// targets; a future cluster/backup-accounting revisit is out of scope here.
-async fn reconcile_tombstone_bytes(store: Arc<dyn MapDataStore>) {
-    let maps = match store.list_maps().await {
-        Ok(maps) => maps,
-        Err(err) => {
-            tracing::warn!(
-                target: "topgun_server::bootstrap",
-                error = %err,
-                "tombstone-bytes reconciliation skipped: list_maps failed; gauge stays process-local"
-            );
-            return;
-        }
-    };
-
-    let mut total: u64 = 0;
-    let mut records_scanned: u64 = 0;
-    // Folded into this existing boot-only walk (no second O(keyspace) scan): the
-    // count of legacy tombstone-only blobs, which a clean-slate store never grows
-    // but a rehydrated pre-epoch store still carries. Durable backends only — this
-    // reconcile runs solely under the redb/postgres startup arm.
-    let mut legacy_rows: u64 = 0;
-
-    for map in &maps {
-        // Walk the whole map: first batch, then follow the cursor until exhausted
-        // so every record is visited regardless of map size. Each batch is itself
-        // cost-bounded, keeping resident cost under the TOPGUN_MAX_RAM_MB ceiling —
-        // a memory-safety property, not just a startup-latency one.
-        let mut batch = match store.scan_values(map, false, 0).await {
-            Ok(batch) => batch,
-            Err(err) => {
-                tracing::warn!(
-                    target: "topgun_server::bootstrap",
-                    map = %map,
-                    error = %err,
-                    "tombstone-bytes reconciliation skipped: scan_values failed; gauge stays process-local"
-                );
-                return;
-            }
-        };
-
-        loop {
-            for (_key, value) in &batch.records {
-                records_scanned += 1;
-                match value {
-                    RecordValue::OrMap { tombstones, .. } => {
-                        for tag in tombstones {
-                            total += tag.len() as u64;
-                        }
-                    }
-                    RecordValue::OrTombstones { .. } => legacy_rows += 1,
-                    RecordValue::Lww { .. } => {}
-                }
-            }
-
-            match batch.next_cursor.take() {
-                None => break,
-                Some(cursor) => {
-                    batch = match store.scan_values_batched(map, false, cursor, 0).await {
-                        Ok(next) => next,
-                        Err(err) => {
-                            tracing::warn!(
-                                target: "topgun_server::bootstrap",
-                                map = %map,
-                                error = %err,
-                                "tombstone-bytes reconciliation skipped: scan_values_batched failed; gauge stays process-local"
-                            );
-                            return;
-                        }
-                    };
-                }
-            }
-        }
-    }
-
-    set_tombstone_bytes(total);
-
-    tracing::info!(
-        target: "topgun_server::bootstrap",
-        tombstone_bytes = total,
-        records_scanned = records_scanned,
-        maps = maps.len(),
-        "OR-Map tombstone-bytes gauge reconciled from persisted keyspace"
-    );
-
-    if let Some(warning) = legacy_tombstone_warning(legacy_rows) {
-        tracing::warn!(
-            target: "topgun_server::bootstrap",
-            legacy_tombstone_rows = legacy_rows,
-            "{warning}"
-        );
     }
 }
 
@@ -737,7 +619,10 @@ async fn main() -> anyhow::Result<()> {
                     // instead of sawtoothing back to 0 on every process start.
                     // Clone the Arc here because `inner_data_store` is moved into
                     // the write-behind wrap below — the walk reads through the clone.
-                    reconcile_tombstone_bytes(Arc::clone(&inner_data_store)).await;
+                    // The returned total is the gauge value the walk just set, which
+                    // the bootstrap has no use for — the side effect IS the point here.
+                    let _reconciled_total =
+                        reconcile_tombstone_bytes(Arc::clone(&inner_data_store)).await;
 
                     // Seed the live sequence counter to one past the highest
                     // sequence ever durably observed. Computed AFTER recovery so

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -3764,7 +3764,8 @@ mod tests {
     ///
     /// The charge is gated on the apply's "this tombstone is genuinely new"
     /// report; charging per remove instead would inflate the gauge without bound
-    /// under client retries, and the SPEC-345 hard gate reads that number.
+    /// under client retries, and the tombstone byte-slope hard gate (TG-OR-004)
+    /// reads that number.
     #[tokio::test]
     async fn duplicate_or_remove_charges_tombstone_bytes_once() {
         let store = Arc::new(ArmableStore::default());

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -34,6 +34,7 @@ use crate::service::operation::{
 use crate::service::registry::{ManagedService, ServiceContext};
 use crate::service::security::WriteAdmission;
 use crate::storage::record::{OrMapEntry, RecordValue};
+use crate::storage::wal::OrDelta;
 use crate::storage::{CallerProvenance, ExpiryPolicy, RecordStoreFactory};
 use crate::tombstone_frontier_impl::TombstoneFrontier;
 use crate::traits::SchemaProvider;
@@ -548,16 +549,14 @@ impl CrdtService {
 
             // Merge the new entry into the resident OR-Map slot IN PLACE rather
             // than reading a full clone, rebuilding, and re-putting the whole
-            // ~130 KB snapshot every op. OR-Map add-wins semantics require all
-            // concurrent additions to be preserved, while observed-remove
-            // semantics require an already-tombstoned tag to stay suppressed
-            // (remove-wins: no resurrection). The algebra below matches core-rust
-            // ORMap (retain survivors, skip tombstoned re-adds) exactly; it is
-            // inlined here rather than wiring core-rust ORMap because that
-            // primitive owns its own HLC + Merkle and is keyed map-wide.
+            // ~130 KB snapshot every op. The add-wins / remove-wins algebra
+            // itself lives in `apply_or_delta` — the single implementation every
+            // OR path routes through, so the resident slot and any later replay
+            // of the same mutation cannot diverge.
             //
-            // `Option::take` moves the entry into the closure without a clone; the
-            // closure runs exactly once (per key, under the writer lock above).
+            // `Option::take` moves the entry into the delta without a clone; the
+            // closure runs exactly once (per key, under the writer lock above),
+            // so the take can never come up empty (TG-OR-001).
             let mut new_entry_opt = Some(new_entry);
             let mut merge_add = move |value: &mut RecordValue| {
                 // Upgrade a legacy non-OrMap resident slot (an OrTombstones blob
@@ -565,21 +564,12 @@ impl CrdtService {
                 // the prior get -> read_or_map_state -> put path — otherwise the add
                 // is dropped and the legacy blob re-persisted unchanged.
                 normalize_to_or_map(value);
-                if let RecordValue::OrMap {
-                    records,
-                    tombstones,
-                } = value
-                {
-                    let entry = new_entry_opt
-                        .take()
-                        .expect("OR_ADD merge closure runs exactly once");
-                    // Remove-wins: a tag already observed-removed is never resurrected.
-                    if !tombstones.contains(&entry.tag) {
-                        // Remove any existing entry with the same tag (idempotent re-add).
-                        records.retain(|e| e.tag != entry.tag);
-                        records.push(entry);
-                    }
-                }
+                let entry = new_entry_opt
+                    .take()
+                    .expect("OR_ADD merge closure runs exactly once");
+                // The apply hands the delta back as a witness; this path owes no
+                // durable record of it, so the outcome is dropped here.
+                apply_or_delta(OrDelta::Add { entry }, value);
                 // Match the prior path, which always re-persisted the slot even
                 // when remove-wins suppressed the add.
                 true
@@ -639,26 +629,19 @@ impl CrdtService {
                     // Upgrade a legacy OrTombstones blob to OrMap first (see OR_ADD);
                     // otherwise the tombstone append is dropped on the upgrade path.
                     normalize_to_or_map(value);
-                    if let RecordValue::OrMap {
-                        records,
-                        tombstones,
-                    } = value
-                    {
-                        records.retain(|e| e.tag != *tag);
-                        // Dedup: a re-issued remove must not duplicate the tombstone.
-                        // Only a genuinely-new tag is counted and epoch-stamped.
-                        if !tombstones.contains(tag) {
-                            tombstones.push(tag.clone());
-                            // Feeds the residency-independent soak leak gauge. Counted
-                            // here, atomically with the resident push (under the engine's
-                            // per-key lock) rather than after the durable write, so a
-                            // failed write + client retry counts the tag exactly once
-                            // (the retry sees it already resident): a post-write
-                            // increment would miss it on retry and later underflow the
-                            // gauge on prune. Eviction/rehydration never move this number.
-                            crate::storage::record::add_tombstone_bytes(tag.len() as u64);
-                            stamped_new_tombstone = true;
-                        }
+                    // Only a genuinely-new tag is counted and epoch-stamped, which
+                    // the apply reports back via `new_tombstone`.
+                    let outcome = apply_or_delta(OrDelta::Remove { tag: tag.clone() }, value);
+                    if outcome.new_tombstone {
+                        // Feeds the residency-independent soak leak gauge. Counted
+                        // here, atomically with the resident push (under the engine's
+                        // per-key lock) rather than after the durable write, so a
+                        // failed write + client retry counts the tag exactly once
+                        // (the retry sees it already resident): a post-write
+                        // increment would miss it on retry and later underflow the
+                        // gauge on prune. Eviction/rehydration never move this number.
+                        crate::storage::record::add_tombstone_bytes(tag.len() as u64);
+                        stamped_new_tombstone = true;
                     }
                     // Match the prior path, which always re-persisted the slot even
                     // for a duplicate (already-tombstoned) remove.
@@ -1237,6 +1220,109 @@ fn normalize_to_or_map(value: &mut RecordValue) {
     }
 }
 
+/// What one [`apply_or_delta`] call did, plus the delta it did it with.
+///
+/// Callers key their own side effects (the tombstone-bytes gauge, the epoch
+/// frontier stamp, the "re-persist this slot" signal) off these flags, which is
+/// what lets the apply itself stay pure.
+#[derive(Debug)]
+pub(crate) struct OrApplyOutcome {
+    /// `Add`: the entry was inserted (`false` = suppressed by remove-wins).
+    #[allow(
+        dead_code,
+        reason = "part of the apply seam's return contract; the live OR_ADD path \
+                  re-persists unconditionally and so reads no flag, while a \
+                  delta-fold caller distinguishes a suppressed add from an \
+                  applied one"
+    )]
+    pub added: bool,
+    /// `Remove`: a genuinely-new tombstone tag was appended (`false` = duplicate remove).
+    pub new_tombstone: bool,
+    /// `Prune`: how many tombstone tags were actually dropped.
+    pub pruned: usize,
+    /// The delta this call consumed, returned unchanged. Ownership goes out the
+    /// same door it came in, so the mutation point that produced the new value
+    /// also still holds the delta describing it and can forward it as a durable
+    /// witness without rebuilding or re-deriving one.
+    #[allow(
+        dead_code,
+        reason = "the witness has no reader until the OR write path emits per-op \
+                  delta frames; it is returned here so that wiring adds a \
+                  forward at the call site instead of re-shaping this seam, \
+                  which would risk a witness derived separately from the value"
+    )]
+    pub witness: OrDelta,
+}
+
+/// Applies exactly ONE [`OrDelta`] to a resident OR-Map slot and hands the delta
+/// back so the caller can forward it as a witness of what it mutated.
+///
+/// This is the ONE implementation of the add-wins / remove-wins / prune algebra:
+/// the live `OR_ADD`, `OR_REMOVE` and epoch-prune paths all route through it, so a
+/// recovery fold that delegates here cannot drift from what the write path did
+/// (TG-OR-003). The algebra matches core-rust `ORMap` (retain survivors, skip
+/// tombstoned re-adds); it lives here rather than wiring core-rust `ORMap`
+/// because that primitive owns its own HLC + Merkle and is keyed map-wide.
+///
+/// PURE: no gauge counters, no tombstone frontier, no I/O. Every side effect
+/// belongs to the caller at the position it occupies there — in particular the
+/// prune decrement must stay outside this function, because it may only fire
+/// once the durable write has succeeded, so that the gauge tracks bytes actually
+/// resident rather than bytes removed from an in-memory copy (TG-OR-004).
+///
+/// A `value` that is not [`RecordValue::OrMap`] is a no-op: callers normalize the
+/// resident slot first, because upgrading a legacy storage shape is a concern of
+/// the slot, not of the algebra.
+pub(crate) fn apply_or_delta(delta: OrDelta, value: &mut RecordValue) -> OrApplyOutcome {
+    let mut added = false;
+    let mut new_tombstone = false;
+    let mut pruned = 0usize;
+
+    if let RecordValue::OrMap {
+        records,
+        tombstones,
+    } = value
+    {
+        match &delta {
+            OrDelta::Add { entry } => {
+                // Remove-wins: a tag already observed-removed is never resurrected.
+                if !tombstones.contains(&entry.tag) {
+                    // Remove any existing entry with the same tag (idempotent re-add).
+                    records.retain(|e| e.tag != entry.tag);
+                    // The resident slot and the returned witness are two owners of
+                    // one entry, so an accepted add copies it exactly once here;
+                    // a suppressed add copies nothing.
+                    records.push(entry.clone());
+                    added = true;
+                }
+            }
+            OrDelta::Remove { tag } => {
+                // Drop only the matched tag, preserving every concurrent survivor.
+                records.retain(|e| e.tag != *tag);
+                // Dedup: a re-issued remove must not duplicate the tombstone, so
+                // only a genuinely-new tag is reported back to the caller (which
+                // is what keeps its gauge and epoch stamp exactly-once).
+                if !tombstones.contains(tag) {
+                    tombstones.push(tag.clone());
+                    new_tombstone = true;
+                }
+            }
+            OrDelta::Prune { tags } => {
+                let before = tombstones.len();
+                tombstones.retain(|t| !tags.contains(t));
+                pruned = before - tombstones.len();
+            }
+        }
+    }
+
+    OrApplyOutcome {
+        added,
+        new_tombstone,
+        pruned,
+        witness: delta,
+    }
+}
+
 /// Order-independent semantic view of an OR-Map slot: the live `(tag, value)`
 /// set and the tombstone set, each canonicalized by sorting, so two slots that
 /// hold the same CRDT state but in a different `Vec` order compare equal.
@@ -1281,14 +1367,13 @@ pub(crate) struct OrMapSemanticView {
 /// ## Recovery-equivalence invariant decision: SEMANTIC-SET (not byte-for-byte)
 ///
 /// The resident `RecordValue::OrMap` is NOT canonically ordered. Evidence from
-/// the OR write path in this file:
+/// the OR write path in this file, all of it inside [`apply_or_delta`]:
 ///
-/// - `OR_ADD` builds `records` with `records.retain(|e| e.tag != new_entry.tag)`
-///   then `records.push(new_entry)` — the vector is in **operation-insertion
-///   order**, never sorted.
-/// - `OR_REMOVE` appends with `tombstones.push(tag.clone())` — also insertion order.
-/// - The prune path (`prune_epoch_tombstones`) `retain`s in place, preserving
-///   whatever order was there.
+/// - `Add` builds `records` with `records.retain(|e| e.tag != entry.tag)` then
+///   `records.push(...)` — the vector is in **operation-insertion order**, never
+///   sorted.
+/// - `Remove` appends with `tombstones.push(tag.clone())` — also insertion order.
+/// - `Prune` `retain`s in place, preserving whatever order was there.
 /// - `storage/record.rs` declares `records: Vec<OrMapEntry>` / `tombstones:
 ///   Vec<String>` with no ordering invariant, and OR-Map cross-node convergence
 ///   is set-based (add-wins / remove-wins), so no canonical byte ordering is
@@ -1368,11 +1453,17 @@ pub(crate) async fn prune_epoch_tombstones(
         let mut dropped = false;
         let result = {
             let mut drop_tag = |value: &mut RecordValue| {
-                if let RecordValue::OrMap { tombstones, .. } = value {
-                    let before = tombstones.len();
-                    tombstones.retain(|t| t != &r.tag);
-                    dropped = tombstones.len() != before;
-                }
+                // Same apply as the live add/remove paths, so a pruned tag is
+                // removed by exactly the algebra the write path defines. The
+                // gauge decrement deliberately stays OUT of the closure (see the
+                // post-write arm below).
+                let outcome = apply_or_delta(
+                    OrDelta::Prune {
+                        tags: vec![r.tag.clone()],
+                    },
+                    value,
+                );
+                dropped = outcome.pruned > 0;
                 dropped
             };
             store

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -3420,6 +3420,13 @@ mod tests {
         }
 
         async fn remove(&self, map: &str, key: &str, _now: i64) -> anyhow::Result<()> {
+            // An armed key rejects every durable write, not just `add` — otherwise a
+            // path that deletes instead of writing would silently succeed against a
+            // store the test believes is failing, and the assertion would pass for
+            // the wrong reason.
+            if self.reject_keys.lock().contains(key) {
+                return Err(anyhow::anyhow!("armed write rejection for {key}"));
+            }
             self.data.lock().remove(&(map.to_string(), key.to_string()));
             Ok(())
         }
@@ -3687,16 +3694,17 @@ mod tests {
             .expect("the apply's body closes at a column-0 brace");
         let body = &tail[..end];
 
-        for counter in [
-            "add_tombstone_bytes",
-            "sub_tombstone_bytes",
-            "set_tombstone_bytes",
-        ] {
-            assert!(
-                !body.contains(counter),
-                "the apply must stay counter-free, found `{counter}` in its body"
-            );
-        }
+        // Match the suffix rather than the three current counter names, so a
+        // future `*_tombstone_bytes` counter cannot be added to the apply without
+        // tripping this. Name-matching still cannot see a counter reached through
+        // a differently-named local helper — the behavioural sibling
+        // (`or_apply_moves_no_tombstone_bytes_on_any_arm`) is the primary guard
+        // and catches that for every arm it drives; this one is the cheap
+        // structural backstop.
+        assert!(
+            !body.contains("_tombstone_bytes"),
+            "the apply must stay counter-free, found a `*_tombstone_bytes` call in its body"
+        );
     }
 
     /// A genuinely-new tombstone is charged to the gauge even when the durable

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -1561,7 +1561,8 @@ pub(crate) async fn prune_epoch_tombstones(
     clippy::collapsible_match
 )]
 mod tests {
-    use std::sync::Arc;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::{Arc, Weak};
 
     use parking_lot::Mutex;
     use topgun_core::messages::Message;
@@ -1578,6 +1579,11 @@ mod tests {
     use crate::storage::datastores::NullDataStore;
     use crate::storage::factory::RecordStoreFactory;
     use crate::storage::impls::StorageConfig;
+    use crate::storage::map_data_store::{LeafSink, MapDataStore, ScanBatch, ScanCursor};
+    use crate::storage::mutation_observer::MutationObserver;
+    use crate::storage::record::Record;
+    use crate::storage::record_store::RecordStore;
+    use crate::storage::tombstone_gauge::with_isolated_gauge;
 
     fn make_factory() -> Arc<RecordStoreFactory> {
         Arc::new(RecordStoreFactory::new(
@@ -3161,7 +3167,29 @@ mod tests {
         Arc<RecordStoreFactory>,
         Arc<TombstoneFrontier>,
     ) {
-        let factory = make_factory();
+        make_service_with_frontier_and_store(Arc::new(NullDataStore), Vec::new())
+    }
+
+    /// Same wiring as [`make_service_with_frontier`], with the backing datastore
+    /// and the store observers supplied by the caller.
+    ///
+    /// A separate constructor rather than a changed signature on the existing
+    /// fixtures: the `NullDataStore`-backed tests must keep running against
+    /// byte-identical wiring, so a test that needs a real (failable, retaining)
+    /// backend cannot perturb them.
+    fn make_service_with_frontier_and_store(
+        data_store: Arc<dyn MapDataStore>,
+        observers: Vec<Arc<dyn MutationObserver>>,
+    ) -> (
+        Arc<CrdtService>,
+        Arc<RecordStoreFactory>,
+        Arc<TombstoneFrontier>,
+    ) {
+        let factory = Arc::new(RecordStoreFactory::new(
+            StorageConfig::default(),
+            data_store,
+            observers,
+        ));
         let registry = Arc::new(ConnectionRegistry::new());
         let query_registry = Arc::new(QueryRegistry::new());
         let frontier = Arc::new(TombstoneFrontier::new(None));
@@ -3310,6 +3338,690 @@ mod tests {
         assert_eq!(
             net_delta, expected,
             "three OR_REMOVE charges minus the single epoch-1 tag the prune drops"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Where the tombstone-byte counters fire, and what the prune does with the
+    // two dispositions a bare `Ok(false)` conflates
+    // -----------------------------------------------------------------------
+
+    /// A retaining `MapDataStore` whose writes can be ARMED to fail for named
+    /// keys AFTER a test has already seeded through it.
+    ///
+    /// Arm-ability — not retention — is what makes the counter-position tests
+    /// reachable at all. An `OR_REMOVE` propagates its write error before the
+    /// tombstone is epoch-stamped, so a store that failed from the start would
+    /// leave the frontier index empty and the prune sweep with nothing to drain:
+    /// there would be no tombstone in existence to assert anything about. Seeding
+    /// un-armed lands the resident record, its durable counterpart and the
+    /// frontier ref; arming then fails exactly the write under test.
+    ///
+    /// Retention is defensive rather than load-bearing: it lets a test compare
+    /// what stayed DURABLE against what the byte gauge claims, which is the whole
+    /// reason the prune decrement sits behind a successful write (TG-OR-004).
+    #[derive(Default)]
+    struct ArmableStore {
+        data: Mutex<HashMap<(String, String), RecordValue>>,
+        reject_keys: Mutex<HashSet<String>>,
+    }
+
+    impl ArmableStore {
+        /// Fail every subsequent write to `key`. Reads keep working, so a test can
+        /// still inspect what survived durably.
+        fn reject_writes_to(&self, key: &str) {
+            self.reject_keys.lock().insert(key.to_string());
+        }
+
+        fn durable(&self, map: &str, key: &str) -> Option<RecordValue> {
+            self.data
+                .lock()
+                .get(&(map.to_string(), key.to_string()))
+                .cloned()
+        }
+
+        /// Place a durable record no resident slot mirrors, so the next read of
+        /// that key goes through the rehydration path.
+        fn seed_durable(&self, map: &str, key: &str, value: RecordValue) {
+            self.data
+                .lock()
+                .insert((map.to_string(), key.to_string()), value);
+        }
+    }
+
+    #[async_trait]
+    impl MapDataStore for ArmableStore {
+        async fn add(
+            &self,
+            map: &str,
+            key: &str,
+            value: &RecordValue,
+            _exp: i64,
+            _now: i64,
+        ) -> anyhow::Result<()> {
+            if self.reject_keys.lock().contains(key) {
+                return Err(anyhow::anyhow!("armed write rejection for {key}"));
+            }
+            self.data
+                .lock()
+                .insert((map.to_string(), key.to_string()), value.clone());
+            Ok(())
+        }
+
+        async fn add_backup(
+            &self,
+            _: &str,
+            _: &str,
+            _: &RecordValue,
+            _: i64,
+            _: i64,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn remove(&self, map: &str, key: &str, _now: i64) -> anyhow::Result<()> {
+            self.data.lock().remove(&(map.to_string(), key.to_string()));
+            Ok(())
+        }
+
+        async fn remove_backup(&self, _: &str, _: &str, _: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn load(&self, map: &str, key: &str) -> anyhow::Result<Option<RecordValue>> {
+            Ok(self
+                .data
+                .lock()
+                .get(&(map.to_string(), key.to_string()))
+                .cloned())
+        }
+
+        async fn load_all(
+            &self,
+            map: &str,
+            keys: &[String],
+        ) -> anyhow::Result<Vec<(String, RecordValue)>> {
+            let guard = self.data.lock();
+            Ok(keys
+                .iter()
+                .filter_map(|key| {
+                    guard
+                        .get(&(map.to_string(), key.clone()))
+                        .map(|value| (key.clone(), value.clone()))
+                })
+                .collect())
+        }
+
+        async fn remove_all(&self, map: &str, keys: &[String]) -> anyhow::Result<()> {
+            let mut guard = self.data.lock();
+            for key in keys {
+                guard.remove(&(map.to_string(), key.clone()));
+            }
+            Ok(())
+        }
+
+        async fn enumerate_leaves(
+            &self,
+            _: &str,
+            _: bool,
+            _: &mut dyn LeafSink,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn scan_values(&self, _: &str, _: bool, _: u64) -> anyhow::Result<ScanBatch> {
+            Ok(ScanBatch::default())
+        }
+
+        async fn scan_values_batched(
+            &self,
+            _: &str,
+            _: bool,
+            _: ScanCursor,
+            _: u64,
+        ) -> anyhow::Result<ScanBatch> {
+            Ok(ScanBatch::default())
+        }
+
+        fn is_loadable(&self, _: &str) -> bool {
+            true
+        }
+
+        fn pending_operation_count(&self) -> u64 {
+            0
+        }
+
+        async fn soft_flush(&self) -> anyhow::Result<u64> {
+            Ok(0)
+        }
+
+        async fn hard_flush(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn flush_key(
+            &self,
+            _: &str,
+            _: &str,
+            _: &RecordValue,
+            _: bool,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn reset(&self) {}
+
+        /// A real (non-null) backend, so the full write-through path runs and a
+        /// non-resident key is rehydrated from durable state on read.
+        fn is_null(&self) -> bool {
+            false
+        }
+    }
+
+    /// Evicts named keys the instant the record store rehydrates them.
+    ///
+    /// This is the only in-process lever that manufactures the "evicted between
+    /// the rehydrating read and the in-place write" race: `on_load` fires after
+    /// the hydrated record has entered the engine and before the caller's next
+    /// write, so a store that evicts there leaves the following `update_in_place`
+    /// with no resident slot to mutate — exactly the state the prune has to tell
+    /// apart from "the tag was already gone".
+    #[derive(Default)]
+    struct EvictOnRehydrate {
+        store: Mutex<Option<Weak<dyn RecordStore>>>,
+        keys: Mutex<HashSet<String>>,
+    }
+
+    impl EvictOnRehydrate {
+        /// Held as a `Weak` so the observer, which the store's own observer chain
+        /// owns, does not keep that store alive through a cycle.
+        fn arm(&self, store: &Arc<dyn RecordStore>, key: &str) {
+            *self.store.lock() = Some(Arc::downgrade(store));
+            self.keys.lock().insert(key.to_string());
+        }
+    }
+
+    impl MutationObserver for EvictOnRehydrate {
+        fn on_put(&self, _: &str, _: &Record, _: Option<&RecordValue>, _: bool) {}
+        fn on_update(&self, _: &str, _: &Record, _: &RecordValue, _: &RecordValue, _: bool) {}
+        fn on_remove(&self, _: &str, _: &Record, _: bool) {}
+        fn on_evict(&self, _: &str, _: &Record, _: bool) {}
+        fn on_load(&self, key: &str, _: &Record, _: bool) {
+            // Drop both guards before evicting: the eviction re-enters the
+            // observer chain (on_evict), and holding these across that call would
+            // be a self-deadlock waiting to happen.
+            let armed = self.keys.lock().contains(key);
+            if !armed {
+                return;
+            }
+            let store = self.store.lock().clone();
+            if let Some(store) = store.and_then(|weak| weak.upgrade()) {
+                store.evict(key, false);
+            }
+        }
+        fn on_replication_put(&self, _: &str, _: &Record, _: bool) {}
+        fn on_clear(&self) {}
+        fn on_reset(&self) {}
+        fn on_destroy(&self, _: bool) {}
+    }
+
+    /// Open both prune gates past epoch 1 only: the low-water mark STRICTLY past
+    /// epoch 1 (cursor 2) and the byte-durability fence wide open. Both are
+    /// injected, so which epoch drains is deterministic — no wall clock, no
+    /// background sweeper.
+    async fn open_prune_gates_past_epoch_one(frontier: &TombstoneFrontier) {
+        let client: String = "a5:alice|dev-1".into();
+        frontier.set_delivered(ConnectionId(1), 100);
+        assert!(
+            frontier
+                .confirm_apply_ack(&client, 2, ConnectionId(1))
+                .await
+        );
+        assert_eq!(frontier.low_water_mark(), 2);
+        frontier.set_durable_epoch_watermark(1000);
+    }
+
+    /// The apply is PURE: no arm of it moves the tombstone-byte gauge, however
+    /// many tombstones it appends or drops.
+    ///
+    /// This is the property a delta-fold recovery caller depends on — folding a
+    /// durable delta must reconstruct state without perturbing a gauge whose
+    /// post-recovery truth comes from the boot re-baseline instead.
+    #[tokio::test]
+    async fn or_apply_moves_no_tombstone_bytes_on_any_arm() {
+        let tag = "T1";
+        let entry = OrMapEntry {
+            value: Value::Int(1),
+            tag: tag.to_string(),
+            timestamp: make_timestamp(),
+        };
+
+        let ((), delta) = with_isolated_gauge(async {
+            let mut value = RecordValue::OrMap {
+                records: Vec::new(),
+                tombstones: Vec::new(),
+            };
+            // Every arm, in both its effective and its no-op disposition, so a
+            // counter hidden on any one of them would show up here.
+            assert!(
+                apply_or_delta(
+                    OrDelta::Add {
+                        entry: entry.clone()
+                    },
+                    &mut value
+                )
+                .added,
+                "a fresh add lands"
+            );
+            assert!(
+                apply_or_delta(
+                    OrDelta::Remove {
+                        tag: tag.to_string()
+                    },
+                    &mut value
+                )
+                .new_tombstone,
+                "the first remove appends a genuinely-new tombstone"
+            );
+            assert!(
+                !apply_or_delta(
+                    OrDelta::Remove {
+                        tag: tag.to_string()
+                    },
+                    &mut value
+                )
+                .new_tombstone,
+                "a re-issued remove appends nothing"
+            );
+            assert!(
+                !apply_or_delta(OrDelta::Add { entry }, &mut value).added,
+                "remove-wins suppresses the re-add"
+            );
+            assert_eq!(
+                apply_or_delta(
+                    OrDelta::Prune {
+                        tags: vec![tag.to_string()]
+                    },
+                    &mut value
+                )
+                .pruned,
+                1,
+                "the prune drops the tombstone"
+            );
+            assert_eq!(
+                apply_or_delta(
+                    OrDelta::Prune {
+                        tags: vec!["absent".to_string()]
+                    },
+                    &mut value
+                )
+                .pruned,
+                0,
+                "pruning an unknown tag drops nothing"
+            );
+        })
+        .await;
+
+        assert_eq!(
+            delta, 0,
+            "the apply is pure: appending and dropping tombstones must move no \
+             gauge bytes, because every counter belongs to the caller at the \
+             position that knows whether the durable write succeeded"
+        );
+    }
+
+    /// Structural companion to `or_apply_moves_no_tombstone_bytes_on_any_arm`:
+    /// the apply's own body does not so much as NAME a byte counter, so the
+    /// purity contract cannot be re-broken by a counter on a path the behavioural
+    /// test happens not to drive.
+    #[test]
+    fn or_apply_body_names_no_tombstone_byte_counter() {
+        const SOURCE: &str = include_str!("crdt.rs");
+
+        let start = SOURCE
+            .find("pub(crate) fn apply_or_delta(")
+            .expect("the apply seam is defined in this file");
+        let tail = &SOURCE[start..];
+        let end = tail
+            .find("\n}\n")
+            .expect("the apply's body closes at a column-0 brace");
+        let body = &tail[..end];
+
+        for counter in [
+            "add_tombstone_bytes",
+            "sub_tombstone_bytes",
+            "set_tombstone_bytes",
+        ] {
+            assert!(
+                !body.contains(counter),
+                "the apply must stay counter-free, found `{counter}` in its body"
+            );
+        }
+    }
+
+    /// A genuinely-new tombstone is charged to the gauge even when the durable
+    /// write that follows FAILS.
+    ///
+    /// The charge is atomic with the resident push, under the engine's per-key
+    /// lock, so a failed write plus a client retry counts the tag exactly once:
+    /// the retry finds the tag already resident and adds nothing. A charge moved
+    /// after the write would be skipped here, and then skipped again on the
+    /// retry, leaving the gauge short of a tombstone that IS resident — which
+    /// later underflows on prune.
+    #[tokio::test]
+    async fn or_remove_charges_tombstone_bytes_when_the_durable_write_fails() {
+        let store = Arc::new(ArmableStore::default());
+        let (svc, factory, _frontier) = make_service_with_frontier_and_store(
+            Arc::clone(&store) as Arc<dyn MapDataStore>,
+            Vec::new(),
+        );
+        let tag = "T1";
+
+        // Seed UN-ARMED, so the failure lands on the remove under test and not on
+        // the record-creating write before it.
+        Arc::clone(&svc)
+            .oneshot(or_add_op("m", "k1", "v1", tag))
+            .await
+            .unwrap();
+        store.reject_writes_to("k1");
+
+        let (result, delta) = with_isolated_gauge(async {
+            Arc::clone(&svc).oneshot(or_remove_op("m", "k1", tag)).await
+        })
+        .await;
+
+        assert!(
+            result.is_err(),
+            "the armed store must fail the OR_REMOVE write-through"
+        );
+        assert_eq!(
+            delta,
+            tag.len() as u64,
+            "the tombstone is charged inside the mutate closure, before the \
+             durable write, so a failed write cannot skip the charge"
+        );
+
+        // The tag is resident-but-not-durable: the gauge counts it because the
+        // retry will find it resident, not because it reached the backend.
+        let (_, resident) = read_or_map(&factory, "m", "k1").await;
+        assert!(
+            resident.contains(&tag.to_string()),
+            "the resident slot keeps the tombstone the closure appended"
+        );
+        let durable = store.durable("m", "k1");
+        assert!(
+            matches!(&durable, Some(RecordValue::OrMap { tombstones, .. }) if tombstones.is_empty()),
+            "the rejected write must leave the durable copy without the \
+             tombstone, got {durable:?}"
+        );
+    }
+
+    /// A re-issued OR_REMOVE of the same tag charges the gauge ONCE.
+    ///
+    /// The charge is gated on the apply's "this tombstone is genuinely new"
+    /// report; charging per remove instead would inflate the gauge without bound
+    /// under client retries, and the SPEC-345 hard gate reads that number.
+    #[tokio::test]
+    async fn duplicate_or_remove_charges_tombstone_bytes_once() {
+        let store = Arc::new(ArmableStore::default());
+        let (svc, factory, _frontier) = make_service_with_frontier_and_store(
+            Arc::clone(&store) as Arc<dyn MapDataStore>,
+            Vec::new(),
+        );
+        let tag = "T1";
+
+        Arc::clone(&svc)
+            .oneshot(or_add_op("m", "k1", "v1", tag))
+            .await
+            .unwrap();
+
+        let ((), delta) = with_isolated_gauge(async {
+            for _ in 0..2 {
+                Arc::clone(&svc)
+                    .oneshot(or_remove_op("m", "k1", tag))
+                    .await
+                    .unwrap();
+            }
+        })
+        .await;
+
+        assert_eq!(
+            delta,
+            tag.len() as u64,
+            "two removes of the same tag are one tombstone, so they are one charge"
+        );
+        // Pins the charge to the tombstone set, so a gauge delta cannot be
+        // explained by a second tombstone having really been appended.
+        let (_, resident) = read_or_map(&factory, "m", "k1").await;
+        assert_eq!(
+            resident,
+            vec![tag.to_string()],
+            "the duplicate remove must not duplicate the tombstone"
+        );
+    }
+
+    /// A prune whose durable write FAILS leaves the gauge exactly where it was.
+    ///
+    /// The decrement fires only in the post-write arm: the gauge tracks bytes
+    /// that are actually still out there, not bytes removed from an in-memory
+    /// copy. Decrementing inside the mutate closure would credit back a tag that
+    /// is still durable, and the frontier ref is re-indexed for retry precisely
+    /// because the reclaim has NOT happened yet.
+    #[tokio::test]
+    async fn prune_leaves_tombstone_bytes_unmoved_when_the_durable_write_fails() {
+        let store = Arc::new(ArmableStore::default());
+        let (svc, factory, frontier) = make_service_with_frontier_and_store(
+            Arc::clone(&store) as Arc<dyn MapDataStore>,
+            Vec::new(),
+        );
+        let (t1, t2) = ("T1", "T2");
+
+        let ((), delta) = with_isolated_gauge(async {
+            // Seed un-armed: k1's tombstone lands in epoch 1 and its frontier ref
+            // is indexed, which is what gives the sweep something to drain.
+            for (key, val, tag) in [("k1", "v1", t1), ("k2", "v2", t2)] {
+                Arc::clone(&svc)
+                    .oneshot(or_add_op("m", key, val, tag))
+                    .await
+                    .unwrap();
+                Arc::clone(&svc)
+                    .oneshot(or_remove_op("m", key, tag))
+                    .await
+                    .unwrap();
+            }
+            assert_eq!(frontier.current_epoch(), 2, "epochs 1..=2 stamped");
+            open_prune_gates_past_epoch_one(&frontier).await;
+
+            // Only NOW arm the rejection, so the drain finds epoch 1's ref and the
+            // prune's own write is the one that fails.
+            store.reject_writes_to("k1");
+            prune_epoch_tombstones(&frontier, &factory, &svc.key_writer).await;
+
+            // Attribution: the closure ran and the in-memory copy lost the tag,
+            // while the durable copy still holds it. That divergence is exactly
+            // why the decrement may not fire from inside the closure.
+            let (_, resident) = read_or_map(&factory, "m", "k1").await;
+            assert!(
+                !resident.contains(&t1.to_string()),
+                "the prune closure ran and dropped the tag from the resident slot"
+            );
+            let durable = store.durable("m", "k1");
+            assert!(
+                matches!(&durable, Some(RecordValue::OrMap { tombstones, .. }) if tombstones.contains(&t1.to_string())),
+                "the rejected write must leave the tag durable, got {durable:?}"
+            );
+        })
+        .await;
+
+        assert_eq!(
+            delta,
+            (t1.len() + t2.len()) as u64,
+            "both OR_REMOVE charges stand and the failed prune returns nothing: \
+             a decrement from inside the mutate closure would credit back bytes \
+             that are still durable"
+        );
+    }
+
+    /// Evicted between the rehydrating read and the in-place write: the frontier
+    /// ref is re-indexed so a later sweep retries.
+    ///
+    /// The closure never ran, so nothing was reclaimed while a durable tombstone
+    /// still exists. The drain already removed the ref's index entry, so dropping
+    /// it here would orphan that tag un-prunable forever.
+    #[tokio::test]
+    async fn prune_restores_the_tombstone_ref_when_the_key_is_evicted_mid_write() {
+        let store = Arc::new(ArmableStore::default());
+        let evictor = Arc::new(EvictOnRehydrate::default());
+        let (svc, factory, frontier) = make_service_with_frontier_and_store(
+            Arc::clone(&store) as Arc<dyn MapDataStore>,
+            vec![Arc::clone(&evictor) as Arc<dyn MutationObserver>],
+        );
+        let (t1, t2) = ("T1", "T2");
+
+        for (key, val, tag) in [("k1", "v1", t1), ("k2", "v2", t2)] {
+            Arc::clone(&svc)
+                .oneshot(or_add_op("m", key, val, tag))
+                .await
+                .unwrap();
+            Arc::clone(&svc)
+                .oneshot(or_remove_op("m", key, tag))
+                .await
+                .unwrap();
+        }
+        open_prune_gates_past_epoch_one(&frontier).await;
+
+        // Model the race: drop k1 from memory (its durable tombstone survives),
+        // then evict it again the moment the sweep's rehydrating read puts it
+        // back, so the in-place write finds no resident slot.
+        let k1_store = factory.get_or_create("m", hash_to_partition("k1"));
+        assert!(
+            k1_store.evict("k1", false).is_some(),
+            "precondition: k1 is resident before the modelled eviction"
+        );
+        evictor.arm(&k1_store, "k1");
+
+        prune_epoch_tombstones(&frontier, &factory, &svc.key_writer).await;
+
+        let durable = store.durable("m", "k1");
+        assert!(
+            matches!(&durable, Some(RecordValue::OrMap { tombstones, .. }) if tombstones.contains(&t1.to_string())),
+            "nothing was reclaimed: the tag is still durable, got {durable:?}"
+        );
+        let retryable = frontier.drain_prunable_tombstones();
+        assert!(
+            retryable
+                .iter()
+                .any(|(epoch, r)| *epoch == 1 && r.key == "k1" && r.tag == t1),
+            "an un-reclaimed tombstone must be re-indexed for a later sweep, got {retryable:?}"
+        );
+    }
+
+    /// The tag was genuinely already gone: the closure RAN and removed nothing,
+    /// so the frontier ref must NOT come back.
+    ///
+    /// There is nothing left to reclaim, and re-indexing a ref no write will ever
+    /// satisfy livelocks the sweep on it forever. This is the disposition a bare
+    /// `Ok(false)` cannot distinguish from the eviction race above, which is why
+    /// the decision is keyed off a flag the closure itself sets.
+    #[tokio::test]
+    async fn prune_does_not_restore_the_tombstone_ref_when_the_tag_is_already_gone() {
+        let store = Arc::new(ArmableStore::default());
+        let (svc, factory, frontier) = make_service_with_frontier_and_store(
+            Arc::clone(&store) as Arc<dyn MapDataStore>,
+            Vec::new(),
+        );
+
+        // A resident record whose tombstone set does NOT hold the tag the sweep
+        // is about to look for.
+        Arc::clone(&svc)
+            .oneshot(or_add_op("m", "k1", "v1", "T1"))
+            .await
+            .unwrap();
+        let ghost = "GHOST";
+        assert_eq!(
+            frontier.stamp_tombstone("m", "k1", ghost),
+            1,
+            "the ghost ref sits in epoch 1"
+        );
+        // A second stamp advances the epoch counter so the low-water mark can sit
+        // strictly past the ghost's epoch without making this one eligible too.
+        assert_eq!(
+            frontier.stamp_tombstone("m", "k2", "FILLER"),
+            2,
+            "the filler pins epoch 2"
+        );
+        open_prune_gates_past_epoch_one(&frontier).await;
+
+        prune_epoch_tombstones(&frontier, &factory, &svc.key_writer).await;
+
+        let retryable = frontier.drain_prunable_tombstones();
+        assert!(
+            !retryable.iter().any(|(_, r)| r.tag == ghost),
+            "a tag that is already gone must not be re-indexed, or the sweep \
+             livelocks on it, got {retryable:?}"
+        );
+    }
+
+    /// A prune that upgrades a legacy-shaped slot but drops no tag still owes —
+    /// and performs — a durable write.
+    ///
+    /// A shape change IS a value change. Reporting "unchanged" would leave the
+    /// resident slot upgraded with a stale cost while the durable record kept the
+    /// legacy shape until some unrelated later write happened to re-persist it.
+    /// The gauge stays put, because nothing was pruned.
+    #[tokio::test]
+    async fn prune_persists_a_legacy_shape_upgrade_with_nothing_pruned() {
+        let store = Arc::new(ArmableStore::default());
+        let (svc, factory, frontier) = make_service_with_frontier_and_store(
+            Arc::clone(&store) as Arc<dyn MapDataStore>,
+            Vec::new(),
+        );
+
+        // Durable-only, in the pre-OrMap shape an older server wrote, holding a
+        // tombstone the sweep is NOT asked to drop.
+        store.seed_durable(
+            "m",
+            "k1",
+            RecordValue::OrTombstones {
+                tags: vec!["OLD".to_string()],
+            },
+        );
+        let ghost = "GHOST";
+        assert_eq!(
+            frontier.stamp_tombstone("m", "k1", ghost),
+            1,
+            "the ghost ref sits in epoch 1"
+        );
+        assert_eq!(
+            frontier.stamp_tombstone("m", "k2", "FILLER"),
+            2,
+            "the filler pins epoch 2"
+        );
+        open_prune_gates_past_epoch_one(&frontier).await;
+
+        let ((), delta) = with_isolated_gauge(async {
+            prune_epoch_tombstones(&frontier, &factory, &svc.key_writer).await;
+        })
+        .await;
+
+        let durable = store.durable("m", "k1");
+        assert!(
+            matches!(
+                &durable,
+                Some(RecordValue::OrMap { records, tombstones })
+                    if records.is_empty() && tombstones == &vec!["OLD".to_string()]
+            ),
+            "the shape upgrade must reach the durable record, got {durable:?}"
+        );
+        let (_, resident) = read_or_map(&factory, "m", "k1").await;
+        assert_eq!(
+            resident,
+            vec!["OLD".to_string()],
+            "the upgrade preserves the legacy tombstone set"
+        );
+        assert_eq!(
+            delta, 0,
+            "no tag was pruned, so a normalize-only write moves no gauge bytes"
         );
     }
 

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -562,7 +562,9 @@ impl CrdtService {
                 // Upgrade a legacy non-OrMap resident slot (an OrTombstones blob
                 // from an older server) to the unified OrMap shape first, matching
                 // the prior get -> read_or_map_state -> put path — otherwise the add
-                // is dropped and the legacy blob re-persisted unchanged.
+                // is dropped and the legacy blob re-persisted unchanged. Its
+                // shape-change report is irrelevant on this path: the closure
+                // re-persists unconditionally below, so the write is already owed.
                 normalize_to_or_map(value);
                 let entry = new_entry_opt
                     .take()
@@ -628,6 +630,8 @@ impl CrdtService {
                 let mut apply_remove = |value: &mut RecordValue| {
                     // Upgrade a legacy OrTombstones blob to OrMap first (see OR_ADD);
                     // otherwise the tombstone append is dropped on the upgrade path.
+                    // Shape-change report ignored for the same reason as OR_ADD:
+                    // this closure returns true unconditionally.
                     normalize_to_or_map(value);
                     // Only a genuinely-new tag is counted and epoch-stamped, which
                     // the apply reports back via `new_tombstone`.
@@ -1204,20 +1208,29 @@ fn read_or_map_state(value: Option<RecordValue>) -> (Vec<OrMapEntry>, Vec<String
 /// `OrMap` is left untouched. Without this the in-place merge closure would fail
 /// its `OrMap` pattern match, silently drop the mutation, and re-persist the
 /// legacy blob unchanged — losing an acked write on the upgrade path.
-fn normalize_to_or_map(value: &mut RecordValue) {
-    if !matches!(value, RecordValue::OrMap { .. }) {
-        let (records, tombstones) = read_or_map_state(Some(std::mem::replace(
-            value,
-            RecordValue::OrMap {
-                records: Vec::new(),
-                tombstones: Vec::new(),
-            },
-        )));
-        *value = RecordValue::OrMap {
-            records,
-            tombstones,
-        };
+///
+/// Returns `true` iff the slot's shape actually changed (a non-`OrMap` slot was
+/// replaced), and `false` when the slot was already `OrMap`. A shape change IS a
+/// value change, so a caller whose closure returns "was anything modified?" owes
+/// a durable write for it: reporting `false` there would leave the resident slot
+/// upgraded with a stale `metadata.cost` while the durable record keeps the legacy
+/// shape until some unrelated later write happens to re-persist it.
+fn normalize_to_or_map(value: &mut RecordValue) -> bool {
+    if matches!(value, RecordValue::OrMap { .. }) {
+        return false;
     }
+    let (records, tombstones) = read_or_map_state(Some(std::mem::replace(
+        value,
+        RecordValue::OrMap {
+            records: Vec::new(),
+            tombstones: Vec::new(),
+        },
+    )));
+    *value = RecordValue::OrMap {
+        records,
+        tombstones,
+    };
+    true
 }
 
 /// What one [`apply_or_delta`] call did, plus the delta it did it with.
@@ -1422,7 +1435,12 @@ pub(crate) fn or_map_semantic_view(value: Option<RecordValue>) -> OrMapSemanticV
 /// A ref whose storage drop FAILS (read or write error) is handed back to the
 /// frontier via `restore_tombstone_ref` so a later sweep retries it — dropping
 /// it here would orphan the tag un-prunable in storage forever, since the drain
-/// already removed its index entry.
+/// already removed its index entry. The same restore covers the one non-error
+/// case that also reclaimed nothing: the key was evicted between the rehydrating
+/// `get` and the in-place write, so the mutate closure never ran. That is told
+/// apart from "the closure ran and the tag was already gone" — which must NOT be
+/// restored, or the prune loop livelocks on it — by a flag the closure itself
+/// sets, because the `Ok(bool)` from `update_in_place` conflates the two.
 pub(crate) async fn prune_epoch_tombstones(
     frontier: &TombstoneFrontier,
     factory: &RecordStoreFactory,
@@ -1451,8 +1469,21 @@ pub(crate) async fn prune_epoch_tombstones(
         // mutate only the present record, never create one), owing a durable write
         // only when a tombstone was actually removed.
         let mut dropped = false;
+        // Whether the mutate closure ran at all. `update_in_place` reports only
+        // `Ok(bool)` here, which cannot tell "the key was evicted between the
+        // rehydrating get above and this write, so nothing was mutated" apart from
+        // "the closure ran and found no matching tag". Those two need opposite
+        // dispositions below, and only the closure itself knows which happened.
+        let mut ran = false;
         let result = {
             let mut drop_tag = |value: &mut RecordValue| {
+                ran = true;
+                // Upgrade a legacy OrTombstones blob to OrMap first, as the live
+                // add/remove closures do — otherwise the prune would fail its
+                // OrMap match and silently re-persist the legacy blob. Not
+                // reachable today (the drop below is the only mutation on this
+                // path), so this is a defence against a future caller, not a fix.
+                let shape_changed = normalize_to_or_map(value);
                 // Same apply as the live add/remove paths, so a pruned tag is
                 // removed by exactly the algebra the write path defines. The
                 // gauge decrement deliberately stays OUT of the closure (see the
@@ -1464,7 +1495,12 @@ pub(crate) async fn prune_epoch_tombstones(
                     value,
                 );
                 dropped = outcome.pruned > 0;
-                dropped
+                // A normalize that upgraded the shape owes a durable write even
+                // with nothing pruned: the production store keeps the closure's
+                // mutation to the resident slot on a `false` return but skips the
+                // re-cost and the write-through, which would leave the slot
+                // upgraded with a stale cost and no durable counterpart.
+                shape_changed || dropped
             };
             store
                 .update_in_place(
@@ -1483,6 +1519,25 @@ pub(crate) async fn prune_epoch_tombstones(
             Ok(_) => {
                 if dropped {
                     crate::storage::record::sub_tombstone_bytes(r.tag.len() as u64);
+                }
+                // The closure never ran: the key was evicted between the
+                // rehydrating get and this write, so init=None mutated nothing
+                // while a durable tombstone may well still exist. Hand the ref
+                // back so a later sweep retries it — the drain already removed
+                // its index entry, so dropping it here would orphan the tag
+                // un-prunable forever. Keyed off `ran` and never off the
+                // `update_in_place` bool, so a normalize-only write (which
+                // reports "changed" with nothing pruned) cannot livelock the
+                // loop by getting the ref restored on every pass. `dropped`
+                // implies `ran`, so the gauge above and this arm are exclusive.
+                if !ran {
+                    tracing::debug!(
+                        map = %r.map,
+                        key = %r.key,
+                        epoch,
+                        "prune found key evicted mid-write, re-indexing tombstone for retry"
+                    );
+                    frontier.restore_tombstone_ref(epoch, r);
                 }
             }
             Err(e) => {

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -569,8 +569,8 @@ impl CrdtService {
                 let entry = new_entry_opt
                     .take()
                     .expect("OR_ADD merge closure runs exactly once");
-                // The apply hands the delta back as a witness; this path owes no
-                // durable record of it, so the outcome is dropped here.
+                // The apply consumes the delta; this path owes no durable record
+                // of it, so the outcome is dropped here.
                 apply_or_delta(OrDelta::Add { entry }, value);
                 // Match the prior path, which always re-persisted the slot even
                 // when remove-wins suppressed the add.
@@ -1233,11 +1233,18 @@ fn normalize_to_or_map(value: &mut RecordValue) -> bool {
     true
 }
 
-/// What one [`apply_or_delta`] call did, plus the delta it did it with.
+/// What one [`apply_or_delta`] call did.
 ///
 /// Callers key their own side effects (the tombstone-bytes gauge, the epoch
 /// frontier stamp, the "re-persist this slot" signal) off these flags, which is
 /// what lets the apply itself stay pure.
+///
+/// Deliberately carries no copy of the delta. A caller that needs to record what
+/// it applied already holds the delta and must serialize it BEFORE handing it
+/// over — borrowing costs nothing, whereas returning it would force the entry to
+/// have two owners (the resident slot and the returned copy) and so charge a
+/// value-sized clone to every accepted add on the hot path. The flags below are
+/// the only thing a caller cannot derive for itself.
 #[derive(Debug)]
 pub(crate) struct OrApplyOutcome {
     /// `Add`: the entry was inserted (`false` = suppressed by remove-wins).
@@ -1253,22 +1260,14 @@ pub(crate) struct OrApplyOutcome {
     pub new_tombstone: bool,
     /// `Prune`: how many tombstone tags were actually dropped.
     pub pruned: usize,
-    /// The delta this call consumed, returned unchanged. Ownership goes out the
-    /// same door it came in, so the mutation point that produced the new value
-    /// also still holds the delta describing it and can forward it as a durable
-    /// witness without rebuilding or re-deriving one.
-    #[allow(
-        dead_code,
-        reason = "the witness has no reader until the OR write path emits per-op \
-                  delta frames; it is returned here so that wiring adds a \
-                  forward at the call site instead of re-shaping this seam, \
-                  which would risk a witness derived separately from the value"
-    )]
-    pub witness: OrDelta,
 }
 
-/// Applies exactly ONE [`OrDelta`] to a resident OR-Map slot and hands the delta
-/// back so the caller can forward it as a witness of what it mutated.
+/// Applies exactly ONE [`OrDelta`] to a resident OR-Map slot, consuming it.
+///
+/// Takes the delta BY VALUE and moves its payload straight into the slot, so an
+/// accepted add transfers the entry exactly once with no copy. A caller that must
+/// durably record what it applied serializes from a borrow before calling; the
+/// delta is gone afterwards, by design.
 ///
 /// This is the ONE implementation of the add-wins / remove-wins / prune algebra:
 /// the live `OR_ADD`, `OR_REMOVE` and epoch-prune paths all route through it, so a
@@ -1296,27 +1295,25 @@ pub(crate) fn apply_or_delta(delta: OrDelta, value: &mut RecordValue) -> OrApply
         tombstones,
     } = value
     {
-        match &delta {
+        match delta {
             OrDelta::Add { entry } => {
                 // Remove-wins: a tag already observed-removed is never resurrected.
                 if !tombstones.contains(&entry.tag) {
                     // Remove any existing entry with the same tag (idempotent re-add).
                     records.retain(|e| e.tag != entry.tag);
-                    // The resident slot and the returned witness are two owners of
-                    // one entry, so an accepted add copies it exactly once here;
-                    // a suppressed add copies nothing.
-                    records.push(entry.clone());
+                    // Moved, not copied: the slot becomes the entry's only owner.
+                    records.push(entry);
                     added = true;
                 }
             }
             OrDelta::Remove { tag } => {
                 // Drop only the matched tag, preserving every concurrent survivor.
-                records.retain(|e| e.tag != *tag);
+                records.retain(|e| e.tag != tag);
                 // Dedup: a re-issued remove must not duplicate the tombstone, so
                 // only a genuinely-new tag is reported back to the caller (which
                 // is what keeps its gauge and epoch stamp exactly-once).
-                if !tombstones.contains(tag) {
-                    tombstones.push(tag.clone());
+                if !tombstones.contains(&tag) {
+                    tombstones.push(tag);
                     new_tombstone = true;
                 }
             }
@@ -1332,7 +1329,6 @@ pub(crate) fn apply_or_delta(delta: OrDelta, value: &mut RecordValue) -> OrApply
         added,
         new_tombstone,
         pruned,
-        witness: delta,
     }
 }
 
@@ -1385,7 +1381,7 @@ pub(crate) struct OrMapSemanticView {
 /// - `Add` builds `records` with `records.retain(|e| e.tag != entry.tag)` then
 ///   `records.push(...)` — the vector is in **operation-insertion order**, never
 ///   sorted.
-/// - `Remove` appends with `tombstones.push(tag.clone())` — also insertion order.
+/// - `Remove` appends with `tombstones.push(tag)` — also insertion order.
 /// - `Prune` `retain`s in place, preserving whatever order was there.
 /// - `storage/record.rs` declares `records: Vec<OrMapEntry>` / `tombstones:
 ///   Vec<String>` with no ordering invariant, and OR-Map cross-node convergence

--- a/packages/server-rust/src/storage/datastores/prefix_watermark_proptest.rs
+++ b/packages/server-rust/src/storage/datastores/prefix_watermark_proptest.rs
@@ -28,6 +28,8 @@ use topgun_core::types::Value;
 
 use super::*;
 use crate::service::middleware::init_observability;
+use crate::storage::record::reconcile_tombstone_bytes;
+use crate::storage::tombstone_gauge::with_isolated_gauge;
 use crate::storage::wal::{
     wal_fail_stop, WalFailStopTier, WalRecovery, WalWriter, FAIL_STOP_TEST_LOCK,
 };
@@ -1783,23 +1785,6 @@ async fn stored_millis(
     }
 }
 
-/// The durable tombstone-byte ground truth, computed the way the boot-time
-/// reconciliation computes it.
-///
-/// The production `reconcile_tombstone_bytes` lives in the server BINARY and
-/// cannot be called from the lib test binary, so this asserts the quantity it
-/// derives — the durable sum — rather than the function call.
-async fn durable_tombstone_bytes(store: &Arc<crate::storage::datastores::RedbDataStore>) -> usize {
-    let mut total = 0usize;
-    let batch = store.scan_values(TEST_MAP, false, 0).await.expect("scan");
-    for (_key, value) in &batch.records {
-        if let RecordValue::OrMap { tombstones, .. } = value {
-            total += tombstones.iter().map(String::len).sum::<usize>();
-        }
-    }
-    total
-}
-
 #[tokio::test]
 async fn a_re_replayed_window_lands_on_the_newest_frame_and_moves_no_tombstone_bytes() {
     let partition = 258;
@@ -1826,7 +1811,20 @@ async fn a_re_replayed_window_lands_on_the_newest_frame_and_moves_no_tombstone_b
         drop(store);
     }
 
-    let before = durable_tombstone_bytes(&redb).await;
+    // The durable tombstone-byte ground truth is read through the PRODUCTION boot
+    // reconciliation, so this test and the server share one accounting and cannot
+    // drift apart. Three differences from the test-local sum this replaced, all
+    // deliberate: it walks EVERY map via `list_maps` rather than `TEST_MAP` alone
+    // (equivalent here, because `TEST_MAP` is the only map this module ever
+    // writes), it returns `u64` rather than `usize`, and it re-baselines the
+    // tombstone-bytes gauge as a side effect. That side effect is why the call is
+    // scoped to a fresh isolated sink: the absolute-set path trips a
+    // `debug_assert!` on the process-global gauge once ANY test in this binary has
+    // fired an `add`, and that gauge is shared across the whole lib test binary.
+    let (before, _scoped_gauge) = with_isolated_gauge(reconcile_tombstone_bytes(
+        Arc::clone(&redb) as Arc<dyn MapDataStore>
+    ))
+    .await;
 
     // Replay the window twice. Re-replay is what widening `[W, max]` makes
     // routine, so landing on the newest frame must be a property of the window,
@@ -1848,9 +1846,12 @@ async fn a_re_replayed_window_lands_on_the_newest_frame_and_moves_no_tombstone_b
     // The gauge assertion kept in its only non-vacuous form: replay bypasses the
     // gauge helpers entirely, so "gauge unchanged" proves nothing — the durable
     // ground truth a boot reconciliation would recompute is what must hold.
+    let (after, _scoped_gauge) = with_isolated_gauge(reconcile_tombstone_bytes(
+        Arc::clone(&redb) as Arc<dyn MapDataStore>
+    ))
+    .await;
     assert_eq!(
-        durable_tombstone_bytes(&redb).await,
-        before,
+        after, before,
         "re-replaying the widened window must not move the durable tombstone \
          ground truth"
     );

--- a/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
+++ b/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
@@ -942,8 +942,8 @@ mod tests {
     //
     // The OR_ADD write path moves its entry into the closure with
     // `Option::take().expect(...)`, so a hidden re-invocation would panic there
-    // — but only that panic guards it, and TG-OR-001's literal call-counter
-    // assertion is catalogued NAKED (TODO-602). A counter closes the OR half:
+    // — but that panic was the ONLY guard, which left TG-OR-001 asserted
+    // nowhere literally. A counter closes the OR half:
     // a re-invocation would double-apply the CRDT mutation, and on the remove
     // path double-charge the tombstone-byte gauge, on any caller whose closure
     // is not `take`-shaped.

--- a/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
+++ b/packages/server-rust/src/storage/or_inplace_mutate_proptest.rs
@@ -935,4 +935,146 @@ mod tests {
             );
         });
     }
+
+    // -----------------------------------------------------------------------
+    // TG-OR-001, counted rather than inferred: one `update_in_place` call
+    // invokes the mutate closure EXACTLY once.
+    //
+    // The OR_ADD write path moves its entry into the closure with
+    // `Option::take().expect(...)`, so a hidden re-invocation would panic there
+    // — but only that panic guards it, and TG-OR-001's literal call-counter
+    // assertion is catalogued NAKED (TODO-602). A counter closes the OR half:
+    // a re-invocation would double-apply the CRDT mutation, and on the remove
+    // path double-charge the tombstone-byte gauge, on any caller whose closure
+    // is not `take`-shaped.
+    //
+    // This asserts the run-once property of the `update_in_place` seam itself,
+    // over the same store + engine pair the record-store factory builds in
+    // production. It says nothing about which production call sites are wired
+    // to that seam — see this module's header.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn update_in_place_invokes_the_mutate_closure_exactly_once_per_call() {
+        block_on_async(async {
+            let datastore = Arc::new(RetainingCountingStore::default());
+            let store = store_sharing(&datastore);
+
+            let calls = AtomicUsize::new(0);
+            let mut counted = |value: &mut RecordValue| {
+                calls.fetch_add(1, Ordering::Relaxed);
+                normalize(value);
+                true
+            };
+            // Insert (no resident slot yet).
+            store
+                .update_in_place(
+                    KEY,
+                    Some(empty_ormap()),
+                    ExpiryPolicy::NONE,
+                    CallerProvenance::CrdtMerge,
+                    &mut counted,
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                calls.load(Ordering::Relaxed),
+                1,
+                "the insert path must invoke the closure exactly once"
+            );
+
+            // Occupied (mutate the resident slot).
+            store
+                .update_in_place(
+                    KEY,
+                    Some(empty_ormap()),
+                    ExpiryPolicy::NONE,
+                    CallerProvenance::CrdtMerge,
+                    &mut counted,
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                calls.load(Ordering::Relaxed),
+                2,
+                "the occupied path must invoke the closure exactly once"
+            );
+
+            // A failed durable write must not be retried behind the caller's
+            // back: the retry is the caller's decision, and a silent internal
+            // one would re-apply the mutation the closure already made.
+            datastore.fail_adds.store(1, Ordering::Relaxed);
+            assert!(
+                store
+                    .update_in_place(
+                        KEY,
+                        Some(empty_ormap()),
+                        ExpiryPolicy::NONE,
+                        CallerProvenance::CrdtMerge,
+                        &mut counted,
+                    )
+                    .await
+                    .is_err(),
+                "injected write-through failure must surface to the caller"
+            );
+            assert_eq!(
+                calls.load(Ordering::Relaxed),
+                3,
+                "a failed write-through must not re-invoke the closure"
+            );
+        });
+    }
+
+    #[test]
+    fn update_in_place_admits_the_take_once_shape_the_or_add_path_uses() {
+        block_on_async(async {
+            let datastore = Arc::new(RetainingCountingStore::default());
+            let store = store_sharing(&datastore);
+
+            // The production OR_ADD closure's exact shape: the entry is MOVED in,
+            // so a second invocation of this one call's closure would panic on
+            // the empty take rather than silently double-applying.
+            let mut entry_opt = Some(OrMapEntry {
+                value: Value::Int(7),
+                tag: "t-once".to_string(),
+                timestamp: ts(1),
+            });
+            let mut merge_once = move |value: &mut RecordValue| {
+                normalize(value);
+                let entry = entry_opt
+                    .take()
+                    .expect("OR_ADD merge closure runs exactly once");
+                if let RecordValue::OrMap {
+                    records,
+                    tombstones,
+                } = value
+                {
+                    if !tombstones.contains(&entry.tag) {
+                        records.retain(|r| r.tag != entry.tag);
+                        records.push(entry);
+                    }
+                }
+                true
+            };
+
+            store
+                .update_in_place(
+                    KEY,
+                    Some(empty_ormap()),
+                    ExpiryPolicy::NONE,
+                    CallerProvenance::CrdtMerge,
+                    &mut merge_once,
+                )
+                .await
+                .unwrap();
+
+            let resident = store.get(KEY, false).await.unwrap().map(|r| r.value);
+            let (records, _) = read_state(resident);
+            assert_eq!(
+                records.len(),
+                1,
+                "the moved entry lands exactly once, with no second application"
+            );
+        });
+    }
 }

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -4,11 +4,13 @@
 //! [`Record`], [`RecordMetadata`], [`RecordValue`], and [`OrMapEntry`].
 
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use topgun_core::hlc::Timestamp;
 use topgun_core::types::Value;
 
+use super::map_data_store::MapDataStore;
 use super::tombstone_gauge::with_sink;
 
 /// Process-monotonic counter for minting per-write identity tokens.
@@ -84,7 +86,8 @@ pub fn tombstone_bytes() -> u64 {
 ///
 /// This is the **only** absolute-set path for the gauge. It exists exclusively
 /// for the one-time startup reconciliation that runs after WAL recovery
-/// completes (see `bin/topgun_server.rs`): the process-local
+/// completes (see [`reconcile_tombstone_bytes`], which the server bootstrap
+/// invokes at that point): the process-local
 /// [`ProcessGauge`](super::tombstone_gauge::ProcessGauge) atomic and both exported Prometheus series
 /// (`topgun_ormap_tombstone_bytes_total` and `topgun_ormap_tombstone_bytes`)
 /// reset to zero/absent on every process start and never re-count rehydrated
@@ -126,8 +129,9 @@ pub fn set_tombstone_bytes(total: u64) {
 /// clients re-sync). This surfaces that at boot so an operator sees the pinned
 /// bytes are deliberate, not a leak.
 ///
-/// Kept a pure `count -> Option<message>` decision so it is unit-testable off the
-/// bin-only boot walk that supplies the count.
+/// Kept a pure `count -> Option<message>` decision so it is unit-testable
+/// independently of [`reconcile_tombstone_bytes`], the boot walk that supplies
+/// the count.
 #[must_use]
 pub fn legacy_tombstone_warning(legacy_row_count: u64) -> Option<String> {
     (legacy_row_count > 0).then(|| {
@@ -136,6 +140,146 @@ pub fn legacy_tombstone_warning(legacy_row_count: u64) -> Option<String> {
              recreate the datastore to reclaim"
         )
     })
+}
+
+/// One-time startup reconciliation of the OR-Map tombstone-bytes gauge.
+///
+/// Runs exactly once, after WAL recovery completes and strictly before the
+/// listener accepts connections, for durable backends only. Walks the full
+/// persisted primary keyspace via the cursor-batched scan surface, sums
+/// `tag.len()` over every tombstone string in every persisted `OrMap` record,
+/// and re-baselines the gauge to that absolute total via [`set_tombstone_bytes`].
+/// This makes the scraped `topgun_ormap_tombstone_bytes_total` series survive a
+/// `kill -9` restart — the gauge otherwise resets to 0 on every process start
+/// and never re-counts rehydrated (redb-persisted) tombstones.
+///
+/// Returns the reconciled total it passed to [`set_tombstone_bytes`], so a
+/// caller (or a test) can assert the reconciled sum through this function
+/// rather than re-deriving it from a second walk.
+///
+/// Never runs on any read/write/rehydration path — boot-only, exactly-once. On
+/// scan failure it logs a WARN, returns `0` and leaves the process-local gauge
+/// at its default (0): reconciliation is a monitoring-accuracy improvement, not
+/// a durability invariant, so a failed reconcile degrades to today's
+/// process-local behavior rather than aborting startup.
+///
+/// `pub` because its consumer is the server bootstrap in
+/// `src/bin/topgun_server.rs` — a separate `[[bin]]` target that links this
+/// crate externally and therefore cannot see `pub(crate)` items. The boot-only
+/// contract travels with that exposure and binds every caller: like
+/// [`set_tombstone_bytes`], which it re-baselines through, it MUST NEVER be
+/// called on the hot read/write path — only once, at boot, before the listener
+/// accepts connections. It is not a general-purpose runtime API: it is a full
+/// O(keyspace) walk and an absolute gauge re-baseline, both of which are only
+/// sound while nothing else is writing.
+///
+/// Legacy `RecordValue::OrTombstones { tags }` blobs are deliberately excluded
+/// from the sum. The live `add_tombstone_bytes` gauge never counts them either:
+/// the read path folds their tags into the unified `OrMap.tombstones` view
+/// WITHOUT emitting to the gauge, so summing them here would over-count relative
+/// to the live gauge this seed re-baselines.
+///
+/// `list_maps` on the redb backend enumerates primary partitions only, so backup
+/// tombstones are excluded — correct for the single-node soak/demo tier this
+/// targets; a future cluster/backup-accounting revisit is out of scope here.
+pub async fn reconcile_tombstone_bytes(store: Arc<dyn MapDataStore>) -> u64 {
+    // Every `tracing` site below keeps the `topgun_server::bootstrap` target even
+    // though this walk now lives in the library rather than the binary: the target
+    // string is an operator-facing boot-log filter contract, so re-targeting it to
+    // this module's path would silently break deployed log filters. The gauge's own
+    // tripwire in `tombstone_gauge` already emits under the same target from inside
+    // the lib, so this is not a novel arrangement.
+    let maps = match store.list_maps().await {
+        Ok(maps) => maps,
+        Err(err) => {
+            tracing::warn!(
+                target: "topgun_server::bootstrap",
+                error = %err,
+                "tombstone-bytes reconciliation skipped: list_maps failed; gauge stays process-local"
+            );
+            return 0;
+        }
+    };
+
+    let mut total: u64 = 0;
+    let mut records_scanned: u64 = 0;
+    // Folded into this existing boot-only walk (no second O(keyspace) scan): the
+    // count of legacy tombstone-only blobs, which a clean-slate store never grows
+    // but a rehydrated pre-epoch store still carries. Durable backends only — this
+    // reconcile runs solely under the redb/postgres startup arm.
+    let mut legacy_rows: u64 = 0;
+
+    for map in &maps {
+        // Walk the whole map: first batch, then follow the cursor until exhausted
+        // so every record is visited regardless of map size. Each batch is itself
+        // cost-bounded, keeping resident cost under the TOPGUN_MAX_RAM_MB ceiling —
+        // a memory-safety property, not just a startup-latency one.
+        let mut batch = match store.scan_values(map, false, 0).await {
+            Ok(batch) => batch,
+            Err(err) => {
+                tracing::warn!(
+                    target: "topgun_server::bootstrap",
+                    map = %map,
+                    error = %err,
+                    "tombstone-bytes reconciliation skipped: scan_values failed; gauge stays process-local"
+                );
+                return 0;
+            }
+        };
+
+        loop {
+            for (_key, value) in &batch.records {
+                records_scanned += 1;
+                match value {
+                    RecordValue::OrMap { tombstones, .. } => {
+                        for tag in tombstones {
+                            total += tag.len() as u64;
+                        }
+                    }
+                    RecordValue::OrTombstones { .. } => legacy_rows += 1,
+                    RecordValue::Lww { .. } => {}
+                }
+            }
+
+            match batch.next_cursor.take() {
+                None => break,
+                Some(cursor) => {
+                    batch = match store.scan_values_batched(map, false, cursor, 0).await {
+                        Ok(next) => next,
+                        Err(err) => {
+                            tracing::warn!(
+                                target: "topgun_server::bootstrap",
+                                map = %map,
+                                error = %err,
+                                "tombstone-bytes reconciliation skipped: scan_values_batched failed; gauge stays process-local"
+                            );
+                            return 0;
+                        }
+                    };
+                }
+            }
+        }
+    }
+
+    set_tombstone_bytes(total);
+
+    tracing::info!(
+        target: "topgun_server::bootstrap",
+        tombstone_bytes = total,
+        records_scanned = records_scanned,
+        maps = maps.len(),
+        "OR-Map tombstone-bytes gauge reconciled from persisted keyspace"
+    );
+
+    if let Some(warning) = legacy_tombstone_warning(legacy_rows) {
+        tracing::warn!(
+            target: "topgun_server::bootstrap",
+            legacy_tombstone_rows = legacy_rows,
+            "{warning}"
+        );
+    }
+
+    total
 }
 
 /// Minimum elapsed milliseconds before a read access updates `last_access_time`.

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -717,6 +717,31 @@ mod tombstone_bytes_gauge_tests {
         }
     }
 
+    /// A non-OR record, so the walk's arm selection is exercised over more than
+    /// the OR arms alone.
+    fn lww_record_value() -> RecordValue {
+        RecordValue::Lww {
+            value: Value::String("plain".to_string()),
+            timestamp: Timestamp {
+                millis: 2,
+                counter: 0,
+                node_id: "node-a".to_string(),
+            },
+        }
+    }
+
+    async fn seed_primary(
+        store: &Arc<dyn MapDataStore>,
+        map: &str,
+        key: &str,
+        value: &RecordValue,
+    ) {
+        store
+            .add(map, key, value, 0, 0)
+            .await
+            .expect("seed a primary record");
+    }
+
     /// The boot reconciliation recomputes the tombstone-byte total from what is
     /// actually persisted, so it is driven here against a real redb keyspace that
     /// has been seeded. A `MapDataStore` double returning an empty `ScanBatch`
@@ -734,79 +759,31 @@ mod tombstone_bytes_gauge_tests {
     ///   tables only and the walk scans each map with `is_backup = false`.
     #[tokio::test]
     async fn reconcile_re_baselines_the_gauge_to_the_durable_primary_ormap_tombstone_sum() {
+        // 4 + 6 + 5 — the primary-partition `OrMap` tombstones and nothing else.
+        const EXPECTED_TOTAL: u64 = 15;
+
         let dir = tempfile::tempdir().expect("tempdir");
         let store: Arc<dyn MapDataStore> =
             Arc::new(RedbDataStore::new(dir.path().join("reconcile.redb")).expect("redb open"));
 
-        // Lengths are spelled as `repeat` counts rather than literal runs of
-        // characters so the expected total below cannot drift from a miscount.
-        let counted_a = "a".repeat(4);
-        let counted_b = "b".repeat(6);
-        let counted_c = "c".repeat(5);
+        // Tag lengths are spelled as `repeat` counts rather than literal runs of
+        // characters so the expected total cannot drift from a miscount.
         let excluded_legacy = "d".repeat(20);
-        let excluded_backup = "e".repeat(9);
-        // 4 + 6 + 5 — the primary-partition `OrMap` tombstones and nothing else.
-        const EXPECTED_TOTAL: u64 = 15;
 
         // Two maps, so the per-map loop over `list_maps` is genuinely iterated,
         // and one non-OR record, so the walk's arm selection is exercised.
+        let counted = or_map_with_tombstones(vec!["a".repeat(4), "b".repeat(6)]);
+        seed_primary(&store, "reconcile_a", "k1", &counted).await;
+        let counted = or_map_with_tombstones(vec!["c".repeat(5)]);
+        seed_primary(&store, "reconcile_b", "k1", &counted).await;
+        seed_primary(&store, "reconcile_b", "k2", &lww_record_value()).await;
+        let legacy = RecordValue::OrTombstones {
+            tags: vec![excluded_legacy.clone()],
+        };
+        seed_primary(&store, "reconcile_a", "legacy", &legacy).await;
+        let backup = or_map_with_tombstones(vec!["e".repeat(9)]);
         store
-            .add(
-                "reconcile_a",
-                "k1",
-                &or_map_with_tombstones(vec![counted_a, counted_b]),
-                0,
-                0,
-            )
-            .await
-            .expect("seed primary OrMap in the first map");
-        store
-            .add(
-                "reconcile_b",
-                "k1",
-                &or_map_with_tombstones(vec![counted_c]),
-                0,
-                0,
-            )
-            .await
-            .expect("seed primary OrMap in the second map");
-        store
-            .add(
-                "reconcile_b",
-                "k2",
-                &RecordValue::Lww {
-                    value: Value::String("plain".to_string()),
-                    timestamp: Timestamp {
-                        millis: 2,
-                        counter: 0,
-                        node_id: "node-a".to_string(),
-                    },
-                },
-                0,
-                0,
-            )
-            .await
-            .expect("seed an LWW record");
-        store
-            .add(
-                "reconcile_a",
-                "legacy",
-                &RecordValue::OrTombstones {
-                    tags: vec![excluded_legacy.clone()],
-                },
-                0,
-                0,
-            )
-            .await
-            .expect("seed the legacy tombstone-only blob");
-        store
-            .add_backup(
-                "reconcile_a",
-                "backup-key",
-                &or_map_with_tombstones(vec![excluded_backup.clone()]),
-                0,
-                0,
-            )
+            .add_backup("reconcile_a", "backup-key", &backup, 0, 0)
             .await
             .expect("seed a backup OrMap row");
 

--- a/packages/server-rust/src/storage/record.rs
+++ b/packages/server-rust/src/storage/record.rs
@@ -609,6 +609,7 @@ pub struct Record {
 #[cfg(test)]
 mod tombstone_bytes_gauge_tests {
     use super::*;
+    use crate::storage::datastores::RedbDataStore;
     use crate::storage::tombstone_gauge::with_isolated_gauge;
 
     // Every test here binds a private sink for the duration of its own future,
@@ -693,6 +694,163 @@ mod tombstone_bytes_gauge_tests {
         assert_eq!(
             delta, 0,
             "a serde round-trip contributes nothing to the scope"
+        );
+    }
+
+    /// An `OrMap` slot carrying one live entry plus the given tombstones.
+    ///
+    /// The live entry's own `tag` is never a tombstone, so it must contribute
+    /// nothing to the reconciled total — a walk that summed record tags as well
+    /// would show up as an over-count.
+    fn or_map_with_tombstones(tombstones: Vec<String>) -> RecordValue {
+        RecordValue::OrMap {
+            records: vec![OrMapEntry {
+                value: Value::String("live".to_string()),
+                tag: "live-tag".to_string(),
+                timestamp: Timestamp {
+                    millis: 1,
+                    counter: 0,
+                    node_id: "node-a".to_string(),
+                },
+            }],
+            tombstones,
+        }
+    }
+
+    /// The boot reconciliation recomputes the tombstone-byte total from what is
+    /// actually persisted, so it is driven here against a real redb keyspace that
+    /// has been seeded. A `MapDataStore` double returning an empty `ScanBatch`
+    /// would walk nothing and pass while proving nothing.
+    ///
+    /// The same seeded corpus pins the walk's two deliberate exclusions. Each
+    /// probe carries a tag whose length makes the corpus-with-that-probe total
+    /// differ from the expected one, so no regression that starts counting it can
+    /// leave the assertion coincidentally green:
+    ///
+    /// - legacy `OrTombstones` blobs are not summed, because the live
+    ///   `add_tombstone_bytes` path never counts them either — summing them here
+    ///   would over-count relative to the gauge this walk re-baselines;
+    /// - backup rows are not summed, because `list_maps` enumerates primary
+    ///   tables only and the walk scans each map with `is_backup = false`.
+    #[tokio::test]
+    async fn reconcile_re_baselines_the_gauge_to_the_durable_primary_ormap_tombstone_sum() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store: Arc<dyn MapDataStore> =
+            Arc::new(RedbDataStore::new(dir.path().join("reconcile.redb")).expect("redb open"));
+
+        // Lengths are spelled as `repeat` counts rather than literal runs of
+        // characters so the expected total below cannot drift from a miscount.
+        let counted_a = "a".repeat(4);
+        let counted_b = "b".repeat(6);
+        let counted_c = "c".repeat(5);
+        let excluded_legacy = "d".repeat(20);
+        let excluded_backup = "e".repeat(9);
+        // 4 + 6 + 5 — the primary-partition `OrMap` tombstones and nothing else.
+        const EXPECTED_TOTAL: u64 = 15;
+
+        // Two maps, so the per-map loop over `list_maps` is genuinely iterated,
+        // and one non-OR record, so the walk's arm selection is exercised.
+        store
+            .add(
+                "reconcile_a",
+                "k1",
+                &or_map_with_tombstones(vec![counted_a, counted_b]),
+                0,
+                0,
+            )
+            .await
+            .expect("seed primary OrMap in the first map");
+        store
+            .add(
+                "reconcile_b",
+                "k1",
+                &or_map_with_tombstones(vec![counted_c]),
+                0,
+                0,
+            )
+            .await
+            .expect("seed primary OrMap in the second map");
+        store
+            .add(
+                "reconcile_b",
+                "k2",
+                &RecordValue::Lww {
+                    value: Value::String("plain".to_string()),
+                    timestamp: Timestamp {
+                        millis: 2,
+                        counter: 0,
+                        node_id: "node-a".to_string(),
+                    },
+                },
+                0,
+                0,
+            )
+            .await
+            .expect("seed an LWW record");
+        store
+            .add(
+                "reconcile_a",
+                "legacy",
+                &RecordValue::OrTombstones {
+                    tags: vec![excluded_legacy.clone()],
+                },
+                0,
+                0,
+            )
+            .await
+            .expect("seed the legacy tombstone-only blob");
+        store
+            .add_backup(
+                "reconcile_a",
+                "backup-key",
+                &or_map_with_tombstones(vec![excluded_backup.clone()]),
+                0,
+                0,
+            )
+            .await
+            .expect("seed a backup OrMap row");
+
+        // An exclusion asserted over a corpus that never held the excluded row is
+        // vacuous, so both probes are confirmed present before the walk runs.
+        match store
+            .load("reconcile_a", "legacy")
+            .await
+            .expect("load the legacy row back")
+        {
+            Some(RecordValue::OrTombstones { tags }) => assert_eq!(
+                tags,
+                vec![excluded_legacy],
+                "the legacy exclusion probe must be stored with its tag intact"
+            ),
+            other => panic!("legacy OrTombstones probe did not land: {other:?}"),
+        }
+        let backup_batch = store
+            .scan_values("reconcile_a", true, 0)
+            .await
+            .expect("scan the backup table");
+        assert_eq!(
+            backup_batch.records.len(),
+            1,
+            "the backup exclusion probe must be stored in the backup table"
+        );
+
+        // Scoped sink: the walk's `set_tombstone_bytes` is an absolute set, which
+        // trips the process-global gauge's tripwire once any test in this binary
+        // has fired an add, and a shared counter could also be perturbed by
+        // foreign traffic. The returned sink value is the walk's own re-baseline.
+        let (returned_total, gauge_after) =
+            with_isolated_gauge(reconcile_tombstone_bytes(Arc::clone(&store))).await;
+
+        assert_eq!(
+            returned_total, EXPECTED_TOTAL,
+            "the reconciled total must be the exact sum of primary-partition \
+             OrMap tombstone tag bytes — legacy blobs (20 bytes) and backup rows \
+             (9 bytes) excluded, record tags never counted"
+        );
+        assert_eq!(
+            gauge_after, EXPECTED_TOTAL,
+            "the walk must re-baseline the gauge to the total it returns, so the \
+             returned value and the observed gauge cannot drift apart"
         );
     }
 }

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 DOC="INVARIANTS.md"
-NAKED_BASELINE=5
+NAKED_BASELINE=4
 
 [ -f "$DOC" ] || { echo "FAIL: $DOC missing"; exit 1; }
 


### PR DESCRIPTION
## Summary

Part 1 of 3 of the OR delta-framing split (reader-first order — every merge point leaves main crash-safe; no format change in this part).

- **Single OR-delta apply seam:** the OR mutation logic extracted into one PURE `pub(crate)` apply function (no counters inside — both gauge calls stay at their call-site positions; `sub_tombstone_bytes` deliberately in the post-write Ok arm tracking RESIDENT bytes). The hot path's `Option::take + expect` run-once shape preserved verbatim — now with a direct call-counter enforcing test, flipping **TG-OR-001 to enforced (NAKED 5→4, ratchet lowered in-diff)**. The `witness` return field was withdrawn as YAGNI until the emitter (349c) consumes it — recorded honestly, the ownership question relocates to 349c.
- **Gauge-reconcile lib seam:** `reconcile_tombstone_bytes` moves bin→lib as plain `pub` (compiler-forced: the bin links the lib externally); the pre-existing test-side duplicates it obsoletes are DELETED and re-pointed at the lib fn (AC4 "no second copy" holds by construction).
- **Prune error-path hardening (TODO-594):** discriminator sited on the REAL crdt.rs prune path with an injectable failing store (FaultStore + data-parameterized fixture) — the mirror module stays un-cited per its own SPEC-351 doc-contract.
- INVARIANTS.md: TG-OR-004 citations updated with the move; check-invariants.sh baseline 5→4.

## Test evidence
4 audit cycles + review APPROVED (5 minors applied inline); `cargo test --release --lib` 1719/0; clippy `-D warnings`; fmt; `check-invariants.sh` 18 entries, 4 NAKED == baseline. Net behavior delta: nil (seam extraction); sim-test exemption stated per convention.

Next: SPEC-349b (delta-frame + fold READER; depends_on this + SPEC-350/352) → SPEC-349c (emitter + plateau controls).