### PR TITLE
Calibrate maturity claims: public stabilization status instead of 'production-ready'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![License](https://img.shields.io/github/license/TopGunBuild/topgun)](LICENSE) [![CI](https://img.shields.io/github/actions/workflow/status/TopGunBuild/topgun/rust.yml?branch=main&label=CI)](.github/workflows/rust.yml) [![Docker](https://github.com/TopGunBuild/topgun/actions/workflows/docker.yml/badge.svg)](https://github.com/TopGunBuild/topgun/actions/workflows/docker.yml) [![npm](https://img.shields.io/npm/v/@topgunbuild/client)](https://www.npmjs.com/package/@topgunbuild/client) [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/NDpMG4dmJu) [![GitHub Stars](https://img.shields.io/github/stars/TopGunBuild/topgun?style=social)](https://github.com/TopGunBuild/topgun)
 
-> **v2.0 — single-node stable; cluster features in progress.** The TypeScript client and Rust server APIs are stable for single-node deployments. Cluster-mode capabilities (Raft-backed distributed locks, cross-node replication) are being actively developed.
+> **v2 — single-node core, in active hardening.** The TypeScript client and Rust server APIs are stable for single-node development and self-hosted evaluation. Before we recommend unattended production use, we're completing a public stabilization program: a machine-checked [invariant catalog](INVARIANTS.md) (every durability claim mapped to an enforcing test — gaps marked honestly), a crash-recovery proof harness, and a 72-hour endurance gate. Durability trade-offs are documented, not hidden (e.g. the default `batched` fsync acks before fsync — see the server docs). Cluster-mode (Raft-backed locks, cross-node replication) is in progress.
 
 Build real-time apps that work offline. Local writes are instant and survive disconnects; reconnecting clients sync seamlessly with automatic conflict resolution. Self-host today with the embedded backend, or wire up Postgres when you need it. Apache-2.0, Rust server, TypeScript client. AI agents talk to your data natively through MCP.
 
-TopGun v2 is a complete rewrite. It's not a port — it's a new architecture designed for production workloads.
+TopGun v2 is a complete rewrite. It's not a port — it's a new architecture built to earn production trust; the status note above says what we do and don't yet claim.
 
 **[Live Demo](https://demo.topgun.build/)** — try it in your browser
 
@@ -86,7 +86,7 @@ export TOPGUN_NO_AUTH=0                       # 0 = enforce auth, 1 = dev-only b
 
 **3. Single-node deployment**
 
-Single-node is fully consistent and production-ready for workloads that fit one server:
+Single-node is fully consistent and stable for workloads that fit one server; the stabilization gates we're completing before recommending unattended production use are public ([INVARIANTS.md](INVARIANTS.md) + the [roadmap](https://topgun.build/docs/roadmap)):
 
 ```bash
 docker compose up --build

--- a/apps/docs-astro/src/content/docs/guides/migrating-from-firebase.mdx
+++ b/apps/docs-astro/src/content/docs/guides/migrating-from-firebase.mdx
@@ -308,7 +308,7 @@ The same auto-batching applies to multiple `useMutation` `.create()` / `.update(
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground">Single-node (recommended for migration)</td>
         <td className="py-3 px-4 text-green-600 dark:text-green-400">Stable</td>
-        <td className="py-3 px-4 text-neutral-500">All Firestore/RTDB capabilities mapped above are production-ready in single-node mode</td>
+        <td className="py-3 px-4 text-neutral-500">All Firestore/RTDB capabilities mapped above are stable in single-node mode — see the <a href="/docs/roadmap#stabilization-status">public stabilization gates</a> before unattended production use</td>
       </tr>
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground">Cluster (current)</td>

--- a/apps/docs-astro/src/content/docs/guides/migrating-from-replicache.mdx
+++ b/apps/docs-astro/src/content/docs/guides/migrating-from-replicache.mdx
@@ -279,7 +279,7 @@ Replicache groups multi-key writes inside a single mutator function so they appl
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground">Single-node (recommended for migration)</td>
         <td className="py-3 px-4 text-green-600 dark:text-green-400">Stable</td>
-        <td className="py-3 px-4 text-neutral-500">All Replicache mappings above are production-ready in single-node mode</td>
+        <td className="py-3 px-4 text-neutral-500">All Replicache mappings above are stable in single-node mode — see the <a href="/docs/roadmap#stabilization-status">public stabilization gates</a> before unattended production use</td>
       </tr>
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground">Cluster (current)</td>

--- a/apps/docs-astro/src/content/docs/guides/migrating-from-supabase-realtime.mdx
+++ b/apps/docs-astro/src/content/docs/guides/migrating-from-supabase-realtime.mdx
@@ -305,7 +305,7 @@ function UserList() {
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground">Single-node (recommended for migration)</td>
         <td className="py-3 px-4 text-green-600 dark:text-green-400">Stable</td>
-        <td className="py-3 px-4 text-neutral-500">All Supabase Realtime capabilities mapped above are production-ready in single-node mode</td>
+        <td className="py-3 px-4 text-neutral-500">All Supabase Realtime capabilities mapped above are stable in single-node mode — see the <a href="/docs/roadmap#stabilization-status">public stabilization gates</a> before unattended production use</td>
       </tr>
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground">Cluster (current)</td>

--- a/apps/docs-astro/src/content/docs/guides/migrating-from-yjs.mdx
+++ b/apps/docs-astro/src/content/docs/guides/migrating-from-yjs.mdx
@@ -258,7 +258,7 @@ function TodoList() {
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground">Single-node (recommended for migration)</td>
         <td className="py-3 px-4 text-green-600 dark:text-green-400">Stable</td>
-        <td className="py-3 px-4 text-neutral-500">All Y.Map/Y.Doc capabilities mapped above are production-ready in single-node mode</td>
+        <td className="py-3 px-4 text-neutral-500">All Y.Map/Y.Doc capabilities mapped above are stable in single-node mode — see the <a href="/docs/roadmap#stabilization-status">public stabilization gates</a> before unattended production use</td>
       </tr>
       <tr className="border-b border-card-border">
         <td className="py-3 px-4 font-medium text-foreground">Cluster (current)</td>

--- a/apps/docs-astro/src/content/docs/roadmap.mdx
+++ b/apps/docs-astro/src/content/docs/roadmap.mdx
@@ -18,9 +18,33 @@ import { ChevronRight } from 'lucide-react';
 
 # Roadmap
 
-Last updated: 2026-05-22
+Last updated: 2026-07-27
 
 This page tracks the maturity level of distributed primitives across deployment modes and consolidates every Planned / not-yet-implemented feature into one auditable status table. It is the canonical single source of truth for "what works today vs what is planned."
+
+## Stabilization Status
+
+TopGun is in an active, **public** hardening program before we recommend unattended production
+use. The receipts are in the repository, not in marketing copy:
+
+- **[Invariant catalog](https://github.com/TopGunBuild/topgun/blob/main/INVARIANTS.md)** — every
+  durability/correctness invariant the system relies on, each mapped to the test that enforces
+  it. Invariants without an enforcing test are marked `NAKED` with a tracking issue, visibly and
+  on purpose; CI fails if that count grows silently.
+- **Crash-recovery proof harness** — a model-based generative test that drives
+  write / flush / crash-at-any-point / recover / GC sequences against an independent reference
+  model, with process-restart crossings inside each case. It re-detects every restart-boundary
+  bug class we have found and fixed.
+- **A 72-hour endurance gate** — the final exam (sustained churn + kill -9 loops with hard
+  memory/disk/tombstone gates) runs once the remaining gates above are closed; we publish the
+  criteria rather than the adjective "production-ready".
+
+Known, documented trade-offs (not hidden): the default `batched` WAL fsync policy acks writes
+before fsync — an unclean crash can lose the last ~10 ms group-commit window server-side (the
+originating client re-converges via its local op-log); set `TOPGUN_WAL_FSYNC_POLICY=per_op` for
+acked-implies-durable. See the server configuration docs for the full list.
+
+Single-node APIs are stable for development and self-hosted evaluation today.
 
 ## Distributed Primitives Maturity
 


### PR DESCRIPTION
## Summary

The README overclaimed relative to the project's own (public) stabilization program: "production-ready", "designed for production workloads". This PR replaces adjectives with receipts, turning honesty into a differentiator:

- **README**: status block now points at the machine-checked [INVARIANTS.md](https://github.com/TopGunBuild/topgun/blob/main/INVARIANTS.md) (durability claims mapped to enforcing tests, gaps marked NAKED on purpose), the crash-recovery proof harness, and the 72h endurance gate; the batched-fsync trade-off is named up front. "Production-ready" claims (intro + deployment section) re-worded to "stable for single-node workloads + here are the public gates".
- **docs site**: the four migration guides' "production-ready in single-node mode" cells re-pointed to a new **Stabilization Status** section on the roadmap page (the rest of the site was already well-calibrated — "single-node stable today" everywhere).
- No positioning change: H1/hero outcome-first framing untouched.

Docs-only; no code. Site auto-deploys on merge.