### PR TITLE
fix(sf-356b): disarm cell E's expectation, adjudicate ADJ-9/10/11 pre-data

### DIFF
--- a/packages/server-rust/benches/soak_harness/evidence/spec356-adj11-xask.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-adj11-xask.md
@@ -1,0 +1,83 @@
+# ADJ-11 adversarial cross-vendor round (glm-5.2, 2026-08-08)
+
+Question put to the vendor (verbatim):
+
+> CONTEXT. A pre-registered measurement protocol (frozen manifest, append-only adjudication addenda) classifies why a tombstone-prune mechanism reclaims a falling fraction of garbage as epoch width grows: THROUGHPUT-BOUND (prune licensed but can't keep up) vs ELIGIBILITY-BOUND (garbage exists but never becomes licensed/eligible for prune). Instrument: a per-prune-pass record exported as Prometheus metrics, scraped every 10s into a CSV.
+> 
+> Key metrics:
+> - topgun_or_prune_eligible_refs — GAUGE "L": licensed (eligible) backlog, sampled PRE-drain inside each prune pass (set at each pass, retains value until next pass; scraped at 10s cadence). Prune passes may run more often than 10s, so scrape-max(L) samples a subset of passes.
+> - topgun_or_prune_nonempty_drains_total, drain_refs_sum, bytes_freed_total — MONOTONE COUNTERS: cumulative drains that removed >0 refs, cumulative refs drained, bytes freed.
+> - topgun_or_prune_split_recomputes_total — counter certifying the eligible/ineligible split recompute actually ran (admissibility gate "Step 0(b)": if this is flat in a window, the window is INDETERMINATE, fail-closed).
+> 
+> THE FORK TO ADJUDICATE (pre-data, must be frozen before any measurement exists):
+> An earlier adjudication (ADJ-7) says: "A Step-2 determination must be reported together with max(L) over the window... A window whose max(L) is also 0 is a window in which the sampler never observed a non-empty drain, and that is an admissibility observation, not evidence that the prune is licensed-and-draining."
+> The audit found a tension: the admissibility gate (Step 0) is fail-closed (any limb fails => whole window INDETERMINATE, no classification), but if max(L)=0 auto-routes to INDETERMINATE, then a genuinely eligibility-starved system (nothing ever becomes licensed => L=0 at every pass) could NEVER be classified as eligibility-bound — the instrument would structurally predetermine against one of the two verdicts it exists to distinguish.
+> 
+> MY PROPOSED ADJUDICATED FORM (attack this):
+> max(L)=0 alone routes nothing to INDETERMINATE. Window disposition is decided by the monotone counters:
+> (i) Step 0(b) fails (split_recomputes_total flat) => INDETERMINATE (existing rule, untouched).
+> (ii) Step 0(b) passes AND nonempty_drains_total FLAT over the window AND the tombstone backlog series grows => max(L)=0 is a VALID measurement consistent with eligibility-bound; flows to Step 2 as evidence. ADJ-7's prohibition stands: it must never be read as "prune is licensed-and-draining".
+> (iii) Step 0(b) passes AND nonempty_drains_total ADVANCES while scrape-max(L)=0 => the 10s gauge cadence under-sampled the pre-drain instants; scrape-max(L) is INADMISSIBLE as a bound for this window; the determination is carried by the counters (drain_refs_sum delta, nonempty_drains_total delta) and the max(L) cell is reported as UNDERSAMPLED, not INDETERMINATE.
+> 
+> QUESTIONS:
+> 1. Does this adjudication predetermine either verdict (throughput-bound or eligibility-bound) in any regime you can construct? Construct concrete adversarial regimes (pass frequency vs scrape cadence, bursty licensing, drain-within-pass timing) that break clauses (ii) or (iii).
+> 2. Is there a hole where a BROKEN instrument (recorder running but gauge wired wrong, e.g. always exporting 0) would be classified as eligibility-bound instead of caught? What cheap cross-check closes it?
+> 3. Is "UNDERSAMPLED" the right disposition in (iii), or should (iii) escalate differently? Keep in mind the protocol's ethos: fail-closed for instrument defects, but never let the instrument's own limitations silently pick a scientific verdict.
+> Answer concisely, findings-first.
+
+Vendor answer (verbatim, z-ai/glm-5.2 via openrouter, cost $0.0094):
+
+> → openrouter z-ai/glm-5.2 answering (0 file(s) embedded)…
+> 
+> [usage] prompt=950 completion=11607 total=12557 cost=$0.0093797432
+> ## Findings
+> 
+> ### Q1: Yes — clause (ii) can false-positive eligibility-bound; clause (iii) loses discriminative power.
+> 
+> **Clause (ii) break — "transient eligibility + stuck drain":**
+> 
+> Passes at 20 Hz (50 ms), scrape at 0.1 Hz (10 s) → 200 passes per scrape. Every 12 s, a recompute finds ~500 eligible refs (L←500), but the drain step is blocked by I/O contention or lock timeout — a genuine throughput pathology. By the next pass (50 ms later), eligibility has expired or been reclassified by a concurrent writer; L←0. The scraper has ~0.4% chance per scrape of catching L>0. Over a 60 s window (6 scrapes), P(all miss) ≈ 97.6%. Result: `nonempty_drains_total` flat, backlog grows, max(L)=0 → clause (ii) fires → **eligibility-bound**. Truth: eligible refs repeatedly appear but prune can't catch them. This is throughput-bound (or prune-broken), misclassified as eligibility-starved. The root cause is that clause (ii) uses flat drains as a proxy for "nothing was eligible," but flat drains only proves "nothing drained," not "nothing was eligible."
+> 
+> **Clause (iii) break — "counters can't finish the job":**
+> 
+> Passes at 100 Hz. Every 5 s, 1000 refs become eligible and drain within one pass (L spikes for ~10 ms then returns to 0). Meanwhile ineligible garbage accumulates at 500 refs/s. Scraper likely misses all spikes. max(L)=0, `nonempty_drains_total` advances → clause (iii) → UNDERSAMPLED, "determination carried by counters." But the counters show only that 6000 refs drained and backlog grew by 15000. Is the growing backlog eligible (throughput-bound) or ineligible (eligibility-bound for that portion)? **The counters cannot answer this.** They exclude pure eligibility-bound but cannot confirm throughput-bound. Clause (iii) silently leans toward "not eligibility-bound" — which is the instrument's sampling limitation picking a side, not a scientific determination.
+> 
+> **Structural bias:** The adjudication doesn't make either verdict *impossible*, but it systematically under-detects throughput-bound in undersampled regimes, and clause (ii) can structurally false-positive eligibility-bound when eligibility is real but transient and drains fail for reasons unrelated to eligibility.
+> 
+> ---
+> 
+> ### Q2: Yes — a broken gauge (always 0) escapes detection in the flat-drain regime.
+> 
+> If the gauge is hard-wired to 0:
+> 
+> | System state | Drains | Clause fired | Disposition | Correct? |
+> |---|---|---|---|---|
+> | Throughput-bound, draining | advancing | (iii) | UNDERSAMPLED | Mislabels defect as undersampling, but counters partially compensate |
+> | Throughput-bound, prune stuck | flat | (ii) | eligibility-bound | **Wrong. Eligible refs exist but gauge hides them.** |
+> | Genuinely eligibility-bound | flat | (ii) | eligibility-bound | Correct by coincidence |
+> 
+> **Cheap cross-check using existing metrics:** You cannot drain >0 refs without L>0 at some pass. Therefore: **if `drain_refs_sum` has *ever* advanced in any historical window where max(L)=0, set a persistent `GAUGE_DEFECT` flag.** Once set, all subsequent clause (ii) dispositions downgrade from "eligibility-bound evidence" to INDETERMINATE(gauge suspect). This closes the hole: a broken gauge will eventually produce a draining window (unless the system is permanently and genuinely eligibility-bound — in which case the classification is correct anyway and the flag never fires).
+> 
+> **Additional cross-check (no new metrics):** Correlate `split_recomputes_total` rate with scrape cadence. If the recompute runs at 100 Hz and the scraper samples at 0.1 Hz, the scraper catches 1 in 1000 passes. In that regime, max(L)=0 is overwhelmingly more likely to be undersampling than genuine eligibility starvation. If the recompute rate is high and L has been 0 for many windows, escalate to INDETERMINATE(instrument suspect) regardless of drain state.
+> 
+> ---
+> 
+> ### Q3: UNDERSAMPLED is too soft. It should split into INADMISSIBLE (for the gauge) + INDETERMINATE (for the primary fork), with counters as secondary evidence only.
+> 
+> The protocol ethos says: fail-closed for instrument *defects*, but never let instrument *limitations* silently pick a verdict. Undersampling due to pass-frequency exceeding scrape cadence is a limitation, not a defect. But clause (iii) currently lets that limitation redirect the verdict to the counters, which then lean toward "not eligibility-bound" (drains happened → something was eligible). That lean is the instrument's sampling gap picking a side.
+> 
+> The counters can **exclude** pure eligibility-bound (drains advanced → eligibility existed at some point). They **cannot confirm** throughput-bound (need to know whether the *growing* backlog is eligible, which requires L). That's a one-sided determination masquerading as a complete one.
+> 
+> **Recommended disposition for (iii):**
+> 
+> - The max(L) cell is **INADMISSIBLE** — not "undersampled," which implies it's a noisy version of the truth. It's a non-sample: it provides no bound, not even a lower bound, on the eligible backlog in this window.
+> - The primary fork classification (throughput-bound vs eligibility-bound) is **INDETERMINATE** for this window. The counters are reported as secondary evidence ("N refs drained, M bytes freed") but cannot carry the primary determination.
+> - If the tombstone backlog series is *stable or shrinking* while drains advance, that's affirmative evidence the system is keeping up (neither verdict in the problematic sense) — report that as a secondary finding. If the backlog is *growing*, the counters alone cannot disambiguate.
+> 
+> This keeps the ethos intact: the instrument's sampling limitation produces an honest "I don't know" rather than a silent lean.
+> 
+> ---
+> 
+> ### One thing I'm uncertain about
+> 
+> I don't have context on what the "tombstone backlog series" actually measures (total tombstones? eligible+ineligible? something else?) or whether it's a Prometheus metric with the same sampling issues as L. If it's also scrape-sampled at 10 s and can miss transient states, my analysis of clause (ii)'s backlog-grows check needs adjustment — the backlog series could also under-sample and mask growth or shrinkage within a window. If it's a monotone counter (cumulative tombstones created), it's more reliable and my analysis holds.

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
@@ -889,3 +889,117 @@ edited to accommodate them.)*
 
 - **AUTHORITY:** SPEC-356a Review v1 finding M3; `/xask` round finding X11; user ruling 2026-08-04.
 - **PRE-DATA / POST-DATA:** **PRE-DATA** — same boundary as ADJ-7: no measurement artifact exists.
