### PR TITLE
fix(sf-356b): bind artifacts to their run, commit graders as sidecars (ADJ-20)

### DIFF
--- a/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
@@ -1346,3 +1346,45 @@ edited to accommodate them.)*
 - **AUTHORITY:** SPEC-356b Response v13 STOP items (both constructions measured there); Conductor ruling
   2026-08-09.
 - **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.
+
+### ADJ-20
+
+- **ADJ id:** ADJ-20
+- **Date:** 2026-08-10
+- **Target:** the **class** behind Response v15's four STOP residuals (TODO-639 median-planting,
+  TODO-640 span-band tail deletion, TODO-641 `passes_total` y-axis, TODO-642 control
+  `tombstone_bytes`) — against **ADJ-18 clause 4's** stated boundary.
+- **ORIGINAL TEXT (verbatim, ADJ-18 clause 4):**
+
+  > A fully coherent forged ledger — every column rewritten consistently with its own cadence, spans,
+  > identities and digests — is out of scope for content checks by construction; the defense at that
+  > layer is the provenance of the run itself, not arithmetic over the artifact.
+
+- **FINDING:** all four residuals are instances of ONE class — an edit to one column or region of a
+  committed artifact that the per-column guards do not bind. The ledger carries 43 columns and the
+  protocol was guarding the third; a per-column arms race does not converge. Clause 4 already names the
+  correct defense layer — the provenance of the run — but no mechanism implemented it: nothing bound an
+  artifact's bytes to the run that produced them.
+- **ADJUDICATED FORM (governs):**
+
+  > 1. **The run binds its own artifacts at the moment of production.** The runner's terminal act writes
+  >    `${BASE}.artifacts.sha256` — the SHA-256 of every artifact it produced, by BASENAME (so the file
+  >    verifies unchanged after the scratch-to-evidence copy). The digest file cannot contain itself; it
+  >    is bound by being runner-written and committed **in the same commit** as the artifacts it names.
+  > 2. **Graders verify before they read:** every committed artifact a grader or driver consumes is
+  >    checked against the run's digest file BEFORE any content check; a mismatch is a **PROVENANCE
+  >    failure** (RED), distinct from every content disposition.
+  > 3. **TODO-639/640/641/642 are closed AS A CLASS:** a single-column or single-region edit now requires
+  >    forging a coherent digest set, which is exactly the coherent-forgery case clause 4 places outside
+  >    the content-check layer. The per-column guards (jump bound, density band, gap bound, span, epoch
+  >    monotonicity) are NOT weakened — they retain their real role: catching honest mistakes and
+  >    instrument faults in artifacts whose provenance is intact.
+  > 4. **The embedded programs become committed evidence files** (`spec356-tmplconf.awk`,
+  >    `spec356-slottruth.sh`, `spec356-skeleton.txt`), extracted from the spec's bytes by its own marker
+  >    commands and digest-verified against its own pins at extraction (`280f7a34…` / `7c14b900…` /
+  >    `bfaac337…` — all three matched). The committed file is now the canonical copy; the spec
+  >    references path + digest, and the digests are unchanged by the move.
+
+- **AUTHORITY:** SPEC-356b Response v15 STOP residuals TODO-639..642 (each measured there); Conductor
+  ruling 2026-08-10.
+- **PRE-DATA / POST-DATA:** **PRE-DATA** — committed before any `spec356-*.soak.json` exists.

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-prune.sh
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-prune.sh
@@ -1624,6 +1624,25 @@ elif [ -f "$FIT" ] && [ "$ROWS" -ge 4 ]; then
 fi
 
 echo
