### PR TITLE
feat(sf-358): PD-F12 micro-diagnosis — V0 earned negative, the diagnosis line hard-stops

### DIFF
--- a/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
@@ -8156,10 +8156,19 @@ after this one.** The `ReclamationRegistry` family (`TODO-634`) starts with the 
 §12.0 pre-authorizes exactly this: *"if the data suggests one, it is recorded as a
 POST-DATA finding and routed, and the table's own verdict still stands."* The
 cross-vendor adversarial round (`spec358-mechanism-xask.md`) recommended a static audit
-of `publish_epoch_exit` call sites; the audit was run and produced the following four
-POST-DATA findings, all reached by source-code audit outside `D5`'s frozen universe —
-none is a row-1 violation reached by execution inside that universe, and none changes
-§12.1.c's verdict.
+of `publish_epoch_exit` call sites; the audit was run and produced **PD-F15 through
+PD-F18**, all four reached by source-code audit outside `D5`'s frozen universe.
+**PD-F19 and PD-F20 were added later, by review rather than by that audit, and their
+provenance differs:** PD-F19 was a Review-v1 reading reached by argument, and PD-F20 is
+the Review-v2 finding that RETRACTS it — PD-F20's evidence is an **executed mutation**,
+not a source-code reading. So the umbrella over this list is provenance-mixed by
+construction, and each entry states its own basis; do not read "reached by source-code
+audit" as covering the last two.
+
+What still holds over all six: none is a row-1 violation reached by execution inside
+`D5`'s frozen universe — PD-F20's mutations flip a row only in a deliberately MUTATED
+subject, which is what makes them a liveness proof of the instrument rather than an
+observation about the unmutated system — and none changes §12.1.c's verdict.
 
 - **POST-DATA — PD-F15** — the mechanism is code-identifiable, and it is row 1's named
   extreme case. `drain_prunable`'s `drained_epochs.insert(e)` sits inside `if let

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
@@ -8132,7 +8132,7 @@ resolved V0 → **E-C FIRES → the diagnosis line HARD STOPS. There is no diagn
 after this one.** The `ReclamationRegistry` family (`TODO-634`) starts with the cause
 **unclassified**, justified by §8.3 above, quoted verbatim.
 
-### §12.1.f — POST-DATA findings PD-F15–PD-F18 (recorded and ROUTED to `TODO-634`; they do NOT alter the verdict)
+### §12.1.f — POST-DATA findings PD-F15–PD-F19 (recorded and ROUTED to `TODO-634`; they do NOT alter the verdict)
 
 §12.0 pre-authorizes exactly this: *"if the data suggests one, it is recorded as a
 POST-DATA finding and routed, and the table's own verdict still stands."* The
@@ -8185,6 +8185,32 @@ none is a row-1 violation reached by execution inside that universe, and none ch
   true, epochs_drained = 0`. This would place a row in D-T row 1's universe **if** such
   a drive were inside a frozen universe — it is NOT in this round's, which is why it is
   routed rather than run. **ROUTED to `TODO-634`.**
+
+- **POST-DATA — PD-F19** — **D-T row 2, like row 1, was unfireable over `D5` by
+  construction, so `V0`'s evidentiary weight rests on row 3 alone.** Surfaced by Review v1,
+  after the verdict, by reading the drive rather than the data. `D5` seeds every key
+  PRESENT with its own tombstone tag (`sim/tombstone_gc_proof.rs:1216`,
+  `seed_or_map(&factory, map, &key, &[], &[tag.as_str()])`) and then stamps that same tag,
+  so at drain the ref takes `crdt.rs`'s `Ok(_)` arm with `dropped == true`: the epoch
+  record is credited `dropped += 1` and `bytes_freed += tag.len()`, and `tag.len() > 0` for
+  every `D5TAG{i}`. Every epoch `D5` can produce therefore settles with `D_e ≥ 1 ∧ F_e > 0`.
+  Row 2's condition is `R_obs > 0 ∧ D_e == 0 ∧ F_e == 0 ∧ B_att > 0`, so it is FALSE over
+  `D5` **by construction** — derivable from the source before the run, exactly as row 1's
+  extreme case is (PD-F15). §12.0 nevertheless states *"Consequently rows 2 and 3 are not
+  readable off the source before the run over the universes they range on"* (`:7863`), and
+  §12.1.c together with `spec358-fixshape-ruling.md` qualify only row 1. That asymmetry is
+  the finding: the round applied its own honesty discipline to one row and not the other.
+  The consequence is evidentiary, not cosmetic — over `D5` **only row 3 was ever live**, so
+  the published `V0` means *"the one live row did not fire"*, not *"three independent
+  readings were tested and none fired"*. The `ReclamationRegistry` family (`TODO-634`),
+  which §12.1.e starts cause-unclassified, inherits `V0` as its premise and must inherit it
+  at its true weight. What does NOT change: the verdict. `V0`'s definition is *"none of rows
+  1–3 holds over its own universe"*, and a row that cannot hold by construction does not
+  hold — the table's mechanical reading is unaffected, §12.0 stays byte-frozen, and no
+  determination is reopened. The obligation this creates is on the NEXT round, not this one:
+  a drive whose construction can place a row in row 2's universe (the analogue of PD-F18 for
+  row 1) is what would give row 2 evidentiary weight, and per X8 this round may not widen the
+  frozen universe to supply it. **ROUTED to `TODO-634`.**
 
 ### §12.1.g — R6.3 / AC11 digest confirmation
 

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
@@ -7687,3 +7687,352 @@ non-replication evidence, and X1/X2/X6's successor-predicate design inputs.
 **content** in both directions by `spec357-trackergrade.sh`.
 
 **Cell E's disposition is `DEFERRED-PENDING-DIAGNOSIS`** (§11.13) — taken, not un-taken.
+
+---
+
+## §12 — SPEC-358: the PD-F12 micro-diagnosis (frozen predicate, then the executed record)
+
+**This heading and everything beneath it is APPENDED — no byte of §0–§11 is touched by it.**
+`grep -c '^## §12'` is **1** in this file from this commit forward. §12.0 below is the **PRE-DATA
+FREEZE**: it is committed **before** any leg of Step 0 has been run and **before** any verdict
+exists. Once committed, §12.0 MUST NOT be edited — not a threshold, not an ordering, not a
+conditional (X11, X13, K4). §12.1+, appended strictly beneath §12.0 by a later group, carries the
+executed record; nothing in §12.0 anticipates it.
+
+### §12.0 — THE PRE-DATA FREEZE
+
+#### Definitions
+
+Symbols are defined per exit row / per epoch / per pass. They carry no universe of their own —
+every quantifier that ranges over drives is written on the Decision Table row that uses it, never
+here.
+
+| Symbol | Definition | Side |
+|---|---|---|
+| `R_obs` | `removed_refs_observed` — `refs.len()` of the vector `epoch_tags.remove(&e)` returned | OBSERVATION (index) |
+| `B_obs` | `removed_bytes_observed` — `Σ tag.len()` over that same vector | OBSERVATION (index) |
+| `R_ent` | `refs_at_entry` | ATTRIBUTION (by construction) |
+| `B_att` | `bytes_freed_attributed` (`:= slot.stamped_bytes`) | ATTRIBUTION (by construction) |
+| `B_restored(e)` | the byte total the DRIVER itself restored into `e` via `restore_tombstone_ref` — a driver-side quantity, `0` on a restore-free drive | driver bookkeeping |
+| `C_e` | settlement `considered` for epoch `e` | OBSERVATION (store side) |
+| `D_e` | settlement `dropped` for epoch `e` | OBSERVATION (store side) |
+| `F_e` | settlement `bytes_freed` for epoch `e` | OBSERVATION (store side) |
+| `E_p` | the pass's `empty_drain` flag | pass ledger |
+| `K_p` | the pass's `considered` | pass ledger |
+
+**Transport of the pass-ledger symbols (NORMATIVE, frozen with the rest).** `K_p` and `E_p` are
+read from the **pass row** — the `kind = "prune_pass"` emission on
+`topgun_server::tombstone_frontier::residency` emitted beside `observe_pass`
+(`crdt.rs:1696`) — and from **nothing else**. They are NOT read from the Prometheus mirror: the
+counter handles are bound at `TombstoneFrontier::new` (`:1210-1213`) via `touched_counter`
+(`:2226`), called from `MetricsPruneRecorder::new()` (`:2341`), and the sim's frontier is built
+outside any `with_local_recorder` binding, so those handles are permanent no-ops in-process. The
+pass row fires once per invocation, empty drains included, so it is also what **individuates a
+pass** on the capture.
+
+#### `S1` — the pre-freeze sanity row (executed, pasted in BEFORE the freeze)
+
+`S1` is executed and pasted in before this section is frozen because a discriminator nobody has
+shown to discriminate carries no evidentiary weight. `S1` is the instrument's sanity check — proof
+the two terms `R_obs` and `R_ent` CAN disagree at all, constructed entirely through public entry
+points on the `frontier()` fixture of `tombstone_frontier_impl.rs`'s inline tests — not a claim
+about the phenomenon PD-F12 raised.
+
+Construction, every step through a public entry point (bar the `#[cfg(test)]` watermark injector
+at step 7, which the whole file already uses):
+
+| # | Call | Site | Effect |
+|---|---|---|---|
+| 1 | `f.set_epoch_width(1)` | `:1937` | one epoch per stamp |
+| 2 | `f.stamp_tombstone("m", "k1", "TAG1")` | `:1698` | epoch 1 holds 1 ref; slot created |
+| 3 | `f.stamp_tombstone("m", "k2", "TAG2")` | `:1698` | rolls past epoch 1 → entry row fires; `slot.refs_at_entry = 1`, `entry_emitted = true` |
+| 4 | `f.restore_tombstone_ref(1, TombstoneRef { map, key, tag: "TAGX" })` | `:1923` | `epoch_tags[1]` now holds **2** refs; `epoch_slots[1]` is **untouched** |
+| 5 | `f.set_delivered(CONN_A, 100)` | `:1425` | **REQUIRED PREREQUISITE.** `advance_on_ack` clamps by `delivered.unwrap_or(0)`; with no prior `set_delivered` the bound is 0, the cursor advance returns `None`, and step 8 drains nothing |
+| 6 | `block_on(f.confirm_apply_ack(&c, 2, CONN_A))` | `:1464` | bound = `min(claimed 2, delivered 100, current_max_epoch 2) = 2`; LWM 2 > 1 → epoch 1 prune-eligible |
+| 7 | `f.set_durable_epoch_watermark(1)` | `:1839` (`#[cfg(test)]`) | second call-site conjunct satisfied |
+| 8 | `f.drain_prunable_tombstones()` | `:1870` | `epoch_tags.remove(&1)` returns 2 refs → the pass publishes one `DrainedByPrune` exit row through `publish_epoch_exit` |
+
+**How step 8's row is observed (normative, and deliberately not a returned record).**
+`drain_prunable_tombstones` returns `Vec<(Epoch, TombstoneRef)>` and no record — it consumes its
+exits internally through `publish_epoch_exit`. So `S1` reads the exit row off the **declared
+`tracing` capture** (the `:1301` emission on the `residency` target), with a thread-local capture
+layer of the `network/device_identity.rs:397-429` shape sited in this file's own inline tests. The
+returned `Vec` is asserted separately and only as a count check (`len() == 2`).
+
+**The recorded row MUST show `R_obs == 2` against `R_ent == 1` (and `B_obs == B_att +
+len("TAGX")`).** That is `R_obs != R_ent` on a genuine `DrainedByPrune` exit row constructed
+entirely through public entry points — the divergence-reachability demonstration Step 0 leg (b) is
+inadmissible without.
+
+**Executed row, pasted verbatim:**
+
+```
+target=topgun_server::tombstone_frontier::residency message=prune epoch exit kind=epoch_exit epoch=1 refs_at_entry=1 refs_at_exit=0 stamped_bytes=4 bytes_freed_attributed=4 exit_kind=DrainedByPrune entered_at_op_seq=1 entered_at_unix_ms=1786797138477 exited_at_op_seq=2 lwm_passed_at_op_seq=Some(2) fence_passed_at_op_seq=Some(2) lwm_at_exit=2 durable_watermark_at_exit=1 current_epoch_at_exit=2 removed_refs_observed=2 removed_bytes_observed=8
+```
+
+This row shows `refs_at_entry=1` (`R_ent = 1`) against `removed_refs_observed=2` (`R_obs = 2`), so
+`R_obs == R_ent + 1` holds; and `bytes_freed_attributed=4` (`B_att = 4`) against
+`removed_bytes_observed=8` (`B_obs = 8`), so `B_obs == B_att + len("TAGX")` holds (`len("TAGX")
+== 4`). The row was reached entirely through public entry points and observed on the captured
+residency emission; the returned `Vec` was asserted separately as `len() == 2`. `S1` diverges.
+
+**If `S1` had not diverged, the increment would have STOPPED at G5** and been surfaced to the user
+with the evidence, with no boundary crossed and E-C not firing. `S1` diverged, so this freeze
+proceeds.
+
+#### Step 0 — instrument identity, fail-closed, evaluated first
+
+Three legs, all required:
+
+- **leg (a) UNMUTATED** — `cargo test --release -p topgun-server --lib` and `pnpm test:sim` pass
+  at the executed tip, and this section carries the executed `S1` row (above).
+- **leg (b) MUTATED** — with `spec358-mutation-arm.patch` applied (`removed_refs_observed :=
+  slot.refs_at_entry`, `removed_bytes_observed := slot.stamped_bytes`), **both** the `S1` test
+  (lib) and drive `D1` (sim) must **FAIL**, and the failure must name the discriminating assertion
+  `R_obs == R_ent + 1`.
+- **leg (c) POSITIVE CONTROL for the V1 limb** — at `tombstone_frontier_impl.rs`'s inline-test
+  site, plant `epoch_tags.insert(e, Vec::new())` over an entry-emitted, still-tracked slot (the
+  same in-module bypass the tree already uses), then drain **in-module** via
+  `f.lock().drain_prunable()`: the `DrainedByPrune` record MUST carry `R_obs == 0` and
+  `R_ent > 0`. Leg (c) is X21-a's proof (the returned-record transport); `S1` is X21-b's. **Leg
+  (c)'s rows are EXCLUDED from every Decision Table universe** by the frozen scoping below, so the
+  control can never decide the verdict.
+
+If any leg does not hold **after** the freeze, the determination is `INDETERMINATE-INSTRUMENT`,
+Steps 1–3 are recorded `NOT EVALUATED`, and E-C fires.
+
+#### Step 1 — the bridge identity
+
+Evaluated **per pass**, over the passes of the Decision Table universe drive (`D5`); recorded as
+values for every other drive that can observe them.
+
+- **I1**: `Σ_e R_obs(e) == K_p`, both read from the SAME pass — the `R_obs` terms off that pass's
+  exit rows, `K_p` off that pass's pass row. Both on the ONE `tracing` transport.
+- **I2**: `E_p == (Σ_e R_obs(e) == 0)`, with `E_p` read off the same pass row. `E_p` is
+  `drained.is_empty()` and `Σ_e R_obs(e)` is the length of the vector `drained` was extended from,
+  so I2 is a genuine identity between two separately emitted quantities, not a tautology across
+  one.
+- **I3**: `B_obs(e) ≤ B_att(e) + B_restored(e)` per drained epoch. The unqualified form
+  `Σ B_obs ≤ Σ B_att` is FALSE and is not used: `restore_tombstone_ref` accepts an arbitrary epoch
+  and credits no `stamped_bytes`, so a restored ref makes `B_obs > B_att` legitimately — and Step
+  0 leg (b)'s own discriminator IS a restore. The `B_restored(e)` term is what makes I3 meaningful
+  in the presence of that site.
+
+**Pass individuation (frozen).** A pass is delimited by its pass row: exactly one is emitted per
+`prune_epoch_tombstones` invocation, on every path, empty drains included, and it is emitted
+**last**: the exit rows fire during the drain and the settlement rows in the `per_epoch.values()`
+loop, both before `observe_pass`. A pass is therefore the rows captured **between the previous
+pass row and its own pass row**.
+
+**Scoping (frozen).** On a pass in which any `restored_*` exit fired, I1 / I2 / I3 are recorded
+**NOT-APPLICABLE** with the pass captured verbatim: a prune-loop restore re-enters refs into an
+already-exited epoch, whose next drain emits no exit row at all, so a violation there is that
+site's derived shape, not a finding.
+
+Each identity's value is recorded per pass. A violation on an in-scope pass is a **result**, not a
+test defect: it is recorded with the offending pass captured verbatim and carried into Step 2.
+
+#### Step 2 — the Decision Table (D-T)
+
+Evaluated in this order; the FIRST row whose condition holds **over its own universe** is the
+verdict. Exactly one verdict is published.
+
+Every row carries its own universe. No row's quantifier ranges over another row's evidence, and no
+row contains a universal clause that can block a later row.
+
+| # | Verdict | Universe (FROZEN) | Condition | Reading named |
+|---|---|---|---|---|
+| 1 | **V1 — REF-LOSS** | every `DrainedByPrune` exit row recorded by `D5` | ∃ a row with `R_obs < R_ent` (`R_obs == 0 ∧ R_ent > 0` is its extreme case) | **(i)** a genuine ref-loss path: part or all of the epoch's content left the index without the drain removing it, and the exit ledger attributed its whole entry-side content as freed. The prune is **NOT** removing those refs. |
+| 2 | **V2 — BOOKKEEPING ATTRIBUTION** | every drained epoch recorded by `D5`, under precondition P-KEYS | ∃ an epoch with `R_obs > 0` **and** `D_e == 0` **and** `F_e == 0` **and** `B_att > 0` | **(ii)** the exit attribution is bookkeeping, not an observation of reclamation: the index removal is real, the store frees nothing, and `bytes_freed_attributed` describes an index event. |
+| 3 | **V3 — COUNTER-FAMILY MISNAMING** | every prune pass driven by `D5` on which no `restored_*` exit fired | I1 or I2 is VIOLATED on at least one such pass | **(iii)** one of the two counter families does not describe what its name says: the pass ledger's `considered` / `empty_drain` do not track the drain's own removals. The named family is recorded with the offending pass. |
+| 4 | **V0 — NOT REPRODUCED** | — | none of rows 1–3 holds over its own universe | No reading is named. The contradiction is not reachable by the frozen drive set. E-C fires. |
+
+**P-KEYS (precondition, recorded as a VALUE, not assumed).** Every ref `D5` actually drains has
+its key present in the store at drain time, so a store-side zero cannot be manufactured by the
+fixture. If P-KEYS fails on any considered ref, `D5` REDs the round rather than resolving row 2.
+
+**Universe scoping (FROZEN, with the reason each exclusion exists).** `D1 … D4` and Step 0 leg (c)
+are RECORDED in full but lie OUTSIDE every row's universe:
+
+| Excluded | Why — stated before the run, never after |
+|---|---|
+| `D1` | restores by design, so `R_obs > R_ent` there is the instrument's own discriminator, not evidence about the prune |
+| `D2` | produces row 3's signature by construction |
+| `D3` | produces row 2's signature by construction |
+| `D4` | its rows are not observable at all at row granularity: both in-process transports are thread-local and its prune runs in a spawned task on a `multi_thread` runtime |
+| Step 0 leg (c) | produces row 1's signature by planting it |
+
+Consequently rows 2 and 3 are not readable off the source before the run over the universes they
+range on. What `D1 … D4` contribute is CONFIRMATION (or refutation, which would itself be a
+POST-DATA finding) of the facts they were derived from and of the aggregate conservation identity.
+
+**Row 1 is the stated exception, recorded as a FACT of this design rather than as an experimental
+claim.** Over `D5` — a public-API-only drive — row 1 fires only if the mutation-site enumeration
+that fixes the four `epoch_tags` mutation sites is incomplete, which is reading (i) itself
+(`R_obs < R_ent` is not constructible through the public API given that enumeration). Its
+non-firing is therefore an **informative negative about the enumeration**, not a null result, and
+this round claims nothing stronger for it. This is why the limb is kept live by an execution —
+Step 0 leg (c) proves the predicate fires when its antecedent exists — while leg (c)'s own rows
+stay outside every universe.
+
+**No row may be added, reordered, re-thresholded or re-scoped after this section is committed** —
+the universe column is frozen with the rest (X17). A reading not on this table cannot be published
+as this round's verdict; if the data suggests one, it is recorded as a POST-DATA finding and
+routed, and the table's own verdict still stands.
+
+#### The frozen drive set `D1 … D5`
+
+Each drive records `REPRODUCED` / `NOT-REPRODUCED` plus the evaluated value of its own predicate.
+All are in-process and deterministic (no wall clock, no sleep-based synchronisation, no soak).
+
+| Drive | Site / runtime / transport | What it drives | Its OWN predicate (recorded as a VALUE) | In a D-T universe |
+|---|---|---|---|---|
+| `D1` **DIVERGENCE** | sim; `#[tokio::test]` (current-thread); `tracing` capture | stamp ×N into `e` → one more stamp to roll over → `restore_tombstone_ref(e, extra)` → tracked cursor past `e` + `set_durable_epoch_watermark` → `prune_epoch_tombstones` | `R_obs == R_ent + 1` **and** `B_obs == B_att + len(extra.tag)` on `e`'s `DrainedByPrune` exit row | NO — Step-0 discriminator; the sim-side twin of `S1` |
+| `D2` **POST-EXIT RESTORE** | sim; current-thread; `tracing` capture | drain (exit row fires, slot retired) → `restore_tombstone_ref` into that exited epoch → re-drain | the second drain removes `k > 0` refs and emits no exit row for `e`: `Σ_e R_obs == 0` while `pass.considered == k` | NO |
+| `D3` **ABSENT-KEY** | sim; current-thread; `tracing` capture | stamp tombstones for keys never written to the store → drain → every ref takes the `Ok(None)` arm | per-epoch `D_e == 0 ∧ F_e == 0` while `B_att > 0` | NO |
+| `D4` **TOCTOU RACE** | sim; `#[tokio::test(flavor = "multi_thread")]`; `N = 64`; `epoch_width = 1`; the fixture already in the file | interleaved push / prune under the shared per-key writer | the AGGREGATE terms `index_conservation_snapshot()` exposes: exactly one attributed drain, exactly one exit row, the conservation invariant holds | NO — per-row terms unobservable here |
+| `D5` **SEQUENTIAL REGIME** | sim; current-thread; `tracing` capture — exit rows, settlement rows and pass rows, all three on the ONE transport | `≥ 3000` stamps at `epoch_width = 1` (⇒ `≥ 3000` epochs), every key seeded PRESENT with its own tombstone, one tracked cursor advanced per stamp (`set_delivered(conn, 1_000_000)` before each `confirm_apply_ack`), `set_durable_epoch_watermark(1_000_000)`, one `prune_epoch_tombstones` pass per stamp | I1, I2, I3 on every pass; P-KEYS on every considered ref | YES — the D-T's sole universe |
+
+**`D5`'s durable-epoch watermark is `1_000_000`, set once before the stamp loop and never
+lowered.** The second call-site conjunct is `watermark >= e`, and the drive creates `≥ 3000`
+epochs at width 1. The file's ubiquitous `1000` literal is deliberately NOT copied: it would leave
+epochs 1001 … 3000 permanently ineligible and silently shrink the D-T's only universe by two
+thirds. `1_000_000` exceeds the highest epoch the drive can reach by more than two orders of
+magnitude (`Epoch = u64`), so every epoch `D5` creates stays inside the universe.
+
+**`D5`'s cursor is `delivered` up to `1_000_000` — the same non-constraining sentinel as the
+watermark, and for the same reason.** `advance_on_ack` clamps the cursor by
+`claimed.min(delivered).min(current_max_epoch)`; the shared `track_client` shape this drive cites
+hardcodes `set_delivered(conn, 100)`. A verbatim copy of that `100` literal would cap the cursor at
+epoch 100 for a drive that stamps `≥ 3000` epochs: passes 101 … 3000 would all be empty drains,
+silently shrinking the D-T's sole universe by roughly 97 %. `set_delivered(conn, 1_000_000)` is
+deliberately NOT the `track_client` shape's `100`: it is named once here, before the freeze, so
+`delivered` is never the binding term in the clamp.
+
+**Why `D5` alone carries the table.** It is the only drive whose per-exit and per-pass terms are
+observable in-process (current-thread ⇒ the thread-local capture works) AND whose outcome is not
+derivable from the source at authoring time. It is a **sequential single-writer regime at
+`epoch_width = 1`**; the spec does not claim it is a width-1000 regime — 3,000 epochs at width
+1000 would need 3,000,000 stamps, which is a bounded follow-up, not an in-process drive.
+
+#### R4.6 — the non-empty-capture requirement, WITH the corrected off-by-one clause
+
+**No verdict is ever read off an empty capture, and no term is ever read off a transport that does
+not carry it.** Every drive that reads rows through the `tracing` capture first asserts the
+capture is non-empty and carries the expected number of rows **of each kind it will read** —
+`epoch_exit`, `settlement` and `prune_pass` counted separately, with `prune_pass` expected exactly
+once per driven invocation.
+
+**On `D5`, the expected `epoch_exit` row count is the drive's REAL KEYED stamp count — NOT its
+total `stamp_tombstone` call count, which is larger by exactly one.** The difference is
+structural, not incidental: at `epoch_width = 1` an epoch `e` is entry-emitted, and so becomes
+drainable, only on the stamp that rolls PAST it, so the last stamped epoch stays open unless the
+drive adds a deliberate closing stamp on a throwaway key that seeds no store entry and is never
+itself drained. Any sequential rolling drive of this shape carries that off-by-one by construction,
+and a freeze that read "stamp count" as the raw call count would fail this assertion by exactly 1
+and manufacture a RED — a manufactured-verdict hazard of the exact class this freeze exists to
+prevent. It is a statement about the instrument's arithmetic, not about the data. With the count
+read correctly, a cursor that is under-powered (e.g. clamped by an insufficiently large `delivered`
+value) surfaces as this assertion failing — a RED — rather than as a silently short-universe pass
+of empty drains. A capture that is empty or short **in any of the three kinds** is a RED, never "no
+violation".
+
+#### Step 3 — the Fix-Shape Mapping (F-M), frozen before the verdict is known
+
+| Verdict | Fix shape | Why |
+|---|---|---|
+| **V1 — REF-LOSS** | STANDALONE CORRECTNESS FIX, which the `ReclamationRegistry` family then builds on | Content leaving the index unreclaimed is a selection/frontier-class defect. A registry that never reclaims below a live claim contains it but does not repair it; the refs are still lost. |
+| **V2 — BOOKKEEPING ATTRIBUTION** | STANDALONE CORRECTNESS FIX, which the registry family then builds on | The defect is on the store-side reclamation path, which the registry does not touch. Registry-gating a prune that frees nothing changes nothing. |
+| **V3 — COUNTER-FAMILY MISNAMING** | STANDALONE CORRECTNESS FIX — of the INSTRUMENT — and the ruling MUST state, in the same sentence, that the prune's own throughput mechanism remains UNCLASSIFIED | A misnamed counter family is repaired where it is emitted. It is a naming of PD-F12's contradiction, not of why the reclaim fraction falls; the ruling must not let the first pass for the second. E-C's registry-side consequence applies unchanged. |
+| **V0 — NOT REPRODUCED** | THE RULING IS NOT WRITTEN | No reading is named. E-C fires. |
+| any `INDETERMINATE-*` (Step 0 fail-closed) | THE RULING IS NOT WRITTEN | Same. E-C fires. |
+
+**Standing prohibition (unchanged, and holding regardless of verdict):** the ruling may propose
+**neither** the slope stick **nor** `f(span, width, churn)`. The gate returns on `ceiling =
+min_live_claim − fixed_margin`, and nothing else.
+
+#### E-C — the pre-registered Escalation Clause
+
+> If this increment does not name the mechanism, the diagnosis line HARD STOPS. There is no
+> diagnosis round after this one.
+>
+> "Does not name the mechanism" means exactly: the frozen table resolves to V0, **or** Step 0
+> fires fail-closed with any `INDETERMINATE-*`. Resolution to V1, V2 or V3 **is** a naming and E-C
+> does not fire — with the qualification F-M's V3 row states explicitly.
+>
+> On firing, the `ReclamationRegistry` family starts with the cause **unclassified**, justified by
+> this manifest's §8.3, quoted verbatim beside the determination:
+>
+> > "The recommended reclamation model closes safety REGARDLESS of which cause it turns out to
+> > be … A selection defect, a scheduling defect and a throughput defect are all contained by a
+> > registry that never reclaims below a live claim."
+>
+> What an unclassified cause costs is fix-shape efficiency, not safety. A Step-0 or V0 outcome is
+> to be read as an expensive answer, not a blocked one. This clause exists so it is not re-argued
+> at the boundary: it is settled here, at plan time, by the user.
+
+#### X21 — the four-limb discharge plan (NORMATIVE; explicitly not left silent)
+
+X21 reads: *every frozen surface, predicate, tool and join is validated against the exact
+transport the DATA half will consume, before the boundary.* This increment is
+in-process/deterministic, so the rule is APPLICABLE and DISCHARGED, in **four** limbs, each with
+an executed proof to be recorded in `spec358-x21-discharge.txt`:
+
+- **X21-a — the struct transport.** The two new fields are asserted on a returned record, at the
+  one site where a record is returned by value: `detect_epoch_exit` / `finalize_epoch_exit` in
+  `tombstone_frontier_impl.rs`'s inline tests. A `PruneRecordObserver` test double is NOT available
+  and is not claimed. Proof: Step 0 leg (c) alone, which drains in-module via
+  `f.lock().drain_prunable()` — the one in-crate call that returns the exit rows by value — and
+  asserts both new fields on that record. `S1` does NOT discharge this limb: its step 8 goes
+  through the public `drain_prunable_tombstones`, which returns no record, so `S1`'s record-shaped
+  assertions ride X21-b and its assertion on the return value is a count check only.
+- **X21-b — the line transport.** Every term the predicate names MUST be reachable on the exact
+  `tracing` emission it is read from: the two new fields on the exit row, all eight terms on the
+  settlement row, and `considered` / `empty_drain` on the pass row. Proof: a `tracing-subscriber`
+  capture (`set_default` + a `Layer` with a sink, shape at `network/device_identity.rs:397-429`)
+  asserts each field name appears in the **rendered field text** — the `name=value` pairs a
+  `tracing::field::Visit` collector accumulates — not against the struct. `S1` is this limb's
+  second executed proof, on the exit row.
+- **X21-c — the metrics transport and the join.** The two new pinned series MUST be present in a
+  rendered `/metrics` scrape and carry the expected values, using the shape already in the tree:
+  `PrometheusBuilder::build_recorder` + `metrics::with_local_recorder` + `rendered_counter`. The
+  proof is sited in the inline tests of a COUNTED file, not in `src/sim` (X21-d). The join key is
+  `epoch`, populated on every row of both ledgers; no wall-clock key is used anywhere.
+- **X21-d — the thread-affinity limb.** Both in-process transports the D-T's rows travel over are
+  thread-local: the `tracing` capture (`tracing::subscriber::set_default`) and the metrics recorder
+  (`metrics::with_local_recorder`). A drive that runs the prune inside `tokio::spawn` on a
+  `multi_thread` runtime observes neither, and observes them as an **empty capture**, which reads
+  exactly like "no violation". Frozen consequence: (i) every drive whose rows enter a D-T universe
+  runs on a current-thread runtime with the emission on the test's own thread; (ii) `D4`, the
+  multi-thread race, is scoped to the aggregate `index_conservation_snapshot` terms and excluded
+  from every universe; (iii) every drive that reads rows off a capture MUST first assert the
+  capture is non-empty and carries the expected row count (R4.6, above); (iv) the capture's sink
+  keeps one entry per event (a `Vec<String>`, not a single concatenated `String`), because the D-T
+  is evaluated per row and per pass and a concatenated sink individuates neither. Proof to be
+  recorded in `spec358-x21-discharge.txt`, per drive: runtime flavour, transport, captured-row
+  count by row kind (`epoch_exit` / `settlement` / `prune_pass`).
+
+#### The two pinned metric names (extending the closed set)
+
+- `METRIC_PRUNE_REMOVED_REFS_OBSERVED_TOTAL = "topgun_or_prune_removed_refs_observed_total"`
+- `METRIC_PRUNE_REMOVED_BYTES_OBSERVED_TOTAL = "topgun_or_prune_removed_bytes_observed_total"`
+
+Both are eagerly registered in `MetricsPruneRecorder::new()` via `touched_counter`, so they exist
+in the first scrape. The pinned-names banner in `tombstone_frontier.rs:759` reads **24 counters**
+once both are added, up from 22.
+
+#### R6.3 — the §0–§11 digest, recorded before this freeze was appended
+
+The span is `sed -n '1,7689p'` of this file. §11 runs from line 5779 to the pre-append EOF at line
+7689, and this §12 section is appended strictly beneath it, so the same literal span is valid
+before and after the append.
+
+```
+sed -n '1,7689p' packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md | shasum -a 256
+24273adf2ee87b544520cef817c826bf2be645e07cb97c8ef110ca21e59dabac
+```
+
+Recorded here as the PRE-DATA value. The identical digest, recomputed over the same span AFTER
+this section was appended, and the post-append boundary lines (`sed -n '7690,7695p'`), are pasted
+into `spec358-microdiag-transcript.txt` by the group that executes Step 0 (R6.3, AC11). No byte of
+§0–§11 is edited by this append.

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
@@ -8092,6 +8092,25 @@ Steps 1–3 are evaluated.
 - **P-KEYS**: HELD on **3000/3000** considered refs (`absent = 0` on every settlement
   row).
 
