### PR TITLE
fix(sf-356b): commit B's source (rendered p50), adjudicate ADJ-12/13/14 pre-data

### DIFF
--- a/packages/server-rust/benches/soak_harness/evidence/spec356-adj12-xask.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-adj12-xask.md
@@ -1,0 +1,118 @@
+# ADJ-12/ADJ-13 adversarial cross-vendor round (glm-5.2, 2026-08-08)
+
+Question put to the vendor (verbatim):
+
+> CONTEXT. Frozen pre-registered protocol (append-only adjudications) classifies a tombstone-prune deficit. The Step 2 vs Steps 3-4 partition is a pair of EXACT COMPLEMENTS on one predicate (celebrated as "mutually exclusive by construction rather than by judgement"):
+> - "licensed work DRAINS" <=> median(L) over the last half <= B  (deficit is in WHAT IS LICENSED -> routes to a claim-registry redesign)
+> - "PERSISTENT licensed backlog" <=> median(L) > B  (further split by a passes-per-epoch slope test into SCHEDULING vs THROUGHPUT -> routes to a prune accelerator)
+> where L = licensed (eligible) backlog gauge sampled pre-drain each pass, scraped every 10s; median(L) = median over scrapes in the last half of the window. B is DEFINED as "the median refs per non-empty drain over the last half. Self-calibrating: it is one prune batch." An earlier adjudication (ADJ-2) deliberately replaced min(L) with median(L) BECAUSE "B is already a median; median-against-median is the coherent comparison".
+> 
+> THE DEFECT (audit, pre-data): B has NO committed source. The metric topgun_or_prune_drain_refs is a histogram, but the committed CSV samples only _sum and _count. A median is not derivable from sum+count. The estimator must be pre-registered NOW (before any data) because the choice decides the modal routing (registry vs accelerator).
+> 
+> AVAILABLE SOURCES (no Rust changes possible; shell runner changes ARE possible with a ~15min evidence-gate re-capture):
+> 1. Monotone counters: drain_refs_sum, nonempty_drains_total -> per-window MEAN batch = Δsum/Δcount. Exact, counter-anchored. But: batch sizes are plausibly right-skewed (occasional huge drains) -> mean > median -> inflated B makes "median(L) <= B" MORE likely -> systematically biases toward the Step 2 verdict, which happens to be the modal/expected outcome (confirmation-shaped bias). Also breaks ADJ-2's median-vs-median coherence.
+> 2. The Prometheus exporter ALREADY renders quantile lines for the histogram (e.g. drain_refs{quantile="0.5"}) at zero code cost; the runner could add this p50 line as one more CSV column (shell-only change + re-capture of the column-census gate artifact). CAVEAT in the instrument's own docs: "the rendered quantile is a window statistic, not an over-the-run distribution" (rolling summary window). Proposed aggregation: B := median over the last-half scrapes of the per-scrape rendered p50 — structurally symmetric with median(L), which is likewise a median-over-scrapes of an instantaneous statistic. Sub-caveats: (i) rolling-window semantics of the exporter's summary (window length is an exporter internal); (ii) scrapes whose window saw no drains render NaN -> need a pre-registered NaN rule; excluding NaN scrapes conditions B on "recent drain occurred" (selection effect).
+> 3. A guard-band on option 1: e.g. verdict requires order-of-magnitude separation (median(L) <= B/10 or > 10B, middle band -> INDETERMINATE). But this DESTROYS the exact-complement partition (a celebrated structural property) and introduces an arbitrary constant (this project has repeatedly killed false-precision constants).
+> 
+> MY LEAN: option 2 (sample the rendered p50; B = median-over-scrapes of p50), with a pre-registered NaN rule, preserving both the partition structure and median-vs-median coherence.
+> 
+> SECOND QUESTION (same protocol, second defect): the "passes-per-epoch" series used by the Step 3/4 slope test has no pre-registered construction. Data: passes_total (counter), current_epoch (monotone-ish gauge), scrape cadence 10s, epochs advance ~every 31s at the widest setting (so Δcurrent_epoch=0 in ~2/3 of scrape intervals; at other widths epochs can be FASTER than scrapes, so one interval can span multiple epochs). Proposed construction: group scrape rows by current_epoch value; passes-in-epoch e = Δpasses_total between the first row at epoch e and the first row at epoch e+1; intervals where Δcurrent_epoch >= 2 span unobserved epoch boundaries -> those epochs are EXCLUDED from the series but COUNTED, with the exclusion fraction reported; the (already-mandated) fit runs on the observed-boundary epochs with the same pinned fitter the protocol uses for its byte-slope. Attack this: does exclusion bias the slope (are excluded epochs systematically the busy ones?), what should the disposition be when the exclusion fraction is large, and is there a construction with no exclusion at all from these two series?
+> 
+> QUESTIONS:
+> 1. Attack option 2: concrete regimes where median-over-scrapes-of-p50 misclassifies the partition (rolling-window aliasing, sparse drains, NaN rule variants). Is the NaN selection effect fatal? Propose the least-bad NaN rule.
+> 2. Is option 1's confirmation-shaped bias actually disqualifying, or would you take mean+declared-bias over p50's window semantics? Which failure is worse for a pre-registered instrument?
+> 3. Second question above: attack the passes-per-epoch construction.
+> 4. Anything in either proposal that lets the instrument's limitations silently pick a verdict (the protocol's cardinal sin)?
+> Concise, findings-first.
+
+Vendor answer (verbatim, z-ai/glm-5.2 via openrouter, cost $0.0172):
+
+> → openrouter z-ai/glm-5.2 answering (0 file(s) embedded)…
+> 
+> [usage] prompt=1245 completion=6810 total=8055 cost=$0.01723871
+> ##1. Attacking Option 2 (median-over-scrapes of rendered p50)
+> 
+> **Median-of-medians ≠ global median.** Each scrape's p50 is the median of batch sizes *within the exporter's rolling window*. Taking the median of these window-medians weights each window equally regardless of how many drains it contains. A window with 1 drain and a window with 50 drains contribute identically. If windows with few drains have systematically different batch sizes than windows with many drains, B is silently biased. Direction is unknown pre-data — could go either way. This is distinct from the NaN issue and is the deeper structural defect.
+> 
+> **Rolling-window aliasing regimes:**
+> 
+> - **Long window (≫ scrape interval):** Adjacent scrapes' p50 values are near-identical (overlapping windows) → pseudoreplication. The median-over-scrapes collapses to ~one observation. You lose the benefit of multiple scrapes and are at the mercy of where the window sits relative to a regime change.
+> - **Regime change within the half-window:** The rolling window smears the transition. B is neither the old nor new regime's median but a blend, with the blend ratio determined by the exporter's internal window length — an instrument parameter you don't control.
+> - **Bursty drains with window length ≈ burst period:** The p50 oscillates between "burst phase" and "gap phase" depending on scrape-window alignment. Whether more scrapes land in burst or gap phase is essentially random w.r.t. drain dynamics → B is a coin flip near the boundary.
+> 
+> **NaN rule — the selection effect is NOT fatal, but has a subtlety:**
+> 
+> B is defined as "median refs per *non-empty* drain." Conditioning on "drain occurred in window" (NaN exclusion) is therefore *correct population selection*, not bias. The definition itself requires excluding empty-drain observations. The concern is narrower: if drain *frequency* correlates with drain *size* (e.g., big drains only happen during backlog spikes), then NaN exclusion conditions on a covariate of batch size, which biases B. But this is a property of the drain process, not the NaN rule per se.
+> 
+> **Least-bad NaN rule:** Exclude NaN scrapes from the B computation. Report the NaN fraction as a pre-registered quality gate. Pre-register a threshold (e.g., NaN fraction > 50% of last-half scrapes → the B estimate is unreliable). The disposition above the threshold should be escalation/INDETERMINATE as a *protocol escape hatch* (separate from the statistical partition), not a guard band on B itself. This preserves the exact complement while admitting that the instrument can fail to produce sufficient evidence.
+> 
+> **Bottom line on option 2:** The median-of-medians weighting problem and the unknown rolling-window length are the real risks, not the NaN rule. Both are instrument internals that affect the verdict near the boundary. You must pre-register the exporter's window length (read it from config, commit it) and the NaN threshold.
+> 
+> ## 2. Option 1 (mean) vs Option 2 (p50): Which failure is worse?
+> 
+> **Option 1's bias:** Known direction (toward Step 2), unknown magnitude (depends on skewness, unobservable pre-data from sum+count). Declared but not correctable. Breaks median-vs-median coherence (ADJ-2's rationale), which was an aesthetic choice, not a structural requirement — so this is minor.
+> 
+> **Option 2's bias:** Unknown direction (median-of-medians can go either way), unknown magnitude (depends on drain-count-per-window distribution and window length). Structurally median-like, preserving coherence.
+> 
+> **My judgment: Option 2 is better, but not for the reason you lean toward it.**
+> 
+> The median-vs-median coherence argument (ADJ-2) is aesthetic and I wouldn't weight it. The real reason to prefer option 2 is that its bias, while unknown in direction, is *bounded* — median-of-medians is a robust statistic that can't be dominated by outliers, and the worst case is a weighting distortion, not an unbounded inflation. Option 1's mean is *unboundedly* biased by heavy tails: a single enormous drain (e.g., a catch-up batch after a stall) inflates the mean arbitrarily, and right-skewed batch distributions are the expectable case for prune workloads.
+> 
+> For a pre-registered instrument, the question is: "can I characterize the failure mode before data?" Option 1: yes, the direction is known, magnitude is not. Option 2: neither direction nor magnitude is fully characterizable pre-data, but the *type* of failure (weighting distortion, not unbounded inflation) is characterizable, and robust statistics are less brittle. I'd take the bounded-unknown over the unbounded-known.
+> 
+> **The disqualifying concern with option 1 is not the bias direction per se — it's the unbounded magnitude.** If the batch distribution has a heavy right tail (plausible for prune workloads — occasional catch-up megabatches), the mean can be 10× the median, which doesn't just "lean toward" Step 2, it *collapses* the partition to Step 2 regardless of the true L. That's the instrument picking the verdict, which is the cardinal sin.
+> 
+> ## 3. Passes-per-epoch construction
+> 
+> **The exclusion is biased, and the bias direction is bad.**
+> 
+> Excluded epochs (Δcurrent_epoch ≥ 2, i.e., multiple epochs per scrape interval) occur precisely when epochs are advancing fast — which is when the system is processing many passes per unit time. If passes-per-epoch is the quantity of interest, fast-advancing epochs are plausibly the *high-pass* epochs (the system is busy). Excluding them biases the observed series toward low-pass epochs → the slope is biased toward flat/negative → **systematically biases toward the SCHEDULING verdict** and away from THROUGHPUT.
+> 
+> This is the same confirmation-shaped concern as option 1 for B, and it's worse because the selection mechanism (fast epochs excluded) is *mechanically* tied to the quantity being measured (passes per epoch).
+> 
+> **Disposition for large exclusion fraction:** Pre-register a threshold (e.g., >25% of epochs excluded). Above it, the slope test is unreliable. Disposition should NOT be to default to either verdict — that's the instrument picking. It should be an escalation hatch (the protocol re-runs with a faster scrape cadence, or a human adjudicates). If the protocol absolutely requires a binary verdict (no escalation), default to the *more aggressive* diagnosis (THROUGHPUT) as a conservative hedge against the downward exclusion bias — but document this as a known-biased default, not a clean adjudication.
+> 
+> **No-exclusion construction exists:** Regress passes_total directly on current_epoch using all scrape points. The cumulative curve's slope is passes-per-epoch. Test for convexity (second derivative > 0 = increasing passes-per-epoch = THROUGHPUT). 
+> 
+> - Points with Δcurrent_epoch = 0 (same epoch, multiple scrapes): these are repeated x-values with vertical scatter — they carry intra-epoch pass-timing information and naturally add weight to that epoch's contribution. No exclusion.
+> - Points with Δcurrent_epoch ≥ 2 (multiple epochs in one interval): the cumulative curve jumps from epoch e to e+k, which is valid — the curve is still monotone and correctly positioned. The fitter sees a coarser step but no information is lost.
+> 
+> This tests the *same hypothesis* (is passes-per-epoch increasing?) via cumulative curvature rather than per-epoch slope. It uses the same pinned fitter. The trade-off is reduced statistical power (curvature is harder to detect than slope), but **zero selection bias and zero exclusion**. Given that the protocol's cardinal sin is letting the instrument pick the verdict, the no-exclusion construction is strongly preferable even at the cost of power.
+> 
+> If the protocol insists on per-epoch deltas (for interpretability), the proportional-distribution alternative (assign Δpasses / Δepochs to each unobserved epoch) is less bad than exclusion but still flattens the series when busy epochs are coarsely observed. I'd reject it in favor of the cumulative approach.
+> 
+> ## 4. Silent verdict-picking audit
+> 
+> **B (option 2):** Three silent pickers:
+> 1. *Exporter rolling-window length* — determines smoothing resolution and transition smearing. If unknown/variable, this is an instrument internal deciding the verdict near regime boundaries. **Mitigation:** commit the window length from config into the pre-registration; if it's not configurable or discoverable, option 2 is unsafe.
+> 2. *NaN fraction* — if high, B is computed from few observations → high variance → noise picks the verdict near boundary. **Mitigation:** pre-registered NaN threshold + escalation hatch.
+> 3. *Median-of-medians weighting* — if few-drain windows have different batch sizes than many-drain windows, B is silently weighted toward the few-drain regime. **No mitigation available without Rust changes.** This is an irreducible limitation; document it as a known bias with unknown direction, accept it, and flag that the partition is unreliable when drain frequency varies substantially across the half-window.
+> 
+> **B (option 1):** One silent picker:
+> 1. *Unknown skewness* — the mean-vs-median gap is unobservable from the committed data and determines whether the partition is shifted or collapsed. If heavy-tailed, the partition collapses to Step 2 always. **No mitigation.** This is worse than option 2's pickers because the collapse is total, not bounded.
+> 
+> **Passes-per-epoch (proposed construction):** One silent picker:
+> 1. *Scrape cadence vs epoch width* — the exclusion fraction is mechanically determined by the ratio of scrape interval to epoch duration. At the widest setting (31s epochs, 10s scrapes), exclusion should be rare (~3% of intervals have Δepoch≥2 if Poisson). At narrower settings, exclusion could dominate. The epoch-width setting — an operational parameter unrelated to the defect being diagnosed — silently determines the slope bias. **This is the instrument picking the verdict.** The cumulative-curve construction eliminates this entirely.
+> 
+> **Summary of cardinal-sin exposure:**
+> 
+> | Defect | Construction | Silent picker? | Bounded? |
+> |--------|-------------|---------------|----------|
+> | B | Option 1 (mean) | Unknown skewness collapses partition | No — unbounded |
+> | B | Option 2 (p50) | Window length, NaN fraction, median-of-medians | Yes — bounded distortion |
+> | Passes/epoch | Proposed (exclude Δepoch≥2) | Scrape cadence vs epoch width biases slope | Yes — bounded but systematic |
+> | Passes/epoch | Cumulative curve | None | N/A |
+> 
+> **Recommendation:** Option 2 for B (with committed window length, NaN threshold, and documented median-of-medians caveat). Cumulative-curve construction for passes-per-epoch (no exclusion, no selection, trades power for unbiasedness). Pre-register escalation hatches for insufficient-data cases (high NaN fraction, uncharacterizable window length) as protocol exits distinct from the statistical partition.
+
+## Post-round empirical correction (Conductor, same day)
+
+The round was posed with a NaN-on-empty-window assumption. A live exposition probe
+(server booted with TOPGUN_PRUNE_RECORD=true, /metrics scraped before any drain)
+showed the installed exporter renders an empty summary window as 0, not NaN:
+
+    topgun_or_prune_drain_refs{quantile="0.5"} 0
+
+Since the summary records only NON-EMPTY drains, a populated window renders p50 >= 1,
+so 0 is a clean reserved sentinel. ADJ-12 adopts the vendor NaN rule with s/NaN/0-sentinel/:
+same exclusion, same reported fraction, same 50% threshold, same Step 0(c) escape hatch.

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
@@ -1003,3 +1003,127 @@ edited to accommodate them.)*
   broken-gauge hazard subsumed because clause 2 no longer rests on the gauge; INADMISSIBLE-plus-
   INDETERMINATE adopted verbatim for the under-sampled regime); Conductor ruling 2026-08-08.
 - **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.