+
+### ADJ-9
+
+- **ADJ id:** ADJ-9
+- **Date:** 2026-08-08
+- **Target:** **§4** (cell E's protocol) versus the runner's cell table (`spec356-prune.sh`, `cellE` arm).
+- **ORIGINAL TEXT (verbatim, §4):**
+
+  > **Cell E carries NO prune-record columns**: the pre-346 server has no recorder, and expecting them is a
+  > category error.
+
+- **FINDING:** the runner's cell table set `cellE) ARMED=yes`, and the arming witness branches ONLY on
+  `ARMED`: an armed cell whose scrape carries zero `topgun_or_prune_` series is `fail_instrument` → exit 9.
+  A pre-346 server structurally emits no such series, so cell E was **guaranteed** to exit 9 — the runner
+  embodied exactly the category error §4 forbids. A second, independent exit 9 followed: with `ARMED=yes`
+  the column checks do not take the disarmed early return, so the six INSTRUMENT columns fail their NONZERO
+  limb. R4.3's *"discarded and re-run"* disposition would loop forever. Raised by SPEC-356b **Audit v3,
+  critical C1**.
+- **ADJUDICATED FORM (governs):**
+
+  > **Cell E is a DISARMED-expectation cell.** The runner's cell-table entry is repaired (`ARMED=yes` →
+  > `ARMED=no`) in the same commit as this addendum, PRE-DATA. The arming witness's disarmed branch — a
+  > scrape carrying **zero** `topgun_or_prune_` series — is the §4-consistent check for this cell, and the
+  > column completeness gate takes the ADJ-6 disarmed early return. `PROVENANCE=yes` is unchanged: cell E
+  > remains the §4.2 half-swap identity-checked cell. **No expected-exit-9 carve-out is created**: exit 9 on
+  > cell E (as on any cell) remains a real instrument-defect signal, and the fail-closed STEP 0 taxonomy is
+  > intact. The repair-the-instrument disposition was chosen over pre-registering an exit-9 interpretation
+  > precisely because teaching the protocol that "exit 9 sometimes means success" would corrode the defect
+  > signal for every later consumer.
+
+- **AUTHORITY:** SPEC-356b Audit v3 critical C1; Conductor ruling 2026-08-08.
+- **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.
+
+### ADJ-10
+
+- **ADJ id:** ADJ-10
+- **Date:** 2026-08-08
+- **Target:** **ADJ-8's adjudicated form** — the costing of the declined `n = 6` series-control extension.
+- **ORIGINAL TEXT (verbatim, ADJ-8):**
+
+  > **`n = 6` is DECLINED, with its cost on the record.** Each cell is a 4 h run, so `n = 6` per arm is
+  > **≈ 48 h of additional control time** — against a family whose next gate (TODO-484) is itself a 72 h soak.
+
+- **FINDING:** the arithmetic was computed from the 4 h `long` cell, but the series-control arms are the
+  1800 s cells (`ctl` / `ctloff`, runner cell table; R4.4). The true incremental cost of `n = 2 → 6` is
+  **8 × 1800 s = 4 h** (all twelve control runs from zero: 6 h) — twelve times smaller than the figure the
+  decline cited. Raised by SPEC-356b **Audit v3, critical C2**.
+- **ADJUDICATED FORM (governs):**
+
+  > The corrected figures govern the record: `n = 2 → 6` costs **≈ 4 h**, not ≈ 48 h. With the cost leg
+  > corrected, **the DECLINE of `n = 6` is RE-AFFIRMED on the role leg alone**: ADJ-8's adjudication that the
+  > series control is a CATASTROPHE DETECTOR stands, `n = 6` would buy a better-powered **non-proof** of
+  > neutrality rather than a neutrality proof, and no downstream consumer of SPEC-356b conditions on an MDE
+  > finer than the reporting bound. The **REPORTING BOUND is unchanged**: every neutrality statement still
+  > cites `MDE ≈ 17 %` (recomputed from the pair's own pooled sd) and *"a smaller perturbation is NOT
+  > excluded"*, verbatim. Any future re-litigation of the extension MUST argue from the corrected 4 h figure.
+
+- **AUTHORITY:** SPEC-356b Audit v3 critical C2; Conductor ruling 2026-08-08.
+- **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.
+
+### ADJ-11
+
+- **ADJ id:** ADJ-11
+- **Date:** 2026-08-08
+- **Target:** **ADJ-7's `max(L)` reporting obligation** and its interaction with **§2.2 Step 0** routing.
+- **ORIGINAL TEXT (verbatim, ADJ-7):**
+
+  > A Step-2 determination must be reported together with `max(L)` over the window, not with the median
+  > alone. A window whose `max(L)` is also 0 is a window in which the sampler never observed a non-empty
+  > drain, and that is an admissibility observation (§2.2 limb (b)'s territory), not evidence that the prune
+  > is licensed-and-draining.
+
+- **FINDING:** the clause leaves a two-sided hazard unadjudicated. (a) If `max(L) = 0` auto-routes to
+  INDETERMINATE via limb (b)'s fail-closed rule, a genuinely eligibility-starved system — one whose every
+  pass observes zero licensed backlog — becomes structurally unclassifiable: the instrument would
+  predetermine against one of the two verdicts it exists to distinguish. (b) `eligible_refs` is a
+  pass-retained GAUGE scraped on a 10 s cadence while prune passes may run far more often, so a scrape-level
+  `max(L) = 0` cannot by itself distinguish genuine starvation from under-sampling. Raised by SPEC-356b
+  Audit v3 recommendation 7; both clauses of the first draft resolution were then broken by an adversarial
+  cross-vendor round (glm-5.2, 2026-08-08, artifact `spec356-adj11-xask.md`): flat drains prove only that
+  nothing DRAINED, not that nothing was ELIGIBLE, and letting counters "carry the determination" in the
+  under-sampled regime is the instrument's own limitation silently picking a verdict.
+- **ADJUDICATED FORM (governs — counter-anchored, the gauge alone decides nothing):**
+
+  > Window disposition under `max(L) = 0` is decided by the MONOTONE COUNTERS, whose per-pass identity
+  > `passes_total == empty_drains_total + nonempty_drains_total` is pinned in code and test (TG-OR-006's
+  > exhaustiveness family). Over the window, with Δ denoting the counter delta:
+  >
+  > 0. **Conservation first:** if `Δpasses ≠ Δempty_drains + Δnonempty_drains`, the window is
+  >    **INDETERMINATE** (unaccounted passes).
+  > 1. **Step 0(b) unchanged:** a window failing the split-recompute certification is **INDETERMINATE**.
+  > 2. **Eligibility-starved evidence requires per-pass counter proof:** `Δnonempty_drains = 0` AND
+  >    `Δempty_drains = Δpasses > 0` AND the error counters are flat (`restored_read_error_total`,
+  >    `restored_write_error_total` — a blocked drain can report an empty drain while licensed work exists)
+  >    AND the tombstone backlog series grows ⇒ **every pass observed zero licensed backlog**: valid
+  >    evidence toward ELIGIBILITY-BOUND, with `max(L) = 0` as corroboration only. ADJ-7's prohibition
+  >    stands — this is never read as "the prune is licensed-and-draining". A window with advancing error
+  >    counters is **INDETERMINATE**.
+  > 3. **Under-sampled regime:** `Δnonempty_drains > 0` while scrape-level `max(L) = 0` ⇒ the `max(L)` cell
+  >    is **INADMISSIBLE** for that window (a non-sample: it bounds nothing), and the window's primary
+  >    classification is **INDETERMINATE**. The counters are reported as SECONDARY evidence (refs drained,
+  >    bytes freed); a backlog stable-or-shrinking while drains advance is an affirmative *keeping-up*
+  >    secondary finding. The counters can EXCLUDE pure eligibility-starvation here; they cannot CONFIRM
+  >    throughput-boundedness, and no clause may treat that one-sided exclusion as a completed
+  >    determination.
+  >
+  > **Diagnostic obligation:** every window report states `Δpasses` alongside its scrape count, so the
+  > under-sampling regime is visible on the record rather than inferred.
+
+- **AUTHORITY:** SPEC-356b Audit v3 recommendation 7; adversarial `/xask` round 2026-08-08 (findings
+  adopted: the transient-eligibility false-positive closed by the empty-drains counter anchor; the
+  broken-gauge hazard subsumed because clause 2 no longer rests on the gauge; INADMISSIBLE-plus-
+  INDETERMINATE adopted verbatim for the under-sampled regime); Conductor ruling 2026-08-08.
+- **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-prune.sh
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-prune.sh
@@ -118,7 +118,7 @@ case "$CELL" in
              MEASUREMENT=yes; BASE="spec356-w100" ;;
   long)      WIDTH="";   ARMED=yes; DURATION=14400; SAMPLE_INTERVAL=60; PROVENANCE=no
              MEASUREMENT=yes; BASE="spec356-long" ;;
-  cellE)     WIDTH="";   ARMED=yes; DURATION=1800;  SAMPLE_INTERVAL=60; PROVENANCE=yes
+  cellE)     WIDTH="";   ARMED=no;  DURATION=1800;  SAMPLE_INTERVAL=60; PROVENANCE=yes
              MEASUREMENT=yes; BASE="spec356-cellE" ;;
   # The two NON-MEASUREMENT cells. Their basenames are deliberately outside
   # SPEC-356b's committed set (ctl / ctloff / w100 / long / cellE), so a stray


