### PR TITLE
fix(sf-356b): pass-rate fit — epoch axis + floor-carried discriminator (ADJ-15)

### DIFF
--- a/packages/server-rust/benches/soak_harness/evidence/spec349c2-fit.awk
+++ b/packages/server-rust/benches/soak_harness/evidence/spec349c2-fit.awk
@@ -17,6 +17,15 @@
 #           because every column it was built for is a megabyte column. For
 #           `tombstone_bytes` the fit is arithmetically identical but the unit
 #           is BYTES per hour -- read the name as "value units per hour" there.
+#   xaxis   OPTIONAL x-axis column, resolved by HEADER NAME. Default:
+#           elapsed_secs, with the historical hours conversion -- every
+#           committed invocation omits this parameter and its output is
+#           byte-identical to the pre-parameter script (regression-proven in
+#           spec356-adj15-xask.md). With an explicit xaxis (e.g.
+#           current_epoch, ADJ-15's pass-rate fit) the x values are used RAW:
+#           no hours conversion, and the output fields are named
+#           x_start/x_end/x_span and slope_per_x_unit, so a reader can never
+#           mistake a per-epoch slope for a per-hour one.
 #   window  last_half (default) | full
 #             last_half = rows [floor(n/2) .. n-1] over the FULL row count n,
 #             the same floor-biased split the harness's own last-half statistic