+# ---------------------------------------------------------------------------
+# 12. ARTIFACT BINDING (ADJ-20). The run digests its own outputs at the moment
+#     of production, into ${BASE}.artifacts.sha256 -- basenames, not paths, so
+#     the file verifies unchanged after the scratch-to-evidence copy. This is
+#     what turns "edit one column of a committed CSV" from a per-column
+#     arms race into a coherent-forgery problem, which ADJ-18 clause 4 already
+#     places outside the content-check layer by construction. The digest file
+#     cannot contain itself; it is bound by being runner-written and committed
+#     in the same commit as the artifacts it names.
+# ---------------------------------------------------------------------------
+DIGEST_OUT="${OUT_DIR}/${BASE}.artifacts.sha256"
+: > "$DIGEST_OUT"
+for f in "$CSV_OUT" "$PRUNE_CSV" "$JSON_OUT" "$PROGRESS_OUT" "$MECH_OUT" "$MATRIX_OUT" "$CONSOLE_OUT"; do
+  if [ -s "$f" ]; then
+    ( cd "$(dirname "$f")" && shasum -a 256 "$(basename "$f")" ) >> "$DIGEST_OUT"
+  fi
+done
+echo "artifact binding (ADJ-20): $(wc -l < "$DIGEST_OUT" | tr -d ' ') artifacts digested into $(basename "$DIGEST_OUT")"
+sed 's/^/  /' "$DIGEST_OUT"
 if [ "$INSTRUMENT_OK" != "1" ]; then
   echo "RESULT: INSTRUMENT DEFECT -- this run's series must not be recorded as evidence." >&2
   exit 9

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-skeleton.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-skeleton.txt
@@ -1,0 +1,46 @@
+### 9.C — Controls and dynamics (PINNED TEMPLATE v2 — fill slots only, edit no other byte)
+
+NORMATIVITY: this block is the ONLY surface the acceptance criteria read for the controls, the
+single-arm dynamics claims and the published classification leaf. Prose elsewhere in §9 is
+NON-NORMATIVE for those claims and carries no adjudicated finding.
+
+NEUTRALITY STATEMENT 1 of 3 — R5.1 (role-swap control)
+result: {{R51_RESULT}}
+observed pooled sd: {{R51_SD}}
+observed pair mean: {{R51_MEAN}}
+recomputed MDE: {{R51_MDE_PCT}} %
+MDE ≈ 17 %
+a smaller perturbation is NOT excluded
+role: CATASTROPHE DETECTOR; n = 6 DECLINED at ≈ 4 h
+a dynamics-only perturbation from recorder presence or activation is not excluded by any control in this protocol
+
+NEUTRALITY STATEMENT 2 of 3 — R5.2 (order control)
+result: {{R52_RESULT}}
+observed pooled sd: {{R52_SD}}
+observed pair mean: {{R52_MEAN}}
+recomputed MDE: {{R52_MDE_PCT}} %
+MDE ≈ 17 %
+a smaller perturbation is NOT excluded
+role: CATASTROPHE DETECTOR; n = 6 DECLINED at ≈ 4 h
+a dynamics-only perturbation from recorder presence or activation is not excluded by any control in this protocol
+
+NEUTRALITY STATEMENT 3 of 3 — cell E disposition
+disposition: {{CELLE_DISPOSITION}}
+MDE ≈ 17 %
+a smaller perturbation is NOT excluded
+role: CATASTROPHE DETECTOR; n = 6 DECLINED at ≈ 4 h
+a dynamics-only perturbation from recorder presence or activation is not excluded by any control in this protocol
+
+DECLINED n = 6 EXTENSION — COST RE-DERIVED, NOT TYPED (ADJ-10)
+{{N6_COST_CELLS}} control cells × 1800 s = {{N6_COST_H}} h
+
+SINGLE-ARM DYNAMICS OBSERVATIONS (ARMED ARM ONLY)
+non-drop exit share = {{EXIT_SHARE_PCT}} % — NOT a comparison; no control arm exists for these
+median(L)/B = {{MEDIAN_L_OVER_B}} — NOT a comparison; no control arm exists for these
+s_late / s_early = {{S_RATIO}} — NOT a comparison; no control arm exists for these
+s_early = {{S_EARLY}} passes/epoch raw, from fitter field {{S_EARLY_FIELD}} — NOT a comparison; no control arm exists for these
+s_late = {{S_LATE}} passes/epoch raw, from fitter field {{S_LATE_FIELD}} — NOT a comparison; no control arm exists for these
+dynamics blind spot owner: TODO-638
+
+CLASSIFICATION LEAF PUBLISHED BY THIS RUN (R8.1's frozen ordered predicate)
+leaf: {{STEP_LEAF}}

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-slottruth.sh
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-slottruth.sh
@@ -1,0 +1,308 @@
+#!/bin/sh
+# slottruth.sh -- RE-DERIVE every re-derivable §9 slot from the COMMITTED artifacts.
+# usage: slottruth.sh <evidence-dir> > truth.tsv
+# It reads ONLY basenames this spec's Delta already commits and runs ONLY the pinned unforked fitter.
+# EVERY WINDOW AND SPLIT BELOW IS ON A COORDINATE, NEVER ON A ROW INDEX, AND THE COORDINATE IS THE ONE
+# PROVENANCE BINDS (ADJ-17 as adjudicated by ADJ-18, both governing):
+#   last-half window = rows whose `elapsed_secs` EXCEEDS the FULL ledger's elapsed midpoint;
+#   early/late split = THAT WINDOW's own `elapsed_secs` SPAN midpoint  (ADJ-18 clause 1);
+#   the FIT axis is UNCHANGED -- every slope is still fitted on `current_epoch`.
+# `elapsed_secs` is bound by limb (d)(ii) (cadence, span, matrix.txt identity); `current_epoch` is a
+# MEASURED column with no independent binding, which is why a split defined on it was movable by a
+# monotone forward stretch of ONE value (600/200 -> 436.8/32.7) and why ADJ-18 moved membership off it.
+# DENSITY is guarded in BOTH directions at [0.8x,1.2x] of span/cadence, PER LEDGER *and* PER DERIVED
+# HALF (ADJ-18 clause 3), and the EPOCH axis carries its own integrity bound -- non-decreasing, and
+# every single-row jump <= 10 x the median positive jump (ADJ-18 clause 2).
+# WHAT THESE LIMBS DO NOT CLAIM is stated ONCE, at R5.7(f) (ADJ-18 clause 4). Do not restate it here.
+# A NONZERO exit means the truth file is INCOMPLETE BY CONSTRUCTION; the grader READS that status and
+# REDs with it PRINTED, so a driver that REFUSED TO RUN is never reported as a mere coverage hole.
+set -e
+E=$1
+FIT=$E/spec349c2-fit.awk
+PR=$E/spec356-long.prune.csv                    # the `long` cell's ledger -- THE ONLY PASS-RATE INPUT
+PP=$E/spec356-long-passrate.csv                 # committed CONVENIENCE COPY of the parent series
+LO=$E/spec356-long-passrate-early.csv           # committed CONVENIENCE COPY of the early slice
+HI=$E/spec356-long-passrate-late.csv            # committed CONVENIENCE COPY of the late slice
+# R5.1's arm B is CROSS-LINEAGE, and its two levels come from SPEC-355's OWN COMMITTED CSVs -- the
+# width-1000 / 1800 s HEAD pair manifest §1.1 cites as `38,715 . 36,624`. Both are REAL basenames in
+# this evidence dir (Delta, NOT MODIFIED). The phantom `spec355-head-r{1,2}.csv` this driver used to
+# read EXISTED NOWHERE and is DELETED (Audit v12 C3).
+H1=$E/spec355-sweep1000.csv                     # SPEC-355 HEAD w1000 replicate 1 -> §10.4.2's 38,715
+H2=$E/spec355-sweep1000b.csv                    # SPEC-355 HEAD w1000 replicate 2 -> §10.4.2's 36,624
+W=${TMPDIR:-/tmp}/slottruth.$$ ; mkdir -p "$W" ; trap 'rm -rf "$W"' EXIT
+die() { echo "SLOTTRUTH FAIL: $*" >&2 ; exit 3 ; }
+
+# ---- (d) PROVENANCE: a measurement cell's committed bytes must be ITS OWN ----
+# Two independent bindings, because either alone is defeated by copying the other file too:
+#  (i) the cell's `matrix.txt` self-description must name THIS cell, THIS width and THIS duration --
+#      the runner's own emitted literals (`spec356-prune.sh:864`, `:882`, `:891`);
+#  (ii) the DRIVER-CONSUMED csv's OWN `elapsed_secs` column must be STRICTLY INCREASING, must SPAN this
+#      cell's duration to +-10 %, and must carry a row count inside `[0.8x, 1.2x]` of `span / cadence`
+#      -- a TWO-SIDED density band (ADJ-17 as TIGHTENED by ADJ-18 clause 3). The upper side catches
+#      PADDING (invented scrapes); the LOWER side catches THINNING, the channel Audit v12 C1 exploited.
+#      [0.5x,1.5x] was too loose to be a bound on a HALF: it left a 50 % deletion budget inside one
+#      half, so value-selective thinning still tilted that half's fit. The observed legitimate skip
+#      rate is ~1 % (one gated tick per smoke), so 20 % headroom is coarse-generous.
+#      THE SAME BAND IS ENFORCED ON EACH DERIVED HALF, below, where the halves exist.
+prov() { # prov <basename> <cell> <width-literal> <duration-s> <driver-consumed csv> <cadence-s>
+  MX=$E/$1.matrix.txt
+  [ -f "$MX" ] || die "$1.matrix.txt is ABSENT: the cell cannot state whose bytes these are"
+  grep -qxF "=== spec356 prune-record run: cell $2 ===" "$MX" || die "$1.matrix.txt does not name cell $2"
+  grep -qxF "  TOPGUN_EPOCH_WIDTH:  $3" "$MX"                 || die "$1.matrix.txt width is not [$3]"
+  grep -qxF "  duration:            $4s" "$MX"                || die "$1.matrix.txt duration is not $4 s"
+  awk -F, -v d="$4" -v cad="$6" '
+    NR==1 { for (i=1;i<=NF;i++) if ($i=="elapsed_secs") c=i; if (!c) exit 1; next }
+    { v = $c + 0; if (n && v <= last) exit 1; if (!n) first = v; last = v; n++ }
+    END { if (n < 2) exit 1
+          span = last - first
+          if (span < 0.9*d || span > 1.1*d) exit 1
+          slots = span / cad
+          if (n < 0.8*slots || n > 1.2*slots) exit 1 }' "$5" \
+    || die "$5 is not cell $2's own ledger: its elapsed_secs must be strictly increasing, span $4 s to +-10%, and carry a row count within [0.8x,1.2x] of span/${6}s"
+  # (iv) THE EPOCH AXIS IS GUARDED TOO, coarsely and on its own terms. `current_epoch` is the OLS
+  # x-axis, and until this limb NOTHING constrained it. `topgun_or_prune_current_epoch` is the LWM
+  # epoch, a MONOTONE COUNTER: it cannot decrease. That is a fact about the instrument, not a bound
+  # fitted to data, which is why it is checkable PRE-DATA. The JUMP bound (ADJ-18 clause 2) is applied
+  # over the PARENT WINDOW, below, which is the scope ADJ-18 gives it.
+  awk -F, '
+    NR==1 { for (i=1;i<=NF;i++) if ($i=="topgun_or_prune_current_epoch") c=i; if (!c) exit 0; next }
+    { if (!c) next; v = $c + 0; if (n && v < last) exit 1; last = v; n++ }' "$5" \
+    || die "$5's topgun_or_prune_current_epoch DECREASES: the LWM epoch is a monotone counter, so this column has been edited"
+}
+prov spec356-ctl-r1    ctl    "<unset: production default 1000>"  1800  "$E/spec356-ctl-r1.csv"    60
+prov spec356-ctl-r2    ctl    "<unset: production default 1000>"  1800  "$E/spec356-ctl-r2.csv"    60
+prov spec356-ctloff-r1 ctloff "<unset: production default 1000>"  1800  "$E/spec356-ctloff-r1.csv" 60
+prov spec356-ctloff-r2 ctloff "<unset: production default 1000>"  1800  "$E/spec356-ctloff-r2.csv" 60
+prov spec356-w100      w100   "100"                               1800  "$E/spec356-w100.csv"      60
+prov spec356-long      long   "<unset: production default 1000>" 14400  "$PR"                      10
+[ -f "$E/spec356-cellE.matrix.txt" ] && \
+prov spec356-cellE     cellE  "<unset: production default 1000>"  1800  "$E/spec356-cellE.prune.csv" 10 || true
+
+# ---- (d) PROVENANCE FOR ARM B, which is a FROZEN artifact of ANOTHER spec and has no spec356 matrix ----
+# A SPEC-355 CSV cannot carry this runner's identity triple, so the binding is CONTENT: the same
+# coordinate window, the same +-10 %/density bands, AND the derived level must equal the literal
+# manifest §10.4.2 published for that replicate. A substituted file fails the last check by construction.
+prov355() { # prov355 <csv> <duration-s> <cadence-s> <published-level-rounded>
+  awk -F, -v d="$2" -v cad="$3" '
+    NR==1 { for (i=1;i<=NF;i++) if ($i=="elapsed_secs") c=i; if (!c) exit 1; next }
+    { v = $c + 0; if (n && v <= last) exit 1; if (!n) first = v; last = v; n++ }
+    END { if (n < 2) exit 1
+          span = last - first
+          if (span < 0.9*d || span > 1.1*d) exit 1
+          slots = span / cad
+          if (n < 0.8*slots || n > 1.2*slots) exit 1 }' "$1" \
+    || die "$1 is not a SPEC-355 1800 s control replicate (coordinates/density)"
+  got=$(level "$1")
+  awk -v g="$got" -v w="$4" 'BEGIN{ d=g-w; if (d<0) d=-d; exit (d<=1 ? 0 : 1) }' \
+    || die "$1's coordinate-window level $got does not reproduce manifest §10.4.2's published $4"
+}
+
+# ---- THE COORDINATE WINDOWS, DERIVED FROM THE LEDGER. THE SLICES ARE NOT INPUTS. ----
+# parent = rows of the FULL ledger with `elapsed_secs > (t_first + t_last)/2`, emitted as
+#          (`current_epoch`, `passes_total`), zero exclusion (Delta / ADJ-13's series leg)
+# early  = parent rows with `elapsed_secs <= (t_lo + t_hi)/2`, where t_lo/t_hi are the PARENT WINDOW's
+#          own first and last elapsed_secs -- the midpoint of the WINDOW'S ELAPSED SPAN, not the median
+#          row and NOT the epoch span (ADJ-18 clause 1). late = the rest.
+# The emitted x column is STILL `current_epoch`: only MEMBERSHIP moved to elapsed, the FIT did not.
+# Four further limbs run here, where the parent window and its halves exist. THE GUARDED AXIS IS
+# CHECKED FIRST and the MEASURED axis last, which is the same precedence prov() already uses:
+#   PER-HALF DENSITY (ADJ-18 clause 3) -- each derived half's row count within [0.8x,1.2x] of its OWN
+#           span/cadence. This is what bounds value-selective thinning INSIDE one half, which the
+#           ledger-global band cannot see. It bounds VOLUME.
+#   PER-HALF MAX GAP (ADJ-19 clause 2) -- within each derived half the largest gap between consecutive
+#           `elapsed_secs` values must be <= 5 x cadence. This bounds DISTRIBUTION, which is the half of
+#           the problem a band cannot reach: any band leaves a budget, and a budget CONCENTRATED at the
+#           split boundary tilts that half's fit while numerator and denominator shrink together (100
+#           contiguous rows deleted below the boundary measured 1.004 x -- inside the band). A legitimate
+#           skipped scrape is 2x and two consecutive skips 3x, against a measured ~1 % skip rate.
+#   (d)(iv) EPOCH JUMP BOUND (ADJ-18 clause 2, GATED BY ADJ-19 clause 1) -- over the parent window,
+#           every single-row jump in `current_epoch` must be <= 10 x the MEDIAN POSITIVE JUMP, and the
+#           rule applies ONLY at >= 5 POSITIVE JUMPS. Below that the reference statistic is dominated by
+#           the attacking row itself ({1, 1398} -> median 699.5, bound 6995, the 1398 jump passes its own
+#           guard), so the epoch axis cannot carry a pass-rate fit at all and the window routes to
+#           INDETERMINATE through R8.1 Step 0(c) -- the EXISTING hatch, no new verdict and no default to
+#           either branch. A guard whose scale the attacker sets is not a guard.
+#   TWO-VALUE FLOOR -- a slice that cannot support a fit is FAIL-CLOSED, not a thin fit. It counts
+#           DISTINCT x-VALUES, not ROWS, and the difference is the whole point: the fit axis is
+#           `current_epoch`, so a half with 360 ROWS and ONE distinct epoch has NO x-variance, the
+#           fitter refuses it (`sxx <= 0`, exit 2) and NO slope exists. Counting rows cleared exactly
+#           that half. A refused fit then reached the grader as an EMPTY slot, which the grader read as
+#           0 -- fail-OPEN in the worst possible direction, and one-directional: an empty S_EARLY is
+#           caught by the `S_EARLY = 0` arithmetic guard, an empty S_LATE was caught by nothing, and
+#           the unguarded side is the one that yields SCHEDULING. BOTH are guarded now, on three
+#           independent limbs: this floor, `slope()`'s status propagation, and the grader's own
+#           empty-value RED. The regime is NOT adversarial -- `topgun_or_prune_current_epoch` is the
+#           LWM epoch and R1.3a says LWM movement STOPS in the Step-3 (scheduling / LWM-stall) regime,
+#           so a genuine late-half stall produces this ledger HONESTLY and the leaf it would publish is
+#           the very leaf the stall is evidence for, read off a slope nobody computed. Such a window
+#           routes to INDETERMINATE via R8.1 Step 0(c) -- the EXISTING hatch -- and the RAW OBSERVATION
+#           (rows and distinct epoch counts per half) is printed with the refusal.
+# The three committed CSVs are CONVENIENCE COPIES for a reader, never inputs: each is `cmp`ed against
+# the derivation and any drift is RED. Every boundary is a pure function of a GUARDED COORDINATE, so no
+# row count enters the verdict and there is no post-data choice left to make.
+src=0
+awk -F, -v P="$W/parent.csv" -v A="$W/early.csv" -v B="$W/late.csv" -v cad=10 '
+  NR==1 { for (i=1;i<=NF;i++) h[$i]=i
+          if (!(("elapsed_secs" in h) && ("topgun_or_prune_current_epoch" in h) \
+                && ("topgun_or_prune_passes_total" in h))) exit 1
+          next }
+  { n++; t[n]=$(h["elapsed_secs"])+0
+         e[n]=$(h["topgun_or_prune_current_epoch"]); p[n]=$(h["topgun_or_prune_passes_total"]) }
+  END { if (n < 2) exit 1
+        tmid = (t[1] + t[n]) / 2
+        for (i = 1; i <= n; i++) if (t[i] > tmid) { m++; pt[m] = t[i]; pe[m] = e[i]; pp[m] = p[i] }
+        if (m < 2) exit 2
+        tlo = pt[1]; thi = pt[m]; tsplit = (tlo + thi) / 2
+        for (i = 1; i <= m; i++) {
+          if (pt[i] <= tsplit) { na++; if (na == 1) alo = pt[i]; ahi = pt[i] }
+          else                 { nb++; if (nb == 1) blo = pt[i]; bhi = pt[i] }
+        }
+        if (na < 2 || nb < 2) exit 2
+        # THE FLOOR IS ON DISTINCT x-VALUES, NOT ON ROWS -- and that is the whole content of the
+        # repair. The OLS x-axis is `current_epoch`; a half carrying 360 rows and ONE distinct epoch
+        # has NO x-variance, so the fitter refuses it (`sxx <= 0`) and no slope exists to publish. A
+        # ROW-counting floor cleared such a half, which is exactly how a declined fit used to reach the
+        # grader as an empty field. This is also the regime the predicate most expects rather than an
+        # adversarial one: `topgun_or_prune_current_epoch` is the LWM epoch, and R1.3a states that LWM
+        # movement STOPS in the R8.1 Step-3 (scheduling / LWM-stall) regime -- so a genuine stall
+        # confined to the late half produces this ledger HONESTLY, and the leaf it would otherwise
+        # publish is the very leaf the stall is evidence for, read off a slope nobody computed.
+        for (i = 1; i <= m; i++) {
+          if (pt[i] <= tsplit) { if (!(pe[i] in DA)) { DA[pe[i]] = 1; da++ } }
+          else                 { if (!(pe[i] in DB)) { DB[pe[i]] = 1; db++ } }
+        }
+        if (da < 2 || db < 2) {
+          printf "  OBSERVED: parent rows=%d; early rows=%d distinct current_epoch=%d; late rows=%d distinct current_epoch=%d\n", \
+            m, na, da, nb, db > "/dev/stderr"
+          exit 7
+        }
+        # Each consecutive-row gap is attributed to the half its EARLIER endpoint sits in, so the
+        # BOUNDARY-CROSSING gap belongs to the early half. That is not a detail: a run deleted at the
+        # EDGE of a half leaves a hole with no interior row on one side of it, and a gap sequence read
+        # inside [alo, ahi] alone is blind to exactly the deletion ADJ-19 clause 2 names.
+        for (i = 2; i <= m; i++) { g = pt[i] - pt[i-1]
+          if (pt[i-1] <= tsplit) { if (g > agap) agap = g } else { if (g > bgap) bgap = g } }
+        # PER-HALF DENSITY, each half against its OWN span (ADJ-18 clause 3) -- VOLUME
+        sa = (ahi - alo) / cad; sb = (bhi - blo) / cad
+        if (na < 0.8*sa || na > 1.2*sa) exit 3
+        if (nb < 0.8*sb || nb > 1.2*sb) exit 3
+        # PER-HALF MAX CONSECUTIVE GAP (ADJ-19 clause 2) -- DISTRIBUTION, which the band cannot see
+        if (agap > 5 * cad || bgap > 5 * cad) exit 5
+        # (d)(iv) EPOCH JUMP BOUND over the parent window (ADJ-18 clause 2), and its MINIMUM EVIDENCE
+        # gate (ADJ-19 clause 1). The gate is evaluated FIRST, because a bound whose own scale comes
+        # from too few samples is not a weaker bound -- it is no bound.
+        np = 0
+        for (i = 2; i <= m; i++) { j = pe[i] - pe[i-1]; if (j > 0) J[++np] = j }
+        if (np < 5) exit 6
+        for (a = 1; a < np; a++) for (b = 1; b < np; b++) \
+          if (J[b] > J[b+1]) { z = J[b]; J[b] = J[b+1]; J[b+1] = z }
+        medj = (np % 2) ? J[(np+1)/2] : (J[np/2] + J[np/2+1]) / 2
+        for (i = 2; i <= m; i++) if (pe[i] - pe[i-1] > 10 * medj) exit 4
+        hdr = "current_epoch,passes_total"
+        print hdr > P; print hdr > A; print hdr > B
+        for (i = 1; i <= m; i++) {
+          print pe[i] "," pp[i] > P
+          if (pt[i] <= tsplit) print pe[i] "," pp[i] > A
+          else                 print pe[i] "," pp[i] > B
+        } }' "$PR" || src=$?
+case $src in
+  0) ;;
+  1) die "the ledger does not carry elapsed_secs + the two pass-rate columns, or has fewer than two rows" ;;
+  2) die "the ADJ-18 elapsed-span midpoint left a slice with fewer than 2 rows: the split is unusable and no slope may be read from it" ;;
+  3) die "a DERIVED HALF is outside the ADJ-18 density band [0.8x,1.2x] of its OWN span/${cad:-10}s: value-selective thinning inside one half is refused, and the ledger-global band cannot see it" ;;
+  4) die "$PR's topgun_or_prune_current_epoch carries a single-row JUMP greater than 10x the window's median positive jump (ADJ-18 clause 2): the epoch axis has been stretched" ;;
+  5) die "a DERIVED HALF carries a gap between consecutive elapsed_secs values greater than 5x the ${cad:-10}s cadence (ADJ-19 clause 2): deletion CONCENTRATED at one point is refused, and the per-half density band -- which bounds VOLUME, not DISTRIBUTION -- reads such a half as in-band" ;;
+  6) die "$PR's topgun_or_prune_current_epoch carries FEWER THAN FIVE positive jumps over the parent window (ADJ-19 clause 1): the 10x-median bound's own reference statistic would be set by the attacking row, so the epoch axis cannot carry a pass-rate fit and this window routes to INDETERMINATE via R8.1 Step 0(c) -- the EXISTING hatch, no new verdict" ;;
+  7) die "a DERIVED HALF's topgun_or_prune_current_epoch carries FEWER THAN TWO DISTINCT VALUES -- the epochs are STATIC across that half (the raw counts are on the OBSERVED line above, which is the LWM-STALL reading R1.3a names). The OLS x-axis has no variance there, so NO slope exists and none may be fabricated: this window routes to INDETERMINATE via R8.1 Step 0(c) -- the EXISTING hatch, no new verdict and no default to either branch" ;;
+  *) die "the coordinate split derivation failed with status $src" ;;
+esac
+cmp -s "$W/parent.csv" "$PP" || die "committed passrate parent != the ledger's coordinate last half"
+cmp -s "$W/early.csv"  "$LO" || die "committed early slice != the ADJ-18 ELAPSED-SPAN MIDPOINT split"
+cmp -s "$W/late.csv"   "$HI" || die "committed late slice  != the ADJ-18 ELAPSED-SPAN MIDPOINT split"
+
+# ---- s_early / s_late: ADJ-15's PINNED INVOCATION, VERBATIM, run TWICE (R6a) on the DERIVED slices ----
+# THE FITTER'S EXIT STATUS IS PROPAGATED, NEVER SWALLOWED, AND THE FUNCTION EMITS ITS OWN SLOT LINE.
+# It used to run the fitter inside `$( ... | tr | awk )` and hand the result to `printf`: a command
+# substitution's failure is invisible to `set -e` in that position, so a fitter REFUSAL (exit 2 -- e.g.
+# `zero variance in elapsed_secs over the window`, which is what a half with ONE distinct x value
+# produces) printed to stderr, returned an EMPTY field, and the driver emitted `S_LATE<TAB>` with
+# exit 0. A statistic the fitter DECLINED to compute is not zero. So the fit runs in THIS shell, ANY
+# nonzero status on a REQUIRED fit is a refusal, and so is an empty field.
+slope() { # slope <csv> <half> <slot-name>
+  awk -v col=passes_total -v xaxis=current_epoch -v window=full -f "$FIT" "$1" > "$W/fit.out" \
+    || die "FIT REFUSED: $2"
+  _v=$(tr ' ' '\n' < "$W/fit.out" | awk -F= '$1=="slope_per_x_unit"{print $2}')
+  [ -n "$_v" ] || die "FIT REFUSED: $2"
+  printf '%s\t%s\n' "$3" "$_v"
+}
+slope "$W/early.csv" early S_EARLY
+slope "$W/late.csv"  late  S_LATE
+# ---- exit share and median(L)/B, over the SAME ADJ-17 COORDINATE last-half window ----
+# Exit share numerator = the five non-`Dropped` exit counters (manifest §5.3); denominator = considered.
+# Both are CUMULATIVE totals, so the last-half share is the DELTA across the window.
+# B is the rendered p50 column (col 43, ADJ-12); median(L) is the median of the eligible_refs gauge.
+awk -F, '
+NR==1 { for (i=1;i<=NF;i++) h[$i]=i; next }
+{ n++; ts[n]=$(h["elapsed_secs"])+0; for (i=1;i<=NF;i++) v[n,i]=$i }
+END {
+  tmid = (ts[1] + ts[n]) / 2                     # ADJ-17: the window is a COORDINATE, not a row index
+  for (i = 1; i <= n; i++) if (ts[i] > tmid) { if (!lo) lo = i; hi = i }
+  if (!lo || lo == hi) exit 0
+  C="topgun_or_prune_considered_total"; MN="topgun_or_prune_matched_nothing_total"
+  AB="topgun_or_prune_absent_total"; RR="topgun_or_prune_restored_read_error_total"
+  RE="topgun_or_prune_restored_evicted_total"; RW="topgun_or_prune_restored_write_error_total"
+  L ="topgun_or_prune_eligible_refs";  B="topgun_or_prune_drain_refs_p50"
+  dC = v[hi,h[C]] - v[lo,h[C]]
+  dX = (v[hi,h[MN]]-v[lo,h[MN]]) + (v[hi,h[AB]]-v[lo,h[AB]]) + (v[hi,h[RR]]-v[lo,h[RR]]) \
+     + (v[hi,h[RE]]-v[lo,h[RE]]) + (v[hi,h[RW]]-v[lo,h[RW]])
+  if (dC > 0) printf "EXIT_SHARE_PCT\t%.6f\n", 100*dX/dC
+  m=0; for (i=lo;i<=hi;i++) { m++; ls[m]=v[i,h[L]]+0; bs[m]=v[i,h[B]]+0 }
+  for (i=1;i<m;i++) for (j=1;j<m;j++) { if (ls[j]>ls[j+1]) {t=ls[j];ls[j]=ls[j+1];ls[j+1]=t}
+                                        if (bs[j]>bs[j+1]) {t=bs[j];bs[j]=bs[j+1];bs[j+1]=t} }
+  med = (m%2) ? ls[(m+1)/2] : (ls[m/2]+ls[m/2+1])/2
+  bb  = (m%2) ? bs[(m+1)/2] : (bs[m/2]+bs[m/2+1])/2
+  if (bb > 0) printf "MEDIAN_L_OVER_B\t%.6f\n", med/bb
+}' "$PR"
+
+# ---- the control arms: per-replicate coordinate-window level, then §1.1's pooled sd and grand mean ----
+# STATED REDUCTION (cite it, do not re-derive it per run): each replicate contributes ONE level -- the
+# mean of its `tombstone_bytes` column over the ADJ-17 coordinate last-half window, EMPTY CELLS SKIPPED
+# exactly as the pinned fitter skips them. That is SPEC-355 §10.4.2's own statistic, and running it on
+# SPEC-355's two committed HEAD CSVs returns 38715.466667 and 36624.133333 -- i.e. it REPRODUCES the
+# `38,715 . 36,624` pair manifest §1.1 publishes, from the real bytes, without being told the answer.
+# `s_pooled` is the two-sample pooled sd over the comparison's two arms at n1 = n2 = 2, so
+# s_pooled = sqrt((s1^2 + s2^2)/2); the percentage denominator is the grand mean of the four levels.
+level() { awk -F, '
+  NR==1 { for (i=1;i<=NF;i++) h[$i]=i; next }
+  { n++; ts[n]=$(h["elapsed_secs"])+0; vs[n]=$(h["tombstone_bytes"]) }
+  END { tmid=(ts[1]+ts[n])/2
+        for (i=1;i<=n;i++) if (ts[i] > tmid && vs[i] !~ /^[ \t]*$/) { s+=vs[i]+0; m++ }
+        if (m) printf "%.6f\n", s/m }' "$1"; }
+# THE CONTROL'S VERDICT IS RE-DERIVED TOO, and it is one line of arithmetic away from the numbers this
+# function already computes. It was the LAST un-re-derived byte in the block AND the byte that decides
+# whether a classification may be published at all: R5.4's 2x2 turns an R5.2 rejection into
+# "No classification number may be read off any run". manifest §1.1 pre-registers the comparison as an
+# EXECUTABLE formula -- two-sample t, df = 2, two-sided alpha = 0.05, CRITICAL VALUE 4.303 -- so
+# emitting the verdict here is EXECUTING the frozen pre-registration, not editing it. At n1 = n2 = 2
+# the standard error is sp * sqrt(1/n1 + 1/n2) = sp, which is why the statistic is |ma - mb| / sp.
+# `_T` is a DIAGNOSTIC, not a slot: the template publishes no t, so the grader records it and prints
+# it in the refusal rather than comparing it to anything.
+arms() { # arms <tag> <armA-r1> <armA-r2> <armB-r1> <armB-r2>
+  tag=$1; a1=$(level "$2"); a2=$(level "$3"); b1=$(level "$4"); b2=$(level "$5")
+  awk -v t="$tag" -v a1="$a1" -v a2="$a2" -v b1="$b1" -v b2="$b2" 'BEGIN{
+    ma=(a1+a2)/2; mb=(b1+b2)/2
+    va=(a1-ma)^2+(a2-ma)^2; vb=(b1-mb)^2+(b2-mb)^2      # each arm: (n-1)s^2 with n = 2
+    sp=sqrt((va+vb)/2)                                   # pooled over df = n1+n2-2 = 2
+    d=ma-mb; if (d<0) d=-d
+    tt = (sp > 0) ? d/sp : (d > 0 ? 1e9 : 0)             # sp = 0 with a real gap is INFINITE evidence
+    printf "%s_SD\t%.6f\n%s_MEAN\t%.6f\n", t, sp, t, (a1+a2+b1+b2)/4
+    printf "%s_T\t%.6f\n%s_RESULT\t%s\n", t, tt, t, (tt > 4.303 ? "REJECTED" : "NOT REJECTED") }'; }
+prov355 "$H1" 1800 60 38715
+prov355 "$H2" 1800 60 36624
+# R5.1 is CROSS-LINEAGE: this build's `ctl` pair against SPEC-355's committed HEAD pair.
+arms R51 "$E/spec356-ctl-r1.csv" "$E/spec356-ctl-r2.csv" "$H1" "$H2"
+# R5.2 is WITHIN-LINEAGE: this build's `ctl` pair against its own `ctloff` pair.
+arms R52 "$E/spec356-ctl-r1.csv" "$E/spec356-ctl-r2.csv" "$E/spec356-ctloff-r1.csv" "$E/spec356-ctloff-r2.csv"
+
+# ---- the declined n = 6 extension's cell count (ADJ-10: 8 further control cells at 1800 s) ----
+printf 'N6_COST_CELLS\t8\n'

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-tmplconf.awk
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-tmplconf.awk
@@ -1,0 +1,371 @@
+# tmplconf.awk -- §9 controls-and-dynamics TEMPLATE CONFORMANCE + RE-DERIVATION (checklists 15/16/18/19).
+# usage: awk -v ev=<evidence-dir> -v tol=0.005 -f tmplconf.awk skeleton.txt submitted.md   <- REAL RUNS
+#        awk -v truth=truth.tsv  -v tol=0.005 -f tmplconf.awk skeleton.txt submitted.md   <- FIXTURE MODE ONLY
+#   (a) [item 15] the block between the markers IS the pinned skeleton, byte-exact modulo slots
+#   (b) [item 16] every slot value is well-formed against its declared grammar
+#   (c) [item 18] every RE-DERIVABLE slot equals the value re-derived from the COMMITTED artifacts,
+#                 and the slots that are arithmetic functions of other slots agree with them
+#   (d) [item 19] the PUBLISHED leaf equals the leaf the frozen R8.1 predicate implies
+# NO ENGLISH IS SCANNED. Prose outside the block is NON-NORMATIVE and is never read.
+# `truth` is REQUIRED whenever the cell has run. Item 18 REDs on a MISSING or INCOMPLETE truth file
+# and NAMES the ungraded slots; item 19 has NO fallback to the published slots and REDs "cannot
+# reconcile" instead. The ONLY vacuous path is `-v nosubject=1` WITH no truth file -- the operator
+# explicitly asserting the cell has not run -- and that assertion is itself FAIL-CLOSED: a block that
+# publishes any leaf but INDETERMINATE contradicts it and REDs.
+# `ev=` IS THE MANDATED MODE FOR A REAL RUN, and it exists because `truth=` is an OPAQUE PATH: a
+# hand-written nine-name truth file whose values are copied from the block certifies that block
+# against ITSELF -- the identical property the deleted item-19 fallback had, mediated by a file the
+# executor authors. Under `ev=` the grader RUNS the driver itself, so `TR` is this run's own
+# re-derivation from the committed artifacts and nothing else. The mode is PRINTED, so a fixture-mode
+# run can never be read as a re-derived one. (Cross-vendor round, Response v11.)
+# BUT `ev=` WAS ITSELF AN OPAQUE PATH UNTIL Audit v12 C2 MEASURED IT, and two limbs close that:
+#   (1) THE DRIVER IS PINNED BY DIGEST. `slottruth.sh` in $PWD was whatever file happened to be there:
+#       `printf '#!/bin/sh\ncat ../forged.tsv\n' > slottruth.sh` bought PASS on the a1 transposition.
+#       The grader now VERIFIES sha256(slottruth.sh) AGAINST DRIVER_SHA256 BEFORE EXECUTING IT, and a
+#       mismatch REDs with both digests printed. The digest is also pinned in checklist 18's prose, so
+#       an executor extracting the two programs has a check that survives every future line-range move.
+#   (2) `ev` IS QUOTED, AND CHARSET-GUARDED. It used to be interpolated RAW into a shell command, so
+#       `-v ev='/dev/null; cat forged.tsv #'` was a command, not a path, and printed PASS. It is now
+#       single-quoted in the command string AND rejected up front if it carries anything outside
+#       [A-Za-z0-9._/-] (which excludes the quote character itself, so the quoting cannot be escaped).
+# THE DRIVER'S EXIT STATUS IS READ, NOT DISCARDED (Audit v12 rec 5). A driver that REFUSED TO RUN
+# (`SLOTTRUTH FAIL`, exit 3) used to be indistinguishable in this transcript from a truth file with a
+# coverage hole -- both printed "INCOMPLETE". A nonzero status now prints its own FAIL 18 line.
+# The status is carried by an APPENDED `echo SLOTTRUTH_EXIT $?` rather than by `close()`, because
+# `close()` on a command pipe returns 0 on this platform's awk (`awk version 20200816`, measured) --
+# reading it would have been a check that silently never fires. The sentinel is portable and is
+# EXEMPT from the slot-name check, and its ABSENCE is itself RED (the pipe died before the echo).
+# (The former header said a missing truth file made 18/19 report NO SUBJECT "rather than passing
+# vacuously". Audit v11 C2 MEASURED that FALSE for item 19 and half-false for 18. It is gone.)
+function grammar(name) {
+  if (name ~ /_RESULT$/)             return "ENUM_RESULT"
+  if (name ~ /_FIELD$/)              return "ENUM_FIELD"
+  if (name == "CELLE_DISPOSITION")   return "ENUM_CELLE"
+  if (name == "STEP_LEAF")           return "ENUM_LEAF"
+  return "REAL"
+}
+function wellformed(name, v,   g) {
+  g = grammar(name)
+  if (v ~ /\{\{/) return 0
+  if (g == "REAL")        return (v ~ /^-?[0-9]+(\.[0-9]+)?$/)
+  if (g == "ENUM_RESULT") return (v == "NOT REJECTED" || v == "REJECTED")
+  # The wrong-axis BELT (Audit v10 C2): the ONLY admissible source field for a per-epoch slope is the
+  # renamed one an explicit -v xaxis= produces. A time-axis fit reports `slope_mb_per_hour`, which this
+  # rejects -- restoring structurally the field-name evidence the template's bare numeral had stripped.
+  if (g == "ENUM_FIELD")  return (v == "slope_per_x_unit")
+  if (g == "ENUM_CELLE")  return (v == "CLOSED-NOT-NEEDED" || v == "RUN-NON-REPRODUCTION-RECORDED-AND-SPUN-OFF" \
+                               || v == "RUN-REPRODUCTION-WIDENS-CLAIM" || v == "RUN-INDETERMINATE")
+  if (g == "ENUM_LEAF")   return (v == "SELECTION / FRONTIER (exit limb)" \
+                               || v == "SELECTION / FRONTIER (licensing limb)" \
+                               || v == "SCHEDULING / LICENSING" || v == "THROUGHPUT" \
+                               || v == "Steps 3–4, NOT SEPARABLE (degenerate pass rate)" \
+                               || v == "INDETERMINATE")
+  return 0
+}
+# PRESENTATION-ONLY normalization, applied to BOTH sides.
+function norm(x) {
+  sub(/^([[:space:]]*>)*[[:space:]]*/, "", x)
+  sub(/[[:space:]]+$/, "", x)
+  return x
+}
+function conform(s, t,   rest, lit, name, nextlit, p, val, st, sl) {
+  rest = t
+  while (1) {
+    st = match(s, /\{\{[A-Z_0-9]+\}\}/)
+    if (st == 0) break
+    sl   = RLENGTH
+    lit  = substr(s, 1, st - 1)
+    name = substr(s, st + 2, sl - 4)
+    s    = substr(s, st + sl)
+    if (substr(rest, 1, length(lit)) != lit) return 0
+    rest = substr(rest, length(lit) + 1)
+    if (match(s, /\{\{[A-Z_0-9]+\}\}/)) nextlit = substr(s, 1, RSTART - 1)
+    else                                nextlit = s
+    if (nextlit == "") { val = rest; rest = "" }
+    else {
+      p = index(rest, nextlit)
+      if (p == 0) return 0
+      val  = substr(rest, 1, p - 1)
+      rest = substr(rest, p)
+    }
+    nslot++; sname[nslot] = name; sval[nslot] = val; sidx[name] = nslot
+  }
+  return (rest == s)
+}
+function has(n) { return (n in sidx) }
+function V(n)   { return sval[sidx[n]] + 0 }
+function SV(n)  { return sval[sidx[n]] }
+# relative agreement; an exact-zero expectation falls back to absolute
+function agree(got, want,   d) {
+  d = got - want; if (d < 0) d = -d
+  if (want < 0 ? -want : want) return (d <= tol * (want < 0 ? -want : want))
+  return (d <= tol)
+}
+function red18(msg) { printf "FAIL 18 -- %s\n", msg; bad18 = 1; rc = 1 }
+function red19(msg) { printf "FAIL 19 -- %s\n", msg; bad19 = 1; rc = 1 }
+# ONE reader for BOTH modes, so the `ev=` and `truth=` paths cannot drift apart -- they were duplicated
+# blocks, and a belt added to one of them would have been a belt on one mode only.
+# THREE things it does that the duplicated inline loops did not:
+#  (i)  AN EMPTY VALUE IS RED, NOT `0`. `tv = a[2] + 0` coerced a missing field to zero, `agree(0,0)`
+#       took the absolute branch and passed, and `leafof(...,0)` returned SCHEDULING / LICENSING off a
+#       slope the fitter had DECLINED to compute. This is the BELT for that: the driver now refuses
+#       first (`FIT REFUSED`), and if it ever did not, an empty cell REDs here on its own limb.
+#  (ii) ENUM slots are compared AS STRINGS. The re-derivation now carries the R5.1/R5.2 verdicts, and
+#       `"NOT REJECTED" + 0` is `0` for every enum value -- a numeric comparison would grade nothing.
+#  (iii) `_T` names are DIAGNOSTICS with no published counterpart and are recorded, not graded.
+function take(ln,   a, tn, tvs, tv, pfx) {
+  if (ln ~ /^#/ || ln ~ /^[[:space:]]*$/) return
+  split(ln, a, "\t")
+  tn = a[1]; tvs = a[2]
+  if (tn ~ /_T$/) { TT[tn] = tvs; return }
+  if (!has(tn)) { red18(sprintf("truth names slot %s, which the template does not carry", tn)); return }
+  if (tvs ~ /^[ \t]*$/) {
+    red18(sprintf("the re-derivation returned an EMPTY VALUE for slot %s: a statistic the derivation DECLINED to compute is NOT zero, and the `+0` coercion that used to make it one is the worst available fail-OPEN. The slot stays UNGRADED, and that is RED.", tn))
+    return
+  }
+  if (grammar(tn) == "ENUM_RESULT") {
+    TR[tn] = tvs; nt18++
+    pfx = tn; sub(/_RESULT$/, "", pfx); pfx = pfx "_T"
+    if (SV(tn) != tvs)
+      red18(sprintf("slot %s = '%s' CONTRADICTS the verdict RE-DERIVED from the committed control CSVs = '%s' (two-sample t = %s against manifest §1.1's pre-registered critical value 4.303, df = 2)", \
+            tn, SV(tn), tvs, (pfx in TT ? TT[pfx] : "<not emitted>")))
+    return
+  }
+  tv = tvs + 0; TR[tn] = tv; nt18++
+  if (!agree(V(tn), tv))
+    red18(sprintf("slot %s = %s CONTRADICTS the value re-derived from the committed artifacts = %.6f", \
+          tn, SV(tn), tv))
+}
+# R5.4's 2x2 as a pure function, so the PUBLISHED licence and the RE-DERIVED licence are computed by
+# the SAME code and a difference between them is a difference in the inputs, never in the reading.
+function licof(r51, r52) {
+  if (r52 != "REJECTED") return "OK"
+  return (r51 == "REJECTED") ? "INDETERMINATE - both suspected" : "INSTRUMENT PERTURBATION"
+}
+# The FROZEN R8.1 ordered predicate, as a pure function. FIRST match wins, exactly as the table states.
+function leafof(share, lb, se, sl) {
+  if (share > 10)      return "SELECTION / FRONTIER (exit limb)"
+  if (lb <= 1)         return "SELECTION / FRONTIER (licensing limb)"
+  if (se < 5)          return "Steps 3–4, NOT SEPARABLE (degenerate pass rate)"
+  if (sl <= 0.5 * se)  return "SCHEDULING / LICENSING"
+  return "THROUGHPUT"
+}
+BEGIN { if (tol + 0 <= 0) tol = 0.005; NSLOT = 19
+        # THE DRIVER, PINNED BY CONTENT. This is sha256 of `slottruth.sh` as extracted from THIS spec's
+        # own bytes by checklist 18's stated extraction command. A digest survives an edit that moves a
+        # line range; a line range does not. Re-pinning the driver means re-pinning this constant and
+        # the two digests checklist 18 prints -- there is no third place to forget.
+        DRIVER_SHA256 = "280f7a3466a0bffc89059815bb3862bb9581cb95d7efa3fe58b1152749b8f060" }
+FNR == NR && FILENAME == ARGV[1] { S[++ns] = norm($0); next }
+/TG356B-CTRL BEGIN v2/ { nbeg++; inb = 1; next }
+/TG356B-CTRL END v2/   { nend++; inb = 0; next }
+inb { T[++nt] = norm($0) }
+END {
+  if (nbeg != 1 || nend != 1) {
+    printf "FAIL 15 -- template markers: expected exactly one BEGIN and one END, got %d/%d%s\n", \
+      nbeg + 0, nend + 0, (nbeg + 0 == 0 ? "  (TEMPLATE ABSENT -- the silent-drop failure mode)" : "")
+    print "FAIL 16 -- slots ungradeable: no single template block"
+    print "FAIL 18 -- slots ungradeable: no single template block"
+    print "FAIL 19 -- leaf ungradeable: no single template block"
+    exit 1
+  }
+  bad = 0
+  if (nt != ns)
+    printf "NOTE   -- block has %d lines, skeleton has %d: a REFLOWED or re-wrapped template cascades.\n         Re-paste the skeleton and fill slots only.\n", nt, ns
+  m = (ns > nt ? ns : nt)
+  for (i = 1; i <= m; i++) {
+    if (i > nt) { printf "FAIL 15 -- template TRUNCATED at line %d (skeleton %d lines, block %d)\n", i, ns, nt; bad = 1; break }
+    if (i > ns) { printf "FAIL 15 -- block carries EXTRA line %d beyond the skeleton: %s\n", i, T[i]; bad = 1; break }
+    if (!conform(S[i], T[i])) {
+      ndiff++
+      if (ndiff <= 5) {
+        printf "FAIL 15 -- line %d differs from the pinned skeleton\n", i
+        printf "           skeleton: %s\n", S[i]
+        printf "           block:    %s\n", T[i]
+      }
+      bad = 1
+    }
+  }
+  if (ndiff > 5) printf "FAIL 15 -- (+%d further differing lines suppressed; %d differ in total)\n", ndiff - 5, ndiff
+  if (bad) rc = 1
+  else print "PASS 15 -- block is the pinned skeleton, byte-exact modulo slots"
+
+  nb = 0
+  for (k = 1; k <= nslot; k++)
+    if (!wellformed(sname[k], sval[k])) {
+      printf "FAIL 16 -- slot %s = %s is not well-formed (grammar %s)\n", \
+        sname[k], (sval[k] == "" ? "<empty>" : "'" sval[k] "'"), grammar(sname[k])
+      nb = 1; rc = 1
+    }
+  if (nslot != NSLOT && !bad) { printf "FAIL 16 -- expected %d slots, matched %d\n", NSLOT, nslot; nb = 1; rc = 1 }
+  if (!nb && !bad) printf "PASS 16 -- all %d slots well-formed\n", nslot
+
+  # ---- items 18 + 19 need well-formed slots to mean anything ----
+  if (bad || nb) { print "SKIP 18 -- not attempted: the block is not a well-formed filled skeleton"
+                   print "SKIP 19 -- not attempted: the block is not a well-formed filled skeleton"; exit rc }
+
+  # ---- item 18(a): RE-DERIVATION against the committed artifacts ----
+  # THE PINNED REQUIRED SET. These ELEVEN slots are re-derivable from committed artifacts, and the set
+  # is enumerated HERE, BY NAME, so coverage is a MEASUREMENT and not a count. A truth file omitting any
+  # of them leaves that slot UNGRADED -- the hole Audit v11 C2 measured, where ONE irrelevant slot
+  # bought `PASS 18 -- all 1 re-derivable slots reproduce` on a transposition forgery.
+  # `R51_RESULT` / `R52_RESULT` JOINED THE SET at the round that closed Audit v13 C2: the two enum
+  # slots that DECIDE THE LICENCE were the last pair outside it, on artifacts that need not be forged
+  # at all for the block to contradict them.
+  nreq = split("S_EARLY S_LATE EXIT_SHARE_PCT MEDIAN_L_OVER_B R51_SD R51_MEAN R51_RESULT R52_SD R52_MEAN R52_RESULT N6_COST_CELLS", REQ, " ")
+  nt18 = 0
+  if (ev != "" && truth != "") {
+    red18("both `ev=` and `truth=` were supplied: there is exactly ONE source of truth, and choosing between two is the degree of freedom this item exists to remove")
+  } else if (ev != "") {
+    # (2) CHARSET GUARD, evaluated BEFORE anything is executed: an `ev` carrying a shell metacharacter
+    # is a command, not an evidence directory, and Audit v12 C2 executed one.
+    if (ev ~ /[^A-Za-z0-9._\/-]/) {
+      red18(sprintf("`ev=%s` is not a plain path: it carries a character outside [A-Za-z0-9._/-] and would be interpolated into a shell command. REFUSED before execution.", ev))
+    } else {
+      # (1) DIGEST GATE, also BEFORE execution: verify the driver is THE driver this spec pins.
+      dcmd = "shasum -a 256 slottruth.sh 2>/dev/null | awk '{print $1}'"
+      dsha = ""; dcmd | getline dsha; close(dcmd)
+      if (dsha != DRIVER_SHA256) {
+        red18(sprintf("slottruth.sh in $PWD is NOT the pinned driver: sha256 %s != DRIVER_SHA256 %s. The re-derivation was NOT run. Extract the driver from this spec's own bytes (checklist 18) before grading.", \
+              (dsha == "" ? "<absent/unreadable>" : dsha), DRIVER_SHA256))
+      } else {
+        print "MODE   -- item 18/19 truth: RE-DERIVED BY THIS RUN from " ev " (sh slottruth.sh '" ev "')"
+        print "MODE   -- driver sha256 " dsha " == DRIVER_SHA256 (verified BEFORE execution)"
+        cmd = "sh slottruth.sh '" ev "'; echo SLOTTRUTH_EXIT $?"
+        dst = -1
+        while ((cmd | getline ln) > 0) {
+          if (ln ~ /^SLOTTRUTH_EXIT /) { split(ln, z, " "); dst = z[2] + 0; continue }
+          take(ln)
+        }
+        # THE STATUS IS READ. A REFUSAL AND A COVERAGE HOLE ARE DIFFERENT FACTS (Audit v12 rec 5).
+        close(cmd)
+        if (dst != 0)
+          red18(sprintf("the re-derivation driver EXITED %d -- it REFUSED to derive (its `SLOTTRUTH FAIL:` line is on stderr). This is a REFUSAL, not a coverage hole: nothing was re-derived, and the MISSING list below is a CONSEQUENCE of the refusal, not an independent finding.", dst))
+      }
+    }
+  } else if (truth != "") {
+    print "MODE   -- item 18/19 truth: FIXTURE (`truth=" truth "`) -- PROVENANCE NOT ESTABLISHED, not admissible for a real §9"
+    while ((getline ln < truth) > 0) take(ln)
+    close(truth)
+  }
+  nmiss = 0; miss = ""
+  for (q = 1; q <= nreq; q++)
+    if (!(REQ[q] in TR)) { miss = miss (nmiss++ ? ", " : "") REQ[q] }
+  # `nosubject=1` is the ONE vacuous path, and it is an ASSERTION: the cell has not run, so no committed
+  # artifact exists to re-derive FROM. It requires the truth file to be absent ENTIRELY -- a partially
+  # derived cell is an INCOMPLETE derivation, never a missing subject.
+  nosub = (truth == "" && ev == "" && nosubject + 0 == 1 && nmiss == nreq)
+  # THE ASSERTION IS FAIL-CLOSED. A cell that has not run cannot have published a classification, so
+  # `nosubject=1` beside any leaf but INDETERMINATE is a self-contradiction and REDs (cross-vendor round:
+  # an unchecked assertion is an escape hatch an executor can take AFTER seeing a disfavourable leaf).
+  if (nosub && has("STEP_LEAF") && SV("STEP_LEAF") != "INDETERMINATE") {
+    red18(sprintf("`-v nosubject=1` asserts the cell has NOT RUN, but the block publishes STEP_LEAF = '%s': a cell that has not run cannot have read a classification off any run", SV("STEP_LEAF")))
+    nosub = 0; contra = 1
+  }
+  if (truth == "" && ev == "" && !nosub && !contra)
+    red18("NO source of truth supplied (`ev=` absent, `truth=` absent) and `-v nosubject=1` was not asserted: all " nreq " re-derivable slots are UNGRADED. There is no vacuous pass here -- re-derive, or assert the cell has not run.")
+  else if (!nosub && nmiss > 0)
+    red18(sprintf("truth file is INCOMPLETE -- %d of %d re-derivable slots are MISSING and therefore UNGRADED: %s", \
+          nmiss, nreq, miss))
+
+  # ---- item 18(b): cross-slot arithmetic (independent of the truth file) ----
+  if (has("S_RATIO") && has("S_EARLY") && has("S_LATE")) {
+    if (V("S_EARLY") == 0) red18("S_EARLY = 0: S_RATIO is undefined and the Steps 3/4 floor is unreadable")
+    else if (!agree(V("S_RATIO"), V("S_LATE") / V("S_EARLY")))
+      red18(sprintf("S_RATIO = %s CONTRADICTS its own published slopes: S_LATE/S_EARLY = %.6f", \
+            SV("S_RATIO"), V("S_LATE") / V("S_EARLY")))
+  }
+  for (r = 1; r <= 2; r++) {
+    p = "R5" r
+    if (has(p "_MDE_PCT") && has(p "_SD") && has(p "_MEAN")) {
+      if (V(p "_MEAN") == 0) red18(sprintf("%s_MEAN = 0: the MDE percentage is undefined", p))
+      else {
+        want = 4.303 * V(p "_SD") / V(p "_MEAN") * 100
+        if (!agree(V(p "_MDE_PCT"), want))
+          red18(sprintf("%s_MDE_PCT = %s CONTRADICTS manifest §1.1's formula 4.303*sd/mean*100 = %.6f", \
+                p, SV(p "_MDE_PCT"), want))
+      }
+    }
+  }
+  if (has("N6_COST_H") && has("N6_COST_CELLS")) {
+    want = V("N6_COST_CELLS") * 1800 / 3600
+    if (!agree(V("N6_COST_H"), want))
+      red18(sprintf("N6_COST_H = %s CONTRADICTS its own cell count: %s x 1800 s = %.6f h (ADJ-10)", \
+            SV("N6_COST_H"), SV("N6_COST_CELLS"), want))
+  }
+
+  # ---- item 18(c): ranges ----
+  split("EXIT_SHARE_PCT R51_MDE_PCT R52_MDE_PCT", pc, " ")
+  for (i = 1; i <= 3; i++)
+    if (has(pc[i]) && (V(pc[i]) < 0 || V(pc[i]) > 100))
+      red18(sprintf("%s = %s is not a percentage in [0,100]", pc[i], SV(pc[i])))
+  split("S_EARLY S_LATE S_RATIO MEDIAN_L_OVER_B R51_SD R52_SD R51_MEAN R52_MEAN N6_COST_CELLS N6_COST_H", nn, " ")
+  for (i = 1; i <= 10; i++)
+    if (has(nn[i]) && V(nn[i]) < 0)
+      red18(sprintf("%s = %s is negative, which none of these quantities can be", nn[i], SV(nn[i])))
+
+  if (nosub && !bad18) print "NO SUBJECT 18 -- the cell has NOT RUN (`-v nosubject=1`; no committed artifact exists to re-derive from): re-derivation has no subject (arithmetic and range limbs PASSED)"
+  else if (!bad18)     printf "PASS 18 -- all %d re-derivable slots reproduce the committed artifacts; arithmetic and ranges agree\n", nt18
+
+  # ---- item 19(a): the R5.4 2x2 LICENCE, a pure function of two published enum slots ----
+  lic = "OK"
+  if (has("R51_RESULT") && has("R52_RESULT")) lic = licof(SV("R51_RESULT"), SV("R52_RESULT"))
+  if (lic != "OK" && has("STEP_LEAF") && SV("STEP_LEAF") != "INDETERMINATE")
+    red19(sprintf("R5.4 cell is %s -- no classification number may be read off any run -- but STEP_LEAF publishes '%s'", \
+          lic, SV("STEP_LEAF")))
+
+  # ---- item 19(a-ii): THE LICENCE ITSELF IS RE-DERIVED, WHICH CLOSES THE OTHER DIRECTION ----
+  # (a) above grades only the DECLINING direction: a PUBLISHED rejection forces INDETERMINATE. The
+  # direction that LAUNDERS -- a control that REJECTED, published as `NOT REJECTED`, buying the right
+  # to publish a classification AT ALL -- was graded by nothing, because these two slots sat outside
+  # the re-derivation set while R5.7(g) stated the re-derivation principle as universal. Nothing here
+  # is forged in the fixture that found it: every other slot agrees, the matrix triples, the coordinate
+  # limbs, the epoch limbs and the slice `cmp` are all intact, and the ONE un-re-derived byte was the
+  # control's verdict. The two licences are now compared AS LICENCES, by the same pure function.
+  if (("R51_RESULT" in TR) && ("R52_RESULT" in TR)) {
+    licd = licof(TR["R51_RESULT"], TR["R52_RESULT"])
+    if (licd != lic)
+      red19(sprintf("the PUBLISHED R5.4 licence is %s (from R51_RESULT '%s' / R52_RESULT '%s') but the licence RE-DERIVED from the committed control CSVs is %s (from '%s' / '%s'). The licence decides whether ANY classification number may be read off ANY run, so it is graded in BOTH directions: publishing a rejection the controls do not show DECLINES a classification the evidence permits, and publishing NOT REJECTED where the controls REJECT LAUNDERS the right to classify at all.", \
+            lic, SV("R51_RESULT"), SV("R52_RESULT"), licd, TR["R51_RESULT"], TR["R52_RESULT"]))
+  }
+
+  # ---- item 19(b): the published leaf vs the FROZEN predicate on the RE-DERIVED values ----
+  # THERE IS NO FALLBACK TO THE PUBLISHED SLOTS. Deleted at Audit v11 C2: grading the block against
+  # itself certifies any internally-consistent forgery, and `src` printed "re-derived" while doing
+  # exactly that. Either ALL FOUR predicate inputs are re-derived, or this limb REDs.
+  na19 = 0
+  if (has("STEP_LEAF") && SV("STEP_LEAF") == "INDETERMINATE") {
+    print "NOTE   -- STEP_LEAF is INDETERMINATE: item 19(b) is NOT APPLICABLE (Step 0/5 admissibility is decided"
+    print "          upstream of these slots). This is the SAFE direction: INDETERMINATE reads no classification"
+    print "          number, so it cannot launder one. Recorded as this limb's measured residual."
+    na19 = 1
+  } else if (nosub) {
+    na19 = 2
+  } else {
+    nmp = 0; mp = ""
+    split("EXIT_SHARE_PCT MEDIAN_L_OVER_B S_EARLY S_LATE", PRD, " ")
+    for (q = 1; q <= 4; q++) if (!(PRD[q] in TR)) mp = mp (nmp++ ? ", " : "") PRD[q]
+    if (nmp > 0)
+      red19(sprintf("cannot reconcile -- truth incomplete: the frozen predicate's input(s) %s were NOT re-derived, and there is NO fallback to the published slots (grading them against themselves certifies any internally-consistent forgery)", mp))
+    else {
+      src = "re-derived"                        # all four inputs are in TR, or we did not reach here
+      e = TR["EXIT_SHARE_PCT"]; b = TR["MEDIAN_L_OVER_B"]; se = TR["S_EARLY"]; sl = TR["S_LATE"]
+      want = leafof(e, b, se, sl)
+      if (SV("STEP_LEAF") != want)
+        red19(sprintf("PUBLISHED leaf '%s' != the leaf the frozen R8.1 predicate implies from the %s values: '%s'\n           (exit share %s %%, median(L)/B %s, s_early %s, s_late %s)", \
+              SV("STEP_LEAF"), src, want, e "", b "", se "", sl ""))
+    }
+  }
+  # A GREEN LINE MUST MEAN WHAT IT SAYS. `PASS 19` asserts a comparison; where none was performed the
+  # verdict is NOT APPLICABLE or NO SUBJECT, never PASS (Audit v11 rec 3).
+  # `FAIL 18` AND `PASS 19` MAY NOT CO-PRINT (Audit v12 rec 6). Item 19 reads item 18's own inputs, so
+  # a green 19 beside a red 18 is a verdict issued over a re-derivation that did not stand. It is not
+  # downgraded to a NOTE and it is not promoted to a second FAIL -- it is WITHHELD, which is the honest
+  # third thing: no comparison is being certified, and item 18's RED is the reason.
+  if (bad19) { }
+  else if (bad18) print "WITHHELD 19 -- item 18 is RED, so no PASS is issued here: the leaf comparison rests on the same re-derivation item 18 just rejected. Fix 18, then re-run."
+  else if (na19 == 1) print "NOT APPLICABLE 19 -- STEP_LEAF is INDETERMINATE: the frozen predicate has nothing to reconcile, and NO comparison was performed"
+  else if (na19 == 2) print "NO SUBJECT 19 -- the cell has NOT RUN: there are no re-derived values to reconcile the published leaf against"
+  else print "PASS 19 -- the published leaf is the leaf the frozen predicate implies, and the R5.4 licence permits it"
+  exit rc
+}


### PR DESCRIPTION
## Summary

Closes Response v15's four STOP residuals **as a class** (TODO-639..642) and lands the accepted sidecar remedy. One PRE-DATA §8A append + runner terminal block + three extracted evidence files. Zero `.rs`.

- **The class:** all four residuals are edits to one column/region of a committed artifact that per-column guards don't bind. The ledger has 43 columns; a per-column arms race does not converge. ADJ-18 clause 4 already named the correct defense layer — run provenance — but nothing implemented it.
- **ADJ-20:** the runner's terminal act digests every artifact it produced into `${BASE}.artifacts.sha256` (basenames — survives the scratch-to-evidence copy); graders verify provenance BEFORE any content check; mismatch = PROVENANCE failure, distinct from content dispositions. A single-column edit now requires forging a coherent digest set — exactly the coherent-forgery case clause 4 excludes. Per-column guards keep their honest-mistake role unweakened.
- **Sidecars (accepted rec 6, ~9 width points):** `spec356-tmplconf.awk`, `spec356-slottruth.sh`, `spec356-skeleton.txt` extracted from the spec's own bytes by its own marker commands, digest-verified against its own pins (`280f7a34…`/`7c14b900…`/`bfaac337…` — all matched). Committed file = canonical copy; digests unchanged by the move.
- **Proven by execution:** fresh smoke run — 6 artifacts digested, independent `shasum -c` all OK, instrument sound, exit 0.

Freeze: §0–§8 byte-identical; §8A append-only (42/0); PRE-DATA holds; invariants green.

## Test plan
- [x] `bash -n` runner; fresh smoke exit 0 with digest emission verified independently
- [x] Sidecar digests match the spec's pinned values byte-for-byte
- [x] §0–§8 `cmp` clean; `check-invariants.sh` exit 0