### PR DESCRIPTION
## Summary

Instrument repair + three PRE-DATA adjudications, all raised by SPEC-356b Audit v3, all landed before any `spec356-*.soak.json` exists.

- **ADJ-9 / runner repair (Audit v3 C1):** the runner armed cell E, but a pre-346 server structurally emits zero `topgun_or_prune_` series, so the arming witness guaranteed exit 9 — the category error manifest §4 forbids, plus a second independent exit 9 from the INSTRUMENT columns' NONZERO limb. One-word fix (`ARMED=yes → no`); the disarmed witness branch (zero prune series expected) is the §4-consistent check. **No expected-exit-9 carve-out**: exit 9 stays a real defect signal everywhere.
- **ADJ-10 (Audit v3 C2):** ADJ-8's declined n=6 control extension was costed at ≈48h from the 4h `long` cell; the control arms are 1800s cells — true cost 4h. Corrected on the record; the decline re-affirmed on the role leg alone (catastrophe detector; reporting bound `MDE ≈ 17%` unchanged).
- **ADJ-11 (Audit v3 rec 7):** `max(L)=0` disposition adjudicated counter-anchored after an adversarial cross-vendor round (glm-5.2, artifact `spec356-adj11-xask.md`) broke both draft clauses. Eligibility-starvation evidence now requires per-pass proof (`Δempty_drains = Δpasses`, flat error counters); the under-sampled regime is INADMISSIBLE + INDETERMINATE — the gauge alone decides nothing, and the instrument's sampling limits can never silently pick a verdict.

Freeze proof: manifest §0–§8 byte-identical to `0e8ebec9` (append-only §8A, 114 additions / 0 deletions). `check-invariants.sh` green (21 entries, 4 NAKED = baseline). Zero `.rs`.

## Test plan
- [x] `bash -n` on the runner (one-word cell-table change)
- [x] §0–§8 byte-freeze verified via `cmp` against `0e8ebec9`
- [x] `scripts/check-invariants.sh` — exit 0
- [x] CI matrix on this PR