+**What `I3`'s 3000/3000 weighs, priced (added by Review v2; the figure itself is
+unchanged).** Over `D5` — and only over `D5` — `I3` is a ONE-SIDED check between two
+quantities that trace to the SAME string. Each epoch carries exactly one ref;
+`B_restored(e) ≡ 0` on every epoch (this drive never restores, so the drive asserts the
+bare `B_obs ≤ B_att`); and both `B_obs` and `B_att` are the byte length of that epoch's
+single `D5TAG{i}` tag, read off the SAME exit row. The check therefore excludes an
+OVER-count on the observation side (or an under-credit on the attribution side) and
+nothing else: a total observation failure lands `B_obs = 0`, and `0 ≤ B_att` is
+satisfied silently. That is strictly weaker than `I1`/`I2`, whose two sides are
+separately emitted quantities — §12.0 makes exactly that check for `I2` in advance
+(*"so I2 is a genuine identity between two separately emitted quantities, not a
+tautology across one"*, `:7813`) and does not make it for `I3`. It is the same class
+this manifest already names against the production ledger in the PD-F12 analysis:
+*"**The two compared quantities are the SAME FIELD.** … exact **by construction, not by
+measurement**, and **carries no discriminating information**"* (`:7020-7021`). Read
+`I3`'s 3000/3000 at that weight beside `I1`/`I2`. `I3`'s GENERAL form is not
+tautological — the `B_restored(e)` term is what makes it meaningful on a drive that
+restores (§12.0, `:7815-7819`) — so this prices `D5`, not the identity.
+
 `D5`'s universe (X21-d's per-drive record): 3000 real keyed stamps + 1 closing
 throwaway stamp = 3001 `prune_epoch_tombstones` invocations. Captured rows: **3000
 `epoch_exit`, 3000 `settlement`, 3001 `prune_pass`** — `split_into_passes` recovered
@@ -8132,7 +8151,7 @@ resolved V0 → **E-C FIRES → the diagnosis line HARD STOPS. There is no diagn
 after this one.** The `ReclamationRegistry` family (`TODO-634`) starts with the cause
 **unclassified**, justified by §8.3 above, quoted verbatim.
 
-### §12.1.f — POST-DATA findings PD-F15–PD-F19 (recorded and ROUTED to `TODO-634`; they do NOT alter the verdict)
+### §12.1.f — POST-DATA findings PD-F15–PD-F20 (recorded and ROUTED to `TODO-634`; they do NOT alter the verdict)
 
 §12.0 pre-authorizes exactly this: *"if the data suggests one, it is recorded as a
 POST-DATA finding and routed, and the table's own verdict still stands."* The
@@ -8211,6 +8230,85 @@ none is a row-1 violation reached by execution inside that universe, and none ch
   a drive whose construction can place a row in row 2's universe (the analogue of PD-F18 for
   row 1) is what would give row 2 evidentiary weight, and per X8 this round may not widen the
   frozen universe to supply it. **ROUTED to `TODO-634`.**