@@ -67,6 +76,7 @@ BEGIN {
     FS = ","
     failed = 0
     if (col == "") die("-v col=<column> is required")
+    if (xaxis == "") xaxis = "elapsed_secs"
     if (window == "") window = "last_half"
     if (window != "last_half" && window != "full") die("-v window= must be last_half or full")
     n = 0
@@ -77,10 +87,10 @@ BEGIN {
 NR == 1 {
     for (i = 1; i <= NF; i++) {
         h = trim($i)
-        if (h == "elapsed_secs") xcol = i
+        if (h == xaxis) xcol = i
         if (h == col) ycol = i
     }
-    if (xcol < 0) die("no elapsed_secs column in header")
+    if (xcol < 0) die("no " xaxis " column in header")
     if (ycol < 0) die("no column named '" col "' in header")
     next
 }
@@ -102,7 +112,7 @@ NR == 1 {
         next
     }
     if (!isnum(xs) || !isnum(ys)) {
-        die("non-numeric cell at line " NR " (elapsed_secs='" xs "', " col "='" ys "')")
+        die("non-numeric cell at line " NR " (" xaxis "='" xs "', " col "='" ys "')")
     }
     t[n] = xs + 0
     y[n] = ys + 0
@@ -121,7 +131,9 @@ END {
 
     sx = 0; sy = 0
     for (i = start; i < n; i++) {
-        x[i] = t[i] / 3600.0          # hours, so the slope is MB/h
+        # The hours conversion is the elapsed_secs convention only; an explicit
+        # xaxis is used raw, so a per-epoch slope stays per-epoch.
+        x[i] = (xaxis == "elapsed_secs") ? t[i] / 3600.0 : t[i]
         sx += x[i]
         sy += y[i]
     }
@@ -162,8 +174,15 @@ END {
     # than folded in as zeros. Reported alongside `skipped_empty` so a reader can
     # see how much of the series was actually measured.
     printf "col=%s window=%s rows_used=%d n=%d skipped_empty=%d", col, window, n, m, skipped + 0
-    printf " t_start_secs=%.1f t_end_secs=%.1f span_secs=%.1f", t[start], t[n-1], t[n-1] - t[start]
-    printf " y_first=%.3f y_last=%.3f", y[start], y[n-1]
-    printf " slope_mb_per_hour=%.6f se_mb_per_hour=%s", b, se_s
-    printf " intercept_mb=%.6f r2=%s sxx_hours2=%.9f sse=%.9f\n", a, r2_s, sxx, sse
+    if (xaxis == "elapsed_secs") {
+        printf " t_start_secs=%.1f t_end_secs=%.1f span_secs=%.1f", t[start], t[n-1], t[n-1] - t[start]
+        printf " y_first=%.3f y_last=%.3f", y[start], y[n-1]
+        printf " slope_mb_per_hour=%.6f se_mb_per_hour=%s", b, se_s
+        printf " intercept_mb=%.6f r2=%s sxx_hours2=%.9f sse=%.9f\n", a, r2_s, sxx, sse
+    } else {
+        printf " xaxis=%s x_start=%.1f x_end=%.1f x_span=%.1f", xaxis, t[start], t[n-1], t[n-1] - t[start]
+        printf " y_first=%.3f y_last=%.3f", y[start], y[n-1]
+        printf " slope_per_x_unit=%.6f se_per_x_unit=%s", b, se_s
+        printf " intercept=%.6f r2=%s sxx=%.9f sse=%.9f\n", a, r2_s, sxx, sse
+    }
 }

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-adj15-xask.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-adj15-xask.md
@@ -1,0 +1,98 @@
+# ADJ-15 adversarial cross-vendor round + regression proof (2026-08-08)
+
+Question put to the vendor (verbatim):
+
+> CONTEXT. Same frozen pre-registered classification protocol as before (append-only adjudications, exact-complement partition). One remaining discriminator: within the "PERSISTENT licensed backlog" branch, Step 3 (SCHEDULING: "the prune is run less and less often as the corpus grows") vs Step 4 (THROUGHPUT: prune scheduled fine but can't keep up). Evidence: the cumulative curve passes_total (monotone counter, y) vs current_epoch (monotone, x) over the last half of a 4h run; split into an early slice and a late slice; each slice fit by a pinned auditable-by-inspection OLS awk script; slopes s_early, s_late in passes-per-epoch.
+> 
+> TWO DEFECTS FOUND BY AUDIT (pre-data, must be adjudicated now):
+> (A) The pinned fitter hardwires x = elapsed time. Regressing passes_total against TIME instead of EPOCH gives the OPPOSITE verdict on accelerating-epoch data (probe: time-axis says s_early=s_late → Step 4; epoch-axis says s_early=21600, s_late=7200 → Step 3). Fix chosen (mechanical, not the question): additive backward-compatible -v xcol= parameter, default unchanged, with a regression-proof that all committed historical invocations produce byte-identical output.
+> (B) The fitter's own doc-contract says: for cumulative autocorrelated series the OLS standard error is OPTIMISTIC ("understates the true uncertainty, often by a large factor... SE separation alone must never carry a discrimination claim; the minimum effect-size floor does"). The current adjudication made SE-separation-alone the sole Step-3/4 discriminator with no floor — violating the instrument's own contract and biasing toward SCHEDULING (optimistic SE makes "significantly below" too easy).
+> 
+> THE QUESTION: what should carry the Step 3 claim? My proposal to attack:
+> 
+> Step 3 (SCHEDULING) requires BOTH:
+>   (leg 1, necessary-not-sufficient) s_late significantly below s_early at one-sided alpha=0.05 using the fitter's (admittedly optimistic) SE — kept only as a cheap sanity precondition;
+>   (leg 2, the floor that carries the claim) s_late <= 0.5 * s_early — a pre-registered coarse halving floor: "run less and less often" must be a MATERIAL decline, not noise.
+> Otherwise Step 4.
+> Sensitivity convention (reusing an existing protocol label, no new routing): the verdict is computed at 0.5; it is ALSO computed at 0.4 and 0.6, and if it flips within that band the verdict carries a pre-existing CONTESTED label (which changes reporting emphasis, not routing).
+> 
+> Project priors you should respect: this project has repeatedly KILLED derived-formula bounds as false precision (a slope-noise formula and a churn formula both died; a fixed coarse margin won each time); it also killed a guard-band proposal that would have destroyed an exact-complement partition (the floor here does NOT create a third branch — Step 4 is simply "not Step 3").
+> 
+> QUESTIONS:
+> 1. Attack the two-leg structure. Is keeping the optimistic-SE leg as a precondition useful, harmful, or theater? Would floor-only be more honest?
+> 2. Attack the halving floor: construct regimes where 0.5 misclassifies (e.g., s_early inflated by an early burst; genuine scheduling decay that is slow but compounding — 0.8x per half repeated; near-zero s_early degeneracy). Is a relative floor the right SHAPE at all, or does the claim need an absolute leg (minimum pass rate) to avoid degeneracy at tiny s_early?
+> 3. Is the 0.4/0.6 CONTESTED sensitivity convention sound, or does it smuggle a band back in?
+> 4. The asymmetry check: does this construction bias toward either verdict through instrument limitations alone (the protocol's cardinal sin)? Consider: epoch axis vs time axis, autocorrelation, slice boundary placement, early-burst contamination.
+> Concise, findings-first.
+
+Vendor answer (verbatim, z-ai/glm-5.2 via openrouter, cost $0.0036):
+
+> → openrouter z-ai/glm-5.2 answering (0 file(s) embedded)…
+> 
+> [usage] prompt=961 completion=4216 total=5177 cost=$0.0036012904
+> ## Findings
+> 
+> ### 1. The SE precondition is theater with a back door
+> 
+> **Verdict: drop it. Floor-only is more honest.**
+> 
+> The SE leg can only be binding in one scenario: floor met (s_late ≤ 0.5·s_early) but optimistic-SE says "not significant." In that case the precondition routes to Step 4 — overriding the material-decline floor using the very instrument whose contract says it *cannot* carry the claim. You've built a gate from a tool you've discredited. The two cases where the SE passes are redundant (floor already carried it); the one case where it fails is the one where it shouldn't be allowed to speak.
+> 
+> If you want a sanity gate against garbage fits, gate on fit quality (residual structure, R²) or on minimum slice length — not on the slope-difference SE of an autocorrelated cumulative series. The floor is your discriminator. Let it discriminate.
+> 
+> ### 2. The halving floor misclassifies in at least three regimes; the shape is right but needs an absolute guard
+> 
+> **Regimes where 0.5 relative fails:**
+> 
+> | Regime | Mechanism | Misclassification direction |
+> |---|---|---|
+> | **Early-burst inflation** | Warmup/initialization inflates s_early; true steady-state ratio is 0.7 but burst makes measured ratio 0.4 | False Step 3 (bias toward scheduling) |
+> | **Slow compounding decay** | Genuine scheduling decay at 0.8× per half; real Step 3 but never crosses 0.5 | False Step 4 (misses real scheduling) |
+> | **Near-zero degeneracy** | s_early = 8, s_late = 3; floor met but both are noise-floor throughput | False Step 3 (amplifies denominator noise) |
+> | **Late stall** | s_late → 0 from either cause; floor trivially met | Conflates scheduling stall with throughput stall |
+> 
+> **Shape assessment:** Relative is the right semantic for "less and less often" — it captures the *rate of decay*, which is what scheduling frequency change means. But a relative-only floor is degenerate at small s_early. You need a **coarse absolute floor on s_early** (minimum passes-per-epoch for the measurement to be informative). This is not a derived formula — it's a fixed coarse margin, consistent with project priors. Framed as "if s_early is below this, the instrument can't discriminate → Step 4," it preserves the exact-complement partition.
+> 
+> The slow-compounding-decay regime (0.8× per half) is the harder problem. A 0.5 floor genuinely can't catch it. But that's a sensitivity limitation, not a bias — and the CONTESTED band partially addresses it (a 0.6 verdict would fire). The alternative (lowering the floor to 0.8) would make early-burst false positives much worse. 0.5 is a reasonable operating point if you accept that slow decay is below detection threshold.
+> 
+> ### 3. CONTESTED is sound *if* the no-routing constraint is enforced — but it's one convention violation away from a guard band
+> 
+> The killed guard-band proposal created a third routing destination. CONTESTED does not — it's a reporting flag on a binary verdict. The partition survives. This is a real distinction, not cosmetic.
+> 
+> **The risk:** CONTESTED becomes a de facto third branch the moment any downstream consumer (human or automated) treats it differently — reruns, escalates, applies different weights, or "holds for review." The protocol needs an explicit, enforceable rule: CONTESTED changes exactly zero routing decisions. If you can't guarantee that in practice, you've smuggled the guard band back in through a side door.
+> 
+> **The band-width question:** 0.4/0.6 is itself a free parameter. Pre-registration mitigates post-hoc tuning, but the choice still needs justification beyond "seemed reasonable." If it's arbitrary, it's a degree of freedom you're not accounting for.
+> 
+> ### 4. Instrument-driven bias: mild but systematic, toward Step 3
+> 
+> | Source | Bias direction | Severity |
+> |---|---|---|
+> | **Early-burst contamination of s_early** | Toward Step 3 (inflated denominator → floor easier to meet) | **High** — warmup is ubiquitous, and the relative floor amplifies it |
+> | **Optimistic SE precondition** (if retained) | Toward Step 3 (too easy to pass) | Moderate — only matters when SE is binding, which it shouldn't be if floor is the discriminator |
+> | **Epoch vs time axis** | Toward Step 4 if time axis is default (per defect A probe) | **High but sidestepped** — the fix preserves default behavior, so if the pre-registered protocol used the default, the pre-registration itself used the wrong axis. "Mechanical, not the question" doesn't eliminate the bias; it defers it. |
+> | **Slice boundary placement** | Direction depends on placement; if boundary is in the transition zone, both slices contaminated | Moderate — the relative floor is more sensitive to this than an absolute measure |
+> | **Autocorrelation in cumulative series** | Doesn't bias the *point estimate* of slopes, only the SE — so floor-only is immune | Eliminated if you drop the SE leg |
+> 
+> **The cardinal sin check:** The construction does introduce instrument-driven asymmetry, primarily through early-burst inflation of s_early interacting with the relative floor. This is a structural bias, not a random one — it systematically favors Step 3 when warmup artifacts exist. The absolute-floor guard on s_early doesn't fix this (the burst inflates s_early *above* the absolute floor, which is the problem). The real fix is slice-boundary robustness: either use a later start for the "early" slice (past warmup) or report sensitivity to boundary placement. If you can't do either, acknowledge that warmup contamination biases toward Step 3 and the protocol is conservative against Step 4 only in the no-warmup regime.
+> 
+> **Bottom line:** Floor-only with an absolute guard on s_early, drop the SE leg, keep CONTESTED with an iron-clad no-routing rule, and flag early-burst contamination as the residual uncontrolled bias. The epoch-axis issue is not actually "not the question" — if the pre-registered protocol defaulted to time axis, the pre-registration is defective and the fix doesn't repair it for going-forward adjudications.
+
+## Conductor divergence from the vendor, recorded
+
+The vendor routed the small-s_early degeneracy to Step 4 to preserve the partition.
+ADJ-15 routes it to Step 0(c) INDETERMINATE instead: the protocol already owns a
+sanctioned non-branch exit (ADJ-12 set the precedent), and defaulting a regime the
+instrument cannot read to EITHER branch is a lean. Everything else is adopted as
+answered: SE leg dropped, absolute guard added, CONTESTED iron rule verbatim.
+
+## Regression proof: the xaxis extension changes no committed reading
+
+Old fitter = `git show f2f72c62:.../spec349c2-fit.awk`; new = HEAD. Every committed
+evidence CSV x {full,last_half} x {rss_mb,wal_mb,redb_mb,disk_total_mb,tombstone_bytes}:
+
+    lines compared: 190
+    cmp: byte-identical (exit 0)
+
+New-mode probe (the fresh armed smoke prune.csv, passes_total vs current_epoch):
+
+    col=passes_total window=full rows_used=12 n=12 skipped_empty=0 xaxis=current_epoch x_start=2.0 x_end=6.0 x_span=4.0 y_first=365.000 y_last=4495.000 slope_per_x_unit=950.394422 se_per_x_unit=65.258090 intercept=-1276.294821 r2=0.954975 sxx=20.916666667 sse=890760.996015936

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
@@ -1127,3 +1127,63 @@ edited to accommodate them.)*
 
 - **AUTHORITY:** SPEC-356b Audit v4 recommendation 6; Conductor ruling 2026-08-08.
 - **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.
+
+### ADJ-15
+
+- **ADJ id:** ADJ-15
+- **Date:** 2026-08-08
+- **Target:** **ADJ-13's adjudicated form** — the pass-rate fit's axis and its Step 3 / Step 4
+  discriminator — against the pinned fitter's own contract (`spec349c2-fit.awk`).
+- **ORIGINAL TEXT (verbatim, ADJ-13):**
+
+  > both fit with the SAME pinned fitter §6 names for `tombstone_bytes` […] **Step 3 (SCHEDULING /
+  > LICENSING) requires `s_late` significantly BELOW `s_early`** (one-sided, α = 0.05 — the original
+  > test's level and direction, recast onto the unbiased construction)
+
+- **FINDING:** two defects, both raised by SPEC-356b **Audit v5 (C1, C2)**. (1) The pinned fitter
+  hardwired `x = elapsed_secs`: the two-column pass-rate CSV was unfittable (exit 2), and the silent
+  workaround — regressing against TIME — yields the OPPOSITE verdict on accelerating-epoch data (probe:
+  time-axis `s_early = s_late` → Step 4 while epoch-axis `21600 / 7200` → Step 3). (2) The fitter's own
+  doc-contract states that for cumulative autocorrelated series its SE is OPTIMISTIC and *"SE separation
+  alone must never carry a discrimination claim; the minimum effect-size floor does"* — yet ADJ-13 made
+  SE-separation-alone the sole discriminator with no floor, biasing toward SCHEDULING, the very direction
+  it rejected the per-epoch construction for. The third adversarial cross-vendor round
+  (`spec356-adj15-xask.md`) then rejected my two-leg repair: an optimistic-SE precondition is **theater
+  with a back door** — the only case where it binds is the one where it overrides the material floor
+  using the instrument its own contract discredits.
+- **ADJUDICATED FORM (governs):**
+
+  > 1. **Axis.** `spec349c2-fit.awk` gains an additive `-v xaxis=<header>` parameter. The default
+  >    (`elapsed_secs`, hours conversion, historical field names) is **byte-identical** to the
+  >    pre-parameter script — regression-proven over EVERY committed evidence CSV × both windows × all
+  >    five columns (190 output lines, `cmp` clean; recorded in `spec356-adj15-xask.md`). The pass-rate
+  >    fit runs `-v col=passes_total -v xaxis=current_epoch` with raw x (no hours conversion) and
+  >    honestly-renamed output fields (`slope_per_x_unit`), on TWO derived slice CSVs: `early` = first
+  >    half of the last-half rows, `late` = second half, each fit with `window=full`.
+  > 2. **Discriminator — floor-only; the SE leg is REMOVED.**
+  >    **Step 3 (SCHEDULING) ⟺ `s_early ≥ 5` passes/epoch AND `s_late ≤ 0.5 × s_early`.** Otherwise
+  >    Step 4 — EXCEPT the degeneracy case `s_early < 5` passes/epoch, which routes via **Step 0(c) to
+  >    INDETERMINATE**: at noise-floor pass rates the instrument cannot distinguish scheduling decline
+  >    from noise, and defaulting to either branch would be the instrument picking. The `5` is a coarse
+  >    fixed margin in this protocol's tradition (not a derived formula): the measured healthy rate on
+  >    the armed smoke probe is ≈ 950 passes/epoch, so the guard sits two orders of magnitude below
+  >    nominal and can only fire on genuine degeneracy.
+  > 3. **Sensitivity — CONTESTED, with an iron no-routing rule.** The verdict at `0.5` GOVERNS. It is
+  >    also computed at `0.4` and `0.6`; a flip within that band attaches ADJ-3's **CONTESTED** label.
+  >    **CONTESTED changes exactly zero routing decisions** — a consumer that re-runs, escalates,
+  >    re-weights or "holds for review" on it is out of contract. The ±20 % band is the same coarseness
+  >    class as the floor itself and is pre-registered as coarse.
+  > 4. **Warmup.** The last-half window is the pre-registered warmup exclusion (the early slice is hours
+  >    2–3 of the 4 h cell). Both raw slopes are REPORTED in §9 so residual transients are visible. Two
+  >    accepted limitations stand on the record: a slow compounding decline (≈ 0.8× per half) is below
+  >    this floor's detection threshold, and a warmup transient surviving into the early slice would
+  >    bias toward Step 3 — the reported raw slopes are the reader's check on both.
+  > 5. **No reading was ever taken under the defective text:** no pass-rate fit was executed before this
+  >    addendum (PRE-DATA holds), so the correction repairs pre-registration text, not results.
+
+- **AUTHORITY:** SPEC-356b Audit v5 criticals C1 and C2; adversarial `/xask` round 2026-08-08
+  (`spec356-adj15-xask.md`: SE leg dropped as theater-with-a-back-door; absolute degeneracy guard added
+  with the INDETERMINATE routing chosen over the vendor's default-to-Step-4 to avoid a lean; CONTESTED
+  no-routing rule adopted verbatim); regression-proof over all committed CSVs; Conductor ruling
+  2026-08-08.
+- **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.


### PR DESCRIPTION
## Summary

Closes SPEC-356b Audit v5's two criticals (both PRE-DATA, §8A append + shell-only fitter extension, zero `.rs`).

- **C1 (axis):** `spec349c2-fit.awk` gains an additive `-v xaxis=<header>` parameter. Default (`elapsed_secs`) is **regression-proven byte-identical** over every committed evidence CSV × {full, last_half} × all five columns — 190 output lines, `cmp` clean (recorded in `spec356-adj15-xask.md`). The pass-rate fit runs `xaxis=current_epoch` with raw x and honestly-renamed fields (`slope_per_x_unit`), on two derived slice CSVs (early/late halves of the last half, each `window=full`).
- **C2 (discriminator):** the optimistic-SE leg is **removed** — the third cross-vendor round showed its only binding case overrides the material floor using the very instrument whose own doc-contract discredits it. Floor-only rule: **Step 3 ⟺ `s_early ≥ 5` passes/epoch AND `s_late ≤ 0.5 × s_early`**; degeneracy (`s_early < 5`, two orders below the ~950/epoch measured nominal) routes via **Step 0(c) → INDETERMINATE** (not defaulted to either branch); CONTESTED sensitivity at 0.4/0.6 with an iron no-routing rule; warmup handled by the pre-registered last-half window, both raw slopes reported; two accepted sensitivity limitations on the record.
- Conductor divergence from the vendor recorded in the artifact (degeneracy → INDETERMINATE, not Step 4).

Freeze: manifest §0–§8 byte-identical to `0e8ebec9` (§8A append-only, 60/0). PRE-DATA: zero `spec356-*.soak.json`. Invariants gate green (21/4 = baseline).

## Test plan
- [x] Regression proof: old vs new fitter byte-identical on all committed CSVs (190 lines)
- [x] New-mode probe on fresh smoke data: `slope_per_x_unit=950.39`, r²=0.955
- [x] §0–§8 `cmp` clean; `scripts/check-invariants.sh` exit 0; `git diff -- '*.rs'` empty