+
+### ADJ-12
+
+- **ADJ id:** ADJ-12
+- **Date:** 2026-08-08
+- **Target:** **§2.1's definition of `B`** and **§5.4's demotion of rendered quantiles**, jointly — the
+  committed source of the Step 2 / Steps 3–4 partition's right-hand side.
+- **ORIGINAL TEXT (verbatim, §2.1 then §5.4):**
+
+  > **`B`** — the **median refs per non-empty drain** over the last half. Self-calibrating: it is one prune
+  > batch.
+
+  > That is why the **per-interval means differenced from the monotone totals are the PRIMARY reading**, and
+  > any exporter-rendered quantile is **corroboration only**.
+
+- **FINDING:** `B` is defined as a median, but no committed column could produce one:
+  `topgun_or_prune_drain_refs` is a histogram and the CSV sampled only `_sum` / `_count`, from which a
+  median is not derivable. The estimator would have been chosen at G4 **with the data visible**, on the
+  partition that decides the modal routing. Raised by SPEC-356b **Audit v4, critical C1**. The adversarial
+  cross-vendor round (artifact `spec356-adj12-xask.md`) then rejected both repair candidates the audit
+  left open: the **mean** (`Δsum/Δcount`) is unboundedly inflated by a heavy right tail — one catch-up
+  megabatch can collapse the partition to Step 2 (the modal outcome) regardless of the true `L`, a
+  confirmation-shaped failure; a **guard band** on the mean destroys the exact-complement partition and
+  introduces an arbitrary constant.
+- **ADJUDICATED FORM (governs):**
+
+  > **`B` := the median over the last-half `prune.csv` rows of the committed column
+  > `topgun_or_prune_drain_refs_p50`** — the exporter-rendered p50 of the batch-size summary, added to the
+  > selection table as column 43 (MEASURAND) in the same commit as this addendum. Bindings:
+  >
+  > - **Window length is COMMITTED, not assumed:** the rolling window is `3 × 20 s = 60 s` — §5.4's own
+  >   figure, re-verified against the locked crate source (`metrics-exporter-prometheus 0.16.2`,
+  >   `src/distribution.rs`: `DEFAULT_SUMMARY_BUCKET_COUNT = 3`, `DEFAULT_SUMMARY_BUCKET_DURATION = 20 s`)
+  >   and the exporter is constructed with no override (`PrometheusBuilder::new()`).
+  > - **The 0-sentinel rule (verified against the live exposition, not assumed):** the summary records only
+  >   NON-EMPTY drains, so a populated window renders `p50 ≥ 1`, and an empty or expired window renders
+  >   **`0`, not `NaN`**. Sentinel rows are **EXCLUDED** from `B`'s median and the excluded fraction is
+  >   **REPORTED** per window.
+  > - **Escape hatch, not a third branch:** if more than **50 %** of the last-half rows are sentinel, `B`
+  >   is unreliable for that window and the window routes via **Step 0(c) (deciding column unreadable) to
+  >   INDETERMINATE**. The Step 2 / Steps 3–4 exact-complement partition is untouched.
+  > - **§5.4 STANDS in full:** no `n`, no sd, no standard error and no t-statistic may be computed by
+  >   counting rows of the p50 column; `B`'s median is a **location estimate** over an autocorrelated
+  >   series (effective independent observations ≈ half-window / 60 s), and the `_sum` / `_count`
+  >   differenced means remain the PRIMARY reading for every THROUGHPUT quantity. The "corroboration only"
+  >   demotion is adjudicated as governing **counting-based inference**, which this use is not: the p50
+  >   column is the one committed order statistic, and `B` is an order-statistic parameter.
+  > - **Known-and-accepted caveat on the record:** a median over per-scrape window-medians weights each
+  >   window equally regardless of how many drains it contains; if batch sizes covary with drain frequency
+  >   across the half-window, `B` carries a bounded weighting distortion of unknown direction. This is
+  >   irreducible without `.rs` changes and is accepted as the bounded-unknown over the mean's
+  >   unbounded-known.
+
+- **AUTHORITY:** SPEC-356b Audit v4 critical C1; adversarial `/xask` round 2026-08-08
+  (`spec356-adj12-xask.md`: mean rejected for unbounded partition collapse, p50 adopted conditional on a
+  committed window length and a pre-registered sentinel threshold with a protocol exit); live exposition
+  probe 2026-08-08 (0-sentinel semantics); Conductor ruling 2026-08-08.
+- **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.
+
+### ADJ-13
+
+- **ADJ id:** ADJ-13
+- **Date:** 2026-08-08
+- **Target:** **§2.3 Steps 3–4** — the passes-per-epoch slope test's series construction (mandated
+  unconditional by ADJ-3, but never constructed).
+- **ORIGINAL TEXT (verbatim, §2.3 Step 3):**
+
+  > (exit share ≤ 10 %) **and** **PERSISTENT** licensed backlog (`min(L) > B`) **and** passes-per-epoch
+  > last-half OLS slope rejects **negative** (α = 0.05)
+
+- **FINDING:** neither document says how the passes-per-epoch series is formed from `passes_total` /
+  `current_epoch`. Raised by SPEC-356b **Audit v4, critical C2**. The natural per-epoch-delta construction
+  (group rows by `current_epoch`, exclude intervals spanning unobserved epoch boundaries) was then broken
+  by the adversarial round: the excluded epochs are **mechanically the fast-advancing (busy) ones**, so
+  exclusion biases the slope toward flat/negative — toward the SCHEDULING verdict — and the exclusion
+  fraction is set by the scrape-cadence-to-epoch-width ratio, an operational parameter with no relation to
+  the defect being diagnosed. An instrument limitation would have picked the verdict.
+- **ADJUDICATED FORM (governs — the cumulative construction, zero exclusion):**
+
+  > The pass-rate evidence is read from the **cumulative curve**: `passes_total` (y) against
+  > `current_epoch` (x) over **ALL** last-half `prune.csv` rows — no grouping, no exclusion. Rows with
+  > `Δcurrent_epoch = 0` add intra-epoch weight; rows jumping several epochs are valid coarse steps; no
+  > information is discarded. The Step 3 / Step 4 discriminator is a **declining-rate test via split-half
+  > slopes of that curve, both fit with the SAME pinned fitter §6 names for `tombstone_bytes`**: let
+  > `s_early` be the fitted slope over the first half of the last half and `s_late` over the second half.
+  > **Step 3 (SCHEDULING / LICENSING) requires `s_late` significantly BELOW `s_early`** (one-sided,
+  > α = 0.05 — the original test's level and direction, recast onto the unbiased construction); otherwise
+  > the branch reads **Step 4 (THROUGHPUT)**. Reduced statistical power relative to a per-epoch series is
+  > **accepted on the record** in exchange for zero selection bias: under this protocol's ranking, an
+  > instrument limitation that silently picks a verdict is strictly worse than one that honestly widens a
+  > confidence interval.
+
+- **AUTHORITY:** SPEC-356b Audit v4 critical C2; adversarial `/xask` round 2026-08-08
+  (`spec356-adj12-xask.md`: exclusion construction rejected for mechanical selection of busy epochs;
+  cumulative construction adopted); Conductor ruling 2026-08-08.
+- **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.
+
+### ADJ-14
+
+- **ADJ id:** ADJ-14
+- **Date:** 2026-08-08
+- **Target:** **ADJ-11's adjudicated form, clause 2** — the unnamed "tombstone backlog series".
+- **ORIGINAL TEXT (verbatim, ADJ-11 clause 2):**
+
+  > AND the tombstone backlog series grows ⇒ **every pass observed zero licensed backlog**: valid
+  > evidence toward ELIGIBILITY-BOUND, with `max(L) = 0` as corroboration only.
+
+- **FINDING:** "the tombstone backlog series" names no committed series, and the candidates disagree: the
+  soak CSV's gauge is on a 60 s cadence while the prune CSV runs at 10 s, and `indexed_refs` is sampled
+  POST-drain (the ADJ-7 asymmetry family). A naïve pick of `topgun_ormap_tombstone_bytes_total` alone
+  would also be wrong in the opposite direction: it is a monotone ADDED-bytes counter and grows even under
+  healthy reclaim. Raised by SPEC-356b **Audit v4, recommendation 6**.
+- **ADJUDICATED FORM (governs):**
+
+  > Backlog growth in ADJ-11 clause 2 is the **difference of two monotone counters from the same
+  > `prune.csv` rows**: `Δbacklog_bytes := Δ topgun_ormap_tombstone_bytes_total −
+  > Δ topgun_or_prune_bytes_freed_total`, and "the backlog grows" ⟺ `Δbacklog_bytes > 0` over the window.
+  > Counter-anchored, same 10 s cadence as every other quantity the clause reads, and immune to the
+  > added-bytes-alone confusion: in clause 2's own regime (`Δnonempty_drains = 0`) the freed term is 0 and
+  > the test degenerates to "garbage kept arriving while nothing drained", which is exactly the starvation
+  > semantics the clause needs. Neither `indexed_refs` nor the 60 s soak-CSV gauge may stand in for it.
+
+- **AUTHORITY:** SPEC-356b Audit v4 recommendation 6; Conductor ruling 2026-08-08.
+- **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-prune.sh
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-prune.sh
@@ -167,15 +167,17 @@ CONSOLE_OUT="${OUT_DIR}/${BASE}.harness-console.log"
 #     Column order is manifest §5.2's: elapsed_secs, then §5.3 in its frozen
 #     order, then the inherited counter.
 #
-#     42 COLUMNS FROM 35 NAMES, AND WHY THE TWO COUNTS ARE THE SAME TABLE.
+#     43 COLUMNS FROM 35 NAMES, AND WHY THE TWO COUNTS ARE THE SAME TABLE.
 #     SPEC-356a R4.3a.2 tags 35 rows — the 33 pinned §5.3 names plus the two
-#     inherited columns — and this table has one row per COLUMN, so it has 42:
+#     inherited columns — and this table has one row per COLUMN, so it has 43:
 #     each of the 7 histogram names contributes its `_sum` and its `_count`
-#     column, and both inherit their name's tag. The tag totals follow the same
-#     arithmetic and are checkable rather than asserted: R4.3a.2's 6 INSTRUMENT
-#     / 29 MEASURAND over names becomes 6 INSTRUMENT / 36 MEASURAND over
-#     columns, because all 7 expanded names are MEASURAND (29 + 7 = 36). A
-#     reader who counts one table against the other and finds 35 vs 42 is
+#     column, and both inherit their name's tag; the batch-size histogram
+#     additionally contributes its rendered `_p50` column (ADJ-12, the
+#     committed source of B). The tag totals follow the same arithmetic and
+#     are checkable rather than asserted: R4.3a.2's 6 INSTRUMENT / 29 MEASURAND
+#     over names becomes 6 INSTRUMENT / 37 MEASURAND over columns, because all
+#     7 expanded names are MEASURAND and so is the p50 (29 + 7 + 1 = 37). A
+#     reader who counts one table against the other and finds 35 vs 43 is
 #     looking at names versus columns, not at a drift.
 #
 #     THE TAG COLUMN IS THE CLASSIFICATION RULE'S OUTPUT, NOT A PREFERENCE.
@@ -235,18 +237,23 @@ PRUNE_COLUMNS='
 40|topgun_or_prune_epoch_bytes_freed_sum|MEASURAND|same trigger; also zero whenever drained epochs free nothing
 41|topgun_or_prune_epoch_bytes_freed_count|MEASURAND|same trigger; also zero whenever drained epochs free nothing
 42|topgun_ormap_tombstone_bytes_total|INSTRUMENT|monotone ADDED-bytes counter on the OR add path; added bytes are an established input and an all-zero reading makes the reclaim fraction uncomputable. It is boot-seeded before the listener accepts connections and the scrape gate forbids a row from an incomplete scrape, so empty > 0 is unreachable here on a correct instrument
+43|topgun_or_prune_drain_refs_p50|MEASURAND|the exporter-rendered p50 of the batch-size summary over its 3x20s rolling window, sampled for ADJ-12 as the committed source of B. The summary records only NON-EMPTY drains, so a populated window renders p50 >= 1 and 0 is the RESERVED empty-window sentinel (verified against the live exposition: an expired or never-filled window renders 0, not NaN); the stall regime legitimately renders the sentinel for the whole run
 '
 
 # The scrape-derived names, in column order, space-separated: every column
-# except the sampler-local elapsed_secs. 41 names.
+# except the sampler-local elapsed_secs. 42 names. The one synthetic name,
+# topgun_or_prune_drain_refs_p50, is resolved by BOTH scrape readers (the
+# sampler and the arming witness) from the labelled exposition line
+# topgun_or_prune_drain_refs{quantile="0.5"} -- the same synthesis in both
+# places, so the witness cannot demand a name the sampler cannot see.
 PRUNE_SCRAPE_NAMES="$(printf '%s\n' "$PRUNE_COLUMNS" \
   | awk -F'|' 'NF >= 3 && $1 != 1 { printf "%s ", $2 } END { print "" }')"
 # The header the sampler writes and the post-run check re-reads.
 PRUNE_HEADER="$(printf '%s\n' "$PRUNE_COLUMNS" \
   | awk -F'|' 'NF >= 3 { if (out == "") out = $2; else out = out "," $2 } END { print out }')"
 PRUNE_COL_COUNT="$(printf '%s\n' "$PRUNE_COLUMNS" | awk -F'|' 'NF >= 3 { n++ } END { print n + 0 }')"
-if [ "$PRUNE_COL_COUNT" != "42" ]; then
-  echo "FATAL: the selection table must govern exactly 42 columns; it governs ${PRUNE_COL_COUNT}." >&2
+if [ "$PRUNE_COL_COUNT" != "43" ]; then
+  echo "FATAL: the selection table must govern exactly 43 columns; it governs ${PRUNE_COL_COUNT}." >&2
   exit 1
 fi
 
@@ -1160,7 +1167,7 @@ SAMPLER_PID=$!
 #     THE SCRAPE GATE (the rule that makes a blank cell unreachable):
 #
 #       On an ARMED cell, a row is written ONLY from a scrape that (a) returned
-#       successfully and (b) carries ALL 41 scrape-derived series. A tick whose
+#       successfully and (b) carries ALL 42 scrape-derived series. A tick whose
 #       scrape fails either test writes NO ROW AT ALL, logs the tick, and
 #       retries on the next tick -- so the first row of prune.csv is the first
 #       COMPLETE scrape, and its elapsed_secs is whatever the sampler's clock
@@ -1202,6 +1209,15 @@ scrape_prune_series() {   # prints "COMPLETE|<missing>|<v1>,<v2>,..." or "SCRAPE
     /^[[:space:]]*#/ { next }
     {
       nm = $1
+      # The one synthetic name: the labelled p50 line of the batch summary is
+      # captured under <base>_p50 BEFORE the label-stripping fold, mirroring
+      # the arming witness exactly.
+      if (nm ~ /\{quantile="0\.5"\}$/) {
+        q = nm
+        sub(/\{.*$/, "", q)
+        q = q "_p50"
+        if (!(q in val)) val[q] = $2
+      }
       sub(/\{.*$/, "", nm)
       if (!(nm in val)) val[nm] = $2
     }
@@ -1475,7 +1491,15 @@ else
   PRUNE_NAMES_SEEN="$(awk -v names="$PRUNE_SCRAPE_NAMES" '
     BEGIN { want = split(names, a, " ") }
     /^[[:space:]]*#/ { next }
-    { nm = $1; sub(/\{.*$/, "", nm); seen[nm] = 1 }
+    {
+      nm = $1
+      # Same p50 synthesis as the sampler: the witness must never demand a
+      # name the sampler cannot resolve from the identical exposition.
+      if (nm ~ /\{quantile="0\.5"\}$/) {
+        q = nm; sub(/\{.*$/, "", q); seen[q "_p50"] = 1
+      }
+      sub(/\{.*$/, "", nm); seen[nm] = 1
+    }
     END {
       c = 0
       for (i = 1; i <= want; i++) {

--- a/packages/server-rust/benches/soak_harness/evidence/spec356a-eager-registration.log
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356a-eager-registration.log
@@ -676,3 +676,124 @@ VERDICT: EG-1 PASS (both limbs) AT THE FINAL INSTRUMENT.
 
 Part I is retained as ADJ-7's before-picture and is not superseded as evidence
 of what the pre-repair instrument did -- only as the discharge of this gate.
+
+
+================================================================================
+PART III -- RE-CAPTURE AT THE ADJ-12 INSTRUMENT (the 43-column selection table).
+================================================================================
+
+WHY PART III EXISTS. ADJ-12 (manifest §8A) made the exporter-rendered p50 of the
+batch-size summary the committed source of B, which added column 43
+(topgun_or_prune_drain_refs_p50, MEASURAND) to the runner's selection table and
+a synthetic-name resolution to BOTH scrape readers. Parts I/II certify a
+42-column instrument that no SPEC-356b cell will run. Per the same rule that
+forced Part II: a code-reading does not discharge this gate; only the artifact
+does. The smoke was re-run; Parts I/II are retained as before-pictures.
+
+BUILD IDENTITY (stated from the runner's own comparison, with the real numbers).
+  server binary: target/release/topgun-server         built 2026-08-08T14:29:41Z
+  bench  binary: target/release/deps/soak_harness-9abf891ab72dea71  built 2026-08-08T14:28:20Z
+  BUILD_GAP = 81s -- inside the runner's 600s same-build window, no WARN.
+  The .rs tree is byte-identical to the pinned instrument commit: `git diff
+  efa2c249..HEAD -- '*.rs'` is EMPTY, so the binaries carry the certified Rust
+  behavior; the changed component is the RUNNER, which is exactly what this
+  re-capture exercises. Behavioral fingerprint of the change: the p50 column
+  below is populated (sentinel 0 and 999.94...), which the Part I/II runner
+  never sampled.
+
+THE RE-CAPTURED CENSUS (verbatim from the fresh smoke console, UNINDENTED so
+downstream greps read the same shape as Parts I/II; the run took the harder
+first-scrape shape again -- a skipped tick, first complete scrape at
+elapsed=10s):
+
+prune.csv:      /tmp/spec356-smoke/spec356-smoke.prune.csv
+prune.csv rows: 12  (cadence 10s)
+prune.csv ticks SKIPPED by the scrape gate: 1
+    elapsed=0s scrape FAILED -- no row written, retrying next tick
+first COMPLETE scrape at elapsed = 10s
+prune.csv columns:
+  elapsed_secs                                 [POPULATN] n=12 empty=0 min=10 max=120
+  topgun_or_prune_passes_total                 [POPULATN] n=12 empty=0 min=365 max=4495
+  topgun_or_prune_considered_total             [POPULATN] n=12 empty=0 min=0 max=3000
+  topgun_or_prune_dropped_total                [POPULATN] n=12 empty=0 min=0 max=3000
+  topgun_or_prune_matched_nothing_total        [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_absent_total                 [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_restored_read_error_total    [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_restored_evicted_total       [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_restored_write_error_total   [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_bytes_freed_total            [POPULATN] n=12 empty=0 min=0 max=61355
+  topgun_or_prune_epochs_drained_total         [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_empty_drains_total           [POPULATN] n=12 empty=0 min=365 max=4492
+  topgun_or_prune_nonempty_drains_total        [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_lwm_advances_total           [POPULATN] n=12 empty=0 min=2 max=6
+  topgun_or_prune_lwm_epochs_advanced_total    [POPULATN] n=12 empty=0 min=2 max=6
+  topgun_or_prune_split_recomputes_total       [POPULATN] n=12 empty=0 min=2 max=9
+  topgun_or_prune_indexed_refs                 [POPULATN] n=12 empty=0 min=365 max=1956
+  topgun_or_prune_indexed_epochs               [POPULATN] n=12 empty=0 min=1 max=2
+  topgun_or_prune_eligible_refs                [POPULATN] n=12 empty=0 min=0 max=1000
+  topgun_or_prune_ineligible_refs              [POPULATN] n=12 empty=0 min=69 max=1108
+  topgun_or_prune_split_computed_epoch         [POPULATN] n=12 empty=0 min=2 max=6
+  topgun_or_prune_current_epoch                [POPULATN] n=12 empty=0 min=2 max=6
+  topgun_or_prune_low_water_mark               [POPULATN] n=12 empty=0 min=2 max=6
+  topgun_or_prune_durable_epoch_watermark      [POPULATN] n=12 empty=0 min=0 max=4
+  topgun_or_prune_last_drained_epoch           [POPULATN] n=12 empty=0 min=0 max=4
+  topgun_or_prune_lwm_stall_seconds            [POPULATN] n=12 empty=0 min=0 max=28
+  topgun_or_prune_tracked_claims               [POPULATN] n=12 empty=0 min=1 max=1
+  topgun_or_prune_drain_refs_sum               [POPULATN] n=12 empty=0 min=0 max=3000
+  topgun_or_prune_drain_refs_count             [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_drain_epochs_sum             [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_drain_epochs_count           [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_claim_span_epochs_sum        [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_claim_span_epochs_count      [POPULATN] n=12 empty=0 min=2 max=9
+  topgun_or_prune_claim_lag_epochs_sum         [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_claim_lag_epochs_count       [POPULATN] n=12 empty=0 min=2 max=9
+  topgun_or_prune_epoch_considered_sum         [POPULATN] n=12 empty=0 min=0 max=3000
+  topgun_or_prune_epoch_considered_count       [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_epoch_dropped_sum            [POPULATN] n=12 empty=0 min=0 max=3000
+  topgun_or_prune_epoch_dropped_count          [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_epoch_bytes_freed_sum        [POPULATN] n=12 empty=0 min=0 max=61355
+  topgun_or_prune_epoch_bytes_freed_count      [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_ormap_tombstone_bytes_total           [POPULATN] n=12 empty=0 min=7120 max=92750
+  topgun_or_prune_drain_refs_p50               [POPULATN] n=12 empty=0 min=0 max=1000
+  progress.jsonl: not required -- duration 120s <= steady interval 300s,
+                  so the harness reached no checkpoint to snapshot.
+  soak.json "walFsync": "batched",
+  soak.json "epochWidth": 1000,
+  soak.json "crashes": 0,
+  soak.json "churnClients": 6,
+  soak.json "keyspace": 200,
+  soak.json "durationSecsActual": 120,
+  mechanism.json "orDeltaFrames": 1704,
+  mechanism.json "orSnapshotFrames": 0,
+
+arming witness:
+  cell expects:        armed=yes
+  TOPGUN_PRUNE_RECORD: true (on the child)
+  topgun_or_prune_ lines in the scrape: 89
+  pinned prune columns resolved:        41/41
+  topgun_ormap_tombstone_bytes present: 2 line(s)
+  => arming witness PASSED: armed cell, all pinned series present.
+
+THE DISARMED DIRECTION (fresh smokeoff run, same binaries):
+
+arming witness:
+  cell expects:        armed=no
+  TOPGUN_PRUNE_RECORD: false (on the child)
+  topgun_or_prune_ lines in the scrape: 0
+  pinned prune columns resolved:        0/41
+  topgun_ormap_tombstone_bytes present: 2 line(s)
+  => arming witness PASSED: disarmed cell, no prune-record series present.
+
+================================================================================
+VERDICT: EG-1 PASS (both limbs) AT THE ADJ-12 INSTRUMENT.
+================================================================================
+
+  limb (a): 33/33 pinned names in the first render -- the NAME set is untouched
+            by ADJ-12 (p50 is a rendered line of an existing summary family,
+            not a new registration); set-identical to Parts I/II.
+  limb (b): empty_fields=0 over every column of every row, 43 columns x 12 rows,
+            the new p50 column included (n=12 empty=0 min=0 max=1000).
+  A9:       0 population defects, 0 instrument defects; RESULT: instrument
+            sound; harness exit code 0.
+  witness:  armed 41/41 resolved (40 + the synthetic p50), PASSED; disarmed
+            direction PASSED on the fresh smokeoff.

--- a/packages/server-rust/benches/soak_harness/evidence/spec356a-step0c-fixture.log
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356a-step0c-fixture.log
@@ -421,3 +421,89 @@ Only the surrounding population figures move, because they are readings from two
 different smoke runs. Keeping the emitted line character-for-character identical
 is a constraint on any future edit to the runner or to either spec: this artifact
 is what makes a drift mechanically visible instead of silently vacuous.
+
+
+================================================================================
+PART III -- RE-CAPTURE AT THE ADJ-12 INSTRUMENT (the 43-column schema).
+================================================================================
+
+WHY. ADJ-12 added column 43 to the prune.csv schema. The fixture path pins the
+fixture header against PRUNE_HEADER, so the Part I/II fixtures are now REFUSED
+by the runner's own header guard -- the guard itself forces this re-cut, which
+is the fail-closed behavior working as designed. The fixture was re-built from
+the post-ADJ-12 smoke artifact by blanking the SAME cell as Parts I/II: one
+row of column index 3 (topgun_or_prune_considered_total, MEASURAND).
+
+THE CAPTURED GUARD-FIRE (verbatim console of the fixture run, UNINDENTED so the
+emitted line remains byte-comparable across all three captures):
+
+=== COLUMN-CHECK FIXTURE PATH (no harness is started) ===
+  fixture:      /tmp/spec356-smoke/fixture-blanked.csv
+  cell:         smoke (armed=yes)
+  shape:        POPULATION-ONLY on every column (non-measurement cell)
+  disposition:  MEASURAND -- the STEP0C admissibility line, which is what
+                this path exists to demonstrate. A MEASURAND failure must NOT
+                carry the instrument-defect literal, must NOT write
+                INSTRUMENT_OK and must NOT exit 9.
+  fixture header: matches the pinned schema (43 columns)
+
+prune.csv columns (fixture):
+  elapsed_secs                                 [POPULATN] n=12 empty=0 min=10 max=120
+  topgun_or_prune_passes_total                 [POPULATN] n=12 empty=0 min=365 max=4495
+  topgun_or_prune_considered_total             [POPULATN] n=11 empty=1 min=0 max=3000
+STEP0C ADMISSIBILITY: topgun_or_prune_considered_total failed the population check (n == 0 or empty > 0 at column index 3) -- the cell STANDS;
+                      this is an admissibility failure that routes the
+                      classification predicate to INDETERMINATE. It is NOT an
+                      instrument defect and it changes no exit status.
+  topgun_or_prune_dropped_total                [POPULATN] n=12 empty=0 min=0 max=3000
+  topgun_or_prune_matched_nothing_total        [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_absent_total                 [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_restored_read_error_total    [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_restored_evicted_total       [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_restored_write_error_total   [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_bytes_freed_total            [POPULATN] n=12 empty=0 min=0 max=61355
+  topgun_or_prune_epochs_drained_total         [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_empty_drains_total           [POPULATN] n=12 empty=0 min=365 max=4492
+  topgun_or_prune_nonempty_drains_total        [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_lwm_advances_total           [POPULATN] n=12 empty=0 min=2 max=6
+  topgun_or_prune_lwm_epochs_advanced_total    [POPULATN] n=12 empty=0 min=2 max=6
+  topgun_or_prune_split_recomputes_total       [POPULATN] n=12 empty=0 min=2 max=9
+  topgun_or_prune_indexed_refs                 [POPULATN] n=12 empty=0 min=365 max=1956
+  topgun_or_prune_indexed_epochs               [POPULATN] n=12 empty=0 min=1 max=2
+  topgun_or_prune_eligible_refs                [POPULATN] n=12 empty=0 min=0 max=1000
+  topgun_or_prune_ineligible_refs              [POPULATN] n=12 empty=0 min=69 max=1108
+  topgun_or_prune_split_computed_epoch         [POPULATN] n=12 empty=0 min=2 max=6
+  topgun_or_prune_current_epoch                [POPULATN] n=12 empty=0 min=2 max=6
+  topgun_or_prune_low_water_mark               [POPULATN] n=12 empty=0 min=2 max=6
+  topgun_or_prune_durable_epoch_watermark      [POPULATN] n=12 empty=0 min=0 max=4
+  topgun_or_prune_last_drained_epoch           [POPULATN] n=12 empty=0 min=0 max=4
+  topgun_or_prune_lwm_stall_seconds            [POPULATN] n=12 empty=0 min=0 max=28
+  topgun_or_prune_tracked_claims               [POPULATN] n=12 empty=0 min=1 max=1
+  topgun_or_prune_drain_refs_sum               [POPULATN] n=12 empty=0 min=0 max=3000
+  topgun_or_prune_drain_refs_count             [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_drain_epochs_sum             [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_drain_epochs_count           [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_claim_span_epochs_sum        [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_claim_span_epochs_count      [POPULATN] n=12 empty=0 min=2 max=9
+  topgun_or_prune_claim_lag_epochs_sum         [POPULATN] n=12 empty=0 min=0 max=0
+  topgun_or_prune_claim_lag_epochs_count       [POPULATN] n=12 empty=0 min=2 max=9
+  topgun_or_prune_epoch_considered_sum         [POPULATN] n=12 empty=0 min=0 max=3000
+  topgun_or_prune_epoch_considered_count       [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_epoch_dropped_sum            [POPULATN] n=12 empty=0 min=0 max=3000
+  topgun_or_prune_epoch_dropped_count          [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_or_prune_epoch_bytes_freed_sum        [POPULATN] n=12 empty=0 min=0 max=61355
+  topgun_or_prune_epoch_bytes_freed_count      [POPULATN] n=12 empty=0 min=0 max=3
+  topgun_ormap_tombstone_bytes_total           [POPULATN] n=12 empty=0 min=7120 max=92750
+  topgun_or_prune_drain_refs_p50               [POPULATN] n=12 empty=0 min=0 max=1000
+
+  STEP0C ADMISSIBILITY lines emitted: 1
+  INSTRUMENT_OK:                      1 (unchanged by a MEASURAND failure)
+  exit status:                        0 (the pinned fall-through, exit "$HARNESS_RC")
+
+VERDICT AT THE ADJ-12 INSTRUMENT:
+  emitted STEP0C line: byte-identical to Parts I/II (same column name, same
+  parenthetical, same column index 3) -- `sort -u` over the three captures
+  yields ONE line. A first append of this Part indented the quoted console by
+  two spaces, which broke that comparison in-file; the append was re-done
+  unindented rather than the claim weakened.
+  instrument-defect literal: count 0 over the run, unchanged exit status 0.


### PR DESCRIPTION
## Summary

Closes SPEC-356b Audit v4's two criticals and rec 6 via PRE-DATA adjudications (§8A appends), a shell-only instrument extension, and re-captured evidence gates. Zero `.rs`.

- **ADJ-12 (Audit v4 C1):** `B` ("median refs per non-empty drain") had no committed source — the CSV sampled only `_sum`/`_count`, from which no median derives; the estimator would have been chosen post-data on the modal branch. Cross-vendor round (glm-5.2, `spec356-adj12-xask.md`) rejected the mean (unbounded heavy-tail inflation collapses the partition to Step 2 — the modal outcome) and the guard band (destroys the exact-complement structure). Adopted: **column 43 = exporter-rendered p50** (rolling window 3×20s=60s pinned from locked crate source; live-exposition probe established the 0-sentinel — an empty window renders 0, not NaN, and populated windows render ≥1), `B` = last-half median with sentinel exclusion, >50%-sentinel → Step 0(c) INDETERMINATE escape hatch. §5.4's aliasing prohibitions stand.
- **ADJ-13 (Audit v4 C2):** passes-per-epoch series construction pre-registered as the **cumulative curve** (`passes_total` vs `current_epoch`, all rows, split-half slopes with the pinned fitter). The per-epoch-delta form was adversarially broken: it mechanically excludes busy epochs, biasing toward SCHEDULING.
- **ADJ-14 (rec 6):** ADJ-11's backlog series named: `Δ tombstone_bytes_total − Δ bytes_freed_total` (two monotone counters, same 10s rows).
- **Runner:** synthetic `_p50` name resolved identically in BOTH scrape readers; 42→43 column guard; fresh armed smoke (census 43×12, `empty_fields=0`, p50 populated — sentinel 0 and 999.94), fresh disarmed smokeoff, fixture re-cut (header guard itself refuses the old fixtures — fail-closed working as designed); STEP0C line byte-identical across all three captures, `sort -u` = 1 line.
- Both EG artifacts carry a labeled **Part III** at the 43-column instrument; Parts I/II retained as before-pictures.

Freeze: manifest §0–§8 byte-identical to `0e8ebec9` (append-only §8A). PRE-DATA: zero `spec356-*.soak.json` anywhere. `check-invariants.sh` green (21/4=baseline).

## Test plan
- [x] `bash -n` runner; armed smoke exit 0 ("instrument sound"); disarmed smokeoff exit 0; fixture STEP0C fired, exit 0
- [x] §0–§8 `cmp` byte-identical; `git diff efa2c249 -- '*.rs'` empty
- [x] `scripts/check-invariants.sh` exit 0