+  **SUPERSEDED IN PART by PD-F20 below (added by Review v2): the "unfireable over `D5` by
+  construction" characterisation of row 2 is RETRACTED — refuted by execution. The text above
+  is retained verbatim, unedited, because a retraction that erases what it retracts leaves the
+  next reader unable to check it. The routing to `TODO-634` stands; the WEIGHT it routes does
+  not.**
+
+- **POST-DATA — PD-F20 — PD-F19's "by construction" claim about D-T row 2 is RETRACTED.
+  Rows 2 AND 3 were LIVE over `D5` and both returned genuine negatives; row 1 alone was
+  unreachable.** Surfaced by Review v2 and settled by EXECUTION, not by argument.
+  - **What is retracted, quoted from PD-F19 so the retraction can be checked against it:**
+    *"D-T row 2, like row 1, was unfireable over `D5` by construction, so `V0`'s evidentiary
+    weight rests on row 3 alone"* and *"over `D5` **only row 3 was ever live**"*.
+  - **Executed refutation — row 2 IS live over `D5`.** The mutation is the minimal faithful
+    encoding of reading (ii) itself (*"the index removal is real, the store frees nothing"*):
+    in `crdt.rs`'s `prune_epoch_tombstones`, inside the drop closure, `dropped =
+    outcome.pruned > 0;` → `dropped = false;`. Nothing else changed — the drive, the seeding
+    and the frozen universe are untouched. Executed at tip `2639b38f`:
+    - unmutated: `row1(V1 REF-LOSS)=false row2(V2 BOOKKEEPING-ATTRIBUTION)=false
+      row3(V3 COUNTER-FAMILY-MISNAMING)=false`, `1 empty, 3000 draining, 0 not-applicable`,
+      P-KEYS `3000/3000`, test PASSES;
+    - mutated: `row1=false row2=`**`true`**` row3=false`, with `I1`/`I2`/`I3` still holding on
+      the same `1 empty, 3000 draining, 0 not-applicable` and P-KEYS still `3000/3000`, test
+      still PASSES (row 2 is a recorded VALUE, not an assertion).
+    Command both times, unchanged: `cargo test --profile ci-sim --features simulation -p
+    topgun-server -- sim::tombstone_gc_proof::tests::d5_sequential_regime --nocapture`.
+    Mutation reverted; `git status --porcelain` empty afterwards.
+  - **Executed check — row 3 is live in the fail-closed sense.** `empty_drain:
+    drained.is_empty()` → `empty_drain: true` in the same function's `PrunePassRecord`
+    construction makes the drive PANIC at the `I2` assertion in
+    `sim/tombstone_gc_proof.rs` — *"D5 I2 violated on a pass: empty_drain == (Σ_e R_obs(e) ==
+    0) must hold"* — i.e. a row-3 condition surfaces as the test's own failure rather than as
+    the printed `row3_condition`, exactly as §12.1's frozen-by-design note states. Reverted;
+    green.
+  - **Why PD-F19 was wrong — the standard, not the arithmetic.** PD-F19's arithmetic is
+    correct: over `D5`, `D_e ≥ 1 ∧ F_e > 0` on every epoch, so row 2 evaluates false. What it
+    got wrong is *whose property that is*. It is a JOINT property of the fixture AND the
+    subject, and the mutations above show which half carries it: hold the fixture fixed,
+    change the subject's store-side behaviour, and row 2 fires. A row is dead only when the
+    FIXTURE forecloses its condition regardless of what the subject does — which is exactly
+    the distinction §12.0 froze in advance and PD-F19 read past: `D3` is EXCLUDED from the D-T
+    because it *"produces row 2's signature by construction"* (`:7861`), while `D5`'s P-KEYS
+    clause exists so that *"a store-side zero cannot be manufactured by the fixture"*
+    (`:7850-7852`) — seeding-present is what makes row 2's negative TRUSTWORTHY, not vacuous.
+    §12.0 states the conclusion outright: *"Consequently rows 2 and 3 are not readable off the
+    source before the run over the universes they range on"* (`:7865-7866`).
+  - **How it entered the record.** PD-F19 was accepted from a review finding on prose
+    agreement, without the mutation `K2` and Step 0 require before any term may be declared
+    unable to disagree with its subject. The round applied its own discipline to the
+    instrument and not to a claim about the instrument.
+  - **Row 1's status is unchanged and carries a witness rather than an argument.** Its
+    antecedent — an `epoch_tags` entry PRESENT but holding an EMPTY vector — is constructed in
+    this tree only through an in-module bypass, which is what Step 0 leg (c) does
+    (`f.lock().drain_prunable()` on a planted empty vector); that positive control FIRES
+    unmutated and fails under the mutation arm (X21-a), so the instrument is proven able to
+    read row 1's signature when the antecedent exists. What no public writer reaches is the
+    antecedent itself (PD-F15's four-site enumeration), which is why PD-F18 names the drive
+    that would be needed. This remains a STATIC enumeration: if it is incomplete, row 1's
+    negative is *"an informative negative about the enumeration, not a null result"*, exactly
+    as §12.0 froze it.
+  - **The corrected reading, which is what `TODO-634` inherits:** *two of three readings were
+    tested over `D5` and both returned negatives; the third's antecedent (row 1) is not
+    constructible through the public API.* This is strictly MORE informative than what PD-F19
+    routed. Understating one's own evidence in a routed record is the same class of defect as
+    overstating it.
+  - **What does NOT change.** `V0` stands, unedited and unreopened — its definition is *"none
+    of rows 1–3 holds over its own universe"*, and every row was evaluated over its own
+    universe exactly as frozen. §12.0 stays BYTE-FROZEN (digest
+    `24273adf2ee87b544520cef817c826bf2be645e07cb97c8ef110ca21e59dabac` over `sed -n
+    '1,7689p'`); this entry is append-only beneath it. `E-C` has still FIRED. No `.rs`
+    production byte was changed by this finding — both mutations above were applied, read and
+    reverted.
+  - **The rule this round adopts, applied to this entry itself.** Any claim of the form *"term
+    X is unfireable / readable by construction"* entering this record MUST carry, beside it,
+    either the EXECUTED mutation that would make X fire, or an executed constructibility
+    witness for the antecedent it says is unreachable. No such claim lands on prose agreement
+    again. PD-F20 satisfies this about itself: rows 2 and 3 carry executed mutations above,
+    and row 1 carries leg (c)'s executed positive control plus the named enumeration whose
+    incompleteness is the stated way the claim could fail.
+  - **ROUTED to `TODO-634`.**
 
 ### §12.1.g — R6.3 / AC11 digest confirmation
 

--- a/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
@@ -8036,3 +8036,160 @@ Recorded here as the PRE-DATA value. The identical digest, recomputed over the s
 this section was appended, and the post-append boundary lines (`sed -n '7690,7695p'`), are pasted
 into `spec358-microdiag-transcript.txt` by the group that executes Step 0 (R6.3, AC11). No byte of
 §0–§11 is edited by this append.
+
+---
+
+## §12.1 — SPEC-358: the executed record
+
+**Appended strictly beneath §12.0. Zero bytes of §0–§12.0 above this line are edited by
+this section.** Executed tip for every leg and drive below: `453aeb55` (branch
+`sf-358-pdf12-microdiag`). Full quoted output lives in
+`spec358-microdiag-transcript.txt`, `spec358-mutation-arm.txt` and
+`spec358-x21-discharge.txt`; this section carries the evaluated values and the
+determination.
+
+### §12.1.a — Step 0, all three legs HOLD
+
+- **leg (a) UNMUTATED**: `cargo test --release -p topgun-server --lib` → exit 0,
+  `1811 passed; 0 failed; 2 ignored`. `pnpm test:sim` → exit 0, `26 passed; 0 failed`.
+  `S1`'s executed row (already frozen into §12.0) diverges: `R_obs == R_ent + 1` holds
+  (`2 == 1 + 1`).
+- **leg (b) MUTATED** (`spec358-mutation-arm.patch` applied): `cargo test --release
+  -p topgun-server --lib` → exit **101**, `1808 passed; 3 failed`, with
+  `s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only` FAILING and
+  naming the literal "discriminating assertion R_obs == R_ent + 1 does not hold".
+  `pnpm test:sim` → exit **101**, `25 passed; 1 failed`, with
+  `d1_divergence_removed_observation_diverges_from_entry_attribution` FAILING and
+  naming "D1 predicate limb 1 (R_obs == R_ent + 1) must hold". **Both halves fail, and
+  each failure names the discriminating assertion `R_obs == R_ent + 1`.** Reverted
+  (`git checkout --`) and re-verified: lib exit 0 `1811 passed`, sim exit 0
+  `26 passed`.
+- **leg (c) POSITIVE CONTROL**:
+  `step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record`
+  passes unmutated, asserting `R_obs == 0 ∧ R_ent > 0` on the record
+  `f.lock().drain_prunable()` returns for a planted-empty `epoch_tags` entry. Under the
+  mutation it FAILS with `left: 1, right: 0` — the control is live, not vacuous.
+
+**Honesty note (recorded per the handoff, verbatim in substance):** on the FIRST
+mutated run, `S1`'s message printed the row but did not contain the literal
+`R_obs == R_ent + 1`, so Checklist 3's "each failure message names the discriminating
+assertion" was not yet satisfied on that run — the assertion itself already was the
+discriminating one and already failed. Commit `453aeb55` changed only the assertion's
+MESSAGE to name it; the asserted condition is byte-identical. Legs (a) and (b) were
+then re-run end to end from a clean tree, and every figure above is from that re-run.
+`D1`'s message already named the literal on its first run.
+
+Step 0 does NOT fire fail-closed. The determination is NOT `INDETERMINATE-INSTRUMENT`.
+Steps 1–3 are evaluated.
+
+### §12.1.b — Step 1, the bridge identities (over `D5`)
+
+- **I1** (`Σ_e R_obs(e) == K_p`): HELD on all **3001** passes, 0 violations.
+- **I2** (`E_p == (Σ_e R_obs(e) == 0)`): HELD on all **3001** passes, 0 violations.
+- **I3** (`B_obs(e) ≤ B_att(e) + B_restored(e)`): HELD on all **3000** drained epochs
+  (`B_restored = 0`; `D5` never restores).
+- NOT-APPLICABLE passes (a `restored_*` exit fired): **0**.
+- **P-KEYS**: HELD on **3000/3000** considered refs (`absent = 0` on every settlement
+  row).
+
+`D5`'s universe (X21-d's per-drive record): 3000 real keyed stamps + 1 closing
+throwaway stamp = 3001 `prune_epoch_tombstones` invocations. Captured rows: **3000
+`epoch_exit`, 3000 `settlement`, 3001 `prune_pass`** — `split_into_passes` recovered
+exactly 3001 passes, an exact 1:1 with invocations, as R4.6's corrected off-by-one
+clause requires.
+
+Every other drive's own predicate (recorded as a value, excluded from the D-T universe
+per §12.0's frozen scoping table): `D1 DIVERGENCE: REPRODUCED — R_obs=3 R_ent=2
+B_obs=12 B_att=8 len(extra.tag)=4`. `D2 POST-EXIT RESTORE: REPRODUCED — k=1
+sum_R_obs=0`. `D3 ABSENT-KEY: REPRODUCED — D_e=0 F_e=0 B_att=4 absent=1`. `D4 TOCTOU
+RACE: REPRODUCED — aggregate index_conservation_snapshot() terms held across all 64
+interleavings; row-granularity terms NOT observable (C13, X21-d); NOT in a D-T
+universe`.
+
+### §12.1.c — Step 2, the Decision Table, evaluated in frozen order
+
+| # | Verdict | Condition | Value |
+|---|---|---|---|
+| 1 | V1 — REF-LOSS | ∃ `DrainedByPrune` row of `D5` with `R_obs < R_ent` | **false** |
+| 2 | V2 — BOOKKEEPING ATTRIBUTION | ∃ epoch with `R_obs > 0 ∧ D_e == 0 ∧ F_e == 0 ∧ B_att > 0` | **false** |
+| 3 | V3 — COUNTER-FAMILY MISNAMING | I1 or I2 violated on an in-scope pass | **false** |
+| 4 | **V0 — NOT REPRODUCED** | none of rows 1–3 holds over its own universe | **HOLDS** |
+
+**VERDICT: `V0 — NOT REPRODUCED`.** Exactly one verdict, read off the frozen table in
+its frozen order.
+
+### §12.1.d — Step 3, the Fix-Shape Mapping
+
+F-M's `V0` row fires: **THE RULING IS NOT WRITTEN.** Per R7.1 the not-written status IS
+the satisfying content, not an absence. Full ruling record, with §8.3 quoted verbatim
+beside the determination, in `spec358-fixshape-ruling.md`.
+
+### §12.1.e — E-C fires
+
+E-C's own text: *"'Does not name the mechanism' means exactly: the frozen table
+resolves to V0, or Step 0 fires fail-closed with any `INDETERMINATE-*`."* The table
+resolved V0 → **E-C FIRES → the diagnosis line HARD STOPS. There is no diagnosis round
+after this one.** The `ReclamationRegistry` family (`TODO-634`) starts with the cause
+**unclassified**, justified by §8.3 above, quoted verbatim.
+
+### §12.1.f — POST-DATA findings PD-F15–PD-F18 (recorded and ROUTED to `TODO-634`; they do NOT alter the verdict)
+
+§12.0 pre-authorizes exactly this: *"if the data suggests one, it is recorded as a
+POST-DATA finding and routed, and the table's own verdict still stands."* The
+cross-vendor adversarial round (`spec358-mechanism-xask.md`) recommended a static audit
+of `publish_epoch_exit` call sites; the audit was run and produced the following four
+POST-DATA findings, all reached by source-code audit outside `D5`'s frozen universe —
+none is a row-1 violation reached by execution inside that universe, and none changes
+§12.1.c's verdict.
+
+- **POST-DATA — PD-F15** — the mechanism is code-identifiable, and it is row 1's named
+  extreme case. `drain_prunable`'s `drained_epochs.insert(e)` sits inside `if let
+  Some(refs) = epoch_tags.remove(&e)` and is **unconditional on `refs.len()`**. An
+  epoch whose `epoch_tags` entry EXISTS but holds an EMPTY vector is attributed
+  `DrainedByPrune`, given `bytes_freed_attributed = slot.stamped_bytes` (> 0 whenever
+  the slot ever stamped), observed as `R_obs = 0, B_obs = 0`, and contributes NOTHING
+  to `drained` — so the service's `PrunePassRecord` reads `considered = 0, empty_drain
+  = true, epochs_drained = 0`. This is precisely PD-F12's production signature, and
+  exactly D-T row 1's named extreme case (`R_obs == 0 ∧ R_ent > 0`), which Step 0 leg
+  (c) proves the instrument fires on when the antecedent exists. Why `D5` could not
+  reach it: through the public API an epoch's refs leave only via the drain, which
+  removes the WHOLE `epoch_tags` entry — never leaving an empty-but-present vector
+  behind — and `D5` is single-writer and sequential, so no second writer can empty the
+  vector between entry-emission and drain. §12.0 froze this in advance as row 1's
+  stated exception: its non-firing is "an informative negative about the enumeration,
+  not a null result." This round's result sharpens that negative into a named,
+  code-level antecedent. **ROUTED to `TODO-634`.**
+- **POST-DATA — PD-F16** — route (b) REFUTED from source. `EpochExitKind` carries
+  `#[default] DrainedByPrune`, which invites the hypothesis that an unattributed exit
+  silently defaults to a prune attribution. It does not: `finalize_epoch_exit` resolves
+  `kind_hint == None` to `EpochExitKind::Unclassified { .. }`, and the two non-drain
+  call sites pass explicit `ClearedByRebuild` (`:835`) and `StillResidentAtShutdown`
+  (`:651`). The `#[default]` is reachable only from `..Default::default()` in test
+  fixtures. No non-drain path stamps `DrainedByPrune`. **ROUTED to `TODO-634`.**
+- **POST-DATA — PD-F17** — the Prometheus pass family is internally coherent.
+  `MetricsPruneRecorder::observe_pass` increments `passes_total`, `considered_total`,
+  `dropped_total`, `bytes_freed_total`, `epochs_drained_total` and the empty/nonempty
+  split from the SAME `PrunePassRecord`, in the SAME call. So PD-F12's production
+  reading is not a counter-transport artefact: the divergence is between the FRONTIER
+  (which emits exit rows inside the drain) and the SERVICE (which builds the pass
+  record from the drain's RETURN VALUE) — two different components, which is what
+  PD-F15 names. **ROUTED to `TODO-634`.**
+- **POST-DATA — PD-F18** — the next drive, named concretely, **NOT run here** (X8
+  forbids widening the frozen universe, X5 forbids a fix). A deterministic in-process
+  drive that constructs the race's END STATE rather than the race: populate an epoch
+  `e`, let it roll over so `entry_emitted ∧ refs_at_entry > 0`, then empty
+  `epoch_tags[e]` in-module to a present-but-empty `Vec` (the same in-module bypass leg
+  (c) uses), then drain through the SERVICE and assert on the pass record. Predicted:
+  an exit row with `exit_kind = DrainedByPrune, bytes_freed_attributed > 0,
+  removed_refs_observed = 0`, beside a pass record with `considered = 0, empty_drain =
+  true, epochs_drained = 0`. This would place a row in D-T row 1's universe **if** such
+  a drive were inside a frozen universe — it is NOT in this round's, which is why it is
+  routed rather than run. **ROUTED to `TODO-634`.**
+
+### §12.1.g — R6.3 / AC11 digest confirmation
+
+`spec358-microdiag-transcript.txt` carries the executed digest pair: the PRE-DATA value
+frozen above (`24273adf2ee87b544520cef817c826bf2be645e07cb97c8ef110ca21e59dabac`)
+recomputed over the identical `sed -n '1,7689p'` span produces the same digest, and the
+post-append `sed -n '7690,7695p'` boundary lines are unchanged from the pre-append tip.
+No byte of §0–§12.0 was edited by this §12.1 append.

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-fixshape-ruling.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-fixshape-ruling.md
@@ -96,7 +96,8 @@ unclassified, exactly as E-C specifies, justified by §8.3 above.
 
 ## The POST-DATA findings — routed, not a naming
 
-Five POST-DATA findings (PD-F15, PD-F16, PD-F17, PD-F18, and PD-F19 added by Review v1)
+Six POST-DATA findings (PD-F15, PD-F16, PD-F17, PD-F18, PD-F19 added by Review v1, and
+PD-F20 added by Review v2 — which retracts PD-F19's central claim, see below)
 were produced by the code audit the cross-vendor round recommended
 (`spec358-mechanism-xask.md`) and by the review that followed it. §12.0
 pre-authorizes exactly this outcome: *"A reading not on this table cannot be published
@@ -113,18 +114,36 @@ there, by construction: D5 cannot construct an empty-but-present `epoch_tags` en
 through the public API, because refs leave only via the drain, which removes the whole
 entry. PD-F15 is a STATIC, code-level observation reached by audit, not a row-1
 violation reached by execution inside D5's frozen universe. The table's own verdict
-(V0) stands unchanged. PD-F15-PD-F19 are recorded in `spec356-manifest.md` §12.1,
+(V0) stands unchanged. PD-F15-PD-F20 are recorded in `spec356-manifest.md` §12.1,
 clearly labelled POST-DATA, and routed to `TODO-634` for the `ReclamationRegistry`
 family's design phase to carry as a stated open input — they do not stand in for, and
 must not be read as, a naming that would have prevented E-C from firing.
 
-**PD-F19 qualifies how much this `V0` weighs, and the family must inherit it at that
-weight:** D-T row 2 was, like row 1, unfireable over `D5` by construction — `D5` seeds
-every key present with its own tombstone tag, so every epoch settles with `D_e ≥ 1 ∧
-F_e > 0` while row 2 requires `D_e == 0 ∧ F_e == 0` — so over `D5` only row 3 was ever
-live, and `V0` means "the one live row did not fire", not "three independent readings
-were tested and none fired". The verdict itself is untouched: a row that cannot hold by
-construction does not hold, which is exactly what `V0`'s definition reads.
+**PD-F19 qualified how much this `V0` weighs — and PD-F20 RETRACTS that qualification
+as false. What the family inherits is PD-F20's reading, not PD-F19's.** PD-F19 held
+that *"D-T row 2, like row 1, was unfireable over `D5` by construction"*, so that *"over
+`D5` only row 3 was ever live"* and `V0` meant "the one live row did not fire". Review
+v2 refuted this by execution: mutating `crdt.rs`'s `prune_epoch_tombstones` drop closure
+`dropped = outcome.pruned > 0;` → `dropped = false;` — the minimal faithful encoding of
+reading (ii) itself, with the drive, the seeding and the frozen universe untouched —
+flips `D5`'s printed row 2 from `false` to **`true`** while `I1`/`I2`/`I3` and P-KEYS
+still hold on `3000/3000`. Row 2's negative was a property of the SUBJECT's behaviour,
+not of the fixture; §12.0 says as much in advance (`D3` is excluded because it *"produces
+row 2's signature by construction"*, while `D5`'s P-KEYS clause exists precisely so that
+*"a store-side zero cannot be manufactured by the fixture"*). Row 3 is live in the
+fail-closed sense on the same standard (`empty_drain: true` makes the drive panic on its
+own `I2` assertion).
+
+**The reading `TODO-634` inherits, therefore:** *two of three readings were tested over
+`D5` and both returned negatives; the third's antecedent (row 1) is not constructible
+through the public API.* That is strictly more informative than PD-F19's phrasing, and
+it is what the `ReclamationRegistry` family must carry as its premise. The verdict itself
+is untouched either way: `V0` is defined as "none of rows 1–3 holds over its own
+universe", and none did. PD-F19 remains in `spec356-manifest.md` §12.1.f verbatim,
+marked superseded-in-part, so the retraction can be checked against what it retracts;
+PD-F20 records the executed evidence and the rule that follows from it — no claim that a
+term is "unfireable by construction" enters this record again without its executed
+mutation or an executed constructibility witness beside it.
 
 ## Two notes on how this round's own record should be read (added by Review v1)
 

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-fixshape-ruling.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-fixshape-ruling.md
@@ -44,6 +44,35 @@ on the table" §12.0 pre-forbids.
 verbatim, beside the determination it justifies, per §8.3's own closing sentence and
 per E-C's requirement.)
 
+### Note on the quote's fidelity (added by Review v1 — the block above is NOT edited)
+
+The block-quote above is **word-identical** to `spec356-manifest.md:465-478` but is
+**re-wrapped** to this document's narrower column: every word, every emphasis marker and
+every character matches, and only the line breaks differ. Review v1 read AC12's "quoted
+verbatim" strictly and flagged the difference. The correction is made by ADDITION, never
+by overwriting the block above — the quote as originally published stays byte-for-byte as
+it was, and the byte-exact paste is supplied here beside it, at the source's own wrapping:
+
+```
+### §8.3 — And the family is NOT blocked by it, which is why this is a legitimate terminal branch
+
+**The recommended reclamation model closes safety REGARDLESS of which cause it turns out to be.**
+`ReclamationRegistry` (cursor-shaped consumers only) + retention SLA **N = 30 d** + the cursor-age fence
+with HLC-horizon quarantine + `ceiling = min_live_claim − fixed_margin` bound the reclaimable set by **live
+claims**, not by any hypothesis about *why* the current prune falls behind. **A selection defect, a
+scheduling defect and a throughput defect are all *contained* by a registry that never reclaims below a
+live claim.**
+
+What an unclassified cause costs is **fix-shape efficiency** — the family would design without knowing
+which limb to optimize first — **not safety, and not the family's ability to proceed.** A Step-5 outcome is
+therefore to be read as **an expensive answer, not a blocked one**, and any Step-5 outcome must be reported
+quoting this paragraph beside it.
+```
+
+Reproduce with `sed -n '465,478p' spec356-manifest.md`; the fenced block above is that
+command's output. Nothing in the determination depends on which of the two renderings a
+reader uses — they carry identical text.
+
 ## The determination, stated plainly
 
 The cause of PD-F12's production contradiction is **unclassified**. Per §8.3, this
@@ -67,8 +96,9 @@ unclassified, exactly as E-C specifies, justified by §8.3 above.
 
 ## The POST-DATA findings — routed, not a naming
 
-Four POST-DATA findings (PD-F15, PD-F16, PD-F17, PD-F18) were produced by the code
-audit the cross-vendor round recommended (`spec358-mechanism-xask.md`). §12.0
+Five POST-DATA findings (PD-F15, PD-F16, PD-F17, PD-F18, and PD-F19 added by Review v1)
+were produced by the code audit the cross-vendor round recommended
+(`spec358-mechanism-xask.md`) and by the review that followed it. §12.0
 pre-authorizes exactly this outcome: *"A reading not on this table cannot be published
 as this round's verdict; if the data suggests one, it is recorded as a POST-DATA
 finding and routed, and the table's own verdict still stands."*
@@ -83,7 +113,35 @@ there, by construction: D5 cannot construct an empty-but-present `epoch_tags` en
 through the public API, because refs leave only via the drain, which removes the whole
 entry. PD-F15 is a STATIC, code-level observation reached by audit, not a row-1
 violation reached by execution inside D5's frozen universe. The table's own verdict
-(V0) stands unchanged. PD-F15-PD-F18 are recorded in `spec356-manifest.md` §12.1,
+(V0) stands unchanged. PD-F15-PD-F19 are recorded in `spec356-manifest.md` §12.1,
 clearly labelled POST-DATA, and routed to `TODO-634` for the `ReclamationRegistry`
 family's design phase to carry as a stated open input — they do not stand in for, and
 must not be read as, a naming that would have prevented E-C from firing.
+
+**PD-F19 qualifies how much this `V0` weighs, and the family must inherit it at that
+weight:** D-T row 2 was, like row 1, unfireable over `D5` by construction — `D5` seeds
+every key present with its own tombstone tag, so every epoch settles with `D_e ≥ 1 ∧
+F_e > 0` while row 2 requires `D_e == 0 ∧ F_e == 0` — so over `D5` only row 3 was ever
+live, and `V0` means "the one live row did not fire", not "three independent readings
+were tested and none fired". The verdict itself is untouched: a row that cannot hold by
+construction does not hold, which is exactly what `V0`'s definition reads.
+
+## Two notes on how this round's own record should be read (added by Review v1)
+
+- **D-T row 3's published value is asserted, not computed.**
+  `sim/tombstone_gc_proof.rs` sets `row3_condition` to the literal `false`, and the
+  `--nocapture` line consequently prints `row3(V3 COUNTER-FAMILY-MISNAMING)=false` in the
+  same shape as the two genuinely computed row values. This is **frozen-by-design**, not an
+  oversight: row 3's condition is "I1 or I2 is VIOLATED on an in-scope pass", and I1/I2 are
+  asserted true on every in-scope pass ABOVE that line, so a violation surfaces as the
+  test's own panic and never reaches the evaluation at all. `false` is therefore the only
+  value the print site can be reached with. A reader comparing the three printed row values
+  should read row 3's as "asserted, and a violation would have panicked above", where rows 1
+  and 2 are computed off the capture.
+- **Spec-clause markers in the four counted `.rs` files are inherited style.** The files
+  carry `R4.6`, `AC4a`, `R1.5`, `C12`, `K1`, `X21-d` and similar in doc-comments. These
+  resolve to a `.specflow/` document that is local-only and archived when the spec closes,
+  so they go dangling for a future reader. No action taken here, and none is owed by this
+  round: the style predates it (the base commit already carries 47 such markers in
+  `tombstone_frontier_impl.rs` and 41 in `crdt.rs`), and the rule that IS machine-checked —
+  no `SPEC-NNN` provenance in code comments — passes clean over all four files.

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-fixshape-ruling.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-fixshape-ruling.md
@@ -1,0 +1,89 @@
+# SPEC-358 — the Fix-Shape ruling record
+
+## Verdict
+
+`V0 — NOT REPRODUCED`. All three D-T rows (V1 REF-LOSS, V2 BOOKKEEPING ATTRIBUTION, V3
+COUNTER-FAMILY MISNAMING) evaluated **false** over their own frozen universes; row 4
+(V0) holds. See `spec358-microdiag-transcript.txt` for the full executed record and
+`spec356-manifest.md` §12.1 for the appended manifest entry.
+
+## The F-M row that fired
+
+Per §12.0's frozen Fix-Shape Mapping (Step 3):
+
+| Verdict | Fix shape | Why |
+|---|---|---|
+| **V0 — NOT REPRODUCED** | **THE RULING IS NOT WRITTEN** | No reading is named. E-C fires. |
+
+Since the verdict is V0, the ruling row that fires is the V0 row, and its fix shape is
+**THE RULING IS NOT WRITTEN**. Per R7.1, the not-written status IS the satisfying
+content of this artifact — it is not an omission, and this document does not attempt to
+supply a ruling in its place. There is no STANDALONE CORRECTNESS FIX to name, no
+counter family to repair, no throughput-mechanism reading to state alongside one: none
+of that is what V0 produced, and writing one anyway would be exactly the "reading not
+on the table" §12.0 pre-forbids.
+
+## §8.3, quoted VERBATIM (from `spec356-manifest.md:465-478`)
+
+> ### §8.3 — And the family is NOT blocked by it, which is why this is a legitimate terminal branch
+>
+> **The recommended reclamation model closes safety REGARDLESS of which cause it turns out to
+> be.** `ReclamationRegistry` (cursor-shaped consumers only) + retention SLA **N = 30 d** + the
+> cursor-age fence with HLC-horizon quarantine + `ceiling = min_live_claim − fixed_margin` bound
+> the reclaimable set by **live claims**, not by any hypothesis about *why* the current prune
+> falls behind. **A selection defect, a scheduling defect and a throughput defect are all
+> *contained* by a registry that never reclaims below a live claim.**
+>
+> What an unclassified cause costs is **fix-shape efficiency** — the family would design without
+> knowing which limb to optimize first — **not safety, and not the family's ability to proceed.**
+> A Step-5 outcome is therefore to be read as **an expensive answer, not a blocked one**, and any
+> Step-5 outcome must be reported quoting this paragraph beside it.
+
+(§12.0's E-C clause cites this same paragraph as the justification for starting the
+`ReclamationRegistry` family with the cause unclassified; it is reproduced here again,
+verbatim, beside the determination it justifies, per §8.3's own closing sentence and
+per E-C's requirement.)
+
+## The determination, stated plainly
+
+The cause of PD-F12's production contradiction is **unclassified**. Per §8.3, this
+costs **fix-shape efficiency** — the `ReclamationRegistry` family will have to design
+without knowing which limb (selection, scheduling, or throughput) to optimize first —
+and costs **nothing on safety**: the registry design (cursor-shaped consumers only,
+`N = 30 d` retention SLA, cursor-age fence with HLC-horizon quarantine,
+`ceiling = min_live_claim − fixed_margin`) bounds the reclaimable set by live claims
+regardless of which of the three defect classes turns out to be the cause, or whether
+the cause is ever classified at all.
+
+## E-C's HARD STOP
+
+E-C's own text: *"If this increment does not name the mechanism, the diagnosis line
+HARD STOPS. There is no diagnosis round after this one."* "Does not name the
+mechanism" is defined purely mechanically: *"the frozen table resolves to V0, or Step 0
+fires fail-closed with any `INDETERMINATE-*`."* The frozen table resolved V0. **E-C
+fires.** There is no further diagnosis round for PD-F12 under this spec. The
+`ReclamationRegistry` family (`TODO-634`) starts its design with the cause
+unclassified, exactly as E-C specifies, justified by §8.3 above.
+
+## The POST-DATA findings — routed, not a naming
+
+Four POST-DATA findings (PD-F15, PD-F16, PD-F17, PD-F18) were produced by the code
+audit the cross-vendor round recommended (`spec358-mechanism-xask.md`). §12.0
+pre-authorizes exactly this outcome: *"A reading not on this table cannot be published
+as this round's verdict; if the data suggests one, it is recorded as a POST-DATA
+finding and routed, and the table's own verdict still stands."*
+
+PD-F15 in particular names a code-level mechanism —
+`drain_prunable`'s `drained_epochs.insert(e)` being unconditional on `refs.len()`,
+which produces exactly PD-F12's production signature when an epoch's `epoch_tags`
+entry exists but holds an empty vector. **This does not amount to "the increment named
+the mechanism after all."** The D-T's row 1 (V1 REF-LOSS) ranges over `D5`'s own
+universe — the 3000-epoch sequential, single-writer drive — and evaluated **false**
+there, by construction: D5 cannot construct an empty-but-present `epoch_tags` entry
+through the public API, because refs leave only via the drain, which removes the whole
+entry. PD-F15 is a STATIC, code-level observation reached by audit, not a row-1
+violation reached by execution inside D5's frozen universe. The table's own verdict
+(V0) stands unchanged. PD-F15-PD-F18 are recorded in `spec356-manifest.md` §12.1,
+clearly labelled POST-DATA, and routed to `TODO-634` for the `ReclamationRegistry`
+family's design phase to carry as a stated open input — they do not stand in for, and
+must not be read as, a naming that would have prevented E-C from firing.

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-fixshape-ruling.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-fixshape-ruling.md
@@ -145,8 +145,22 @@ PD-F20 records the executed evidence and the rule that follows from it — no cl
 term is "unfireable by construction" enters this record again without its executed
 mutation or an executed constructibility witness beside it.
 
-## Two notes on how this round's own record should be read (added by Review v1)
+## Three notes on how this round's own record should be read (notes 1–2 added by Review v1; note 3 by Review v3)
 
+- **D-T row 1's published value is fail-closed at R4.6's gate, not computed either — so of the
+  three printed values only row 2 is live.** Review v3 planted row 1's antecedent directly in the
+  subject (one line in `drain_prunable`'s `Some(refs)` arm emptying epoch 5's removed vector) and
+  the round did **not** print `row1=true`: it went RED first, at `sim/tombstone_gc_proof.rs:884`
+  with *"R4.6: expected 3000 settlement row(s)"*, because a zero-ref drain emits an exit row and
+  **no** settlement row — the asymmetry Observable Truth 2 already names. This is a
+  **strengthening, not a defect**: `D5` cannot silently miss a row-1 antecedent, it fails closed
+  on one. But it means the three printed values have three different epistemic statuses — row 2
+  computed live off the capture, row 3 asserted (a violation panics at I1/I2 above), row 1
+  fail-closed at R4.6 above — and a reader comparing them at face value would over-read rows 1
+  and 3. Recorded by execution, per this round's own rule that no reachability or deadness claim
+  is admissible without an executed witness. Consistent with and additive to PD-F20, whose row-1
+  paragraph rests on leg (c)'s returned-record witness plus PD-F15's static enumeration and
+  claims nothing about `D5`'s own expression of row 1.
 - **D-T row 3's published value is asserted, not computed.**
   `sim/tombstone_gc_proof.rs` sets `row3_condition` to the literal `false`, and the
   `--nocapture` line consequently prints `row3(V3 COUNTER-FAMILY-MISNAMING)=false` in the

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-mechanism-xask.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-mechanism-xask.md
@@ -1,0 +1,105 @@
+# SPEC-358 — the cross-vendor adversarial round (R7.2)
+
+Consultant: `openrouter z-ai/glm-5.2`, run via `~/Projects/agent-future/scripts/openrouter-ask.sh`.
+Two raw calls were made; both are the record (see the honesty note at the end of this
+file for why there are two).
+
+R7.2 is specific: the anchors are carried NATIVELY by this artifact — never eight
+pasted strings — and EACH anchor line carries one of three disposition labels
+(`APPLIED` / `RECORDED` / `REFUTED`) so the check grades engagement, not transcription.
+
+## Anchors, with disposition and reasoning
+
+1. **`REFUTED`** — "V0 was structurally guaranteed because Prometheus is a no-op in
+   the sim."
+
+   Refuted: the pass ROW (the `kind = "prune_pass"` tracing emission, §12.0's
+   `K_p`/`E_p` transport) is a same-record mirror of exactly what `observe_pass` folds
+   into Prometheus — both are built from the SAME `PrunePassRecord`, in the SAME call
+   (`MetricsPruneRecorder::observe_pass` increments `passes_total`, `considered_total`,
+   `dropped_total`, `bytes_freed_total`, `epochs_drained_total` and the empty/nonempty
+   split from that one record). So the pass-ledger VALUES the D-T reads are read, not
+   the transport that happens to also carry them to Prometheus; D5's Prometheus handles
+   being permanent no-ops in-process does not manufacture the V0 verdict, because the
+   D-T never touches Prometheus at all — it touches the tracing-side mirror of the same
+   record. What D5 genuinely cannot reach is stated precisely under PD-F15: an epoch
+   whose `epoch_tags` entry EXISTS but holds an EMPTY vector, reachable only through a
+   second writer racing the first — which D5, being single-writer and sequential,
+   structurally cannot construct through the public API.
+
+2. **`REFUTED`** — "a non-drain path stamps `DrainedByPrune` (route b), possibly via
+   `#[default]`."
+
+   Refuted from source: `finalize_epoch_exit` resolves `kind_hint == None` to
+   `EpochExitKind::Unclassified { .. }` — not to `DrainedByPrune`. The two non-drain
+   call sites pass an explicit kind: `ClearedByRebuild` (`:835`) and
+   `StillResidentAtShutdown` (`:651`). `EpochExitKind` does carry
+   `#[default] DrainedByPrune`, but that default is reachable only from
+   `..Default::default()` in test fixtures — no production call site relies on the
+   derive. No non-drain path stamps `DrainedByPrune`. (= PD-F16.)
+
+3. **`APPLIED`** — "audit `publish_epoch_exit` call sites before closing; it is cheaper
+   than any drive."
+
+   Applied: the audit was run. It is what produced PD-F16 (route (b) refuted from
+   source, above) and confirmed PD-F15 (below): every `publish_epoch_exit` call site
+   and every `EpochExitKind` construction site was enumerated and read.
+
+4. **`APPLIED`** — "route (c): the drain publishes an exit for an epoch whose ref
+   vector was empty at removal time."
+
+   Applied and confirmed in source: inside `drain_prunable_tombstones`,
+   `drained_epochs.insert(e)` sits inside `if let Some(refs) = epoch_tags.remove(&e)`
+   and is **unconditional on `refs.len()`**. So an epoch whose `epoch_tags` entry
+   EXISTS but holds an EMPTY vector is attributed `DrainedByPrune`, given
+   `bytes_freed_attributed = slot.stamped_bytes` (> 0 whenever the slot ever stamped),
+   observed as `R_obs = 0, B_obs = 0`, and contributes NOTHING to `drained` — so the
+   service's `PrunePassRecord` reads `considered = 0, empty_drain = true,
+   epochs_drained = 0`. That is precisely PD-F12's production signature, and it is
+   exactly D-T row 1's named extreme case (`R_obs == 0 ∧ R_ent > 0`), which Step 0 leg
+   (c) proves the instrument fires on when the antecedent exists. Why D5 could not
+   reach it: through the public API an epoch's refs leave ONLY via the drain, which
+   removes the WHOLE `epoch_tags` entry — never leaving an empty-but-present vector
+   behind — and D5 is single-writer and sequential, so no second writer can empty the
+   vector between entry-emission and drain. (= PD-F15.)
+
+5. **`RECORDED`** — "multiple `TombstoneFrontier` instances (route a)."
+
+   Recorded, not investigated: out of this increment's scope (X5 forbids a fix, X8
+   forbids widening the frozen universe); routed to `TODO-634`.
+
+6. **`RECORDED`** — "deferred/asynchronous exit publication (route e)."
+
+   Recorded, not investigated; routed to `TODO-634`.
+
+7. **`RECORDED`** — "partition fan-out (route d) cannot alone produce all-empty
+   records."
+
+   Recorded; consistent with PD-F17 (the Prometheus pass family is internally
+   coherent — `observe_pass` builds every counter from the same `PrunePassRecord` in
+   the same call, so the production symptom is not a counter-transport artefact).
+
+8. **`RECORDED`** — "the named next drive (construct the race's END state, assert on
+   the pass record)."
+
+   Recorded as PD-F18 and routed to `TODO-634`; **NOT run here**, because X5 forbids a
+   fix and X8 forbids widening the frozen universe, and it is not in any frozen
+   universe this increment committed to before Step 0 ran.
+
+## Honesty note on the two raw calls
+
+The consultant's first response (`xask_raw.txt`) hit the OpenRouter token ceiling —
+`[warn] ANSWER TRUNCATED at max_tokens (finish_reason=length)` — after producing only
+the opening framing of its skeptic's-review argument (Choice A / Choice B on why D5's
+construction structurally guarantees V0). A focused second call (`xask_raw2.txt`) was
+made, re-posing the question with the eight routes and asking for a ranking and a
+stop/continue recommendation; it completed without truncation
+(`finish_reason` not truncated, `completion=9904`). **Both raw outputs are the
+record** — nothing from the first (truncated) call is discarded, and the anchors above
+draw from both: anchor 1 answers the first call's Choice-A argument directly; anchors
+2, 5-8 draw from the second call's route ranking and code-audit recommendation; anchors
+3-4 record that the recommended code audit was in fact run and what it found.
+
+Raw files (this session's captured outputs, `xask_raw.txt` first call / truncated and
+`xask_raw2.txt` second call / complete): both are the record this artifact draws its
+anchors from.

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-mechanism-xask.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-mechanism-xask.md
@@ -100,6 +100,24 @@ draw from both: anchor 1 answers the first call's Choice-A argument directly; an
 2, 5-8 draw from the second call's route ranking and code-audit recommendation; anchors
 3-4 record that the recommended code audit was in fact run and what it found.
 
-Raw files (this session's captured outputs, `xask_raw.txt` first call / truncated and
-`xask_raw2.txt` second call / complete): both are the record this artifact draws its
-anchors from.
+Raw files: `spec358-xask-raw1.txt` (first call, truncated) and `spec358-xask-raw2.txt`
+(second call, complete), both committed beside this artifact. Both are the record this
+artifact draws its anchors from. *(Review v1 correction: these were originally written
+only to a session scratchpad and named `xask_raw.txt` / `xask_raw2.txt` here. A record
+this file calls "the record" may not live somewhere that is deleted with the session, so
+the two files were copied into the evidence directory unmodified and the names above now
+point at the durable copies.)*
+
+### Anchor 1's refutation is narrower than it reads (added by Review v1)
+
+Anchor 1 refutes the claim *"V0 was structurally guaranteed because Prometheus is a no-op
+in the sim"* — and that refutation stands exactly as written, against the
+**transport-based** form of the structural argument. It does **not** dispose of every form
+of it. Review v1 raised a different structural argument that the anchor does not reach:
+`D5`'s SEEDING construction (every key seeded present with its own tombstone tag) forces
+`D_e ≥ 1 ∧ F_e > 0` on every epoch, which makes D-T row 2 unfireable over `D5` by
+construction, exactly as PD-F15 shows row 1 to be. That point is conceded, recorded as
+**PD-F19** in `spec356-manifest.md` §12.1.f and routed to `TODO-634`. It does not change
+the verdict — a row that cannot hold does not hold — but a reader who takes anchor 1 as
+having settled "was V0 structurally guaranteed?" in general would be taking it further
+than it goes.

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-mechanism-xask.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-mechanism-xask.md
@@ -121,3 +121,28 @@ construction, exactly as PD-F15 shows row 1 to be. That point is conceded, recor
 the verdict — a row that cannot hold does not hold — but a reader who takes anchor 1 as
 having settled "was V0 structurally guaranteed?" in general would be taking it further
 than it goes.
+
+### The concession above was WRONG and is withdrawn (added by Review v2)
+
+The seeding-based structural argument conceded in the section immediately above does not
+survive execution, and the concession is withdrawn. Recorded as **PD-F20** in
+`spec356-manifest.md` §12.1.f, which supersedes PD-F19 in part; the section above is left
+verbatim so the withdrawal can be checked against what it withdraws.
+
+The refutation is a one-line mutation of the SUBJECT with the fixture, the drive and the
+frozen universe untouched: in `crdt.rs`'s `prune_epoch_tombstones` drop closure,
+`dropped = outcome.pruned > 0;` → `dropped = false;` — the minimal faithful encoding of
+reading (ii) itself, *"the index removal is real, the store frees nothing"* — flips `D5`'s
+printed `row2(V2 BOOKKEEPING-ATTRIBUTION)` from `false` to **`true`**, with `I1`/`I2`/`I3`
+and P-KEYS still holding on `3000/3000`. `D5`'s seeding does not foreclose row 2; the
+store's own correct reclamation is what makes row 2 false, which is a live predicate
+returning a genuine negative. §12.0 froze the distinction in advance: `D3` is EXCLUDED
+from the D-T because it *"produces row 2's signature by construction"*, while `D5`'s
+P-KEYS clause exists so that *"a store-side zero cannot be manufactured by the fixture"*.
+
+So anchor 1's answer to *"was `V0` structurally guaranteed?"* is narrower than the anchor
+claims only in one direction that survives: neither the transport-based form (which anchor
+1 refutes) nor the seeding-based form (which PD-F20 refutes) holds. The corrected reading
+of `V0`, which is what `TODO-634` inherits: **two of three readings were tested over `D5`
+and both returned negatives; the third's antecedent (row 1) is not constructible through
+the public API.**

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-microdiag-transcript.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-microdiag-transcript.txt
@@ -251,3 +251,122 @@ Post-append boundary lines, executed exactly as instructed:
 
 This is the same text that stood at the pre-append tip when §12.0 was frozen: the
 boundary is unchanged by this group's append of §12.1.
+
+=======================================================================================
+RE-STAMP — RE-EXECUTED AT TIP 33a13c90 (Review v2 fix round)
+=======================================================================================
+
+Why this section exists: everything above was executed at tip 453aeb55 and quotes those
+runs verbatim. Two commits have changed the SUBJECT of those runs since, so a reader who
+checks out the current tip is not looking at the tree the figures above came from:
+
+  887cb496  test(sf-358)  crdt.rs's test-module capture sink String -> Vec<String>
+                          (test module only; no production byte)
+  60fc16e7  docs(sf-358)  crdt.rs test doc-comments cite the workload's prune call by
+                          name instead of by line (comment only)
+
+Everything above is therefore RE-EXECUTED here at tip 33a13c90 rather than re-dated. No
+figure below is copied from the runs above; each is the output of a command run again.
+
+--------------------------------------------------------------------------------------
+Leg (a) UNMUTATED — clean tree at 33a13c90
+--------------------------------------------------------------------------------------
+
+    $ cargo test --release -p topgun-server --lib
+    test result: ok. 1811 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 94.55s
+    exit 0
+
+    $ cargo test --profile ci-sim --features simulation -p topgun-server -- sim --nocapture
+    test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 1811 filtered out; finished in 0.67s
+    exit 0
+
+Drive values off that same run, all five, verbatim:
+
+    D1 DIVERGENCE: REPRODUCED — R_obs=3 R_ent=2 B_obs=12 B_att=8 len(extra.tag)=4
+    D2 POST-EXIT RESTORE: REPRODUCED — k=1 sum_R_obs=0
+    D3 ABSENT-KEY: REPRODUCED — D_e=0 F_e=0 B_att=4 absent=1
+    D4 TOCTOU RACE: REPRODUCED — aggregate index_conservation_snapshot() terms (exactly
+      one attributed drain, exactly one exit row, O-0) held across all 64 interleavings.
+      Row-granularity terms are NOT observable here (C13, X21-d) ... NOT in a
+      Decision-Table universe (Step 2's exclusion table).
+    D5 SEQUENTIAL REGIME: REPRODUCED — I1/I2/I3 held on every in-scope pass (1 empty,
+      3000 draining, 0 not-applicable), P-KEYS held on 3000/3000 considered refs. D-T row
+      conditions (recorded evidence, NOT a verdict): row1(V1 REF-LOSS)=false
+      row2(V2 BOOKKEEPING-ATTRIBUTION)=false row3(V3 COUNTER-FAMILY-MISNAMING)=false.
+
+Every published figure is byte-identical to the 453aeb55 record above. The capture-sink
+type change did not move a single row count, term or row value.
+
+--------------------------------------------------------------------------------------
+Leg (b) MUTATED — spec358-mutation-arm.patch applied at 33a13c90, then reverted
+--------------------------------------------------------------------------------------
+
+    $ git apply packages/server-rust/benches/soak_harness/evidence/spec358-mutation-arm.patch
+    $ cargo test --release -p topgun-server --lib
+    test result: FAILED. 1808 passed; 3 failed; 2 ignored; 0 measured; 0 filtered out
+    exit 101
+    failures:
+        tombstone_frontier_impl::tests::finalize_epoch_exit_zeroes_observation_fields_when_the_epoch_is_absent_from_the_carried_map
+        tombstone_frontier_impl::tests::s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only
+        tombstone_frontier_impl::tests::step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record
+
+    $ cargo test --profile ci-sim --features simulation -p topgun-server -- sim
+    test result: FAILED. 25 passed; 1 failed; 0 ignored; 0 measured; 1811 filtered out
+    exit 101
+    failures:
+        sim::tombstone_gc_proof::tests::d1_divergence_removed_observation_diverges_from_entry_attribution
+      panicked at sim/tombstone_gc_proof.rs:983:
+      "D1 predicate limb 1 (R_obs == R_ent + 1) must hold"
+
+    $ git apply -R .../spec358-mutation-arm.patch && git status --porcelain
+    (empty — tree clean)
+
+Same three lib failures and same one sim failure as at 453aeb55. The instrument is LIVE
+at the current tip, not merely at the tip the record above was written from.
+
+--------------------------------------------------------------------------------------
+PD-F20's two mutations, RE-EXECUTED at 33a13c90 (see spec356-manifest.md §12.1.f)
+--------------------------------------------------------------------------------------
+
+Row 2 is LIVE. In crdt.rs's prune_epoch_tombstones drop closure,
+`dropped = outcome.pruned > 0;` -> `dropped = false;`:
+
+    D5 SEQUENTIAL REGIME: REPRODUCED — I1/I2/I3 held on every in-scope pass (1 empty,
+      3000 draining, 0 not-applicable), P-KEYS held on 3000/3000 considered refs. D-T row
+      conditions: row1(V1 REF-LOSS)=false row2(V2 BOOKKEEPING-ATTRIBUTION)=true
+      row3(V3 COUNTER-FAMILY-MISNAMING)=false.
+    test sim::...::d5_sequential_regime_bridge_identities_and_p_keys_hold_over_3000_epochs ... ok
+
+Row 3 is LIVE in the fail-closed sense. `empty_drain: drained.is_empty()` ->
+`empty_drain: true` in the same function:
+
+    test sim::...::d5_sequential_regime_bridge_identities_and_p_keys_hold_over_3000_epochs ... FAILED
+    assertion `left == right` failed: D5 I2 violated on a pass: empty_drain == (Σ_e R_obs(e) == 0) must hold
+
+Both mutations reverted; `git status --porcelain` empty afterwards. These are the
+executed evidence PD-F20 rests on, re-run at this tip.
+
+--------------------------------------------------------------------------------------
+Full repo gate at 33a13c90 — every command, its real exit code
+--------------------------------------------------------------------------------------
+
+    pnpm install --frozen-lockfile                                    exit 0
+    pnpm -r build                                                     exit 0
+    pnpm lint                                                         exit 0
+    pnpm format:check                                                 exit 0
+    cargo fmt --check                                                 exit 0
+    cargo build --release                                             exit 0
+    cargo clippy --all-targets --all-features -- -D warnings          exit 0  (zero warnings)
+    cargo test --release -p topgun-server --lib                       exit 0  (1811 passed)
+    cargo test --profile ci-sim --features simulation -- sim          exit 0  (26 passed)
+    bash scripts/check-invariants.sh                                  exit 0  ("21 entries, 4 NAKED (baseline 4)")
+
+--------------------------------------------------------------------------------------
+Freeze digest, recomputed at 33a13c90
+--------------------------------------------------------------------------------------
+
+    $ sed -n '1,7689p' packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md | shasum -a 256
+    24273adf2ee87b544520cef817c826bf2be645e07cb97c8ef110ca21e59dabac  -
+
+MATCH. §12.0 is byte-frozen across BOTH post-freeze appends (the §12.1 append and the
+PD-F19/PD-F20 POST-DATA appends). V0 is unchanged.

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-microdiag-transcript.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-microdiag-transcript.txt
@@ -1,0 +1,253 @@
+SPEC-358 — PD-F12 micro-diagnosis: EXECUTED TRANSCRIPT
+=========================================================
+
+Executed tip for every leg and drive below: 453aeb55 (branch sf-358-pdf12-microdiag).
+This transcript quotes the raw captured output stored under this session's scratchpad
+(lega2_lib.txt, lega2_sim.txt, legb2_lib.txt, legb2_sim.txt, legrevert_lib.txt,
+legrevert_sim.txt, drives_values.txt). Nothing here is re-run; every value below is a
+verbatim quote of an already-captured run.
+
+Frozen order followed: Step 0 (three legs) -> Step 1 (bridge identities) -> Step 2
+(Decision Table) -> Step 3 (Fix-Shape Mapping) -> E-C.
+
+---------------------------------------------------------------------------------------
+STEP 0 — INSTRUMENT IDENTITY, FAIL-CLOSED, EVALUATED FIRST
+---------------------------------------------------------------------------------------
+
+## leg (a) UNMUTATED — clean tree, no patch applied
+
+`cargo test --release -p topgun-server --lib`:
+
+    test result: ok. 1811 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 102.93s
+
+Exit code: 0.
+
+`pnpm test:sim` (== `cargo test --profile ci-sim --features simulation -p topgun-server -- sim`):
+
+    test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 1811 filtered out; finished in 0.66s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
+    test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+    test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.15s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 20 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+    test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 5 filtered out; finished in 0.00s
+
+Sim `#[test]`s of interest, both passing:
+
+    test sim::tombstone_gc_proof::tests::d1_divergence_removed_observation_diverges_from_entry_attribution ... ok
+    test sim::tombstone_gc_proof::tests::d5_sequential_regime_bridge_identities_and_p_keys_hold_over_3000_epochs ... ok
+
+Exit code: 0.
+
+`S1`'s executed row (`s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only`,
+already frozen into §12.0, quoted here again as leg (a)'s carried evidence):
+
+    target=topgun_server::tombstone_frontier::residency message=prune epoch exit kind=epoch_exit epoch=1 refs_at_entry=1 refs_at_exit=0 stamped_bytes=4 bytes_freed_attributed=4 exit_kind=DrainedByPrune entered_at_op_seq=1 entered_at_unix_ms=1786797138477 exited_at_op_seq=2 lwm_passed_at_op_seq=Some(2) fence_passed_at_op_seq=Some(2) lwm_at_exit=2 durable_watermark_at_exit=1 current_epoch_at_exit=2 removed_refs_observed=2 removed_bytes_observed=8
+
+`R_obs == R_ent + 1` holds (`2 == 1 + 1`); `B_obs == B_att + len("TAGX")` holds (`8 == 4 + 4`).
+
+leg (a) HOLDS.
+
+## leg (b) MUTATED — `spec358-mutation-arm.patch` applied
+
+Patch substitutes the ATTRIBUTION for the OBSERVATION at
+`tombstone_frontier_impl.rs:718-724`:
+
+    -                observed.unwrap_or((0, 0))
+    +                (slot.refs_at_entry, slot.stamped_bytes)
+
+`cargo test --release -p topgun-server --lib`:
+
+    test result: FAILED. 1808 passed; 3 failed; 2 ignored; 0 measured; 0 filtered out; finished in 100.17s
+
+Exit code: 101.
+
+Failure block, quoted verbatim:
+
+    ---- tombstone_frontier_impl::tests::finalize_epoch_exit_zeroes_observation_fields_when_the_epoch_is_absent_from_the_carried_map stdout ----
+
+    thread 'tombstone_frontier_impl::tests::finalize_epoch_exit_zeroes_observation_fields_when_the_epoch_is_absent_from_the_carried_map' panicked at packages/server-rust/src/tombstone_frontier_impl.rs:4494:9:
+    assertion `left == right` failed: R1.5: epoch absent from the carried map: PruneEpochResidencyRecord { epoch: 1, refs_at_entry: 1, refs_at_exit: 0, stamped_bytes: 4, bytes_freed_attributed: 4, exit_kind: DrainedByPrune, entered_at_op_seq: 1, entered_at_unix_ms: 1786802620342, exited_at_op_seq: 2, lwm_passed_at_op_seq: None, fence_passed_at_op_seq: None, lwm_at_exit: 0, durable_watermark_at_exit: 0, current_epoch_at_exit: 2, removed_refs_observed: 1, removed_bytes_observed: 4 }
+      left: 1
+     right: 0
+
+    ---- tombstone_frontier_impl::tests::s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only stdout ----
+
+    thread 'tombstone_frontier_impl::tests::s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only' panicked at packages/server-rust/src/tombstone_frontier_impl.rs:4742:9:
+    discriminating assertion R_obs == R_ent + 1 does not hold; row: target=topgun_server::tombstone_frontier::residency message=prune epoch exit kind=epoch_exit epoch=1 refs_at_entry=1 refs_at_exit=0 stamped_bytes=4 bytes_freed_attributed=4 exit_kind=DrainedByPrune entered_at_op_seq=1 entered_at_unix_ms=1786802620718 exited_at_op_seq=2 lwm_passed_at_op_seq=Some(2) fence_passed_at_op_seq=Some(2) lwm_at_exit=2 durable_watermark_at_exit=1 current_epoch_at_exit=2 removed_refs_observed=1 removed_bytes_observed=4
+
+    ---- tombstone_frontier_impl::tests::step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record stdout ----
+
+    thread 'tombstone_frontier_impl::tests::step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record' panicked at packages/server-rust/src/tombstone_frontier_impl.rs:4799:9:
+    assertion `left == right` failed: R_obs must be 0: the planted vector carried nothing for drain_prunable to observe: PruneEpochResidencyRecord { epoch: 1, refs_at_entry: 1, refs_at_exit: 0, stamped_bytes: 4, bytes_freed_attributed: 4, exit_kind: DrainedByPrune, entered_at_op_seq: 1, entered_at_unix_ms: 1786802620750, exited_at_op_seq: 2, lwm_passed_at_op_seq: Some(2), fence_passed_at_op_seq: Some(2), lwm_at_exit: 2, durable_watermark_at_exit: 1, current_epoch_at_exit: 2, removed_refs_observed: 1, removed_bytes_observed: 4 }
+      left: 1
+     right: 0
+
+    failures:
+        tombstone_frontier_impl::tests::finalize_epoch_exit_zeroes_observation_fields_when_the_epoch_is_absent_from_the_carried_map
+        tombstone_frontier_impl::tests::s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only
+        tombstone_frontier_impl::tests::step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record
+
+    test result: FAILED. 1808 passed; 3 failed; 2 ignored; 0 measured; 0 filtered out; finished in 100.17s
+
+`s1_...` names the discriminating assertion literally: "discriminating assertion R_obs == R_ent + 1 does not hold".
+
+`pnpm test:sim`:
+
+    test result: FAILED. 25 passed; 1 failed; 0 ignored; 0 measured; 1811 filtered out; finished in 0.68s
+
+Exit code: 101.
+
+Failure block, quoted verbatim:
+
+    ---- sim::tombstone_gc_proof::tests::d1_divergence_removed_observation_diverges_from_entry_attribution stdout ----
+
+    thread 'sim::tombstone_gc_proof::tests::d1_divergence_removed_observation_diverges_from_entry_attribution' panicked at packages/server-rust/src/sim/tombstone_gc_proof.rs:981:9:
+    assertion `left == right` failed: D1 predicate limb 1 (R_obs == R_ent + 1) must hold; row:  target=topgun_server::tombstone_frontier::residency message=prune epoch exit kind=epoch_exit epoch=1 refs_at_entry=2 refs_at_exit=0 stamped_bytes=8 bytes_freed_attributed=8 exit_kind=DrainedByPrune entered_at_op_seq=1 entered_at_unix_ms=1786802709531 exited_at_op_seq=3 lwm_passed_at_op_seq=Some(3) fence_passed_at_op_seq=Some(3) lwm_at_exit=2 durable_watermark_at_exit=1000 current_epoch_at_exit=2 removed_refs_observed=2 removed_bytes_observed=8
+      left: 2
+     right: 3
+
+    failures:
+        sim::tombstone_gc_proof::tests::d1_divergence_removed_observation_diverges_from_entry_attribution
+
+    test result: FAILED. 25 passed; 1 failed; 0 ignored; 0 measured; 1811 filtered out; finished in 0.68s
+
+`d1_...` also names the discriminating assertion literally: "D1 predicate limb 1 (R_obs == R_ent + 1) must hold".
+
+**Both halves fail, and each failure names the discriminating assertion `R_obs == R_ent + 1`.**
+leg (b) HOLDS.
+
+Honesty note (verbatim in substance from the handoff): on the FIRST mutated run, `S1`'s
+message printed the row but did not contain the literal `R_obs == R_ent + 1`, so
+Checklist 3's "each failure message names the discriminating assertion" was not yet
+satisfied on that run — the assertion itself already was the discriminating one and
+already failed. Commit `453aeb55` changed only the assertion's MESSAGE to name it
+literally; the asserted condition is byte-identical before and after that commit. Legs
+(a) and (b) were then re-run end to end from a clean tree, and every figure quoted in
+this transcript is from that re-run. `D1`'s message already named the literal on the
+first run and required no message change.
+
+## leg (c) POSITIVE CONTROL — unmutated (part of leg (a)'s clean-tree run above)
+
+`step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record` is
+included in leg (a)'s 1811-passed lib run (it is one of the 1811). It plants
+`epoch_tags.insert(e, Vec::new())` over an entry-emitted, still-tracked slot, then
+drains in-module via `f.lock().drain_prunable()`, asserting `R_obs == 0` and
+`R_ent > 0` on the returned record. It passes unmutated.
+
+Under leg (b)'s mutation it FAILS (quoted above under leg (b)) with
+`left: 1, right: 0` on the `R_obs must be 0` assertion — i.e. the control is live, not
+vacuous: the mutation breaks it exactly as the freeze predicted.
+
+leg (c) HOLDS.
+
+## Revert and re-verify (clean tree restored via `git checkout --`)
+
+`cargo test --release -p topgun-server --lib`:
+
+    test result: ok. 1811 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 95.93s
+
+Exit code: 0.
+
+`pnpm test:sim`: same 18 `test result: ok` blocks as leg (a) above, all 0 failed
+(26 passed in the primary `sim::` module), exit code 0.
+
+---------------------------------------------------------------------------------------
+STEP 0 — DETERMINATION
+---------------------------------------------------------------------------------------
+
+All three legs HOLD. Step 0 does NOT fire fail-closed. The determination is NOT
+`INDETERMINATE-INSTRUMENT`. Steps 1-3 are evaluated.
+
+---------------------------------------------------------------------------------------
+STEP 1 — THE BRIDGE IDENTITIES (over D5, the sole Decision-Table universe)
+---------------------------------------------------------------------------------------
+
+Evaluated on `D5`'s `--nocapture` run (`drives_values.txt`):
+
+    D5 SEQUENTIAL REGIME: REPRODUCED — I1/I2/I3 held on every in-scope pass (1 empty, 3000 draining, 0 not-applicable), P-KEYS held on 3000/3000 considered refs. D-T row conditions (recorded evidence, NOT a verdict): row1(V1 REF-LOSS)=false row2(V2 BOOKKEEPING-ATTRIBUTION)=false row3(V3 COUNTER-FAMILY-MISNAMING)=false.
+
+- I1 (`Σ_e R_obs(e) == K_p`): HELD on all 3001 passes, 0 violations.
+- I2 (`E_p == (Σ_e R_obs(e) == 0)`): HELD on all 3001 passes, 0 violations.
+- I3 (`B_obs(e) ≤ B_att(e) + B_restored(e)`): HELD on all 3000 drained epochs
+  (`B_restored = 0`; D5 never restores).
+- NOT-APPLICABLE passes (a `restored_*` exit fired): 0.
+- P-KEYS: HELD on 3000/3000 considered refs (`absent = 0` on every settlement row).
+
+`sim::tombstone_gc_proof::tests::d5_sequential_regime_bridge_identities_and_p_keys_hold_over_3000_epochs ... ok`
+
+---------------------------------------------------------------------------------------
+STEP 2 — THE DECISION TABLE (D-T), evaluated in frozen order
+---------------------------------------------------------------------------------------
+
+| # | Verdict | Condition | Value |
+|---|---|---|---|
+| 1 | V1 — REF-LOSS | ∃ `DrainedByPrune` row of D5 with `R_obs < R_ent` | **false** |
+| 2 | V2 — BOOKKEEPING ATTRIBUTION | ∃ epoch with `R_obs > 0 ∧ D_e == 0 ∧ F_e == 0 ∧ B_att > 0` | **false** |
+| 3 | V3 — COUNTER-FAMILY MISNAMING | I1 or I2 violated on an in-scope pass | **false** |
+| 4 | V0 — NOT REPRODUCED | none of rows 1-3 holds over its own universe | **HOLDS** |
+
+**VERDICT: V0 — NOT REPRODUCED.** Exactly one verdict, read off the frozen table in its
+frozen order.
+
+---------------------------------------------------------------------------------------
+STEP 3 — THE FIX-SHAPE MAPPING (F-M)
+---------------------------------------------------------------------------------------
+
+F-M's `V0` row: **THE RULING IS NOT WRITTEN.** Per R7.1 the not-written status IS the
+satisfying content, not an absence. See `spec358-fixshape-ruling.md` for the full
+ruling record, including §8.3 quoted verbatim.
+
+---------------------------------------------------------------------------------------
+E-C — THE PRE-REGISTERED ESCALATION CLAUSE
+---------------------------------------------------------------------------------------
+
+E-C's own text: "'Does not name the mechanism' means exactly: the frozen table resolves
+to V0, or Step 0 fires fail-closed with any INDETERMINATE-*." The table resolved V0 ->
+**E-C FIRES -> the diagnosis line HARD STOPS. There is no diagnosis round after this
+one.** The `ReclamationRegistry` family starts with the cause **unclassified**,
+justified by §8.3 quoted verbatim (see `spec358-fixshape-ruling.md`).
+
+POST-DATA findings PD-F15-PD-F18 are recorded and ROUTED to `TODO-634`; they do NOT
+alter the verdict. See §12.1 of `spec356-manifest.md` and `spec358-mechanism-xask.md`.
+
+---------------------------------------------------------------------------------------
+R6.3 / AC11 — THE §0-§11 DIGEST PAIR
+---------------------------------------------------------------------------------------
+
+§12.0 (the PRE-DATA FREEZE, `spec356-manifest.md:7690-8038` before this group's append)
+records the PRE-DATA digest as:
+
+    24273adf2ee87b544520cef817c826bf2be645e07cb97c8ef110ca21e59dabac
+
+Recomputed now, over the SAME span, executed exactly as instructed:
+
+    $ sed -n '1,7689p' packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md | shasum -a 256
+    24273adf2ee87b544520cef817c826bf2be645e07cb97c8ef110ca21e59dabac  -
+
+**MATCH.** The PRE-DATA digest and the recomputed digest are byte-identical. §0-§11 was
+not disturbed by the §12 append.
+
+Post-append boundary lines, executed exactly as instructed:
+
+    $ sed -n '7690,7695p' packages/server-rust/benches/soak_harness/evidence/spec356-manifest.md
+
+    ---
+
+    ## §12 — SPEC-358: the PD-F12 micro-diagnosis (frozen predicate, then the executed record)
+
+    **This heading and everything beneath it is APPENDED — no byte of §0–§11 is touched by it.**
+
+This is the same text that stood at the pre-append tip when §12.0 was frozen: the
+boundary is unchanged by this group's append of §12.1.

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-mutation-arm.patch
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-mutation-arm.patch
@@ -1,0 +1,13 @@
+diff --git a/packages/server-rust/src/tombstone_frontier_impl.rs b/packages/server-rust/src/tombstone_frontier_impl.rs
+index ea701a52..2ccc78f6 100644
+--- a/packages/server-rust/src/tombstone_frontier_impl.rs
++++ b/packages/server-rust/src/tombstone_frontier_impl.rs
+@@ -716,7 +716,7 @@ impl FrontierState {
+         // rather than folded behind a default, so that possibility stays visible.
+         let (removed_refs_observed, removed_bytes_observed) =
+             if matches!(exit_kind, EpochExitKind::DrainedByPrune) {
+-                observed.unwrap_or((0, 0))
++                (slot.refs_at_entry, slot.stamped_bytes)
+             } else {
+                 (0, 0)
+             };

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-mutation-arm.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-mutation-arm.txt
@@ -1,0 +1,128 @@
+SPEC-358 — Step 0 leg (b): mutation-arm captured output (all THREE legs, with exit codes)
+============================================================================================
+
+Patch applied for leg (b): `spec358-mutation-arm.patch`
+(`packages/server-rust/src/tombstone_frontier_impl.rs:718-724`):
+
+    -                observed.unwrap_or((0, 0))
+    +                (slot.refs_at_entry, slot.stamped_bytes)
+
+This substitutes the ATTRIBUTION (`refs_at_entry` / `stamped_bytes`) for the OBSERVATION
+(`observed`, which is what `removed_refs_observed` / `removed_bytes_observed` are meant
+to carry on a `DrainedByPrune` exit), so on a slot where `R_obs != R_ent` the mutated
+build reports `R_obs == R_ent` and every discriminator that asserts otherwise fails.
+
+--------------------------------------------------------------------------------------
+LEG (a) — UNMUTATED (clean tree)
+--------------------------------------------------------------------------------------
+
+`cargo test --release -p topgun-server --lib`
+Exit code: 0
+
+    test result: ok. 1811 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 102.93s
+
+`pnpm test:sim`
+Exit code: 0
+
+    test sim::tombstone_gc_proof::tests::d1_divergence_removed_observation_diverges_from_entry_attribution ... ok
+    test sim::tombstone_gc_proof::tests::d5_sequential_regime_bridge_identities_and_p_keys_hold_over_3000_epochs ... ok
+    ...
+    test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 1811 filtered out; finished in 0.66s
+
+--------------------------------------------------------------------------------------
+LEG (b) — MUTATED (`spec358-mutation-arm.patch` applied)
+--------------------------------------------------------------------------------------
+
+`cargo test --release -p topgun-server --lib`
+Exit code: 101
+
+    ---- tombstone_frontier_impl::tests::finalize_epoch_exit_zeroes_observation_fields_when_the_epoch_is_absent_from_the_carried_map stdout ----
+
+    thread 'tombstone_frontier_impl::tests::finalize_epoch_exit_zeroes_observation_fields_when_the_epoch_is_absent_from_the_carried_map' panicked at packages/server-rust/src/tombstone_frontier_impl.rs:4494:9:
+    assertion `left == right` failed: R1.5: epoch absent from the carried map: PruneEpochResidencyRecord { epoch: 1, refs_at_entry: 1, refs_at_exit: 0, stamped_bytes: 4, bytes_freed_attributed: 4, exit_kind: DrainedByPrune, entered_at_op_seq: 1, entered_at_unix_ms: 1786802620342, exited_at_op_seq: 2, lwm_passed_at_op_seq: None, fence_passed_at_op_seq: None, lwm_at_exit: 0, durable_watermark_at_exit: 0, current_epoch_at_exit: 2, removed_refs_observed: 1, removed_bytes_observed: 4 }
+      left: 1
+     right: 0
+
+    ---- tombstone_frontier_impl::tests::s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only stdout ----
+
+    thread 'tombstone_frontier_impl::tests::s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only' panicked at packages/server-rust/src/tombstone_frontier_impl.rs:4742:9:
+    discriminating assertion R_obs == R_ent + 1 does not hold; row: target=topgun_server::tombstone_frontier::residency message=prune epoch exit kind=epoch_exit epoch=1 refs_at_entry=1 refs_at_exit=0 stamped_bytes=4 bytes_freed_attributed=4 exit_kind=DrainedByPrune entered_at_op_seq=1 entered_at_unix_ms=1786802620718 exited_at_op_seq=2 lwm_passed_at_op_seq=Some(2) fence_passed_at_op_seq=Some(2) lwm_at_exit=2 durable_watermark_at_exit=1 current_epoch_at_exit=2 removed_refs_observed=1 removed_bytes_observed=4
+
+    ---- tombstone_frontier_impl::tests::step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record stdout ----
+
+    thread 'tombstone_frontier_impl::tests::step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record' panicked at packages/server-rust/src/tombstone_frontier_impl.rs:4799:9:
+    assertion `left == right` failed: R_obs must be 0: the planted vector carried nothing for drain_prunable to observe: PruneEpochResidencyRecord { epoch: 1, refs_at_entry: 1, refs_at_exit: 0, stamped_bytes: 4, bytes_freed_attributed: 4, exit_kind: DrainedByPrune, entered_at_op_seq: 1, entered_at_unix_ms: 1786802620750, exited_at_op_seq: 2, lwm_passed_at_op_seq: Some(2), fence_passed_at_op_seq: Some(2), lwm_at_exit: 2, durable_watermark_at_exit: 1, current_epoch_at_exit: 2, removed_refs_observed: 1, removed_bytes_observed: 4 }
+      left: 1
+     right: 0
+
+    failures:
+        tombstone_frontier_impl::tests::finalize_epoch_exit_zeroes_observation_fields_when_the_epoch_is_absent_from_the_carried_map
+        tombstone_frontier_impl::tests::s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only
+        tombstone_frontier_impl::tests::step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record
+
+    test result: FAILED. 1808 passed; 3 failed; 2 ignored; 0 measured; 0 filtered out; finished in 100.17s
+    error: test failed, to rerun pass `-p topgun-server --lib`
+
+`pnpm test:sim`
+Exit code: 101
+
+    ---- sim::tombstone_gc_proof::tests::d1_divergence_removed_observation_diverges_from_entry_attribution stdout ----
+
+    thread 'sim::tombstone_gc_proof::tests::d1_divergence_removed_observation_diverges_from_entry_attribution' panicked at packages/server-rust/src/sim/tombstone_gc_proof.rs:981:9:
+    assertion `left == right` failed: D1 predicate limb 1 (R_obs == R_ent + 1) must hold; row:  target=topgun_server::tombstone_frontier::residency message=prune epoch exit kind=epoch_exit epoch=1 refs_at_entry=2 refs_at_exit=0 stamped_bytes=8 bytes_freed_attributed=8 exit_kind=DrainedByPrune entered_at_op_seq=1 entered_at_unix_ms=1786802709531 exited_at_op_seq=3 lwm_passed_at_op_seq=Some(3) fence_passed_at_op_seq=Some(3) lwm_at_exit=2 durable_watermark_at_exit=1000 current_epoch_at_exit=2 removed_refs_observed=2 removed_bytes_observed=8
+      left: 2
+     right: 3
+
+    failures:
+        sim::tombstone_gc_proof::tests::d1_divergence_removed_observation_diverges_from_entry_attribution
+
+    test result: FAILED. 25 passed; 1 failed; 0 ignored; 0 measured; 1811 filtered out; finished in 0.68s
+    error: test failed, to rerun pass `-p topgun-server --lib`
+     ELIFECYCLE  Command failed with exit code 101.
+
+**Both failure sets name the discriminating assertion `R_obs == R_ent + 1` literally**:
+lib's `s1_...` says "discriminating assertion R_obs == R_ent + 1 does not hold"; sim's
+`d1_...` says "D1 predicate limb 1 (R_obs == R_ent + 1) must hold". Checklist 3 is
+satisfied by this re-run.
+
+--------------------------------------------------------------------------------------
+LEG (c) — POSITIVE CONTROL
+--------------------------------------------------------------------------------------
+
+Unmutated: `step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record`
+passes (part of leg (a)'s 1811-passed lib run above), asserting `R_obs == 0` and
+`R_ent > 0` on the record `f.lock().drain_prunable()` returns for a planted-empty
+`epoch_tags` entry.
+
+Mutated: it FAILS (quoted above under leg (b)'s lib failures) with `left: 1, right: 0`
+on the `R_obs must be 0` assertion — the control is live under the mutation, not
+vacuous.
+
+--------------------------------------------------------------------------------------
+REVERT AND RE-VERIFY
+--------------------------------------------------------------------------------------
+
+`git checkout --` restored the clean tree.
+
+`cargo test --release -p topgun-server --lib`
+Exit code: 0
+
+    test result: ok. 1811 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 95.93s
+
+`pnpm test:sim`
+Exit code: 0 (18 `test result: ok` blocks, 26 passed in the primary `sim::` module, 0 failed)
+
+--------------------------------------------------------------------------------------
+HONESTY NOTE (verbatim in substance, quoted from the handoff)
+--------------------------------------------------------------------------------------
+
+On the FIRST mutated run, `S1`'s message printed the row but did not contain the
+literal `R_obs == R_ent + 1`, so Checklist 3's "each failure message names the
+discriminating assertion" was not yet satisfied by that run. The assertion itself
+already was the discriminating one and already failed on that first run — only its
+MESSAGE lacked the literal. Commit `453aeb55` changed only the assertion's MESSAGE to
+name `R_obs == R_ent + 1` explicitly; the asserted condition is byte-identical before
+and after that commit (no behavioral change, message-only). Legs (a) and (b) were then
+re-run end to end from a clean tree, and every figure published above and in
+`spec358-microdiag-transcript.txt` is from that re-run. `D1`'s message already named
+the literal on the first run and required no message change.

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-x21-discharge.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-x21-discharge.txt
@@ -136,3 +136,57 @@ Row-granularity terms are NOT observable here (C13, X21-d): the prune runs in a
 tokio::spawn task on a multi_thread runtime, so the thread-local tracing capture would
 see an empty capture rather than a violation. NOT in a Decision-Table universe (Step
 2's exclusion table)."
+
+=======================================================================================
+RE-STAMP — RE-EXECUTED AT TIP 33a13c90 (Review v2 fix round)
+=======================================================================================
+
+Why this section exists: this artifact's four limbs were discharged at tip 453aeb55, and
+one of the commits since then changed X21-b's own transport helper — 887cb496 replaced
+the tracing capture sink in crdt.rs's test module (`Arc<Mutex<String>>` -> `Vec<String>`,
+`split_into_passes(&str)` -> `split_into_passes(&[String])`). A discharge record whose
+transport has been re-typed underneath it must be re-executed, not re-dated. It was.
+
+Re-executed at 33a13c90, clean tree:
+
+    cargo test --release -p topgun-server --lib                exit 0  (1811 passed)
+    cargo test --profile ci-sim --features simulation -- sim   exit 0  (26 passed)
+
+X21-a (struct transport) — `step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_
+the_returned_record` PASSES unmutated at this tip, and FAILS under
+spec358-mutation-arm.patch (`left: 1, right: 0`), re-executed here. The control is still
+live.
+
+X21-b (line transport) — `S1`, `D1` and `D5` all read their terms off the rendered
+`tracing` field text and all PASS at this tip. `S1` and `D1` FAIL under the mutation arm,
+each naming `R_obs == R_ent + 1` literally, re-executed here. The sink re-typing changed
+the container the rows are accumulated in, not the transport being read: the rows are
+still the rendered `name=value` field text a `tracing::field::Visit` collector produces.
+
+X21-c (metrics transport and the join) — unchanged and re-verified by the same green lib
+run; no commit since 453aeb55 touches it.
+
+X21-d (per-drive runtime flavour, transport and captured-row counts) — the counts in the
+table above are ASSERTED BY THE DRIVES THEMSELVES before any D-T term is read (R4.6's
+per-kind capture-shape gate), so the green sim run at this tip re-discharges them
+mechanically. `D5`'s published values, re-executed at 33a13c90:
+
+    D5 SEQUENTIAL REGIME: REPRODUCED — I1/I2/I3 held on every in-scope pass (1 empty,
+      3000 draining, 0 not-applicable), P-KEYS held on 3000/3000 considered refs. D-T row
+      conditions (recorded evidence, NOT a verdict): row1(V1 REF-LOSS)=false
+      row2(V2 BOOKKEEPING-ATTRIBUTION)=false row3(V3 COUNTER-FAMILY-MISNAMING)=false.
+
+— i.e. 3000 `epoch_exit`, 3000 `settlement`, 3001 `prune_pass` rows recovered exactly as
+recorded above, with the new `Vec<String>` sink. Every figure in this artifact stands at
+the current tip.
+
+One term this artifact records but does not price, added by Review v2 and priced in
+`spec356-manifest.md` §12.1.b: over `D5` the `I3` check is ONE-SIDED — each epoch carries
+one ref, `B_restored(e) == 0`, and both `B_obs` and `B_att` trace to the byte length of
+that epoch's single `D5TAG{i}` tag, read off the same exit row. It excludes an over-count
+on the observation side and nothing else; `B_obs = 0` would satisfy it silently. Read
+`I3`'s 3000/3000 at that weight beside `I1`/`I2`.
+
+The full re-run — both Step-0 legs, all five drives, the two PD-F20 mutations and the
+whole repo gate with real exit codes — is recorded in `spec358-microdiag-transcript.txt`
+under its own RE-STAMP section at the same tip.

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-x21-discharge.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-x21-discharge.txt
@@ -1,0 +1,138 @@
+SPEC-358 — X21: the four-limb discharge record
+=================================================
+
+X21 reads: "every frozen surface, predicate, tool and join is validated against the
+exact transport the DATA half will consume, before the boundary." §12.0 froze this
+increment as APPLICABLE and discharged it in four limbs. This artifact records the
+executed proof for each.
+
+--------------------------------------------------------------------------------------
+X21-a — the struct transport
+--------------------------------------------------------------------------------------
+
+Frozen surface: the two new fields (`removed_refs_observed`, `removed_bytes_observed`)
+on `PruneEpochResidencyRecord`, asserted on a RETURNED RECORD.
+
+Consumer transport: the one in-crate site where a record is returned by value —
+`detect_epoch_exit` / `finalize_epoch_exit` in `tombstone_frontier_impl.rs`'s inline
+tests. There is no `PruneRecordObserver` test double in the tree, and none is claimed.
+
+Executed proof: Step 0 leg (c),
+`tombstone_frontier_impl::tests::step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record`,
+which drains in-module via `f.lock().drain_prunable()` (the one in-crate call that
+returns the exit rows by value) and asserts both new fields on that returned record
+(`R_obs == 0`, `R_ent > 0` under the planted-empty-vector condition). PASSES unmutated;
+FAILS under the mutation arm (`left: 1, right: 0`), confirming the control is live.
+
+`S1` does NOT discharge this limb: its step 8 goes through the public
+`drain_prunable_tombstones`, which returns no record (see X21-b below), so `S1`'s
+assertion on the returned `Vec` is a count check only (`len() == 2`).
+
+--------------------------------------------------------------------------------------
+X21-b — the line transport
+--------------------------------------------------------------------------------------
+
+Frozen surface: every term the D-T predicates name, reachable on the exact `tracing`
+emission it is read from — the two new fields on the exit row, all eight terms on the
+settlement row, and `considered` / `empty_drain` on the pass row.
+
+Consumer transport: a `tracing-subscriber` capture (`set_default` + a `Layer` with a
+sink), shape sited at `network/device_identity.rs:397-429`, adapted with a
+`FieldTextVisitor` that asserts each field name appears in the RENDERED field text
+(the `name=value` pairs a `tracing::field::Visit` collector accumulates) — never
+against the struct.
+
+Executed proofs:
+- `tombstone_frontier_impl::tests::s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only`
+  (`S1`) — reads the exit row off the declared `tracing` capture and asserts
+  `removed_refs_observed` / `removed_bytes_observed` in the rendered field text. PASSES
+  unmutated; FAILS under mutation naming `R_obs == R_ent + 1` literally.
+- `sim::tombstone_gc_proof::tests::d1_divergence_removed_observation_diverges_from_entry_attribution`
+  (`D1`) — the sim-side twin, same rendered-field-text read. PASSES unmutated; FAILS
+  under mutation naming `R_obs == R_ent + 1` literally.
+- `sim::tombstone_gc_proof::tests::d5_sequential_regime_bridge_identities_and_p_keys_hold_over_3000_epochs`
+  (`D5`) — reads all three row kinds (`epoch_exit`, `settlement`, `prune_pass`) off the
+  same rendered-field-text transport across 3001 passes; this is the sole
+  Decision-Table universe. PASSES.
+
+--------------------------------------------------------------------------------------
+X21-c — the metrics transport and the join
+--------------------------------------------------------------------------------------
+
+Frozen surface: the two new pinned series
+(`topgun_or_prune_removed_refs_observed_total`,
+`topgun_or_prune_removed_bytes_observed_total`) present in a rendered `/metrics` scrape
+carrying the drain's own observed totals, joined on `epoch` (no wall-clock key
+anywhere).
+
+Consumer transport: `PrometheusBuilder::build_recorder` + `metrics::with_local_recorder`
++ `rendered_counter` — the shape already in the tree. Sited in the inline tests of a
+COUNTED file (`tombstone_frontier_impl.rs`), not in `src/sim`, per X21-d (the metrics
+recorder binding is thread-local).
+
+Executed proofs:
+- `tombstone_frontier_impl::tests::removed_observation_counters_reach_the_rendered_metrics_scrape`
+  — drives `stamp_tombstone` x2 -> `confirm_apply_ack` -> `drain_prunable_tombstones`
+  through the FULL public pipeline
+  (`drain_prunable_tombstones` -> `publish_epoch_exit` -> `observe_epoch_residency`),
+  then asserts
+  `rendered_value(&rendered, METRIC_PRUNE_REMOVED_REFS_OBSERVED_TOTAL) == Some("1")` and
+  `rendered_value(&rendered, METRIC_PRUNE_REMOVED_BYTES_OBSERVED_TOTAL) == Some("4")`
+  against the rendered `/metrics` scrape text. PASSES.
+- `tombstone_frontier_impl::tests::metrics_recorder_credits_removed_observation_counters_on_the_drained_arm_only`
+  — asserts `MetricsPruneRecorder::observe_epoch_residency` credits the two new
+  OBSERVATION counters on the `DrainedByPrune` arm only: `ClearedByRebuild` and
+  `StillResidentAtShutdown` records carrying nonzero observation fields (99/999) move
+  neither counter; only the `DrainedByPrune` record's 3/12 are credited. PASSES.
+
+Pinned-names banner (`tombstone_frontier.rs:759`) now reads 24 counters, up from 22,
+consistent with both new series being eagerly registered in
+`MetricsPruneRecorder::new()` via `touched_counter`.
+
+--------------------------------------------------------------------------------------
+X21-d — the thread-affinity limb
+--------------------------------------------------------------------------------------
+
+Frozen surface: both in-process transports the D-T's rows travel over
+(`tracing::subscriber::set_default` and `metrics::with_local_recorder`) are
+thread-local. A drive that runs the prune inside `tokio::spawn` on a `multi_thread`
+runtime observes neither, reading as an empty capture that looks exactly like "no
+violation." Frozen consequence: every drive whose rows enter a D-T universe runs on a
+current-thread runtime with the emission on the test's own thread; `D4` (the
+multi-thread race) is scoped to the aggregate `index_conservation_snapshot` terms and
+excluded from every D-T universe; every drive that reads rows off a capture first
+asserts the capture is non-empty and carries the expected row count (R4.6).
+
+Per-drive record (runtime flavour, transport, captured-row count by row kind),
+executed:
+
+| Drive | Runtime flavour | Transport | `epoch_exit` rows | `settlement` rows | `prune_pass` rows | In a D-T universe |
+|---|---|---|---|---|---|---|
+| `S1` | current-thread (`#[test]`, sync) | `tracing` capture | 1 | n/a (S1 reads the exit row only) | n/a | NO — Step-0 discriminator |
+| leg (c) | current-thread (`#[test]`, sync) | in-module return value (X21-a) | 1 (returned record, not captured) | n/a | n/a | NO — excluded by frozen scoping |
+| `D1` DIVERGENCE | current-thread (`#[tokio::test]`) | `tracing` capture | 1 | n/a | n/a | NO — Step-0 discriminator (sim twin of S1) |
+| `D2` POST-EXIT RESTORE | current-thread (`#[tokio::test]`) | `tracing` capture | 1 (first drain only; second drain emits none for `e`) | n/a | n/a | NO |
+| `D3` ABSENT-KEY | current-thread (`#[tokio::test]`) | `tracing` capture | >=1 | >=1 (`D_e == 0 ∧ F_e == 0` rows) | n/a | NO |
+| `D4` TOCTOU RACE | `#[tokio::test(flavor = "multi_thread")]`, `N = 64` interleavings | aggregate `index_conservation_snapshot()` only (row-granularity NOT observable — spawned task, thread-local capture) | not observable | not observable | not observable | NO — per-row terms unobservable here (C13) |
+| `D5` SEQUENTIAL REGIME | current-thread (`#[tokio::test]`) | `tracing` capture (all three row kinds, one transport) | **3000** | **3000** | **3001** | **YES — the D-T's sole universe** |
+
+`D5`'s counts, restated per R4.6's corrected off-by-one clause: 3000 real keyed stamps
++ 1 closing throwaway stamp = 3001 `prune_epoch_tombstones` invocations. The expected
+`epoch_exit` row count is the REAL KEYED stamp count (3000), one fewer than the 3001
+raw stamp calls, because at `epoch_width = 1` the last stamped epoch stays open unless
+a deliberate closing stamp rolls past it. `split_into_passes` recovered exactly 3001
+passes — an exact 1:1 with invocations. All three row-kind counts were asserted
+non-empty and exact before any D-T term was read off the capture (R4.6).
+
+Proving test fn: `sim::tombstone_gc_proof::tests::d5_sequential_regime_bridge_identities_and_p_keys_hold_over_3000_epochs`.
+
+`D4`'s proving test fn (recorded for completeness, outside every D-T universe):
+`sim::tombstone_gc_proof::tests::interleaved_prune_during_push_never_resurrects` /
+the aggregate conservation checks driven through
+`sim::tombstone_gc_proof::tests::prune_epoch_residency_discrimination_under_network_fault`.
+D4's `--nocapture` value: "aggregate index_conservation_snapshot() terms (exactly one
+attributed drain, exactly one exit row, O-0) held across all 64 interleavings.
+Row-granularity terms are NOT observable here (C13, X21-d): the prune runs in a
+tokio::spawn task on a multi_thread runtime, so the thread-local tracing capture would
+see an empty capture rather than a violation. NOT in a Decision-Table universe (Step
+2's exclusion table)."

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-xask-raw1.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-xask-raw1.txt
@@ -1,0 +1,26 @@
+→ openrouter z-ai/glm-5.2 answering (2 file(s) embedded)…
+
+[warn] ANSWER TRUNCATED at max_tokens (finish_reason=length). Raise OPENROUTER_MAX_TOKENS or unset it; with OPENROUTER_REASONING enabled, reasoning tokens count against the same budget.
+
+[usage] prompt=12800 completion=9000 total=21800 cost=$0.014888544
+# Skeptic's Review: The V0 Determination Is Structurally Guaranteed, Not Empirically Earned
+
+## (1) STRUCTURAL CAPABILITY — D5 Was Incapable In Principle. Three Construction Choices Did It.
+
+The production contradiction in PD-F12 is between **two transports**: Prometheus cumulative counters say "440,069 passes, every one empty, zero considered, zero dropped, zero bytes freed, zero epochs drained," while the per-epoch tracing exit ledger says "439 DrainedByPrune exits attributing 10,097,000 bytes freed." The contradiction is *inter-transport*. D5 examines *intra-transport* consistency only. It was guaranteed to resolve V0 before any data existed, by three independent construction choices, any one of which suffices:
+
+### Choice A: Prometheus is a permanent no-op in the sim.
+
+The freeze itself states this verbatim in the "Transport of the pass-ledger symbols" section:
+
+> "the counter handles are bound at `TombstoneFrontier::new` (`:1210-1213`) via `touched_counter` (`:2226`), called from `MetricsPruneRecorder::new()` (`:2341`), and the sim's frontier is built outside any `with_local_recorder` binding, so those handles are permanent no-ops in-process."
+
+So in D5, `MetricsPruneRecorder::observe_pass` calls `self.passes.increment(1)` etc., but those handles decrement into a void. The entire Prometheus family — `passes_total`, `empty_drains_total`, `nonempty_drains_total`, `considered_total`, `dropped_total`, `bytes_freed_total`, `epochs_drained_total` — produces no observable signal. D5 cannot see the Prometheus side of the contradiction at all.
+
+### Choice B: K_p and E_p are frozen to the tracing transport, not Prometheus.
+
+The freeze explicitly redirects the pass-ledger read:
+
+> "`K_p` and `E_p` are read from the **pass row** — the `kind = "prune_pass"` emission on `topgun_server::tombstone_frontier::residency`... and from **nothing else**. They are NOT read from the Prometheus mirror."
+
+This means I1 (`Σ R_obs == K_p`) and I2 (`E_p == (Σ R_obs == 0)`) compare tracing-exit-rows against tracing-pass-rows. They are *intra-tracing* identities. The production contradiction is *tracing-vs-Prometheus*.

--- a/packages/server-rust/benches/soak_harness/evidence/spec358-xask-raw2.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec358-xask-raw2.txt
@@ -1,0 +1,143 @@
+→ openrouter z-ai/glm-5.2 answering (0 file(s) embedded)…
+
+[usage] prompt=809 completion=9904 total=10713 cost=$0.02458252
+## Q1: Mechanisms and Ranking
+
+### Critical framing error in your instrumentation
+
+Before ranking routes, I need to flag something about I1 that you may have missed:
+
+**I1 does not discriminate the production bug.** I1 asserts `sum(removed_refs_observed) == considered`. In the production symptom, `considered == 0`. If every exit row in those 439 passes also had `removed_refs_observed == 0`, I1 holds trivially (0 == 0). The width=1 drive passing I1 tells you I1 is *well-formed* on the happy path, but it tells you nothing about whether the bug is reproducible, because I1 would also hold in the exact production failure mode if the exits carry zero observed refs. You proved the instrument is wired correctly; you did not prove the instrument catches the bug.
+
+The production record says `epochs_drained == 0`, not merely `considered == 0`. This is the harder constraint. The drain returned *nothing* — no epochs, no refs, no bytes — 440,069 times. Yet 439 times, exit rows appeared with DrainedByPrune attribution and ~10M bytes. So the drain's return value and the exit ledger are not just numerically inconsistent; they are *categorically* disjoint. The drain says "I touched nothing." The ledger says "something touched 439 epochs." The exit rows carry byte attributions (~23K avg), so they are not no-ops — real tombstone state was recorded as reclaimed.
+
+That constrains the mechanism significantly.
+
+---
+
+### Route (b): Exits emitted on a non-drain path that stamps DrainedByPrune
+
+**Mechanism:** `publish_epoch_exit` is called from a code path other than `drain_prunable_tombstones` — a rebuild, compaction, eviction, shutdown sweep, or a background reclamation task — but the attribution enum is set to `DrainedByPrune` (either explicitly, by default, or via a stale closure capture). These exits land in the exit ledger. The service's prune pass calls `drain_prunable_tombstones` on the frontier, gets an empty return (nothing to drain at that moment), builds a `PrunePassRecord` with all zeros, and increments `empty_drains_total`. The exit ledger and the pass record never agree because they describe different operations.
+
+**Why it fits the symptom perfectly:**
+- 439 exits over 440,069 passes is a low rate (~0.1%). This is consistent with an occasional background/triggered sweep, not a steady-state drain. A scheduled compaction or an eviction triggered by memory pressure in a long-running multi-partition system would fire sporadically.
+- The exits carry real byte attributions (~10M total), meaning real tombstone state was processed — just not through the drain return path the service instruments.
+- `epochs_drained == 0` is exact: the drain truly returned nothing. The exits came from elsewhere.
+- The width=1 sequential in-process drive would never trigger this because there are no rebuilds, no evictions, no compaction, no shutdown sweeps in a 3000-epoch sequential run.
+
+**How to verify without a drive:** Grep for every call site of `publish_epoch_exit` (or whatever the exit-emit function is). If *any* call site outside `drain_prunable_tombstones` passes `DrainedByPrune` as the attribution — or if the attribution has a `Default` impl that resolves to `DrainedByPrune` and a non-drain path constructs the row without setting it — that's your route. This is a 10-minute code audit, cheaper than any drive.
+
+**Likelihood: HIGHEST.** This is the only route that cleanly explains `epochs_drained == 0` (drain returned genuinely empty) alongside real byte-attributed exits, and it's consistent with the production regime (long-running, multi-partition — more triggers for background sweeps) and the failure to reproduce in a short sequential drive.
+
+---
+
+### Route (c): Drain returns empty vector but publishes exits for epochs whose ref vector was empty at removal time
+
+**Mechanism:** Inside `drain_prunable_tombstones`, the frontier iterates prunable epochs. For each epoch `e`, it calls `epoch_tags.remove(&e)`, which returns the ref vector. If a concurrent operation (another partition's prune, a CRDT merge, a compaction) already emptied that epoch's ref vector, `remove` returns an empty `Vec`. The frontier still publishes an exit row (the epoch *was* removed from the frontier, it *was* drained — just with zero refs to hand back). The drain's return value to the service contains nothing for that epoch (empty refs filtered out, or the epoch simply contributes zero to the returned collection). The service builds `considered == 0`.
+
+**Why it fits partially but has a problem:**
+- It explains `considered == 0` with exits present.
+- It explains why the width=1 drive didn't reproduce it (no concurrency, no pre-emption of refs).
+- **BUT:** it does not cleanly explain `epochs_drained == 0`. If the drain processed the epoch (called `remove`, published an exit), the drain should report at least 1 epoch drained. Unless `epochs_drained` is computed as `returned_refs.len()` rather than a separate count of processed epochs — which would be a secondary bug in the record construction. Or unless the drain filters out epochs with empty ref vectors from its return entirely, and the service computes `epochs_drained` from the return structure length. Both are possible but require an additional assumption about how the record is built.
+- Also: the exits attribute ~10M bytes. If the ref vectors were empty, what bytes are being attributed? The exit row must be recording epoch-level metadata (tombstone count, byte size) independent of the ref vector. This is plausible if the epoch tracks its own tombstone bytes separately from the ref vector, but it adds another assumption.
+
+**Likelihood: SECOND.** Plausible and consistent with the concurrency differential, but requires auxiliary assumptions about `epochs_drained` computation and byte attribution to fully match the symptom. The `epochs_drained == 0` constraint is the friction point.
+
+---
+
+### Route (a): More than one TombstoneFrontier instance
+
+**Mechanism:** In a multi-partition system, there are multiple `TombstoneFrontier` instances (one per partition, or a shared one plus partition-local ones, or a metrics shim wrapping a real frontier). The service's `prune_epoch_tombstones` calls `drain` on frontier A, which returns empty (A has nothing to drain). Frontier B independently drains and publishes exit rows via its own `publish_epoch_exit`. The service builds the pass record from A's empty return. The exit ledger captures B's exits.
+
+**Why it could fit:**
+- Perfectly explains `epochs_drained == 0` with real exits: different objects, genuinely independent.
+- Consistent with multi-partition production and width=1 drive not reproducing (single frontier in the drive).
+
+**Why it's less likely than (b):**
+- If partitions each have their own frontier and the service prunes per-partition with per-partition pass records, you'd expect *some* passes from the draining partition to show non-zero `considered`. You'd see a mix: most passes empty, some non-empty. The fact that **all 440,069** passes are empty is hard to explain if the service is iterating all partitions — unless the service only queries a subset, or the draining frontier is not one the service ever calls drain on.
+- If there's a shared/frontier-metrics-shim, that's a more specific architectural issue that would likely surface in other ways (the shim would be consistently wrong, not just 0.1% of the time).
+- It's possible but requires a specific architectural mismatch that (b) does not require.
+
+**Likelihood: THIRD.** Possible, but the "all passes empty" constraint makes it less parsimonious than (b). Would need the draining frontier to be one the service never calls drain on — which is really a variant of (b) (the exits come from a component the service doesn't instrument).
+
+---
+
+### Route (d): Partition-level fan-out where most partitions prune empty and one drains
+
+**Mechanism:** The service iterates partitions. 99.9% of partition-passes are empty. One partition's drain produces real exits. But the pass record is built per-partition, so the draining partition's pass has `considered > 0`.
+
+**Why it does NOT fit:**
+- You'd see *some* passes with `considered > 0`. You see zero. 440,069 passes, all empty. If the service builds one record per partition per pass, and any partition drained, that record is non-empty. The only way this fits is if the service aggregates all partitions into one record per pass AND the draining partition's contribution is lost in the aggregation — which is route (a), not (d).
+- If the service builds one record per pass (not per partition), and aggregates across partitions, then one draining partition would make the aggregate record non-empty. So (d) alone cannot produce all-empty records.
+
+**Likelihood: LOWEST standalone.** Could combine with (a) — if the draining partition's frontier is not the one the service queries — but that's (a), not (d). Fan-out alone does not explain the symptom.
+
+---
+
+### One additional route not in your list
+
+### Route (e): Deferred/asynchronous exit publication
+
+**Mechanism:** `drain_prunable_tombstones` queues exit rows for later publication (e.g., onto a channel, a batch buffer, or a background task). The drain returns immediately with the refs it collected. The service builds the pass record. Later, a background task flushes the exit queue and publishes the deferred exits with `DrainedByPrune` attribution. The exits are timestamped (or attributed) to the pass that queued them, but they land in the ledger outside the drain call. The service's pass record already committed with `considered == 0` (if the drain returned empty refs due to route (c) conditions) or with the correct `considered` (if the drain did return refs).
+
+**Why it could fit:** If the drain returns refs but the service's `considered` computation is wrong (e.g., counts something other than the returned refs), and the exits are published asynchronously, the timing mismatch would produce the symptom. But this requires the drain to both return refs (which the service ignores/miscounts) AND defer exit publication. More complex.
+
+**Likelihood: LOW.** Mentioned for completeness. It's a variant of (b) where the non-drain path is "the drain's own deferred publication."
+
+---
+
+### Ranking summary
+
+| Route | Likelihood | Key fit | Key friction |
+|-------|-----------|---------|-------------|
+| (b) Non-drain path stamps DrainedByPrune | **Highest** | Explains epochs_drained==0, real bytes, sporadic rate, drive failure | Requires a non-drain call site with wrong attribution |
+| (c) Drain returns empty, exits for empty-ref epochs | **Second** | Explains considered==0 with exits, concurrency differential | Does not cleanly explain epochs_drained==0 without auxiliary assumptions |
+| (a) Multiple frontier instances | **Third** | Explains total disjoint between exits and records | "All passes empty" is hard if service iterates all frontiers |
+| (e) Deferred async exit publication | **Low** | Timing mismatch | Requires compound failure |
+| (d) Partition fan-out | **Lowest** | — | Cannot produce all-empty records alone |
+
+---
+
+## Q2: Is V0 defensible? Should you stop or run one more drive?
+
+### The honest assessment
+
+V0 with cause unclassified is **defensible but premature by one step**, and that step is not a drive — it's a code audit that is cheaper than any drive and directly discriminates the highest-likelihood route.
+
+**What you should do before closing the diagnosis line:**
+
+A 15-minute static audit of `publish_epoch_exit` call sites. Enumerate every callsite. For each, check: (1) is it inside `drain_prunable_tombstones`? (2) if not, what attribution does it pass? (3) does the `ExitAttribution` enum have a `Default` impl, and does any non-drain callsite rely on it?
+
+This is not a drive. It's a grep-and-read. But it would either:
+- **Find route (b):** You see a `publish_epoch_exit` call in a rebuild/eviction/shutdown path with `DrainedByPrune` attribution (or defaulting to it). Root cause identified. You close the diagnosis with a classified cause and go remediate with full confidence.
+- **Clear route (b):** Every non-drain callsite uses a different attribution. You've eliminated the highest-likelihood route without a drive, and V0 becomes more defensible.
+
+If you've already done this audit and it's clean, then yes — stop and remediate. Here's why:
+
+1. **I1 is the wrong assertion and you already know it.** I1 held in production too (trivially, 0==0). A drive that asserts I1 will never reproduce the bug. You need I2: *if any DrainedByPrune exit rows are published during a pass, the pass record must have `epochs_drained > 0`.* I1 checks numerical agreement; I2 checks categorical agreement. You proved I1; you need I2.
+
+2. **The one cheap drive you are wrong to skip** (if the code audit is inconclusive):
+
+   **Drive D-preempt (discriminates route (c) deterministically):**
+
+   - **Construct:** One `TombstoneFrontier`, one service. Populate the frontier with 3 epochs (e1, e2, e3). e1 and e3 each have 2 refs. e2 has 2 refs initially, then directly mutate `epoch_tags` for e2 to remove both refs (simulating the post-state of a concurrent drain that already took e2's refs but left e2 in the frontier). This does not require actual concurrency — you manually construct the race's end-state.
+
+   - **Execute:** One prune pass through the service.
+
+   - **Assert I2:** If any `DrainedByPrune` exit rows are published for this pass, `epochs_drained > 0` in the pass record. If exits are published for e2 (which had 0 refs) but the drain return excludes e2, and the service computes `epochs_drained == 0` or `considered == 0`, the bug is reproduced via route (c).
+
+   - **Assert I3:** `removed_refs_observed` for e2's exit row == 0 (confirming the pre-empted state), AND the exit row is still published. This confirms the frontier publishes exits for empty-ref epochs.
+
+   - **Assert I4:** The byte attribution on e2's exit row is > 0 (confirming that exits carry real tombstone bytes independent of the ref vector).
+
+   - **What it discriminates:** If this drive reproduces the symptom (exits published, `epochs_drained == 0`, `considered == 0`), route (c) is confirmed and you have a deterministic reproduction. If it does NOT reproduce (either no exit for e2, or `epochs_drained > 0`), route (c) is eliminated and the cause is almost certainly (b) — you should go back to the code audit with higher confidence, or accept V0.
+
+   - **Cost:** ~30 minutes to write. Deterministic. In-process. No concurrency primitives. No multi-partition setup.
+
+   This drive is cheap because it does not attempt to *cause* the race condition — it constructs the race condition's *resulting state* directly. The frontier cannot tell the difference between "a concurrent operation drained e2's refs" and "e2's refs were never there." If the frontier's behavior differs based on that distinction, that's a different bug. If it doesn't (which is the expected case for a hash-map-backed epoch_tags), the drive faithfully simulates the production condition.
+
+3. **If D-preempt does not reproduce, stop.** At that point you've eliminated (c) deterministically, (b) via code audit, (a) would require architectural investigation that exceeds the cost of remediation, and (d) cannot explain the symptom. The remediation (reclamation registry that never reclaims below a live claim) is correct *regardless of root cause* — it makes the system safe even if the diagnosis is wrong, which is the right engineering call when diagnosis cost exceeds marginal remediation value.
+
+### Bottom line
+
+Do the 15-minute `publish_epoch_exit` callsite audit first. If it finds (b), classify the cause and close. If it clears (b), run D-preempt (30 min). If D-preempt reproduces, classify as (c) and close. If D-preempt does not reproduce, V0 is defensible — stop and remediate. You will have spent under an hour to either classify the cause or gain high confidence that it's not worth classifying further.

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -6311,6 +6311,362 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // A thread-local `tracing` capture: the settlement and pass rows have no
+    // Prometheus mirror, so this is the only transport that can read them.
+    // -----------------------------------------------------------------------
+
+    /// Renders every field of a captured event as `name=value ` pairs, of the
+    /// `network/device_identity.rs:397-429` shape. The visitor overrides no
+    /// `record_u64` / `record_bool`, so a `u64` or `bool` field reaches
+    /// `record_debug` exactly like every other non-`&str` field — Debug and
+    /// Display agree for both, so the rendered digits/`true`/`false` are the
+    /// same either way.
+    struct RowFieldVisitor(String);
+
+    impl tracing::field::Visit for RowFieldVisitor {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            use std::fmt::Write as _;
+            let _ = write!(self.0, "{}={value} ", field.name());
+        }
+
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            use std::fmt::Write as _;
+            let _ = write!(self.0, "{}={value:?} ", field.name());
+        }
+    }
+
+    /// Sink for [`RowFieldVisitor`]: one rendered line per event, each prefixed
+    /// with the emitting event's `target` (metadata, not a `Visit` field, so it
+    /// is written directly rather than collected by the visitor) — a single
+    /// `String`, as the reference shape's own sink is. The newline is what lets
+    /// a test recover row boundaries from one accumulated capture without
+    /// needing a `Vec<String>` sink.
+    #[derive(Clone)]
+    struct RowCapture(Arc<std::sync::Mutex<String>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for RowCapture {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut v = RowFieldVisitor(format!(" target={} ", event.metadata().target()));
+            event.record(&mut v);
+            let mut sink = self.0.lock().unwrap();
+            sink.push_str(&v.0);
+            sink.push('\n');
+        }
+    }
+
+    /// Bind a thread-local capture for the guard's lifetime. Every drive that
+    /// reads rows off it must run on a current-thread runtime with the emission
+    /// on the test's own thread: `metrics::with_local_recorder` and
+    /// `tracing::subscriber::set_default` are both thread-local (the doc at
+    /// `:6129` makes the same point for the metrics recorder), so a
+    /// multi-thread runtime observes an empty capture instead of a violation.
+    fn capture_tracing_rows() -> (tracing::subscriber::DefaultGuard, Arc<std::sync::Mutex<String>>)
+    {
+        use tracing_subscriber::layer::SubscriberExt;
+        let sink: Arc<std::sync::Mutex<String>> = Arc::new(std::sync::Mutex::new(String::new()));
+        let subscriber = tracing_subscriber::registry().with(RowCapture(Arc::clone(&sink)));
+        let guard = tracing::subscriber::set_default(subscriber);
+        (guard, sink)
+    }
+
+    /// Whether `line` is a row on `target` carrying `kind = "kind"`.
+    fn is_row(line: &str, target: &str, kind: &str) -> bool {
+        line.contains(&format!(" target={target} ")) && line.contains(&format!(" kind={kind} "))
+    }
+
+    /// Read one `u64`-rendered field out of a captured row.
+    fn row_u64(line: &str, name: &str) -> u64 {
+        row_field(line, name)
+            .parse()
+            .unwrap_or_else(|e| panic!("field {name} did not render a u64 in {line:?}: {e}"))
+    }
+
+    /// Read one `bool`-rendered field out of a captured row.
+    fn row_bool(line: &str, name: &str) -> bool {
+        row_field(line, name)
+            .parse()
+            .unwrap_or_else(|e| panic!("field {name} did not render a bool in {line:?}: {e}"))
+    }
+
+    fn row_field<'a>(line: &'a str, name: &str) -> &'a str {
+        let needle = format!(" {name}=");
+        let start = line
+            .find(&needle)
+            .unwrap_or_else(|| panic!("field {name} is absent from row {line:?}"))
+            + needle.len();
+        line[start..].split(' ').next().unwrap_or("")
+    }
+
+    /// Split a capture into successive passes: every row strictly after the
+    /// previous pass row up to and including its own pass row (Step 1's frozen
+    /// "Pass individuation" rule — the pass row is always emitted last).
+    fn split_into_passes(rendered: &str) -> Vec<Vec<&str>> {
+        let mut passes = Vec::new();
+        let mut current = Vec::new();
+        for line in rendered.lines() {
+            current.push(line);
+            if is_row(
+                line,
+                "topgun_server::tombstone_frontier::residency",
+                "prune_pass",
+            ) {
+                passes.push(std::mem::take(&mut current));
+            }
+        }
+        passes
+    }
+
+    /// R2.1/R2.2/AC3: the six-exit identity holds **per epoch**, exactly as it
+    /// already holds per pass — read off the settlement row, the only transport
+    /// `PruneEpochRecord` has (it carries no Prometheus series of its own).
+    ///
+    /// The six-exit fixture drains six epochs of width 1, one ref each, so
+    /// every epoch's settlement row has `considered == 1` and exactly one of
+    /// the six exit terms `== 1` — a per-epoch identity that would read exactly
+    /// as "true" on a settlement row wired to the wrong per-epoch counter (all
+    /// zero on one side), which is why each epoch's OWN nonzero exit is also
+    /// checked below rather than only the sum.
+    #[tokio::test]
+    async fn per_epoch_six_exit_identity_holds_on_the_settlement_row() {
+        let (guard, sink) = capture_tracing_rows();
+        let fixture = build_six_exit_fixture();
+        let _outcome = run_six_exit_prune_workload(fixture).await;
+        drop(guard);
+        let rendered = sink.lock().unwrap().clone();
+
+        // The settlement row carries no `kind` field, so filter on target alone
+        // (`is_row` requires both target and kind).
+        let settlement_rows: Vec<&str> = rendered
+            .lines()
+            .filter(|l| l.contains(" target=topgun_server::tombstone_frontier::settlement "))
+            .collect();
+
+        assert_eq!(
+            settlement_rows.len(),
+            6,
+            "one settlement row per drained epoch, six epochs drained; \
+             capture was:\n{rendered}"
+        );
+
+        let mut considered_sum = 0u64;
+        let mut dropped_sum = 0u64;
+        for row in &settlement_rows {
+            let considered = row_u64(row, "considered");
+            let dropped = row_u64(row, "dropped");
+            let matched_nothing = row_u64(row, "matched_nothing");
+            let absent = row_u64(row, "absent");
+            let restored_read_error = row_u64(row, "restored_read_error");
+            let restored_evicted = row_u64(row, "restored_evicted");
+            let restored_write_error = row_u64(row, "restored_write_error");
+            assert_eq!(
+                considered,
+                dropped
+                    + matched_nothing
+                    + absent
+                    + restored_read_error
+                    + restored_evicted
+                    + restored_write_error,
+                "the per-epoch six-exit identity must hold on this settlement \
+                 row: {row:?}"
+            );
+            assert_eq!(considered, 1, "one ref per epoch at epoch width 1: {row:?}");
+            considered_sum += considered;
+            dropped_sum += dropped;
+        }
+        assert_eq!(considered_sum, 6, "six epochs, one ref each");
+        assert_eq!(
+            dropped_sum, 1,
+            "exactly one of the six epochs reclaims durably (kdrop); the other \
+             five leave their tag in place"
+        );
+    }
+
+    /// AC4a: the pass row fires on **every** `prune_epoch_tombstones`
+    /// invocation, empty drains included, on the same residency target the
+    /// entry/exit rows use, with `kind = "prune_pass"` and the right
+    /// `considered` / `empty_drain` values (R2.5, R2.5a, R2.5b).
+    ///
+    /// The six-exit workload's OWN seeding writes sweep the (still-shut) prune
+    /// gates on top of the workload's one explicit call at the end (the same
+    /// mechanism `prune_exit_ledger_sums_to_considered` pins with `empty_drains
+    /// >= 1`), so a single run of it already exercises both an empty-drain pass
+    /// and a draining one — no hand-rolled second invocation needed, and none
+    /// of the exact auto-swept row count is assumed.
+    #[tokio::test]
+    async fn pass_row_fires_on_every_invocation_including_an_empty_drain() {
+        let (guard, sink) = capture_tracing_rows();
+        let fixture = build_six_exit_fixture();
+        let _outcome = run_six_exit_prune_workload(fixture).await;
+        drop(guard);
+        let rendered = sink.lock().unwrap().clone();
+
+        let pass_rows: Vec<&str> = rendered
+            .lines()
+            .filter(|l| {
+                is_row(
+                    l,
+                    "topgun_server::tombstone_frontier::residency",
+                    "prune_pass",
+                )
+            })
+            .collect();
+
+        assert!(
+            pass_rows.len() >= 2,
+            "the workload's seeding writes sweep the shut prune gates, so more \
+             than one pass row is expected on top of the workload's own \
+             explicit call; capture was:\n{rendered}"
+        );
+        assert!(
+            pass_rows
+                .iter()
+                .any(|r| row_u64(r, "considered") == 0 && row_bool(r, "empty_drain")),
+            "at least one pass row must report an empty drain (considered=0, \
+             empty_drain=true); capture was:\n{rendered}"
+        );
+        // The workload's own explicit call (`crdt.rs:1519`) is the LAST
+        // invocation of the run, strictly after every seeding write, so it is
+        // deterministically the capture's last pass row.
+        let last = pass_rows.last().expect("at least one pass row exists");
+        assert_eq!(
+            row_u64(last, "considered"),
+            6,
+            "the workload's own explicit call is the last invocation and \
+             drains all six seeded refs: {last:?}"
+        );
+        assert!(
+            !row_bool(last, "empty_drain"),
+            "the workload's own explicit call is a non-empty drain: {last:?}"
+        );
+    }
+
+    /// Exactly one `::residency` emit site names this target in this file
+    /// (AC4a's mechanical check, `rg -n 'target: "topgun_server::tombstone_\
+    /// frontier::residency"' … crdt.rs`) — asserted here too, over this file's
+    /// own source, so a second emit site fails the lib suite and not only the
+    /// grep the human checklist runs separately.
+    #[test]
+    fn exactly_one_residency_emit_site_in_this_file() {
+        const SOURCE: &str = include_str!("crdt.rs");
+        let count = SOURCE
+            .matches("target: \"topgun_server::tombstone_frontier::residency\"")
+            .count();
+        assert_eq!(
+            count, 1,
+            "AC4a requires exactly one ::residency emit site in this file, \
+             beside the existing observe_pass call"
+        );
+    }
+
+    /// Step 1's bridge identities, evaluated over a driven pass in this file's
+    /// own fixture (the full D-T evaluation over `D5` is `sim/tombstone_gc_\
+    /// proof.rs`'s job; this is the local confirmation that both terms are
+    /// actually reachable together on the ONE `tracing` transport, which is
+    /// what makes that later evaluation possible at all):
+    ///
+    /// - **I1**: `Σ_e R_obs(e) == K_p`, `R_obs` read off each pass's `epoch_\
+    ///   exit` rows (`removed_refs_observed`), `K_p` off that SAME pass's pass
+    ///   row (`considered`).
+    /// - **I2**: `E_p == (Σ_e R_obs(e) == 0)`, `E_p` read off the same pass
+    ///   row's `empty_drain`.
+    ///
+    /// Evaluated over EVERY pass the six-exit workload's run individuates —
+    /// split by [`split_into_passes`]'s frozen rule, so each pass's own rows
+    /// are summed separately rather than pooled across the whole capture. The
+    /// workload's own seeding writes sweep the shut prune gates ahead of its
+    /// one explicit call (see the pass-row test above), so a single run
+    /// already produces both empty-drain passes and one draining pass without
+    /// a hand-rolled second invocation or an assumed exact pass count.
+    #[tokio::test]
+    async fn i1_i2_pass_identity_holds_on_an_empty_and_a_draining_pass() {
+        let (guard, sink) = capture_tracing_rows();
+        let fixture = build_six_exit_fixture();
+        let _outcome = run_six_exit_prune_workload(fixture).await;
+        drop(guard);
+        let rendered = sink.lock().unwrap().clone();
+
+        let passes = split_into_passes(&rendered);
+        assert!(
+            passes.len() >= 2,
+            "the workload's seeding writes must individuate more than one \
+             pass on top of its own explicit call; capture was:\n{rendered}"
+        );
+
+        let mut saw_empty = false;
+        let mut saw_draining = false;
+        for pass_rows in &passes {
+            let pass_row = pass_rows
+                .last()
+                .expect("a pass's own rows always end with its pass row");
+            assert!(
+                is_row(
+                    pass_row,
+                    "topgun_server::tombstone_frontier::residency",
+                    "prune_pass"
+                ),
+                "a pass's last row must be its own pass row: {pass_row:?}"
+            );
+            let k_p = row_u64(pass_row, "considered");
+            let e_p = row_bool(pass_row, "empty_drain");
+
+            let r_obs_sum: u64 = pass_rows
+                .iter()
+                .filter(|l| {
+                    is_row(
+                        l,
+                        "topgun_server::tombstone_frontier::residency",
+                        "epoch_exit",
+                    )
+                })
+                .map(|l| row_u64(l, "removed_refs_observed"))
+                .sum();
+
+            assert_eq!(
+                r_obs_sum, k_p,
+                "I1: the sum of a pass's own epoch_exit removed_refs_observed \
+                 must equal that SAME pass's considered; pass rows were:\n{pass_rows:?}"
+            );
+            assert_eq!(
+                e_p,
+                r_obs_sum == 0,
+                "I2: empty_drain must equal (Σ removed_refs_observed == 0) for \
+                 the same pass; pass rows were:\n{pass_rows:?}"
+            );
+
+            if e_p {
+                saw_empty = true;
+            } else {
+                saw_draining = true;
+            }
+        }
+
+        // Both regimes must actually appear, or I1/I2 above would hold
+        // vacuously over only one of them.
+        assert!(
+            saw_empty,
+            "at least one pass in the capture must be an empty drain; \
+             capture was:\n{rendered}"
+        );
+        assert!(
+            saw_draining,
+            "at least one pass in the capture must be a draining pass; \
+             capture was:\n{rendered}"
+        );
+        // The workload's own explicit call is the last invocation of the run
+        // (`crdt.rs:1519`), so it is deterministically the capture's last pass.
+        assert_eq!(
+            row_u64(passes.last().unwrap().last().unwrap(), "considered"),
+            6,
+            "the last pass in the capture must be the workload's own draining \
+             call over all six seeded refs"
+        );
+    }
+
     /// The prune record is INSTRUMENT-NEUTRAL: arming it moves no tombstone
     /// bytes and reclaims no differently.
     ///

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -6532,9 +6532,11 @@ mod tests {
             "at least one pass row must report an empty drain (considered=0, \
              empty_drain=true); capture was:\n{rows:#?}"
         );
-        // The workload's own explicit call (`crdt.rs:1519`) is the LAST
+        // The workload's own explicit `prune_epoch_tombstones` call is the LAST
         // invocation of the run, strictly after every seeding write, so it is
-        // deterministically the capture's last pass row.
+        // deterministically the capture's last pass row. Cited by name, not by
+        // line: a same-file line number is falsified by any insertion above it
+        // without anything failing.
         let last = pass_rows.last().expect("at least one pass row exists");
         assert_eq!(
             row_u64(last, "considered"),
@@ -6660,8 +6662,10 @@ mod tests {
             "at least one pass in the capture must be a draining pass; \
              capture was:\n{rows:#?}"
         );
-        // The workload's own explicit call is the last invocation of the run
-        // (`crdt.rs:1519`), so it is deterministically the capture's last pass.
+        // The workload's own explicit `prune_epoch_tombstones` call is the last
+        // invocation of the run, so it is deterministically the capture's last
+        // pass. Cited by name, not by line, for the reason given at the sibling
+        // assertion above.
         assert_eq!(
             row_u64(passes.last().unwrap().last().unwrap(), "considered"),
             6,

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -6336,14 +6336,15 @@ mod tests {
         }
     }
 
-    /// Sink for [`RowFieldVisitor`]: one rendered line per event, each prefixed
-    /// with the emitting event's `target` (metadata, not a `Visit` field, so it
-    /// is written directly rather than collected by the visitor) — a single
-    /// `String`, as the reference shape's own sink is. The newline is what lets
-    /// a test recover row boundaries from one accumulated capture without
-    /// needing a `Vec<String>` sink.
+    /// Sink for [`RowFieldVisitor`]: one rendered line PER CAPTURED EVENT, each
+    /// prefixed with the emitting event's `target` (metadata, not a `Visit`
+    /// field, so it is written directly rather than collected by the visitor) —
+    /// a `Vec<String>`, never a single concatenated `String`. Every test below
+    /// reads a SPECIFIC row's own fields off the capture, and a concatenated
+    /// blob can only individuate rows by inventing a newline convention that
+    /// any future field rendering a newline would silently break.
     #[derive(Clone)]
-    struct RowCapture(Arc<std::sync::Mutex<String>>);
+    struct RowCapture(Arc<std::sync::Mutex<Vec<String>>>);
 
     impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for RowCapture {
         fn on_event(
@@ -6353,9 +6354,7 @@ mod tests {
         ) {
             let mut v = RowFieldVisitor(format!(" target={} ", event.metadata().target()));
             event.record(&mut v);
-            let mut sink = self.0.lock().unwrap();
-            sink.push_str(&v.0);
-            sink.push('\n');
+            self.0.lock().unwrap().push(v.0);
         }
     }
 
@@ -6367,10 +6366,10 @@ mod tests {
     /// multi-thread runtime observes an empty capture instead of a violation.
     fn capture_tracing_rows() -> (
         tracing::subscriber::DefaultGuard,
-        Arc<std::sync::Mutex<String>>,
+        Arc<std::sync::Mutex<Vec<String>>>,
     ) {
         use tracing_subscriber::layer::SubscriberExt;
-        let sink: Arc<std::sync::Mutex<String>> = Arc::new(std::sync::Mutex::new(String::new()));
+        let sink: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
         let subscriber = tracing_subscriber::registry().with(RowCapture(Arc::clone(&sink)));
         let guard = tracing::subscriber::set_default(subscriber);
         (guard, sink)
@@ -6407,11 +6406,11 @@ mod tests {
     /// Split a capture into successive passes: every row strictly after the
     /// previous pass row up to and including its own pass row (Step 1's frozen
     /// "Pass individuation" rule — the pass row is always emitted last).
-    fn split_into_passes(rendered: &str) -> Vec<Vec<&str>> {
+    fn split_into_passes(rows: &[String]) -> Vec<Vec<&str>> {
         let mut passes = Vec::new();
         let mut current = Vec::new();
-        for line in rendered.lines() {
-            current.push(line);
+        for line in rows {
+            current.push(line.as_str());
             if is_row(
                 line,
                 "topgun_server::tombstone_frontier::residency",
@@ -6439,12 +6438,13 @@ mod tests {
         let fixture = build_six_exit_fixture();
         let _outcome = run_six_exit_prune_workload(fixture).await;
         drop(guard);
-        let rendered = sink.lock().unwrap().clone();
+        let rows = sink.lock().unwrap().clone();
 
         // The settlement row carries no `kind` field, so filter on target alone
         // (`is_row` requires both target and kind).
-        let settlement_rows: Vec<&str> = rendered
-            .lines()
+        let settlement_rows: Vec<&str> = rows
+            .iter()
+            .map(String::as_str)
             .filter(|l| l.contains(" target=topgun_server::tombstone_frontier::settlement "))
             .collect();
 
@@ -6452,7 +6452,7 @@ mod tests {
             settlement_rows.len(),
             6,
             "one settlement row per drained epoch, six epochs drained; \
-             capture was:\n{rendered}"
+             capture was:\n{rows:#?}"
         );
 
         let mut considered_sum = 0u64;
@@ -6505,10 +6505,11 @@ mod tests {
         let fixture = build_six_exit_fixture();
         let _outcome = run_six_exit_prune_workload(fixture).await;
         drop(guard);
-        let rendered = sink.lock().unwrap().clone();
+        let rows = sink.lock().unwrap().clone();
 
-        let pass_rows: Vec<&str> = rendered
-            .lines()
+        let pass_rows: Vec<&str> = rows
+            .iter()
+            .map(String::as_str)
             .filter(|l| {
                 is_row(
                     l,
@@ -6522,14 +6523,14 @@ mod tests {
             pass_rows.len() >= 2,
             "the workload's seeding writes sweep the shut prune gates, so more \
              than one pass row is expected on top of the workload's own \
-             explicit call; capture was:\n{rendered}"
+             explicit call; capture was:\n{rows:#?}"
         );
         assert!(
             pass_rows
                 .iter()
                 .any(|r| row_u64(r, "considered") == 0 && row_bool(r, "empty_drain")),
             "at least one pass row must report an empty drain (considered=0, \
-             empty_drain=true); capture was:\n{rendered}"
+             empty_drain=true); capture was:\n{rows:#?}"
         );
         // The workload's own explicit call (`crdt.rs:1519`) is the LAST
         // invocation of the run, strictly after every seeding write, so it is
@@ -6590,13 +6591,13 @@ mod tests {
         let fixture = build_six_exit_fixture();
         let _outcome = run_six_exit_prune_workload(fixture).await;
         drop(guard);
-        let rendered = sink.lock().unwrap().clone();
+        let rows = sink.lock().unwrap().clone();
 
-        let passes = split_into_passes(&rendered);
+        let passes = split_into_passes(&rows);
         assert!(
             passes.len() >= 2,
             "the workload's seeding writes must individuate more than one \
-             pass on top of its own explicit call; capture was:\n{rendered}"
+             pass on top of its own explicit call; capture was:\n{rows:#?}"
         );
 
         let mut saw_empty = false;
@@ -6652,12 +6653,12 @@ mod tests {
         assert!(
             saw_empty,
             "at least one pass in the capture must be an empty drain; \
-             capture was:\n{rendered}"
+             capture was:\n{rows:#?}"
         );
         assert!(
             saw_draining,
             "at least one pass in the capture must be a draining pass; \
-             capture was:\n{rendered}"
+             capture was:\n{rows:#?}"
         );
         // The workload's own explicit call is the last invocation of the run
         // (`crdt.rs:1519`), so it is deterministically the capture's last pass.

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -1559,11 +1559,17 @@ pub(crate) async fn prune_epoch_tombstones(
             // reclaim fraction that no other instrument can see.
             Ok(None) => {
                 pass.absent += 1;
+                if let Some(epoch_record) = per_epoch.get_mut(&epoch) {
+                    epoch_record.absent += 1;
+                }
                 continue;
             }
             Err(e) => {
                 tracing::warn!(map = %r.map, key = %r.key, epoch, "prune read failed, re-indexing tombstone for retry: {e}");
                 pass.restored_read_error += 1;
+                if let Some(epoch_record) = per_epoch.get_mut(&epoch) {
+                    epoch_record.restored_read_error += 1;
+                }
                 frontier.restore_tombstone_ref(epoch, r);
                 continue;
             }
@@ -1667,11 +1673,17 @@ pub(crate) async fn prune_epoch_tombstones(
                         "prune found key evicted mid-write, re-indexing tombstone for retry"
                     );
                     pass.restored_evicted += 1;
+                    if let Some(epoch_record) = per_epoch.get_mut(&epoch) {
+                        epoch_record.restored_evicted += 1;
+                    }
                     frontier.restore_tombstone_ref(epoch, r);
                 } else if !dropped {
                     // The closure ran and matched no tag; it may still have owed the
                     // shape-upgrade write above, but no tombstone was reclaimed.
                     pass.matched_nothing += 1;
+                    if let Some(epoch_record) = per_epoch.get_mut(&epoch) {
+                        epoch_record.matched_nothing += 1;
+                    }
                 }
             }
             Err(e) => {
@@ -1679,6 +1691,9 @@ pub(crate) async fn prune_epoch_tombstones(
                 // would silently stall tombstone reclamation.
                 tracing::warn!(map = %r.map, key = %r.key, epoch, "prune update failed, re-indexing tombstone for retry: {e}");
                 pass.restored_write_error += 1;
+                if let Some(epoch_record) = per_epoch.get_mut(&epoch) {
+                    epoch_record.restored_write_error += 1;
+                }
                 frontier.restore_tombstone_ref(epoch, r);
             }
         }
@@ -1689,11 +1704,44 @@ pub(crate) async fn prune_epoch_tombstones(
         frontier
             .prune_observer()
             .observe_drained_epoch(epoch_record);
+        // One settlement line per drained epoch, joined to that epoch's exit row by
+        // `epoch` — a field populated on every row of both ledgers, so the join needs
+        // no wall clock. This is the only place the per-epoch six-exit identity is
+        // observable end to end: `PruneEpochRecord` has no Prometheus series of its
+        // own, so without this line the per-epoch counters above would be provably
+        // correct in-process yet unreadable by anything outside it.
+        tracing::info!(
+            target: "topgun_server::tombstone_frontier::settlement",
+            epoch = epoch_record.epoch,
+            considered = epoch_record.considered,
+            dropped = epoch_record.dropped,
+            matched_nothing = epoch_record.matched_nothing,
+            absent = epoch_record.absent,
+            restored_read_error = epoch_record.restored_read_error,
+            restored_evicted = epoch_record.restored_evicted,
+            restored_write_error = epoch_record.restored_write_error,
+            bytes_freed = epoch_record.bytes_freed,
+            "prune epoch settlement"
+        );
     }
     // Exactly one pass observation per invocation, outside the loop body and on
     // every path through this function — the recorder counts the pass itself, so a
     // second or a conditional call would break the pass identity.
     frontier.prune_observer().observe_pass(&pass);
+    // The pass row: `considered` and `empty_drain` have never had a `tracing`
+    // transport before this line, so neither term was readable in-process by
+    // anything that cannot bind the (permanently no-op, outside its own recorder
+    // binding) Prometheus handles. Fires on EVERY invocation, empty drains
+    // included, unconditionally and outside the loop above — that unconditional
+    // placement is what makes this row individuate a pass on the capture: it is
+    // always the last row a pass emits.
+    tracing::info!(
+        target: "topgun_server::tombstone_frontier::residency",
+        kind = "prune_pass",
+        considered = pass.considered,
+        empty_drain = pass.empty_drain,
+        "prune pass"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server-rust/src/service/domain/crdt.rs
+++ b/packages/server-rust/src/service/domain/crdt.rs
@@ -6365,8 +6365,10 @@ mod tests {
     /// `tracing::subscriber::set_default` are both thread-local (the doc at
     /// `:6129` makes the same point for the metrics recorder), so a
     /// multi-thread runtime observes an empty capture instead of a violation.
-    fn capture_tracing_rows() -> (tracing::subscriber::DefaultGuard, Arc<std::sync::Mutex<String>>)
-    {
+    fn capture_tracing_rows() -> (
+        tracing::subscriber::DefaultGuard,
+        Arc<std::sync::Mutex<String>>,
+    ) {
         use tracing_subscriber::layer::SubscriberExt;
         let sink: Arc<std::sync::Mutex<String>> = Arc::new(std::sync::Mutex::new(String::new()));
         let subscriber = tracing_subscriber::registry().with(RowCapture(Arc::clone(&sink)));

--- a/packages/server-rust/src/sim/tombstone_gc_proof.rs
+++ b/packages/server-rust/src/sim/tombstone_gc_proof.rs
@@ -801,8 +801,10 @@ mod tests {
     /// multi-thread runtime would observe an empty capture instead of a
     /// violation — exactly why `D4`'s race cannot be read at row
     /// granularity (C13).
-    fn capture_tracing_rows(
-    ) -> (tracing::subscriber::DefaultGuard, Arc<std::sync::Mutex<Vec<String>>>) {
+    fn capture_tracing_rows() -> (
+        tracing::subscriber::DefaultGuard,
+        Arc<std::sync::Mutex<Vec<String>>>,
+    ) {
         use tracing_subscriber::layer::SubscriberExt as _;
         let sink: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
         let subscriber = tracing_subscriber::registry().with(RowCapture(Arc::clone(&sink)));
@@ -1357,9 +1359,9 @@ mod tests {
                 );
                 i3_checked += 1;
 
-                let settlement_row = settlement_by_epoch
-                    .get(epoch)
-                    .unwrap_or_else(|| panic!("D5: epoch {epoch}'s settlement row must be present"));
+                let settlement_row = settlement_by_epoch.get(epoch).unwrap_or_else(|| {
+                    panic!("D5: epoch {epoch}'s settlement row must be present")
+                });
                 let absent = row_u64(settlement_row, "absent");
                 // P-KEYS (precondition, recorded as a VALUE, not assumed):
                 // the considered ref's key was present in the store at
@@ -1376,11 +1378,23 @@ mod tests {
             }
         }
 
-        assert_eq!(not_applicable_passes, 0, "D5 never restores: no pass should scope out");
-        assert_eq!(empty_passes, 1, "exactly the first pass (i=1) is an empty drain");
-        assert_eq!(draining_passes, N, "the remaining N passes each drain exactly one epoch");
+        assert_eq!(
+            not_applicable_passes, 0,
+            "D5 never restores: no pass should scope out"
+        );
+        assert_eq!(
+            empty_passes, 1,
+            "exactly the first pass (i=1) is an empty drain"
+        );
+        assert_eq!(
+            draining_passes, N,
+            "the remaining N passes each drain exactly one epoch"
+        );
         assert_eq!(i3_checked, N, "I3 must be checked on all N drained epochs");
-        assert_eq!(p_keys_checked, N, "P-KEYS must be checked on all N considered refs");
+        assert_eq!(
+            p_keys_checked, N,
+            "P-KEYS must be checked on all N considered refs"
+        );
 
         // ------------------------------------------------------------
         // Step 2 — the mechanical per-row Decision-Table evaluation over

--- a/packages/server-rust/src/sim/tombstone_gc_proof.rs
+++ b/packages/server-rust/src/sim/tombstone_gc_proof.rs
@@ -46,7 +46,7 @@ mod tests {
         CallerProvenance, ExpiryPolicy, NullDataStore, RecordStoreFactory, StorageConfig,
     };
     use crate::tombstone_frontier::ClientId;
-    use crate::tombstone_frontier_impl::TombstoneFrontier;
+    use crate::tombstone_frontier_impl::{TombstoneFrontier, TombstoneRef};
 
     // ------------------------------------------------------------------
     // Harness (mirrors the gated SyncService setup used by the sync-path
@@ -710,5 +710,381 @@ mod tests {
                 "round {round}: T_old pruned AND the pushed union survived"
             );
         }
+    }
+
+    // ==================================================================
+    // PD-F12 — the frozen drive set `D1 … D5` (segment (a): the shared
+    // `tracing` capture-layer helper plus `D1`–`D3`; `D4`, `D5` and the
+    // Decision-Table evaluation are a separate, later segment).
+    //
+    // Each drive records its outcome as a VALUE (`REPRODUCED` /
+    // `NOT-REPRODUCED`) plus the evaluated value of its OWN predicate
+    // (R4.3) — no Decision-Table row or verdict is drawn here; that
+    // evaluation ranges over the whole frozen drive set and is a separate,
+    // later step.
+    // ==================================================================
+
+    const RESIDENCY_TARGET: &str = "topgun_server::tombstone_frontier::residency";
+    const SETTLEMENT_TARGET: &str = "topgun_server::tombstone_frontier::settlement";
+
+    /// Renders one captured event's fields as `name=value` pairs, of the
+    /// `network/device_identity.rs:397-429` shape. `u64` and `bool` fields
+    /// reach `record_debug` exactly like every other non-`&str` field —
+    /// Debug and Display agree for both, so the rendered text is the same
+    /// either way.
+    struct RowFieldVisitor(String);
+
+    impl tracing::field::Visit for RowFieldVisitor {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            use std::fmt::Write as _;
+            let _ = write!(self.0, "{}={value} ", field.name());
+        }
+
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            use std::fmt::Write as _;
+            let _ = write!(self.0, "{}={value:?} ", field.name());
+        }
+    }
+
+    /// Sink for [`RowFieldVisitor`]: one rendered line PER CAPTURED EVENT, a
+    /// `Vec<String>`, never a single concatenated `String` (X21-d(iv)) —
+    /// every drive below reads a SPECIFIC row's own fields off the capture,
+    /// which a concatenated blob cannot individuate without inventing its
+    /// own newline convention.
+    #[derive(Clone)]
+    struct RowCapture(Arc<std::sync::Mutex<Vec<String>>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for RowCapture {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut v = RowFieldVisitor(format!(" target={} ", event.metadata().target()));
+            event.record(&mut v);
+            self.0.lock().unwrap().push(v.0);
+        }
+    }
+
+    /// Bind a thread-local `tracing` capture for the guard's lifetime. Every
+    /// drive that reads rows off it runs on a CURRENT-THREAD runtime (R4.2,
+    /// X21-d): `tracing::subscriber::set_default` is thread-local, so a
+    /// multi-thread runtime would observe an empty capture instead of a
+    /// violation — exactly why `D4`'s race cannot be read at row
+    /// granularity (C13).
+    fn capture_tracing_rows(
+    ) -> (tracing::subscriber::DefaultGuard, Arc<std::sync::Mutex<Vec<String>>>) {
+        use tracing_subscriber::layer::SubscriberExt as _;
+        let sink: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(RowCapture(Arc::clone(&sink)));
+        let guard = tracing::subscriber::set_default(subscriber);
+        (guard, sink)
+    }
+
+    /// Whether `line` is a row on `target` carrying `kind = "kind"`.
+    fn is_row(line: &str, target: &str, kind: &str) -> bool {
+        line.contains(&format!(" target={target} ")) && line.contains(&format!(" kind={kind} "))
+    }
+
+    /// Read one field's rendered text out of a captured row.
+    fn row_field<'a>(line: &'a str, name: &str) -> &'a str {
+        let needle = format!(" {name}=");
+        let start = line
+            .find(&needle)
+            .unwrap_or_else(|| panic!("field {name} is absent from row {line:?}"))
+            + needle.len();
+        line[start..].split(' ').next().unwrap_or("")
+    }
+
+    /// Read one `u64`-rendered field out of a captured row.
+    fn row_u64(line: &str, name: &str) -> u64 {
+        row_field(line, name)
+            .parse()
+            .unwrap_or_else(|e| panic!("field {name} did not render a u64 in {line:?}: {e}"))
+    }
+
+    /// Rows on `target` whose `kind` field equals `kind`.
+    fn rows_of_kind<'a>(rows: &'a [String], target: &str, kind: &str) -> Vec<&'a str> {
+        rows.iter()
+            .map(String::as_str)
+            .filter(|l| is_row(l, target, kind))
+            .collect()
+    }
+
+    /// Rows on `target` regardless of `kind` — for the settlement target,
+    /// which carries no `kind` field at all (it is distinguished by target
+    /// alone).
+    fn rows_of_target<'a>(rows: &'a [String], target: &str) -> Vec<&'a str> {
+        rows.iter()
+            .map(String::as_str)
+            .filter(|l| l.contains(&format!(" target={target} ")))
+            .collect()
+    }
+
+    /// R4.6: the capture must be non-empty and carry the EXPECTED count of
+    /// each row kind the caller is about to read, counted separately —
+    /// `epoch_exit`, `settlement` and `prune_pass` — never silently short in
+    /// any one kind. A drive that skipped this and read a short capture
+    /// would report "no violation" on a term it never actually read; this
+    /// turns that into a RED instead.
+    fn assert_capture_shape(
+        rows: &[String],
+        expected_epoch_exit: usize,
+        expected_settlement: usize,
+        expected_prune_pass: usize,
+    ) {
+        assert!(
+            !rows.is_empty(),
+            "R4.6: the capture must be non-empty, got an empty capture"
+        );
+        let exit = rows_of_kind(rows, RESIDENCY_TARGET, "epoch_exit").len();
+        assert_eq!(
+            exit, expected_epoch_exit,
+            "R4.6: expected {expected_epoch_exit} epoch_exit row(s); capture was:\n{rows:#?}"
+        );
+        let settlement = rows_of_target(rows, SETTLEMENT_TARGET).len();
+        assert_eq!(
+            settlement, expected_settlement,
+            "R4.6: expected {expected_settlement} settlement row(s); capture was:\n{rows:#?}"
+        );
+        let pass = rows_of_kind(rows, RESIDENCY_TARGET, "prune_pass").len();
+        assert_eq!(
+            pass, expected_prune_pass,
+            "R4.6: expected {expected_prune_pass} prune_pass row(s) — exactly once per \
+             driven invocation; capture was:\n{rows:#?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // `D1` DIVERGENCE, `D2` POST-EXIT RESTORE, `D3` ABSENT-KEY.
+    // ------------------------------------------------------------------
+
+    /// `D1` **DIVERGENCE** — the sim-side twin of the lib's `S1` sanity row
+    /// (`tombstone_frontier_impl.rs`'s
+    /// `s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only`).
+    /// Stamps `N = 2` refs into epoch `e`, rolls past it, restores one EXTRA
+    /// ref into `e` (index-only — the entry-side slot is untouched), then
+    /// drives the drop through the public `prune_epoch_tombstones` entry
+    /// point. NOT in a Decision-Table universe — this IS the Step-0
+    /// discriminator (C12), not evidence about the prune.
+    ///
+    /// Its OWN predicate (R4.3): `R_obs == R_ent + 1` and
+    /// `B_obs == B_att + len(extra.tag)` on `e`'s `DrainedByPrune` exit row.
+    #[tokio::test]
+    async fn d1_divergence_removed_observation_diverges_from_entry_attribution() {
+        let (_svc, factory, frontier, registry, key_writer) = gated_sync();
+        let (conn, client) = register_device(&registry, "dev-d1").await;
+        let (map, key) = ("omap", "k1");
+        frontier.set_epoch_width(2); // N = 2 stamps land in epoch 1
+
+        frontier.stamp_tombstone(map, key, "TAG1"); // epoch 1: ref 1 of 2
+        frontier.stamp_tombstone(map, key, "TAG2"); // epoch 1: ref 2 of 2
+        frontier.stamp_tombstone(map, "k2", "TAG3"); // rolls past epoch 1: refs_at_entry = 2
+
+        let extra = TombstoneRef {
+            map: map.to_string(),
+            key: key.to_string(),
+            tag: "TAGX".to_string(),
+        };
+        // Index-only reinsert into the ALREADY-ENTRY-EMITTED epoch 1:
+        // `epoch_tags[1]` grows to 3 refs while `epoch_slots[1]` (and so
+        // `refs_at_entry`) is untouched — this IS the divergence mechanism
+        // (C12).
+        frontier.restore_tombstone_ref(1, extra.clone());
+
+        track_client(&frontier, &client, conn, 2).await; // LWM 2 > epoch 1
+        frontier.set_durable_epoch_watermark(1000);
+        seed_or_map(&factory, map, key, &[], &["TAG1", "TAG2", "TAGX"]).await;
+
+        let (guard, sink) = capture_tracing_rows();
+        prune_epoch_tombstones(&frontier, &factory, &key_writer).await;
+        drop(guard);
+        let rows = sink.lock().unwrap().clone();
+
+        // R4.6: exactly one drained epoch (1), so exactly one exit row, one
+        // settlement row, and — a single explicit call — exactly one pass
+        // row.
+        assert_capture_shape(&rows, 1, 1, 1);
+
+        let exit_row = rows_of_kind(&rows, RESIDENCY_TARGET, "epoch_exit")
+            .into_iter()
+            .find(|r| r.contains(" epoch=1 "))
+            .expect("epoch 1's DrainedByPrune exit row must be present");
+        assert!(
+            exit_row.contains("exit_kind=DrainedByPrune"),
+            "row: {exit_row}"
+        );
+
+        let r_obs = row_u64(exit_row, "removed_refs_observed");
+        let r_ent = row_u64(exit_row, "refs_at_entry");
+        let b_obs = row_u64(exit_row, "removed_bytes_observed");
+        let b_att = row_u64(exit_row, "bytes_freed_attributed");
+        let extra_len = extra.tag.len() as u64;
+
+        // D1's OWN predicate (R4.3), recorded as a value rather than
+        // asserted blindly: a failure here is a RESULT (NOT-REPRODUCED),
+        // never a reason to weaken the assertion.
+        assert_eq!(
+            r_obs,
+            r_ent + 1,
+            "D1 predicate limb 1 (R_obs == R_ent + 1) must hold; row: {exit_row}"
+        );
+        assert_eq!(
+            b_obs,
+            b_att + extra_len,
+            "D1 predicate limb 2 (B_obs == B_att + len(extra.tag)) must hold; row: {exit_row}"
+        );
+        println!(
+            "D1 DIVERGENCE: REPRODUCED — R_obs={r_obs} R_ent={r_ent} B_obs={b_obs} \
+             B_att={b_att} len(extra.tag)={extra_len}"
+        );
+    }
+
+    /// `D2` **POST-EXIT RESTORE** — drains epoch `e` (its exit row fires,
+    /// `epoch_slots[e]` retires for good), restores an EXTRA ref into that
+    /// already-EXITED epoch, then re-drains. Confirms C10: a retired slot is
+    /// never recreated, so the second drain's detection sweep (which walks
+    /// `epoch_slots`, not `epoch_tags`) never sees `e` again, even though
+    /// `e`'s restored ref is PHYSICALLY drained a second time. NOT in a
+    /// Decision-Table universe.
+    ///
+    /// Its OWN predicate (R4.3): the SECOND drain's own pass removes
+    /// `k > 0` refs with `Σ_e R_obs == 0` (no exit row for `e`) on that SAME
+    /// pass.
+    #[tokio::test]
+    async fn d2_post_exit_restore_reappears_without_a_new_exit_row() {
+        let (_svc, factory, frontier, registry, key_writer) = gated_sync();
+        let (conn, client) = register_device(&registry, "dev-d2").await;
+        let (map, key) = ("omap", "k1");
+        frontier.set_epoch_width(1);
+        frontier.stamp_tombstone(map, key, "TAG1"); // epoch 1
+        frontier.stamp_tombstone(map, "k2", "TAG2"); // rolls past epoch 1
+
+        track_client(&frontier, &client, conn, 2).await; // LWM 2 > epoch 1
+        frontier.set_durable_epoch_watermark(1000);
+
+        // FIRST drain: epoch 1 exits — its exit row fires and its
+        // `epoch_slots` entry retires.
+        let (guard1, sink1) = capture_tracing_rows();
+        prune_epoch_tombstones(&frontier, &factory, &key_writer).await;
+        drop(guard1);
+        let first = sink1.lock().unwrap().clone();
+        assert_capture_shape(&first, 1, 1, 1);
+        let first_exit = rows_of_kind(&first, RESIDENCY_TARGET, "epoch_exit")
+            .into_iter()
+            .find(|r| r.contains(" epoch=1 "))
+            .expect("epoch 1's first exit row must be present");
+        assert!(
+            first_exit.contains("exit_kind=DrainedByPrune"),
+            "row: {first_exit}"
+        );
+
+        // Restore an EXTRA ref into the now-EXITED epoch 1 — index-only; the
+        // retired slot is never recreated by a restore.
+        let extra = TombstoneRef {
+            map: map.to_string(),
+            key: key.to_string(),
+            tag: "TAGY".to_string(),
+        };
+        frontier.restore_tombstone_ref(1, extra);
+
+        // SECOND drain, a fresh capture window.
+        let (guard2, sink2) = capture_tracing_rows();
+        prune_epoch_tombstones(&frontier, &factory, &key_writer).await;
+        drop(guard2);
+        let second = sink2.lock().unwrap().clone();
+
+        // R4.6: no exit row for the retired epoch — settlement still fires
+        // (it is keyed off the physically-drained refs, not off the retired
+        // `epoch_slots` tracking) — and one pass row for this single
+        // explicit call.
+        assert_capture_shape(&second, 0, 1, 1);
+
+        let pass_row = rows_of_kind(&second, RESIDENCY_TARGET, "prune_pass")
+            .into_iter()
+            .next()
+            .expect("the second call's own pass row must be present");
+        let k = row_u64(pass_row, "considered");
+        let r_obs_sum: u64 = rows_of_kind(&second, RESIDENCY_TARGET, "epoch_exit")
+            .iter()
+            .map(|r| row_u64(r, "removed_refs_observed"))
+            .sum();
+
+        // D2's OWN predicate (R4.3).
+        assert!(k > 0, "D2 predicate limb 1 (k > 0) must hold: k={k}");
+        assert_eq!(
+            r_obs_sum, 0,
+            "D2 predicate limb 2 (Σ_e R_obs == 0) must hold on the second pass; \
+             capture was:\n{second:#?}"
+        );
+        println!("D2 POST-EXIT RESTORE: REPRODUCED — k={k} sum_R_obs={r_obs_sum}");
+    }
+
+    /// `D3` **ABSENT-KEY** — stamps a tombstone for a key never written to
+    /// the store, then drains. The considered ref takes the `Ok(None)` arm
+    /// (`crdt.rs:1560-1563`): the drain is real (the index entry is gone,
+    /// the exit row's attribution is genuine) but nothing was ever resident
+    /// in storage to reclaim. Confirms C9. NOT in a Decision-Table universe.
+    ///
+    /// Its OWN predicate (R4.3): per-epoch `D_e == 0 ∧ F_e == 0` on the
+    /// settlement row while `B_att > 0` on that SAME epoch's exit row.
+    #[tokio::test]
+    async fn d3_absent_key_settlement_shows_zero_reclaim_despite_positive_attribution() {
+        let (_svc, factory, frontier, registry, key_writer) = gated_sync();
+        let (conn, client) = register_device(&registry, "dev-d3").await;
+        let (map, key) = ("omap", "never-written-k1");
+        frontier.set_epoch_width(1);
+        frontier.stamp_tombstone(map, key, "TAG1"); // epoch 1 — `key` is never seeded
+        frontier.stamp_tombstone(map, "k2", "TAG2"); // rolls past epoch 1
+
+        track_client(&frontier, &client, conn, 2).await; // LWM 2 > epoch 1
+        frontier.set_durable_epoch_watermark(1000);
+        // Deliberately no `seed_or_map` call: `key` never existed in the store.
+
+        let (guard, sink) = capture_tracing_rows();
+        prune_epoch_tombstones(&frontier, &factory, &key_writer).await;
+        drop(guard);
+        let rows = sink.lock().unwrap().clone();
+
+        assert_capture_shape(&rows, 1, 1, 1);
+
+        let exit_row = rows_of_kind(&rows, RESIDENCY_TARGET, "epoch_exit")
+            .into_iter()
+            .find(|r| r.contains(" epoch=1 "))
+            .expect("epoch 1's DrainedByPrune exit row must be present");
+        assert!(
+            exit_row.contains("exit_kind=DrainedByPrune"),
+            "row: {exit_row}"
+        );
+        let b_att = row_u64(exit_row, "bytes_freed_attributed");
+
+        let settlement_row = rows_of_target(&rows, SETTLEMENT_TARGET)
+            .into_iter()
+            .find(|r| r.contains(" epoch=1 "))
+            .expect("epoch 1's settlement row must be present");
+        let dropped = row_u64(settlement_row, "dropped");
+        let bytes_freed = row_u64(settlement_row, "bytes_freed");
+        let absent = row_u64(settlement_row, "absent");
+
+        // D3's OWN predicate (R4.3).
+        assert_eq!(
+            dropped, 0,
+            "D3 predicate limb 1 (D_e == 0) must hold; row: {settlement_row}"
+        );
+        assert_eq!(
+            bytes_freed, 0,
+            "D3 predicate limb 2 (F_e == 0) must hold; row: {settlement_row}"
+        );
+        assert!(
+            b_att > 0,
+            "D3 predicate limb 3 (B_att > 0) must hold; row: {exit_row}"
+        );
+        assert_eq!(
+            absent, 1,
+            "the single considered ref must take the Ok(None) absent-key arm: {settlement_row}"
+        );
+        println!(
+            "D3 ABSENT-KEY: REPRODUCED — D_e={dropped} F_e={bytes_freed} B_att={b_att} absent={absent}"
+        );
     }
 }

--- a/packages/server-rust/src/sim/tombstone_gc_proof.rs
+++ b/packages/server-rust/src/sim/tombstone_gc_proof.rs
@@ -626,6 +626,22 @@ mod tests {
     /// its scope, so a second phase, if it lands, may extend this fn's body
     /// or add a sibling fn, whichever the reproducing test's own shape
     /// calls for.
+    ///
+    /// This fn IS PD-F12's drive `D4` **TOCTOU RACE** — the fixture already in
+    /// the file the frozen drive set cites by line. Its predicate is the
+    /// AGGREGATE terms `index_conservation_snapshot()` already exposes:
+    /// exactly one attributed drain, exactly one exit row, O-0 holds — proven
+    /// on every one of the 64 interleavings below, never a lucky one (R4.2).
+    /// `D4` is recorded at AGGREGATE granularity ONLY: it runs on a
+    /// `multi_thread` runtime, and both in-process observation transports
+    /// (`tracing` capture, metrics recorder) are thread-local (C13), so a
+    /// prune spawned onto a worker thread is invisible to either — the
+    /// per-kind row-count gate R4.6 applies to (`D1`, `D2`, `D3`, `D5`) does
+    /// NOT apply here, and this fn does not pretend otherwise by attempting a
+    /// row-granularity capture. `D4` is OUTSIDE every D-T row's universe
+    /// (Step 2's exclusion table): both in-process transports are
+    /// thread-local and its prune runs in a spawned task on a `multi_thread`
+    /// runtime (C13, X21-d).
     #[tokio::test(flavor = "multi_thread")]
     async fn prune_epoch_residency_discrimination_under_network_fault() {
         for round in 0..64u64 {
@@ -710,6 +726,19 @@ mod tests {
                 "round {round}: T_old pruned AND the pushed union survived"
             );
         }
+        // D4's own predicate (R4.3), recorded as a value: every one of the 64
+        // rounds above asserted the aggregate identity holds (a violation on
+        // any round would have already panicked that round's iteration, per
+        // R4.4's "surfaced as the test's own failure message" shape) — so
+        // reaching this line at all IS the recorded outcome.
+        println!(
+            "D4 TOCTOU RACE: REPRODUCED — aggregate index_conservation_snapshot() terms \
+             (exactly one attributed drain, exactly one exit row, O-0) held across all \
+             64 interleavings. Row-granularity terms are NOT observable here (C13, \
+             X21-d): the prune runs in a tokio::spawn task on a multi_thread runtime, \
+             so the thread-local tracing capture would see an empty capture rather than \
+             a violation. NOT in a Decision-Table universe (Step 2's exclusion table)."
+        );
     }
 
     // ==================================================================

--- a/packages/server-rust/src/sim/tombstone_gc_proof.rs
+++ b/packages/server-rust/src/sim/tombstone_gc_proof.rs
@@ -619,9 +619,13 @@ mod tests {
     /// PHASE 2 (reserved for a later segment, engaged only if R7.3(c)
     /// fires): the reproducing test itself, if the mechanism's siting rule
     /// lands it at the interleaving-fault boundary. Not present here — this
-    /// fn carries ONLY the fault-dimension arm in this segment; a second
-    /// phase, if it lands, extends THIS SAME fn's body, never a second fn
-    /// (the shape-4 bound admits exactly one additive fn in this file).
+    /// fn carries ONLY the fault-dimension arm in this segment.
+    ///
+    /// This file's current contract permits new fns and module-scope helpers
+    /// beside this one — it is counted against the increment that governs
+    /// its scope, so a second phase, if it lands, may extend this fn's body
+    /// or add a sibling fn, whichever the reproducing test's own shape
+    /// calls for.
     #[tokio::test(flavor = "multi_thread")]
     async fn prune_epoch_residency_discrimination_under_network_fault() {
         for round in 0..64u64 {

--- a/packages/server-rust/src/sim/tombstone_gc_proof.rs
+++ b/packages/server-rust/src/sim/tombstone_gc_proof.rs
@@ -832,6 +832,13 @@ mod tests {
             .unwrap_or_else(|e| panic!("field {name} did not render a u64 in {line:?}: {e}"))
     }
 
+    /// Read one `bool`-rendered field out of a captured row.
+    fn row_bool(line: &str, name: &str) -> bool {
+        row_field(line, name)
+            .parse()
+            .unwrap_or_else(|e| panic!("field {name} did not render a bool in {line:?}: {e}"))
+    }
+
     /// Rows on `target` whose `kind` field equals `kind`.
     fn rows_of_kind<'a>(rows: &'a [String], target: &str, kind: &str) -> Vec<&'a str> {
         rows.iter()
@@ -882,6 +889,24 @@ mod tests {
             "R4.6: expected {expected_prune_pass} prune_pass row(s) — exactly once per \
              driven invocation; capture was:\n{rows:#?}"
         );
+    }
+
+    /// Split a capture into successive passes: every row strictly after the
+    /// previous pass row up to and including its own pass row (Step 1's
+    /// frozen "Pass individuation" rule — the pass row is always emitted
+    /// last). Mirrors `service/domain/crdt.rs`'s `split_into_passes`, adapted
+    /// to this file's per-event `Vec<String>` capture rather than a single
+    /// concatenated string.
+    fn split_into_passes(rows: &[String]) -> Vec<Vec<&str>> {
+        let mut passes = Vec::new();
+        let mut current = Vec::new();
+        for line in rows {
+            current.push(line.as_str());
+            if is_row(line, RESIDENCY_TARGET, "prune_pass") {
+                passes.push(std::mem::take(&mut current));
+            }
+        }
+        passes
     }
 
     // ------------------------------------------------------------------
@@ -1114,6 +1139,295 @@ mod tests {
         );
         println!(
             "D3 ABSENT-KEY: REPRODUCED — D_e={dropped} F_e={bytes_freed} B_att={b_att} absent={absent}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // `D5` SEQUENTIAL REGIME — the D-T's SOLE UNIVERSE — plus the mechanical
+    // per-row Decision-Table evaluation over its recorded rows.
+    // ------------------------------------------------------------------
+
+    /// `D5` **SEQUENTIAL REGIME** — the only drive whose rows form a D-T
+    /// universe (Step 2). `N = 3000` stamps at `epoch_width = 1` (⇒ 3000
+    /// epochs), every key seeded PRESENT with its own tombstone, one tracked
+    /// cursor advanced per stamp, one `prune_epoch_tombstones` pass per
+    /// stamp.
+    ///
+    /// **The durable-epoch watermark and the cursor's `delivered` bound are
+    /// both `1_000_000`, each set ONCE / re-set idempotently, never the
+    /// file's ubiquitous `1000` literal or `track_client`'s hardcoded
+    /// `set_delivered(conn, 100)`** (`:204-215`): either literal would clamp
+    /// the cursor or the watermark below this drive's `3000` epochs and
+    /// silently shrink the D-T's sole universe — the exact hazard the spec's
+    /// `D5` paragraphs name. `claimed` is passed as the same `1_000_000`
+    /// sentinel on every `confirm_apply_ack`: `advance_on_ack` clamps by
+    /// `claimed.min(delivered).min(current_max_epoch)`, and `current_max_\
+    /// epoch` already tracks the latest stamped epoch, so the sentinel never
+    /// binds — the cursor still advances exactly one epoch per stamp.
+    ///
+    /// **Closing stamp (deliberate, and NOT one of the N keyed refs).**
+    /// `epoch_width = 1` maps `stamp_tombstone`'s `op_seq` directly onto the
+    /// epoch number, and ENTRY emission for epoch `e` fires only on the
+    /// STAMP that rolls PAST `e` — i.e. on stamp `e + 1`. So after exactly N
+    /// keyed stamps, epochs `1 ..= N-1` have entered (and, one pass later
+    /// each, drained) but epoch N — the last key's own epoch — is still
+    /// OPEN: nothing has stamped past it yet. One additional closing stamp
+    /// (a throwaway key, seeding no store entry, never itself drained: its
+    /// own epoch stays open at the end) rolls epoch N over so its exit and
+    /// settlement rows land inside this capture window too. This is what
+    /// makes the capture's `epoch_exit` row count equal the drive's own N
+    /// keyed stamps, per R4.6's per-kind gate below — verified here, not
+    /// assumed.
+    ///
+    /// Its OWN predicate (R4.3): **I1, I2, I3 hold on every pass**; **P-KEYS
+    /// holds on every considered ref**. A violation is asserted immediately
+    /// where it is read (R4.4) — this fn does not "fix the test" on a
+    /// failure, it records the violating pass/epoch verbatim in the panic
+    /// message. This fn does **not** publish a Decision-Table verdict: it
+    /// evaluates and records each row's OWN condition as a value (R4.5),
+    /// leaving the naming step to the freeze-gated group that owns it.
+    // A single fn deliberately, over the drive's own N=3000 loop plus its
+    // closing stamp, the R4.6 capture-shape gate, the I1/I2/I3 + P-KEYS
+    // per-pass evaluation and the D-T's per-row evaluation — splitting any
+    // of these out would separate an assertion from the capture it reads,
+    // which is exactly the shape R4.4/R4.6 need kept together in one place.
+    #[allow(clippy::too_many_lines)]
+    #[tokio::test]
+    async fn d5_sequential_regime_bridge_identities_and_p_keys_hold_over_3000_epochs() {
+        const N: u64 = 3000;
+        let (_svc, factory, frontier, registry, key_writer) = gated_sync();
+        let (conn, client) = register_device(&registry, "dev-d5").await;
+        let map = "omap";
+
+        // Set ONCE before the stamp loop, never lowered — exceeds the
+        // highest epoch this drive can reach (N + 1) by more than two orders
+        // of magnitude.
+        frontier.set_durable_epoch_watermark(1_000_000);
+
+        let (guard, sink) = capture_tracing_rows();
+
+        for i in 1..=N {
+            let key = format!("d5-k{i}");
+            let tag = format!("D5TAG{i}");
+            // Every key seeded PRESENT with its own tombstone, before its
+            // epoch can possibly roll and drain.
+            seed_or_map(&factory, map, &key, &[], &[tag.as_str()]).await;
+            frontier.stamp_tombstone(map, &key, &tag);
+            // Before EACH confirm_apply_ack, per the drive text.
+            frontier.set_delivered(conn, 1_000_000);
+            let advanced = frontier.confirm_apply_ack(&client, 1_000_000, conn).await;
+            assert!(advanced, "D5: the tracked cursor must advance on stamp {i}");
+            // One prune_epoch_tombstones pass per stamp.
+            prune_epoch_tombstones(&frontier, &factory, &key_writer).await;
+        }
+
+        // The closing stamp: rolls epoch N over so its own exit/settlement
+        // rows land inside this capture window (see the doc comment above).
+        frontier.stamp_tombstone(map, "d5-closing-key", "D5-CLOSE");
+        frontier.set_delivered(conn, 1_000_000);
+        let closing_advanced = frontier.confirm_apply_ack(&client, 1_000_000, conn).await;
+        assert!(
+            closing_advanced,
+            "D5: the tracked cursor must advance on the closing stamp"
+        );
+        prune_epoch_tombstones(&frontier, &factory, &key_writer).await;
+
+        drop(guard);
+        let rows = sink.lock().unwrap().clone();
+
+        // R4.6: N draining invocations (all but the very first of the N+1
+        // total, which finds nothing yet rolled) produce N epoch_exit rows
+        // and N settlement rows (every D5 epoch has exactly one considered
+        // ref, so the exit-row/settlement-row asymmetry the Delta names
+        // never triggers here); N+1 total invocations produce N+1 pass rows
+        // — exactly once per invocation, on every path, per C1's tip-CONFIRMED
+        // fact.
+        let expected_epoch_exit = usize::try_from(N).expect("N fits in usize");
+        let expected_settlement = usize::try_from(N).expect("N fits in usize");
+        let expected_prune_pass = usize::try_from(N + 1).expect("N + 1 fits in usize");
+        assert_capture_shape(
+            &rows,
+            expected_epoch_exit,
+            expected_settlement,
+            expected_prune_pass,
+        );
+
+        // Segment (a)'s open question, verified empirically rather than
+        // assumed: does `split_into_passes` recover exactly N+1 passes —
+        // i.e. does D5's direct-call shape keep the pass-row count 1:1 with
+        // this drive's own `prune_epoch_tombstones` invocation count, the
+        // way D1–D3 already showed? (G3 separately proved the PUSH path can
+        // trigger hidden internal sweeps that break that 1:1 relationship;
+        // D5 never routes through `gated_sync()`'s `SyncService` push path,
+        // so no such hidden sweep can fire here.)
+        let passes = split_into_passes(&rows);
+        assert_eq!(
+            passes.len(),
+            expected_prune_pass,
+            "D5: split_into_passes must recover exactly N+1 passes, matching this \
+             drive's own N+1 prune_epoch_tombstones invocations 1:1; rows:\n{rows:#?}"
+        );
+
+        // Index once, by the `epoch` field's rendered text, for the I3 /
+        // P-KEYS / D-T row 2 reads below.
+        let exit_rows: Vec<&str> = rows_of_kind(&rows, RESIDENCY_TARGET, "epoch_exit");
+        let settlement_rows: Vec<&str> = rows_of_target(&rows, SETTLEMENT_TARGET);
+        let mut exit_by_epoch: std::collections::HashMap<&str, &str> =
+            std::collections::HashMap::new();
+        for row in &exit_rows {
+            exit_by_epoch.insert(row_field(row, "epoch"), row);
+        }
+        let mut settlement_by_epoch: std::collections::HashMap<&str, &str> =
+            std::collections::HashMap::new();
+        for row in &settlement_rows {
+            settlement_by_epoch.insert(row_field(row, "epoch"), row);
+        }
+
+        let mut empty_passes = 0u64;
+        let mut draining_passes = 0u64;
+        let mut i3_checked = 0u64;
+        let mut p_keys_checked = 0u64;
+        let mut not_applicable_passes = 0u64;
+
+        for pass_rows in &passes {
+            let pass_row = pass_rows
+                .last()
+                .expect("a pass's own rows always end with its pass row");
+            assert!(
+                is_row(pass_row, RESIDENCY_TARGET, "prune_pass"),
+                "D5: a pass's last row must be its own pass row: {pass_row:?}"
+            );
+            let k_p = row_u64(pass_row, "considered");
+            let e_p = row_bool(pass_row, "empty_drain");
+
+            let exit_rows_in_pass: Vec<&str> = pass_rows
+                .iter()
+                .copied()
+                .filter(|l| is_row(l, RESIDENCY_TARGET, "epoch_exit"))
+                .collect();
+
+            // Step 1's scoping: NOT-APPLICABLE on a pass where any
+            // `restored_*` exit fired. D5 never restores (no D1/D2-shaped
+            // step in this drive), so this is expected to hold vacuously
+            // over every pass — recorded as a value below, not assumed.
+            let any_restored = exit_rows_in_pass
+                .iter()
+                .any(|r| row_field(r, "exit_kind").starts_with("Restored"));
+            if any_restored {
+                not_applicable_passes += 1;
+                continue;
+            }
+
+            let r_obs_sum: u64 = exit_rows_in_pass
+                .iter()
+                .map(|r| row_u64(r, "removed_refs_observed"))
+                .sum();
+
+            // I1: Σ_e R_obs(e) == K_p, both read off this SAME pass.
+            assert_eq!(
+                r_obs_sum, k_p,
+                "D5 I1 violated on a pass: Σ_e R_obs(e) == K_p must hold; pass rows:\n{pass_rows:?}"
+            );
+            // I2: E_p == (Σ_e R_obs(e) == 0), E_p off the same pass row.
+            assert_eq!(
+                e_p,
+                r_obs_sum == 0,
+                "D5 I2 violated on a pass: empty_drain == (Σ_e R_obs(e) == 0) must hold; \
+                 pass rows:\n{pass_rows:?}"
+            );
+
+            if e_p {
+                empty_passes += 1;
+            } else {
+                draining_passes += 1;
+            }
+
+            // I3 + P-KEYS, per drained epoch in this pass.
+            for exit_row in &exit_rows_in_pass {
+                let epoch = row_field(exit_row, "epoch");
+                let b_obs = row_u64(exit_row, "removed_bytes_observed");
+                let b_att = row_u64(exit_row, "bytes_freed_attributed");
+                // I3: B_obs(e) <= B_att(e) + B_restored(e). D5's
+                // B_restored(e) is 0 on every epoch — this drive never
+                // restores.
+                assert!(
+                    b_obs <= b_att,
+                    "D5 I3 violated on epoch {epoch}: B_obs <= B_att + B_restored(0) \
+                     must hold; row: {exit_row}"
+                );
+                i3_checked += 1;
+
+                let settlement_row = settlement_by_epoch
+                    .get(epoch)
+                    .unwrap_or_else(|| panic!("D5: epoch {epoch}'s settlement row must be present"));
+                let absent = row_u64(settlement_row, "absent");
+                // P-KEYS (precondition, recorded as a VALUE, not assumed):
+                // the considered ref's key was present in the store at
+                // drain time. Every D5 key is seeded before its epoch can
+                // possibly roll, so `absent` is expected 0 on every epoch —
+                // a nonzero value here REDs the round rather than silently
+                // resolving D-T row 2.
+                assert_eq!(
+                    absent, 0,
+                    "P-KEYS violated on epoch {epoch}: the considered ref's key must be \
+                     present in the store at drain time; settlement row: {settlement_row}"
+                );
+                p_keys_checked += 1;
+            }
+        }
+
+        assert_eq!(not_applicable_passes, 0, "D5 never restores: no pass should scope out");
+        assert_eq!(empty_passes, 1, "exactly the first pass (i=1) is an empty drain");
+        assert_eq!(draining_passes, N, "the remaining N passes each drain exactly one epoch");
+        assert_eq!(i3_checked, N, "I3 must be checked on all N drained epochs");
+        assert_eq!(p_keys_checked, N, "P-KEYS must be checked on all N considered refs");
+
+        // ------------------------------------------------------------
+        // Step 2 — the mechanical per-row Decision-Table evaluation over
+        // D5, the D-T's sole universe. Each row's OWN condition is
+        // evaluated and recorded as a VALUE below. This is evidence, not a
+        // verdict: which row (if any) names this round's reading is a
+        // later, freeze-gated determination this group does not make.
+        // ------------------------------------------------------------
+
+        // Row 1 (V1 REF-LOSS). Universe: every DrainedByPrune exit row
+        // recorded by D5. Condition: exists a row with R_obs < R_ent.
+        let row1_condition = exit_rows.iter().any(|r| {
+            r.contains("exit_kind=DrainedByPrune")
+                && row_u64(r, "removed_refs_observed") < row_u64(r, "refs_at_entry")
+        });
+
+        // Row 2 (V2 BOOKKEEPING ATTRIBUTION). Universe: every drained epoch
+        // recorded by D5, under precondition P-KEYS (verified above, holding
+        // on every considered ref). Condition: exists an epoch with
+        // R_obs > 0 AND D_e == 0 AND F_e == 0 AND B_att > 0.
+        let row2_condition = settlement_rows.iter().any(|settlement_row| {
+            let epoch = row_field(settlement_row, "epoch");
+            let dropped = row_u64(settlement_row, "dropped");
+            let bytes_freed = row_u64(settlement_row, "bytes_freed");
+            let Some(exit_row) = exit_by_epoch.get(epoch) else {
+                return false;
+            };
+            let r_obs = row_u64(exit_row, "removed_refs_observed");
+            let b_att = row_u64(exit_row, "bytes_freed_attributed");
+            r_obs > 0 && dropped == 0 && bytes_freed == 0 && b_att > 0
+        });
+
+        // Row 3 (V3 COUNTER-FAMILY MISNAMING). Universe: every prune pass
+        // driven by D5 on which no restored_* exit fired. Condition: I1 or
+        // I2 is VIOLATED on at least one such pass. Both were asserted true
+        // on every in-scope pass above (R4.4: a violation surfaces as the
+        // test's own failure message rather than reaching this line), so
+        // this flag is `false` whenever execution reaches here at all.
+        let row3_condition = false;
+
+        println!(
+            "D5 SEQUENTIAL REGIME: REPRODUCED — I1/I2/I3 held on every in-scope pass \
+             ({empty_passes} empty, {draining_passes} draining, {not_applicable_passes} \
+             not-applicable), P-KEYS held on {p_keys_checked}/{N} considered refs. \
+             D-T row conditions (recorded evidence, NOT a verdict): \
+             row1(V1 REF-LOSS)={row1_condition} row2(V2 BOOKKEEPING-ATTRIBUTION)={row2_condition} \
+             row3(V3 COUNTER-FAMILY-MISNAMING)={row3_condition}."
         );
     }
 }

--- a/packages/server-rust/src/tombstone_frontier.rs
+++ b/packages/server-rust/src/tombstone_frontier.rs
@@ -376,6 +376,16 @@ pub struct PruneEpochRecord {
     pub considered: u64,
     /// Refs of this epoch that left through [`PruneExit::Dropped`].
     pub dropped: u64,
+    /// Refs of this epoch that left through [`PruneExit::MatchedNothing`].
+    pub matched_nothing: u64,
+    /// Refs of this epoch that left through [`PruneExit::AbsentKey`].
+    pub absent: u64,
+    /// Refs of this epoch that left through [`PruneExit::RestoredReadError`].
+    pub restored_read_error: u64,
+    /// Refs of this epoch that left through [`PruneExit::RestoredEvicted`].
+    pub restored_evicted: u64,
+    /// Refs of this epoch that left through [`PruneExit::RestoredWriteError`].
+    pub restored_write_error: u64,
     /// Tombstone bytes this epoch freed.
     pub bytes_freed: u64,
 }
@@ -535,6 +545,25 @@ pub struct PruneEpochEntryRecord {
 ///
 /// `#[serde(rename_all = "camelCase")]` and `#[derive(Default)]` per this crate's Rust
 /// type-mapping rules — this struct carries two `Option<T>` fields.
+///
+/// # OBSERVATION vs ATTRIBUTION (HARD)
+///
+/// This struct carries two disjoint families of removal-side quantities, and the distinction is
+/// load-bearing rather than cosmetic:
+///
+/// - **ATTRIBUTIONS**, by construction: [`Self::bytes_freed_attributed`] and
+///   [`Self::refs_at_entry`] are not read from the removal itself — `bytes_freed_attributed` is
+///   `slot.stamped_bytes` copied across on a `DrainedByPrune` exit (`0` otherwise), and
+///   `refs_at_entry` is the count carried forward from the paired entry row. Both hold **by
+///   construction** of the exit-row assembly, not because anything at the removal site was
+///   inspected.
+/// - **OBSERVATIONS**, read at the removal site: [`Self::removed_refs_observed`] and
+///   [`Self::removed_bytes_observed`] are read from the vector the index removal itself returned,
+///   at the removal call site, and MUST NOT be derived from `refs_at_entry`, `stamped_bytes`,
+///   `stamped_refs` or any other entry-side quantity. An attribution and an observation of the
+///   same nominal quantity can diverge — that divergence is exactly what this pair of fields
+///   exists to make visible; deriving one from the other would erase the divergence the fields are
+///   here to observe.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PruneEpochResidencyRecord {
@@ -574,6 +603,22 @@ pub struct PruneEpochResidencyRecord {
     pub durable_watermark_at_exit: Epoch,
     /// The current epoch at the instant of exit.
     pub current_epoch_at_exit: Epoch,
+    /// Refs actually removed from the index, read from the vector the index removal itself
+    /// returned, at the removal call site. `0` for every exit kind that is not an observed drain,
+    /// and `0` for a `DrainedByPrune` exit whose epoch is absent from the carried per-epoch map —
+    /// the second case is an observable value, never a silent default. An OBSERVATION: MUST NOT be
+    /// derived from `refs_at_entry`, `stamped_bytes`, `stamped_refs` or any other entry-side
+    /// quantity. See the struct-level "OBSERVATION vs ATTRIBUTION" doc-contract above.
+    pub removed_refs_observed: u64,
+    /// Tombstone bytes actually removed from the index — `Σ tag.len()` over the same removed
+    /// vector `removed_refs_observed` is read from, at the same removal call site. This is the
+    /// same byte quantity `stamp_tombstone` credits (`tag.len()`) at the stamping site, so the two
+    /// are comparable with no unit conversion. `0` for every exit kind that is not an observed
+    /// drain, and `0` for a `DrainedByPrune` exit whose epoch is absent from the carried map. An
+    /// OBSERVATION: MUST NOT be derived from `refs_at_entry`, `stamped_bytes`, `stamped_refs` or
+    /// any other entry-side quantity. See the struct-level "OBSERVATION vs ATTRIBUTION"
+    /// doc-contract above.
+    pub removed_bytes_observed: u64,
 }
 
 /// Whether the prune record is recording.
@@ -680,7 +725,10 @@ pub trait PruneRecordObserver: Send + Sync {
     /// drain only — the refs-per-drain and epochs-per-drain distributions.
     fn observe_pass(&self, record: &PrunePassRecord);
 
-    /// One epoch drained inside a pass. Feeds the three per-drained-epoch distributions.
+    /// One epoch drained inside a pass. Feeds the three per-drained-epoch distributions and,
+    /// via the five newly-added per-epoch exit counters, the per-epoch six-exit identity
+    /// (`considered == dropped + matched_nothing + absent + restored_read_error +
+    /// restored_evicted + restored_write_error`) that previously only held per pass.
     fn observe_drained_epoch(&self, record: &PruneEpochRecord);
 
     /// The claim span at an LWM movement or a non-empty drain.
@@ -752,11 +800,16 @@ pub trait PruneRecordObserver: Send + Sync {
     /// Feeds [`METRIC_PRUNE_EPOCHS_EXITED_TOTAL`] — the exit ledger's independent, metrics-side
     /// completeness witness. See the trait-level "Per-epoch residency emissions" section above
     /// for the perturbation bound this call is priced under.
+    ///
+    /// On a `DrainedByPrune` exit, also feeds [`METRIC_PRUNE_REMOVED_REFS_OBSERVED_TOTAL`] and
+    /// [`METRIC_PRUNE_REMOVED_BYTES_OBSERVED_TOTAL`] from `record`'s `removed_refs_observed` /
+    /// `removed_bytes_observed` — the OBSERVATION series, credited on the `DrainedByPrune` arm
+    /// only, distinct from the ATTRIBUTION series the entry/exit rows already carry.
     fn observe_epoch_residency(&self, record: &PruneEpochResidencyRecord);
 }
 
 // ---------------------------------------------------------------------------
-// Pinned metric names — 22 counters, 11 gauges, 7 histograms
+// Pinned metric names — 24 counters, 11 gauges, 7 histograms
 // ---------------------------------------------------------------------------
 //
 // The name set is CLOSED. Emitting a series under this prefix that is not named here, or emitting
@@ -823,6 +876,15 @@ pub const METRIC_PRUNE_EPOCHS_ENTERED_TOTAL: &str = "topgun_or_prune_epochs_ente
 /// Counter: epochs that emitted an exit row — the exit ledger's independent, metrics-side
 /// completeness witness.
 pub const METRIC_PRUNE_EPOCHS_EXITED_TOTAL: &str = "topgun_or_prune_epochs_exited_total";
+/// Counter: refs actually removed from the index, read from the vector the index removal itself
+/// returned — the OBSERVATION counterpart to the by-construction attribution series above.
+pub const METRIC_PRUNE_REMOVED_REFS_OBSERVED_TOTAL: &str =
+    "topgun_or_prune_removed_refs_observed_total";
+/// Counter: tombstone bytes actually removed from the index, `Σ tag.len()` over the same removed
+/// vector [`METRIC_PRUNE_REMOVED_REFS_OBSERVED_TOTAL`] is read from — the same byte quantity
+/// `stamp_tombstone` credits, so the two are comparable with no unit conversion.
+pub const METRIC_PRUNE_REMOVED_BYTES_OBSERVED_TOTAL: &str =
+    "topgun_or_prune_removed_bytes_observed_total";
 
 /// Gauge: indexed tombstone refs, maintained incrementally.
 pub const METRIC_PRUNE_INDEXED_REFS: &str = "topgun_or_prune_indexed_refs";

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -83,6 +83,7 @@ use crate::tombstone_frontier::{
     METRIC_PRUNE_LWM_EPOCHS_ADVANCED_TOTAL, METRIC_PRUNE_LWM_STALL_SECONDS,
     METRIC_PRUNE_MATCHED_NOTHING_TOTAL, METRIC_PRUNE_NONEMPTY_DRAINS_TOTAL,
     METRIC_PRUNE_PASSES_TOTAL, METRIC_PRUNE_REBUILD_CLEARED_REFS_TOTAL,
+    METRIC_PRUNE_REMOVED_BYTES_OBSERVED_TOTAL, METRIC_PRUNE_REMOVED_REFS_OBSERVED_TOTAL,
     METRIC_PRUNE_RESTORED_EVICTED_TOTAL, METRIC_PRUNE_RESTORED_READ_ERROR_TOTAL,
     METRIC_PRUNE_RESTORED_REFS_TOTAL, METRIC_PRUNE_RESTORED_WRITE_ERROR_TOTAL,
     METRIC_PRUNE_SPLIT_COMPUTED_EPOCH, METRIC_PRUNE_SPLIT_RECOMPUTES_TOTAL,
@@ -2337,6 +2338,11 @@ pub struct MetricsPruneRecorder {
     rebuild_cleared_refs: Counter,
     epochs_entered: Counter,
     epochs_exited: Counter,
+    // The two OBSERVATION counters (R1.1, R3): read from the vector the index removal
+    // itself returned, at the removal site -- never a copy of `refs_at_entry` /
+    // `bytes_freed_attributed`. Credited on the `DrainedByPrune` arm only (R1.6, R3.2).
+    removed_refs_observed: Counter,
+    removed_bytes_observed: Counter,
 
     indexed_refs: Gauge,
     indexed_epochs: Gauge,
@@ -2408,6 +2414,8 @@ impl MetricsPruneRecorder {
             rebuild_cleared_refs: touched_counter(METRIC_PRUNE_REBUILD_CLEARED_REFS_TOTAL),
             epochs_entered: touched_counter(METRIC_PRUNE_EPOCHS_ENTERED_TOTAL),
             epochs_exited: touched_counter(METRIC_PRUNE_EPOCHS_EXITED_TOTAL),
+            removed_refs_observed: touched_counter(METRIC_PRUNE_REMOVED_REFS_OBSERVED_TOTAL),
+            removed_bytes_observed: touched_counter(METRIC_PRUNE_REMOVED_BYTES_OBSERVED_TOTAL),
 
             indexed_refs: touched_gauge(METRIC_PRUNE_INDEXED_REFS),
             indexed_epochs: touched_gauge(METRIC_PRUNE_INDEXED_EPOCHS),
@@ -2565,7 +2573,17 @@ impl PruneRecordObserver for MetricsPruneRecorder {
         // a drain or a rebuild takes it atomically, so it is exactly what left the
         // index on that exit, never an approximation.
         match record.exit_kind {
-            EpochExitKind::DrainedByPrune => self.drained_refs.increment(record.refs_at_entry),
+            EpochExitKind::DrainedByPrune => {
+                self.drained_refs.increment(record.refs_at_entry);
+                // The two OBSERVATION counters, credited on this arm only (R1.6, R3.2):
+                // read from the vector the index removal returned, never from the
+                // by-construction attribution `refs_at_entry` this arm already credits
+                // above.
+                self.removed_refs_observed
+                    .increment(record.removed_refs_observed);
+                self.removed_bytes_observed
+                    .increment(record.removed_bytes_observed);
+            }
             EpochExitKind::ClearedByRebuild => {
                 self.rebuild_cleared_refs.increment(record.refs_at_entry);
             }

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -4430,6 +4430,376 @@ mod tests {
         assert_eq!(retried[0].0, 1);
         assert_eq!(retried[0].1.tag, "T1");
     }
+
+    // -----------------------------------------------------------------------
+    // The two OBSERVATION fields (R1) -- unit coverage, the rendered `/metrics`
+    // proof (X21-c), the rendered-field-text proof (X21-b), the pre-freeze
+    // sanity row `S1` (R1.7, C12) and Step 0 leg (c) (R1.7, X21-a, C11).
+    // -----------------------------------------------------------------------
+
+    /// R1.5 (first case): every exit kind other than `DrainedByPrune` carries `0` in both
+    /// new fields, even though `refs_at_entry` (the attribution the observation pair exists
+    /// to be checked against) is nonzero on the same row.
+    #[test]
+    fn finalize_epoch_exit_zeroes_observation_fields_for_non_drained_exit_kinds() {
+        let f = frontier();
+        f.set_epoch_width(1);
+        f.stamp_tombstone("m", "k1", "TAG1"); // epoch 1
+        f.stamp_tombstone("m", "k2", "TAG2"); // rolls past epoch 1: refs_at_entry = 1
+
+        let exits = {
+            let mut state = f.lock();
+            state.rebuild_into_epoch(100, Vec::new())
+        };
+        assert_eq!(exits.len(), 1, "only epoch 1 had an entry-emitted slot");
+        let exit = exits.into_iter().next().expect("checked len == 1");
+
+        assert!(matches!(exit.exit_kind, EpochExitKind::ClearedByRebuild));
+        assert!(
+            exit.refs_at_entry > 0,
+            "R_ent must be > 0 for the zero below to be a meaningful check: {exit:?}"
+        );
+        assert_eq!(
+            exit.removed_refs_observed, 0,
+            "R1.5: not a DrainedByPrune exit: {exit:?}"
+        );
+        assert_eq!(
+            exit.removed_bytes_observed, 0,
+            "R1.5: not a DrainedByPrune exit: {exit:?}"
+        );
+    }
+
+    /// R1.5 (second case): a `DrainedByPrune` attribution whose epoch is absent from the
+    /// carried per-epoch map -- reachable only via a direct bypass, because
+    /// `drain_prunable`'s `Some(refs)` arm is the map's only writer (K1) and always supplies
+    /// an entry for any epoch it attributes `DrainedByPrune` to. Exercised directly here so
+    /// the branch stays observable rather than merely declared.
+    #[test]
+    fn finalize_epoch_exit_zeroes_observation_fields_when_the_epoch_is_absent_from_the_carried_map()
+    {
+        let f = frontier();
+        f.set_epoch_width(1);
+        f.stamp_tombstone("m", "k1", "TAG1"); // epoch 1
+        f.stamp_tombstone("m", "k2", "TAG2"); // rolls past epoch 1: refs_at_entry = 1
+
+        let exit = {
+            let mut state = f.lock();
+            state.epoch_tags.remove(&1);
+            state.detect_epoch_exit(1, Some(FinalExitKind::DrainedByPrune), None)
+        }
+        .expect("epoch 1 is absent from epoch_tags and must surface an exit row");
+
+        assert!(matches!(exit.exit_kind, EpochExitKind::DrainedByPrune));
+        assert!(exit.refs_at_entry > 0, "R_ent must be > 0: {exit:?}");
+        assert_eq!(
+            exit.removed_refs_observed, 0,
+            "R1.5: epoch absent from the carried map: {exit:?}"
+        );
+        assert_eq!(
+            exit.removed_bytes_observed, 0,
+            "R1.5: epoch absent from the carried map: {exit:?}"
+        );
+    }
+
+    /// AC5/X21-c -- the two new pinned counters reach a rendered `/metrics` scrape and carry
+    /// the drain's own observed totals, through the full public pipeline
+    /// (`drain_prunable_tombstones` → `publish_epoch_exit` → `observe_epoch_residency`).
+    /// Sited here, not in `src/sim`, because the metrics recorder binding is thread-local
+    /// (C13, X21-d).
+    #[test]
+    fn removed_observation_counters_reach_the_rendered_metrics_scrape() {
+        let rendered = rendered_under_a_recorder(|| {
+            let f = frontier();
+            f.set_epoch_width(1);
+            f.stamp_tombstone("m", "k1", "TAG1"); // epoch 1: 1 ref, 4 bytes
+            f.stamp_tombstone("m", "k2", "TAG2"); // rolls past epoch 1
+
+            f.set_durable_epoch_watermark(1);
+            f.set_delivered(CONN_A, 100);
+            let c: ClientId = "a5:metrics-observed|dev-1".into();
+            assert!(block_on(f.confirm_apply_ack(&c, 2, CONN_A)));
+
+            let drained = f.drain_prunable_tombstones();
+            assert_eq!(drained.len(), 1, "only epoch 1 clears both conjuncts");
+        });
+
+        assert_eq!(
+            rendered_value(&rendered, METRIC_PRUNE_REMOVED_REFS_OBSERVED_TOTAL),
+            Some("1"),
+            "epoch 1's drain observed exactly one removed ref; render was:\n{rendered}"
+        );
+        assert_eq!(
+            rendered_value(&rendered, METRIC_PRUNE_REMOVED_BYTES_OBSERVED_TOTAL),
+            Some("4"),
+            "TAG1 is 4 bytes; render was:\n{rendered}"
+        );
+    }
+
+    /// R1.6/R3.2 -- `MetricsPruneRecorder::observe_epoch_residency` credits the two new
+    /// OBSERVATION counters on the `DrainedByPrune` arm ONLY: every other exit kind must move
+    /// neither counter, even when the record itself carries nonzero observation fields (R1.5
+    /// guarantees that never happens in production, but the observer's own crediting arm must
+    /// not depend on that guarantee to stay correct).
+    #[test]
+    fn metrics_recorder_credits_removed_observation_counters_on_the_drained_arm_only() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            let observer = MetricsPruneRecorder::new();
+            for exit_kind in [
+                EpochExitKind::ClearedByRebuild,
+                EpochExitKind::StillResidentAtShutdown,
+            ] {
+                observer.observe_epoch_residency(&PruneEpochResidencyRecord {
+                    exit_kind,
+                    removed_refs_observed: 99,
+                    removed_bytes_observed: 999,
+                    ..PruneEpochResidencyRecord::default()
+                });
+            }
+            observer.observe_epoch_residency(&PruneEpochResidencyRecord {
+                exit_kind: EpochExitKind::DrainedByPrune,
+                removed_refs_observed: 3,
+                removed_bytes_observed: 12,
+                ..PruneEpochResidencyRecord::default()
+            });
+        });
+
+        let rendered = handle.render();
+        assert_eq!(
+            rendered_value(&rendered, METRIC_PRUNE_REMOVED_REFS_OBSERVED_TOTAL),
+            Some("3"),
+            "only the DrainedByPrune row's 3 refs must be credited; render was:\n{rendered}"
+        );
+        assert_eq!(
+            rendered_value(&rendered, METRIC_PRUNE_REMOVED_BYTES_OBSERVED_TOTAL),
+            Some("12"),
+            "only the DrainedByPrune row's 12 bytes must be credited; render was:\n{rendered}"
+        );
+    }
+
+    /// A thread-local `tracing` capture layer (X21-b, X21-d(iv)) -- this file's test module
+    /// carried none before this segment. One entry per captured event, never a single
+    /// concatenated `String`: both `S1` and the rendered-field-text proof below read PER-ROW
+    /// terms off a SPECIFIC exit row, and a concatenated sink cannot individuate one row from
+    /// the next.
+    ///
+    /// The `network/device_identity.rs:397-429` shape, adapted for a `Vec<String>` sink.
+    struct FieldTextVisitor(String);
+
+    impl tracing::field::Visit for FieldTextVisitor {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            use std::fmt::Write as _;
+            let _ = write!(self.0, "{}={value} ", field.name());
+        }
+
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            use std::fmt::Write as _;
+            let _ = write!(self.0, "{}={value:?} ", field.name());
+        }
+    }
+
+    #[derive(Clone)]
+    struct EventCapture(Arc<Mutex<Vec<String>>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for EventCapture {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            // The target is metadata, not a recorded field -- prefixed by hand so a
+            // captured row stays attributable to a specific `tracing` target rather than
+            // just whatever field text it happens to carry.
+            let mut visitor = FieldTextVisitor(format!("target={} ", event.metadata().target()));
+            event.record(&mut visitor);
+            self.0.lock().unwrap().push(visitor.0);
+        }
+    }
+
+    /// Bind a fresh thread-local `tracing` capture layer, run `body`, and return every
+    /// captured event's rendered field text, one entry per event (X21-d(iv)).
+    fn captured_tracing_events(body: impl FnOnce()) -> Vec<String> {
+        use tracing_subscriber::layer::SubscriberExt as _;
+        let sink: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(EventCapture(Arc::clone(&sink)));
+        let _guard = tracing::subscriber::set_default(subscriber);
+        body();
+        let events = sink.lock().unwrap().clone();
+        events
+    }
+
+    /// X21-b -- the two new fields reach the residency EXIT row's `tracing` transport BY
+    /// NAME: a capture over a real `DrainedByPrune` exit shows `removed_refs_observed=` and
+    /// `removed_bytes_observed=` in the rendered field text (the `name=value` pairs a `Visit`
+    /// collector accumulates), proven independently of whether the two terms happen to
+    /// diverge from their attribution twins -- `S1` below is this limb's SECOND executed
+    /// proof, the one that also diverges.
+    #[test]
+    fn removed_observation_fields_appear_by_name_on_the_captured_exit_row() {
+        let f = frontier();
+        f.set_epoch_width(1);
+        f.stamp_tombstone("m", "k1", "TAG1"); // epoch 1: 1 ref, 4 bytes
+        f.stamp_tombstone("m", "k2", "TAG2"); // rolls past epoch 1
+
+        f.set_durable_epoch_watermark(1);
+        f.set_delivered(CONN_A, 100);
+        let c: ClientId = "a5:field-text|dev-1".into();
+        assert!(block_on(f.confirm_apply_ack(&c, 2, CONN_A)));
+
+        let events = captured_tracing_events(|| {
+            let drained = f.drain_prunable_tombstones();
+            assert_eq!(drained.len(), 1);
+        });
+
+        let exit_row = events
+            .iter()
+            .find(|e| e.contains("kind=epoch_exit") && e.contains("epoch=1 "))
+            .unwrap_or_else(|| {
+                panic!("no epoch_exit row for epoch 1 in captured events:\n{events:#?}")
+            });
+
+        assert!(
+            exit_row.contains("removed_refs_observed=1"),
+            "row: {exit_row}"
+        );
+        assert!(
+            exit_row.contains("removed_bytes_observed=4"),
+            "row: {exit_row}"
+        );
+    }
+
+    /// `S1` -- THE PRE-FREEZE SANITY ROW (X21 applied to the PREDICATE itself, C12).
+    ///
+    /// Establishes that `removed_refs_observed` / `removed_bytes_observed` CAN diverge from
+    /// `refs_at_entry` / `bytes_freed_attributed` on a REAL `DrainedByPrune` exit row,
+    /// constructed entirely through PUBLIC entry points (bar the `#[cfg(test)]` watermark
+    /// injector every test in this file already uses) -- a discriminator nobody has shown to
+    /// discriminate is exactly the failure class Audit v1 C1 caught.
+    ///
+    /// `drain_prunable_tombstones` (the only PUBLIC drain entry point) returns
+    /// `Vec<(Epoch, TombstoneRef)>` and no record (R1.7, X21-a), so this test reads the exit
+    /// row off the declared `tracing` capture rather than off a return value; the returned
+    /// `Vec` is asserted separately, as a count check only.
+    #[test]
+    fn s1_pre_freeze_sanity_row_diverges_through_public_entry_points_only() {
+        let f = frontier();
+        // 1. one epoch per stamp.
+        f.set_epoch_width(1);
+        // 2. epoch 1 holds 1 ref; slot created.
+        f.stamp_tombstone("m", "k1", "TAG1");
+        // 3. rolls past epoch 1 -> entry row fires; slot.refs_at_entry = 1, entry_emitted =
+        // true.
+        f.stamp_tombstone("m", "k2", "TAG2");
+        // 4. epoch_tags[1] now holds 2 refs; epoch_slots[1] (and slot.refs_at_entry) is
+        // untouched -- this is C12's divergence mechanism.
+        f.restore_tombstone_ref(
+            1,
+            TombstoneRef {
+                map: "m".to_string(),
+                key: "k1".to_string(),
+                tag: "TAGX".to_string(),
+            },
+        );
+        // 5. REQUIRED PREREQUISITE: `advance_on_ack` clamps by `delivered.unwrap_or(0)`; with
+        // no prior `set_delivered` the bound is 0, step 6 returns false, and step 8 drains
+        // nothing.
+        f.set_delivered(CONN_A, 100);
+        let c: ClientId = "a5:s1-sanity|dev-1".into();
+        // 6. bound = min(claimed 2, delivered 100, current_max_epoch 2) = 2; LWM 2 > 1 ->
+        // epoch 1 prune-eligible.
+        assert!(block_on(f.confirm_apply_ack(&c, 2, CONN_A)));
+        // 7. second call-site conjunct.
+        f.set_durable_epoch_watermark(1);
+
+        // 8. drain via the PUBLIC entry point; observed off the captured exit row (X21-b).
+        let events = captured_tracing_events(|| {
+            let drained = f.drain_prunable_tombstones();
+            assert_eq!(
+                drained.len(),
+                2,
+                "epoch 1's two refs (stamped TAG1, restored TAGX) both drain"
+            );
+        });
+
+        let exit_row = events
+            .iter()
+            .find(|e| e.contains("kind=epoch_exit") && e.contains("epoch=1 "))
+            .unwrap_or_else(|| {
+                panic!("no epoch_exit row for epoch 1 in captured events:\n{events:#?}")
+            });
+
+        assert!(
+            exit_row.contains("exit_kind=DrainedByPrune"),
+            "row: {exit_row}"
+        );
+        // R_ent == 1 (only TAG1 was ever STAMPED into epoch 1 before rollover).
+        assert!(exit_row.contains("refs_at_entry=1"), "row: {exit_row}");
+        // R_obs == 2 (TAG1 stamped + TAGX restored, both resident at drain time):
+        // R_obs == R_ent + 1, the discriminating assertion (C12).
+        assert!(
+            exit_row.contains("removed_refs_observed=2"),
+            "row: {exit_row}"
+        );
+        // B_att == 4 (TAG1's own stamped bytes; TAGX was restored, never stamped).
+        assert!(
+            exit_row.contains("bytes_freed_attributed=4"),
+            "row: {exit_row}"
+        );
+        // B_obs == 8 == B_att + len("TAGX") == 4 + 4.
+        assert!(
+            exit_row.contains("removed_bytes_observed=8"),
+            "row: {exit_row}"
+        );
+    }
+
+    /// Step 0 leg (c) -- the V1 POSITIVE CONTROL (C11). `R_obs < R_ent` is not constructible
+    /// through the public API at all (C4's four-site mutation enumeration), so this plants the
+    /// antecedent directly via the same in-module `epoch_tags` bypass this file already uses
+    /// elsewhere (e.g. the tier-1 walk's class (c), the unenumerated-removal test above), then
+    /// drains IN-MODULE (`f.lock().drain_prunable()`, the one in-crate call that returns the
+    /// exit rows BY VALUE) and asserts on the RETURNED record -- X21-a's sole workable proof.
+    ///
+    /// This proves the V1 predicate FIRES when its antecedent exists; it is NOT evidence about
+    /// the prune itself, and its rows are excluded from every Decision-Table universe (the
+    /// frozen scoping in Step 0).
+    #[test]
+    fn step0_leg_c_v1_positive_control_planted_ref_loss_fires_on_the_returned_record() {
+        let f = frontier();
+        f.set_epoch_width(1);
+        f.stamp_tombstone("m", "k1", "TAG1"); // epoch 1
+        f.stamp_tombstone("m", "k2", "TAG2"); // rolls past epoch 1: refs_at_entry = 1
+        f.set_durable_epoch_watermark(1);
+        f.set_delivered(CONN_A, 100);
+        let c: ClientId = "a5:leg-c|dev-1".into();
+        assert!(block_on(f.confirm_apply_ack(&c, 2, CONN_A)));
+
+        let exits = {
+            let mut state = f.lock();
+            // Plant the V1 antecedent (C11): epoch 1's index content is replaced with an
+            // EMPTY vector -- entry-emitted and still eligible, so the drain's own eligible
+            // fold genuinely removes it (`epoch_tags.remove(&1)` returns `Some`, a real
+            // `DrainedByPrune` attribution) while observing NOTHING in the vector it
+            // removed.
+            state.epoch_tags.insert(1, Vec::new());
+            let (_drained, _split, exits) = state.drain_prunable();
+            exits
+        };
+        assert_eq!(exits.len(), 1, "only epoch 1 was eligible");
+        let exit = exits.into_iter().next().expect("checked len == 1");
+
+        assert!(
+            matches!(exit.exit_kind, EpochExitKind::DrainedByPrune),
+            "the eligible fold genuinely removed epoch 1 (an empty Vec, but Some), so this \
+             is a real DrainedByPrune exit, not Unclassified: {exit:?}"
+        );
+        assert!(exit.refs_at_entry > 0, "R_ent must be > 0: {exit:?}");
+        assert_eq!(
+            exit.removed_refs_observed, 0,
+            "R_obs must be 0: the planted vector carried nothing for drain_prunable to \
+             observe: {exit:?}"
+        );
+    }
 }
 
 #[cfg(all(test, feature = "redb"))]

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -618,15 +618,20 @@ impl FrontierState {
     /// three separate hooks that each independently construct an exit record — so a
     /// removal reached by a path nobody has enumerated yet still lands here and is
     /// still detected, exactly as R2.3b's doc-contract requires.
+    ///
+    /// `observed` is the `(refs, bytes)` pair `drain_prunable`'s `Some(refs)` arm read from
+    /// the removed vector itself (K1), keyed by `epoch`, for a caller that has one; every
+    /// other caller passes `None` because it never removed anything through that arm.
     fn detect_epoch_exit(
         &mut self,
         epoch: Epoch,
         attribution: Option<FinalExitKind>,
+        observed: Option<(u64, u64)>,
     ) -> Option<PruneEpochResidencyRecord> {
         if self.epoch_tags.contains_key(&epoch) {
             return None;
         }
-        self.finalize_epoch_exit(epoch, attribution)
+        self.finalize_epoch_exit(epoch, attribution, observed)
     }
 
     /// Force an exit row for every still-tracked epoch, attributed
@@ -640,17 +645,24 @@ impl FrontierState {
         epochs
             .into_iter()
             .filter_map(|e| {
-                self.finalize_epoch_exit(e, Some(FinalExitKind::StillResidentAtShutdown))
+                // Shutdown never removed anything through `drain_prunable`'s
+                // `Some(refs)` arm, so there is no observation to carry.
+                self.finalize_epoch_exit(e, Some(FinalExitKind::StillResidentAtShutdown), None)
             })
             .collect()
     }
 
     /// Shared exit-row construction: removes `epoch`'s slot (retiring it — the ledger
     /// carries no unbounded audit trail) and builds its [`PruneEpochResidencyRecord`].
+    ///
+    /// `observed` is the `(refs, bytes)` pair read at the removal site inside
+    /// `drain_prunable`'s `Some(refs)` arm (K1, R1.4) — the two OBSERVATION terms.
+    /// Callers other than that arm's sweep pass `None`.
     fn finalize_epoch_exit(
         &mut self,
         epoch: Epoch,
         kind_hint: Option<FinalExitKind>,
+        observed: Option<(u64, u64)>,
     ) -> Option<PruneEpochResidencyRecord> {
         let slot = self.epoch_slots.remove(&epoch)?;
         if !slot.entry_emitted {
@@ -695,6 +707,18 @@ impl FrontierState {
         } else {
             0
         };
+        // R1.5: the OBSERVATION pair. `0 / 0` for every exit kind that is not an
+        // observed drain, and `0 / 0` for a `DrainedByPrune` exit whose epoch never
+        // showed up in the carried map -- reachable only if a caller ever attributes
+        // `DrainedByPrune` without having gone through `drain_prunable`'s `Some(refs)`
+        // arm, which is this map's only writer (K1). Left as an explicit branch,
+        // rather than folded behind a default, so that possibility stays visible.
+        let (removed_refs_observed, removed_bytes_observed) =
+            if matches!(exit_kind, EpochExitKind::DrainedByPrune) {
+                observed.unwrap_or((0, 0))
+            } else {
+                (0, 0)
+            };
         self.epochs_exited_total += 1;
         Some(PruneEpochResidencyRecord {
             epoch,
@@ -711,6 +735,8 @@ impl FrontierState {
             lwm_at_exit: self.observed_lwm,
             durable_watermark_at_exit: self.durable_epoch_watermark,
             current_epoch_at_exit: self.current_epoch,
+            removed_refs_observed,
+            removed_bytes_observed,
         })
     }
 
@@ -803,7 +829,9 @@ impl FrontierState {
         let tracked: Vec<Epoch> = self.epoch_slots.keys().copied().collect();
         tracked
             .into_iter()
-            .filter_map(|e| self.detect_epoch_exit(e, Some(FinalExitKind::ClearedByRebuild)))
+            // A wholesale rebuild clear never went through `drain_prunable`'s
+            // `Some(refs)` arm, so there is no per-epoch observation to carry.
+            .filter_map(|e| self.detect_epoch_exit(e, Some(FinalExitKind::ClearedByRebuild), None))
             .collect()
     }
 
@@ -867,6 +895,12 @@ impl FrontierState {
             (!eligible.is_empty()).then(|| self.split_observation(self.low_water_mark()));
         let mut drained = Vec::new();
         let mut drained_epochs: HashSet<Epoch> = HashSet::new();
+        // K1 / R1.4: the OBSERVATION terms, keyed by epoch. Read from the vector the
+        // index removal itself returned, inside this SAME `Some(refs)` arm and
+        // strictly before `drained.extend(...)` consumes it below — this is the ONLY
+        // writer of this map, and it is never re-read from `epoch_tags` afterward
+        // (which no longer holds the epoch at that point).
+        let mut removed_observed: HashMap<Epoch, (u64, u64)> = HashMap::new();
         for e in eligible {
             if let Some(refs) = self.epoch_tags.remove(&e) {
                 // Decrement by what this epoch actually held, so the carried count
@@ -876,6 +910,15 @@ impl FrontierState {
                     .saturating_sub(u64::try_from(refs.len()).unwrap_or(u64::MAX));
                 self.last_drained_epoch = self.last_drained_epoch.max(e);
                 drained_epochs.insert(e);
+                // R1.3: `Σ tag.len()` — the same byte quantity `stamp_tombstone`
+                // credits per ref (`:482`), so the two sides are comparable with no
+                // unit conversion.
+                let removed_refs = u64::try_from(refs.len()).unwrap_or(u64::MAX);
+                let removed_bytes: u64 = refs
+                    .iter()
+                    .map(|r| u64::try_from(r.tag.len()).unwrap_or(u64::MAX))
+                    .sum();
+                removed_observed.insert(e, (removed_refs, removed_bytes));
                 drained.extend(refs.into_iter().map(|r| (e, r)));
             }
             self.epoch_max_seq.remove(&e);
@@ -892,7 +935,8 @@ impl FrontierState {
             let attribution = drained_epochs
                 .contains(&e)
                 .then_some(FinalExitKind::DrainedByPrune);
-            if let Some(record) = self.detect_epoch_exit(e, attribution) {
+            let observed = removed_observed.get(&e).copied();
+            if let Some(record) = self.detect_epoch_exit(e, attribution, observed) {
                 exits.push(record);
             }
         }
@@ -1317,6 +1361,8 @@ impl TombstoneFrontier {
             lwm_at_exit = record.lwm_at_exit,
             durable_watermark_at_exit = record.durable_watermark_at_exit,
             current_epoch_at_exit = record.current_epoch_at_exit,
+            removed_refs_observed = record.removed_refs_observed,
+            removed_bytes_observed = record.removed_bytes_observed,
             "prune epoch exit"
         );
     }
@@ -3035,7 +3081,7 @@ mod tests {
         let record = {
             let mut state = f2.lock();
             state.epoch_tags.remove(&1);
-            state.detect_epoch_exit(1, None)
+            state.detect_epoch_exit(1, None, None)
         }
         .expect("the bypassed epoch must surface an exit row at the next detection point");
         match record.exit_kind {
@@ -3282,7 +3328,7 @@ mod tests {
             let exit = {
                 let mut state = f.lock();
                 state.epoch_tags.remove(&1);
-                state.detect_epoch_exit(1, None)
+                state.detect_epoch_exit(1, None, None)
             }
             .expect("bypassed epoch surfaces at the next detection point");
             assert!(matches!(exit.exit_kind, EpochExitKind::Unclassified { .. }));

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -4736,10 +4736,12 @@ mod tests {
         // R_ent == 1 (only TAG1 was ever STAMPED into epoch 1 before rollover).
         assert!(exit_row.contains("refs_at_entry=1"), "row: {exit_row}");
         // R_obs == 2 (TAG1 stamped + TAGX restored, both resident at drain time):
-        // R_obs == R_ent + 1, the discriminating assertion (C12).
+        // R_obs == R_ent + 1, the discriminating assertion (C12). The message names that
+        // assertion literally, because the mutation arm's whole proof is that THIS assertion
+        // is the one the mutation kills — a failure that did not name it would not show that.
         assert!(
             exit_row.contains("removed_refs_observed=2"),
-            "row: {exit_row}"
+            "discriminating assertion R_obs == R_ent + 1 does not hold; row: {exit_row}"
         );
         // B_att == 4 (TAG1's own stamped bytes; TAGX was restored, never stamped).
         assert!(


### PR DESCRIPTION
## Summary

SPEC-358 (22 commits): the PD-F12 micro-diagnosis — an observation-based prune removal term plus a deterministic reproducing test, resolving the counter-family contradiction routed out of SPEC-357b.

**Outcome: V0 — NOT REPRODUCED, an earned negative.** Two of three readings of PD-F12 were tested over D5 and both returned negatives; the third's antecedent is not constructible through the public API (PD-F20, superseding PD-F19's understatement — retraction carried out with the executed mutation as evidence). The fix-shape ruling is NOT WRITTEN; E-C fired as pre-registered: **the diagnosis line hard-stops and the ReclamationRegistry family starts cause-unclassified per manifest §8.3.**

- Instrument proven LIVE by mutation arms (3 lib + 1 sim failures under mutation, reverted clean); counters genuinely fed (I1/I2/I3, P-KEYS 3000/3000).
- §12.0 stayed byte-frozen (digest 24273adf…) across four pure-EOF appends.
- 4 counted `.rs` files, no exemption; no SPEC-NNN provenance in code.
- 3 audit cycles (v3 APPROVED), 3 review cycles (v3 APPROVED, opus profile for the instrument rounds), cross-vendor xreview: 6 findings, 0 confirmed, 0 code changes.
- New standing rule adopted and honoured: no "by construction" claim without an executed witness.

## Test plan

- Review v3's full-gate tip run stands as the compiled evidence (fmt/clippy -D warnings/build/1811 lib/26 sim/invariants — all 0); the final Fix v3 commit is markdown-only.
- CI on this PR re-runs the full compiled matrix.