### PR TITLE
feat(sf-361b): carve 7b — the margin knob becomes stated policy, with the recovery envelope

### DIFF
--- a/packages/server-rust/benches/soak_harness/evidence/spec361b-witness-arm.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361b-witness-arm.txt
@@ -1,0 +1,807 @@
+================================================================================
+SPEC-361b — EXECUTED WITNESS ARMS (THIS HALF ONLY)
+================================================================================
+
+BASE_SHA = 20edabde2381d2efde9ee150501031eddc83a866
+
+THE ARITHMETIC, JOINT FIRST SO THE PARTIAL COUNT IS NEVER READ AS THE TOTAL.
+
+  joint total across BOTH halves ...... 9 arms / 18 legs / 9 transcripts
+    SPEC-361a owns and executes ....... 6 arms / 12 legs / 6 transcripts
+                                        (W1-W5 one arm each, plus W9's one;
+                                        recorded in spec361a-witness-arm.txt)
+    SPEC-361b owns and executes ....... 3 arms /  6 legs /  3 transcripts
+                                        (W6 (a), W6 (b), W7 (b) — THIS FILE)
+
+  3 + 6 = 9 arms.  6 + 12 = 18 legs.  3 + 6 = 9 transcripts.
+
+THIS FILE HOLDS THREE TRANSCRIPTS AND THAT IS THE CORRECT NUMBER, NOT A
+SHORTFALL. W7's former arm (a) — `None => self.boot_floor` -> `None =>
+Epoch::MAX` — is RETIRED: its named obligation (P3, the empty case) is coverage
+the tree already has at `a_registry_that_never_claimed_and_never_swept_sits_on_
+its_boot_floor` and `releasing_everything_returns_the_proposal_to_the_boot_
+floor`, so an arm pointed at it would prove nothing this half owns. It survives
+only as m5 in the refuted table under the W7 (b) transcript below. W7 therefore
+has exactly ONE arm. W8 has no arm in either half (it is SPEC-361a's neutral
+control run). The struck figure "fourteen" (7 x 2) is not this register's count
+and appears nowhere here.
+
+A transcript is ONE ARM carrying BOTH its legs — the applied mutation with the
+RED set it produced, and the revert. Three transcripts, six legs.
+
+THE COLLATERAL SET IN EACH TRANSCRIPT IS EXECUTED, NEVER AUTHORED. Each set
+below is what the run PRINTED, transcribed by test name and by failing-assertion
+line. Where the spec's seed rows and the executed set disagree, the EXECUTED set
+is what is recorded and the disagreement is called out in the open rather than
+pruned to match. No test was edited to make an arm RED or green, and no mutation
+survives: the tree is byte-identical to BASE_SHA + the four committed changes
+before and after every arm.
+
+Section index:
+  BASELINE   — the unmutated green every arm below is read against
+  W7 (b)     — the order-inverting boot-floor read            [transcript 1/3]
+  W6 (a)     — the drain's strictly-below eligibility conjunct[transcript 2/3]
+  W6 (b)     — the delivery clamp                             [transcript 3/3]
+  POST-ARM   — the tree after all three reverts, and the full gate
+
+================================================================================
+BASELINE — THE UNMUTATED TREE
+================================================================================
+
+Owner group : G6
+Branch      : spec-361b-carve7-halfb
+Tree        : 892bf6ab (G3a's four doc-contract commits + G3b's two witnesses;
+              no mutation applied)
+
+An arm that REDs against a tree that was already red proves nothing about the
+arm. This is the run the three RED sets below are differences against.
+
+$ SDKROOT=$(/usr/bin/xcrun --sdk macosx --show-sdk-path) \
+  cargo test --release -p topgun-server --lib
+
+    test result: ok. 1864 passed; 0 failed; 2 ignored; 0 measured;
+    0 filtered out; finished in 89.67s
+
+1864 / 0 / 2. Every count below is stated against those numbers.
+
+================================================================================
+TRANSCRIPT 1/3 — W7 (b): THE ORDER-INVERTING BOOT-FLOOR READ
+================================================================================
+
+Owner group : G6 (test authored by G3b at commit a70168dc)
+Test under  : reclamation_registry::proptests::
+              a_staler_boot_floor_can_only_lower_the_boundary
+              (packages/server-rust/src/reclamation_registry.rs:2516)
+
+--------------------------------------------------------------------------------
+W7 (b) — NAMED OBLIGATION
+--------------------------------------------------------------------------------
+
+P2, AND NOTHING ELSE IS CLAIMED OF THIS ARM. For any `floor' <= floor`,
+`ceiling(floor') <= ceiling(floor)` and `executed(floor') <= executed(floor)`
+under an identical claim/sweep sequence — the formalization of "the persisted
+minimum can only UNDER-state the true minimum", i.e. that a staler checkpoint is
+always the SAFE direction and can never license MORE reclamation.
+
+P1 (safety: the proposal never reaches a live claim) and P3 (the empty case: the
+proposal is the boot floor) are RESTATED inherited coverage carried in the same
+fixture for coherence. They carry NO registered arm and this arm is not graded
+on them.
+
+--------------------------------------------------------------------------------
+W7 (b) — ASSERTED DECISIVENESS PRECONDITION (KL-E)
+--------------------------------------------------------------------------------
+
+Two terms must be pinned non-deciding at the read point or the arm can go
+quietly green. BOTH are asserted in the fixture BEFORE the ceiling comparison,
+and both are quoted here verbatim from the test.
+
+(1) The floor-INDEPENDENT `Some` arm is not the one taken. `prune_ceiling`'s
+    `Some(min) => min.saturating_sub(self.margin_epochs)` (:704) consults the
+    floor not at all, so a pair compared only in that state agrees for a reason
+    unrelated to the floor. Asserted on BOTH registries at :2581 and :2587:
+
+        prop_assert_eq!(
+            staler.registry.live_claims(ClaimScope::Global),
+            0,
+            "the staler registry must reach the empty claim set for the read to \
+             be about the floor"
+        );
+        prop_assert_eq!(
+            fresher.registry.live_claims(ClaimScope::Global),
+            0,
+            "the fresher registry must reach the empty claim set for the read to \
+             be about the floor"
+        );
+
+(2) `floor' < floor` STRICTLY. At equality the inverting mutant yields
+    `MAX - floor' == MAX - floor`, the order still holds, and the arm does NOT
+    RED — the exact silent-loss shape KL-E exists to forbid. The strict pair is
+    FORCED in the strategy, not left to the draw, and re-asserted at :2521:
+
+        prop_assert!(
+            stale < fresh,
+            "the floors must be STRICTLY ordered: {} !< {}",
+            stale,
+            fresh
+        );
+
+    with the drawable-range pin immediately after at :2527:
+
+        prop_assert!(
+            stale <= MAX_BOOT_FLOOR && fresh <= MAX_BOOT_FLOOR,
+            "both floors must stay inside the drawable range: {} / {}",
+            stale,
+            fresh
+        );
+
+--------------------------------------------------------------------------------
+W7 (b) — LEG 1: THE MUTATION, APPLIED TO THE PRODUCTION EXPRESSION
+--------------------------------------------------------------------------------
+
+FILE: packages/server-rust/src/reclamation_registry.rs
+SITE: :705, the `None` arm of `fn prune_ceiling(&self, scope: ClaimScope)`.
+
+    fn prune_ceiling(&self, scope: ClaimScope) -> Epoch {
+        match self.min_live_claim(scope) {
+            Some(min) => min.saturating_sub(self.margin_epochs),
+    -       None => self.boot_floor,
+    +       None => Epoch::MAX.saturating_sub(self.boot_floor),
+        }
+    }
+
+    $ git diff --stat packages/server-rust/src/reclamation_registry.rs
+     packages/server-rust/src/reclamation_registry.rs | 2 +-
+     1 file changed, 1 insertion(+), 1 deletion(-)
+
+THE PRODUCTION SITE, AND ONLY IT. The same text appears at :1650 inside the
+inline `mod proptests` reference model (`fn prune_ceiling(&self)` on the test
+double, mirror at :1647-1652 beside the `min_live_claim` mirror at :1643-1645).
+That is a TEST DOUBLE and is NEVER an arm site — mutating it would move the
+oracle rather than the object, which proves nothing. It was verified untouched
+after the edit:
+
+    $ sed -n '1650p' packages/server-rust/src/reclamation_registry.rs
+                    None => self.boot_floor,
+
+WHY THIS MUTANT FALSIFIES P2: for `floor' < floor` the mutated ceiling gives
+`MAX - floor' > MAX - floor` — the STALER checkpoint licenses MORE reclamation,
+exactly the direction P2 forbids.
+
+--------------------------------------------------------------------------------
+W7 (b) — THE RECORDED RED SET (EXECUTED, VERBATIM)
+--------------------------------------------------------------------------------
+
+$ SDKROOT=$(/usr/bin/xcrun --sdk macosx --show-sdk-path) \
+  cargo test --release -p topgun-server --lib
+  exit=101
+
+    test result: FAILED. 1849 passed; 15 failed; 2 ignored; 0 measured;
+    0 filtered out; finished in 102.17s
+
+FIFTEEN REDs. All fifteen, by test name and by the line of the assertion that
+failed. (The proptest harness reports the panic at its own runner line
+`reclamation_registry.rs:2026`; the line recorded below is the one the harness
+NAMES in `Test failed: ... at <file>:<line>`, which is the failing assertion.)
+
+  *** THE NAMED OBLIGATION — this is the RED the arm is owed ***
+
+   1. reclamation_registry::proptests::a_staler_boot_floor_can_only_lower_the_boundary
+      failing assertion: reclamation_registry.rs:2596
+      Test failed: the staler floor 0 licensed MORE reclamation than the fresher
+      floor 1: 18446744073709551615 > 18446744073709551614
+
+      It fires on the `stale_ceiling <= fresh_ceiling` comparison, by
+      construction the first read after the two decisiveness pins, and its
+      message prints the two floors AND the two ceilings, so the inverted
+      direction is legible from the failure alone. Both `live_claims == 0` pins
+      (:2581, :2587) and the strict-order pin (:2521) PASSED under the mutation
+      — the arm reached the comparison rather than tripping a precondition.
+
+  COLLATERAL, INSIDE reclamation_registry.rs:
+
+   2. reclamation_registry::proptests::a_registry_that_never_claimed_and_never_swept_sits_on_its_boot_floor
+      failing assertion: reclamation_registry.rs:2128
+      Test failed: assertion failed: `(left == right)`  right: `0`
+
+   3. reclamation_registry::proptests::an_empty_claim_set_never_drags_the_watermark_down
+      failing assertion: reclamation_registry.rs:2405
+      Test failed: assertion failed: `(left == right)`  right: `Some(0)`:
+      a sweep over an empty claim set snapshots the boot floor
+
+   4. reclamation_registry::proptests::ending_a_sweep_lands_on_the_consumed_token_bound_and_no_further
+      failing assertion: reclamation_registry.rs:2448
+      Test failed: assertion failed: `(left == right)`  right: `0`:
+      the token must carry the ceiling the sweep began on
+
+   5. reclamation_registry::proptests::releasing_everything_returns_the_proposal_to_the_boot_floor
+      failing assertion: reclamation_registry.rs:2150
+      Test failed: assertion failed: `(left == right)`  right: `0`
+
+   6. reclamation_registry::proptests::every_admission_resolves_to_one_verdict_and_records_unconditionally
+      failing assertion: reclamation_registry.rs:2276
+      Test failed: assertion failed: `(left == right)`  right: `Honoured { claim: 64 }`
+
+   7. reclamation_registry::proptests::the_minimum_is_the_fold_over_every_live_claim
+      failing assertion: reclamation_registry.rs:2031
+      Test failed: assertion failed: `(left == right)`  right: `Some(1)`:
+      the published minimum must be the fold over the live claim set
+
+   8. reclamation_registry::proptests::the_watermark_never_falls_while_the_proposal_tracks_the_minimum
+      failing assertion: reclamation_registry.rs:2065
+      Test failed: assertion failed: `(left == right)`  right: `0`:
+      the proposal must equal the fleet minimum less the margin, falls included
+
+   9. reclamation_registry::proptests::the_proposal_never_reaches_a_live_claim
+      failing assertion: reclamation_registry.rs:2109
+      Test failed: the proposal 18446744073709551615 reaches the live claim at 1
+
+  10. reclamation_registry::proptests::the_watermark_never_passes_a_live_claim_at_any_instant
+      failing assertion: reclamation_registry.rs:2329
+      Test failed: the watermark at 3 passed the live claim at 1
+
+  11. reclamation_registry::tests::empty_claim_set_proposes_the_boot_floor_and_reports_no_minimum
+      failing assertion: reclamation_registry.rs:1003
+      assertion `left == right` failed
+        left: 18446744073709551608
+       right: 7
+
+  12. reclamation_registry::tests::end_sweep_advances_with_max_and_never_overwrites
+      failing assertion: reclamation_registry.rs:1179
+      assertion `left == right` failed
+        left: 101
+       right: 30
+
+  COLLATERAL, REACHED THROUGH THE FRONTIER THAT OWNS THE REGISTRY:
+
+  13. tombstone_frontier_impl::persistence_tests::ac3d_kill9_recovery_rebuilds_into_maximally_lagging_e_rec
+      failing assertion: tombstone_frontier_impl.rs:6928
+      nothing prunable until every tracked client re-confirms past E_rec
+
+  14. tombstone_frontier_impl::persistence_tests::boundary_and_low_water_mark_decide_every_epoch_alike_with_no_margin
+      failing assertion: tombstone_frontier_impl.rs:6655
+      assertion `left == right` failed: both boundaries must sit at 0 after no
+      device has reconnected yet
+        left: (18446744073709551615, 0)
+       right: (0, 0)
+
+  15. tombstone_frontier_impl::tests::an_untracked_fleet_reclaims_nothing_on_a_pass_that_really_runs
+      failing assertion: tombstone_frontier_impl.rs:5024
+      assertion `left == right` failed: an unclaimed fleet proposes the boot
+      floor, not the epoch the server reached
+        left: 18446744073709551615
+       right: 0
+
+--------------------------------------------------------------------------------
+W7 (b) — WHERE THE EXECUTED SET AND THE SPEC'S SEED ROWS DISAGREE
+--------------------------------------------------------------------------------
+
+Recorded in the open, because the procedure is authoritative over the seeds and
+a silent reconciliation would be exactly the authored-list failure Checklist 2
+exists to prevent.
+
+ONE SEED ROW CARRIED AN EXPLICIT NEGATIVE CLAIM THAT THE RUN REFUTES.
+The spec's seed table states, parenthetically:
+
+    "(`the_proposal_never_reaches_a_live_claim` (`:2032`) does NOT RED: it
+     asserts only when the model's minimum is `Some`.)"
+
+IT DOES RED — item 9 above, at :2109, with the message "the proposal
+18446744073709551615 reaches the live claim at 1". The reasoning behind the
+seed's claim is sound as far as it goes (the assertion is guarded on a `Some`
+minimum) but incomplete: the guard only requires a live claim to exist at the
+INSTANT of the check, and the mutated `None` arm still reaches the comparison
+through a state the program passes through, at which point the proposal — now
+near `u64::MAX` — sits far above that minimum. This is a normal outcome of the
+procedure, is IN the recorded set, and is NOT a checklist failure under criterion
+(iii); it is recorded so the spec's parenthetical is not carried forward as
+established.
+
+TEN MEMBERS THE SEEDS DID NOT NAME. Items 4, 6, 7, 10, 13, 14, 15 (and, as line
+drift rather than new members, 2, 3, 5, 11, 12) came out of the run. All are
+recorded; none was pruned. The seeds are explicitly "known members entered now,
+not the whole set", so a wider executed set is the procedure working.
+
+LINE DRIFT AGAINST THE SPEC'S ANCHORS IS EXPECTED AND IS NOT A FINDING. The
+spec's anchors were taken before this branch's four doc-contract commits and two
+witness commits landed. Observed-versus-spec, for the seeds that name a line:
+`empty_claim_set_proposes_the_boot_floor_and_reports_no_minimum` spec :950 ->
+observed panic :1003; `end_sweep_advances_with_max_and_never_overwrites` spec
+:1116 (REDs at :1130/:1131) -> observed panic :1179;
+`an_empty_claim_set_never_drags_the_watermark_down` spec :2302 (:2335-2339) ->
+observed :2405; `the_watermark_never_falls_while_the_proposal_tracks_the_minimum`
+spec :1978 (:1995-1999) -> observed :2065;
+`a_registry_that_never_claimed_and_never_swept_sits_on_its_boot_floor` spec :2052
+-> observed :2128; `releasing_everything_returns_the_proposal_to_the_boot_floor`
+spec :2064 -> observed :2150. Every observed line above is a line in the tree as
+it stands at 892bf6ab.
+
+--------------------------------------------------------------------------------
+W7 (b) — THE MUTANTS N11 ATTEMPTED AND REFUTED (m1-m6)
+--------------------------------------------------------------------------------
+
+Carried here because a claim that a property is hard to falsify is worth nothing
+without the attempts. Six mutants were attempted against P2 and all six were
+REFUTED — none of them can falsify it — which is what makes the seventh, the
+order-inverting read above, the arm. Site column gives the spec's anchor and,
+after the arrow, the same site in the tree as it stands (the branch's earlier
+commits shifted the file).
+
+ #  | Mutant                                     | Site           | Why it CANNOT falsify P2
+----+--------------------------------------------+----------------+--------------------------
+ m1 | the fold's `min` -> `max`                  | :646 -> :695   | RETIRED BY RULING (Audit v2 critical 2). Touches no floor term: with claims the ceiling stays floor-INDEPENDENT, with none both sides return their own floors. It does RED P1 — see the residual below.
+ m2 | `boot_floor` -> `0` in the constructor     | :730 -> :779   | FLOOR-COLLAPSING: both sides become 0, so the order is preserved (weakly) and P2 holds.
+ m3 | `.or_insert(boot_floor)` -> `.or_insert(0)`| :881 -> :930   | Floor-collapsing on the `executed` conjunct: both sides seed at 0.
+ m4 | `previous.max(candidate)` -> `candidate`   | :886 -> :935   | Both sides take the same claim-derived candidate => equal => monotone.
+ m5 | `None => self.boot_floor` -> `None => Epoch::MAX` | :656 -> :705 | FLOOR-CONSTANT: both sides return `Epoch::MAX`, so the order is preserved. This was W7's former ARM (a); it REDs P3, which is INHERITED coverage, and that is precisely why it is RETIRED as an arm (Audit v3 critical 2, ruled) and appears here only as a refuted mutant.
+ m6 | `.unwrap_or(self.boot_floor)` -> `.unwrap_or(0)` | :665 -> :714 | Floor-collapsing on `executed`.
+
+WHY THE RULED INSTRUCTION COULD NOT BE FOLLOWED LITERALLY, RECORDED RATHER THAN
+ASSERTED. Audit v2's ruling asked for a mutation of "the `.max(persisted...)`
+fold, or the persist step itself". Neither exists in this tree:
+`reclamation_registry.rs` is IN-MEMORY ONLY (claims and the executed watermark
+are fresh at every construction and survive no restart), the non-decreasing-floor
+obligation is explicitly the CALLER's, the sole production call site passes a
+literal (`ReclamationRegistry::new(0)` in `tombstone_frontier_impl.rs`, whose doc
+says no durable prune checkpoint exists in this tree), and `prune_ceiling`
+contains NO `.max(boot_floor)` fold at all — its `Some` arm ignores the floor
+entirely, so there is no max-fold whose removal could let the ceiling fall below
+the floor. The floor is a constructor parameter with exactly four production
+reads (:705, :714, :930, :935 at HEAD). m1-m6 are the attempts that stood in for
+the site the ruling named.
+
+RESIDUAL, DISCLOSED RATHER THAN ABSORBED. P1 carries NO registered arm, and
+after Audit v3's critical 2 that is the CORRECT outcome and not a budget
+casualty: P1's coverage is inherited from `the_proposal_never_reaches_a_live_
+claim` and the strictly stronger `the_proposal_is_the_minimum_less_the_margin_
+with_no_exception`. The mutant that would RED it is m1, recorded above as an
+UNREGISTERED, UNEXECUTED candidate. ITS ROUTING IS SPEC-TEXT-ONLY: it is named
+in SPEC-361b's text and in that spec's AC23 and nowhere else.
+`.specflow/todos/TODO-634.md` is byte-frozen and contains no mention of m1, NO
+standalone TODO is opened for it, and once the spec is archived the item is
+knowingly discoverable only through the archive. That is the accepted cost of the
+freeze, stated so a later auditor does not read it as an untracked deferral. It
+is NOT a deferred audit finding and opens no tracker file.
+
+--------------------------------------------------------------------------------
+W7 (b) — LEG 2: THE REVERT
+--------------------------------------------------------------------------------
+
+    $ git checkout -- packages/server-rust/src/reclamation_registry.rs
+    $ git status --porcelain
+    (empty)
+    $ sed -n '705p' packages/server-rust/src/reclamation_registry.rs
+                None => self.boot_floor,
+
+Tree byte-identical to the BASELINE tree above. The executed green re-run is
+recorded once, under POST-ARM, after the last revert.
+
+--------------------------------------------------------------------------------
+W7 (b) — VERDICT
+--------------------------------------------------------------------------------
+
+EARNED. P2 REDs on the order-inverting boot-floor read, with both decisiveness
+preconditions asserted before the arm and both PASSING under it, so the arm
+reached the property rather than tripping a guard. The failure names the
+direction P2 forbids and prints the floors and the ceilings that show it.
+Reverted; nothing survives.
+
+================================================================================
+TRANSCRIPT 2/3 — W6 (a): THE DRAIN'S STRICTLY-BELOW ELIGIBILITY CONJUNCT
+================================================================================
+
+Owner group : G6 (test authored by G3b at commit 892bf6ab)
+Test under  : tombstone_frontier_impl::tests::
+              margin_zero_retains_the_confirmed_epoch_and_delivery_bounds_an_over_claim
+              (packages/server-rust/src/tombstone_frontier_impl.rs:4856)
+
+--------------------------------------------------------------------------------
+W6 (a) — NAMED OBLIGATION
+--------------------------------------------------------------------------------
+
+ASSERTION 2 ONLY — the D-retained / (D-1)-drained read OF THE DRAINED SET. A
+fleet confirmed through epoch D leaves epoch D RETAINED by the drain (a cursor at
+`e` means applied through `e` INCLUSIVE, while the eligibility conjunct is
+strictly-below), while D-1 IS drained. One epoch of implicit retention, executed.
+
+IT IS NOT REQUIRED, AND IS NOT REPORTED, TO RED ASSERTION 1. Assertion 1
+(`prune_ceiling() == D`) is computed upstream in the registry and the drain
+filters on a ceiling the SweepToken snapshotted before it ran, so no mutation at
+this site can move it. That is KL-D, and the run below confirms it: the test
+reached :4923 (assertion 2) with assertion 1 at :4889 having PASSED.
+
+The siting rule is load-bearing and was honoured: the RED-carrying read is
+`drain_prunable_tombstones()`, NOT `is_epoch_prune_eligible`, whose strictness is
+a separate expression elsewhere in the file. An assertion 2 written against the
+predicate would leave this arm unable to RED it.
+
+--------------------------------------------------------------------------------
+W6 (a) — ASSERTED DECISIVENESS PRECONDITION (KL-E)
+--------------------------------------------------------------------------------
+
+The eligibility filter is a THREE-WAY conjunction, and the whole drain returns
+dark when the durable watermark is 0. Assertion 2's green form ("D retained, D-1
+drained") is satisfied by any watermark in [D-1, inf), INCLUDING exactly D-1 —
+under which epoch D is ineligible on the WATERMARK conjunct alone, under both the
+production and the mutated expression, and the arm goes quietly green with the
+leg silently lost. All three conjuncts plus the dark-path guard are therefore
+pinned IMMEDIATELY BEFORE the drain. Quoted verbatim from the fixture:
+
+    :4903  assert!(
+               f.durable_epoch_watermark() >= d,
+               "the durability conjunct must be SATISFIED at {d}, or {d} is \
+                retained by the fence instead of by the boundary"
+           );
+    :4908  assert!(
+               d != 0,
+               "the zero-epoch conjunct must be visibly non-deciding at the \
+                probe epoch"
+           );
+    :4912  assert_eq!(
+               f.reclamation().prune_ceiling(ClaimScope::Global),
+               d,
+               "the boundary must be EXACTLY at {d} when the sweep runs: at \
+                exactly {d} the strictly-below term is what decides {d}, which \
+                is the whole point of the read below"
+           );
+
+The watermark is opened to 1000 at :4897 (well past every stamped epoch), which
+also discharges the dark-path return since a non-zero watermark is what lets the
+drain fold at all. `ceiling == D` is the exact mechanical form of decisiveness:
+at `ceiling == D` the production term `ceiling > D` is FALSE while the mutated
+term `ceiling >= D` is TRUE, so flipping `>` to `>=` — and nothing else on the
+path — is what moves D into the drained set. A fixture pinning only
+`ceiling >= D` or only `ceiling > D-1` has not pinned decisiveness.
+
+--------------------------------------------------------------------------------
+W6 (a) — LEG 1: THE MUTATION
+--------------------------------------------------------------------------------
+
+FILE: packages/server-rust/src/tombstone_frontier_impl.rs
+SITE: :971, the eligibility filter inside the drain.
+
+    -           .filter(|&e| watermark >= e && e != 0 && ceiling > e)
+    +           .filter(|&e| watermark >= e && e != 0 && ceiling >= e)
+
+    $ git diff --stat packages/server-rust/src/tombstone_frontier_impl.rs
+     packages/server-rust/src/tombstone_frontier_impl.rs | 2 +-
+     1 file changed, 1 insertion(+), 1 deletion(-)
+
+--------------------------------------------------------------------------------
+W6 (a) — THE RECORDED RED SET (EXECUTED, VERBATIM)
+--------------------------------------------------------------------------------
+
+$ SDKROOT=$(/usr/bin/xcrun --sdk macosx --show-sdk-path) \
+  cargo test --release -p topgun-server --lib
+  exit=101
+
+    test result: FAILED. 1849 passed; 15 failed; 2 ignored; 0 measured;
+    0 filtered out; finished in 86.39s
+
+FIFTEEN REDs, all fifteen recorded.
+
+  *** THE NAMED OBLIGATION — this is the RED the arm is owed ***
+
+   1. tombstone_frontier_impl::tests::margin_zero_retains_the_confirmed_epoch_and_delivery_bounds_an_over_claim
+      failing assertion: tombstone_frontier_impl.rs:4923
+      epoch 3 is confirmed THROUGH, not past — it must survive the sweep,
+      got [2, 3, 1]
+
+      That is assertion 2's `!epochs.contains(&d)` read of the DRAINED SET, and
+      the message prints the set the sweep actually returned, with epoch 3 in it.
+      The three decisiveness pins (:4903, :4908, :4912) and assertion 1 (:4889)
+      all PASSED under the mutation — the test reached the drained-set read
+      rather than tripping earlier, which is what makes the leg valid.
+
+  COLLATERAL, IN tombstone_frontier_impl.rs:
+
+   2. tombstone_frontier_impl::tests::a_laggard_lowers_the_boundary_and_is_recorded_in_either_ack_order
+      failing assertion: tombstone_frontier_impl.rs:5120
+      assertion `left == right` failed: only the epochs strictly below the
+      trailing device's cursor are reclaimed
+        left: [1, 2, 3]
+       right: [1, 2]
+
+   3. tombstone_frontier_impl::tests::one_behind_client_pins_epoch_fleet_wide
+      failing assertion: tombstone_frontier_impl.rs:4715
+      assertion `left == right` failed: only epochs 1..=2 (strictly below the
+      LWM) drained; 3..=5 pinned fleet-wide
+        left: 3
+       right: 2
+
+   4. tombstone_frontier_impl::tests::a_split_frozen_at_its_last_recompute_is_detectable_from_the_recompute_counter
+      failing assertion: tombstone_frontier_impl.rs:3851
+      assertion failed: f.drain_prunable_tombstones().is_empty()
+
+   5. tombstone_frontier_impl::tests::restore_tombstone_ref_round_trips_through_drain
+      failing assertion: tombstone_frontier_impl.rs:4978
+      assertion `left == right` failed: epoch 1's ref drained
+        left: 2
+       right: 1
+
+   6. tombstone_frontier_impl::persistence_tests::ac3e_activation_end_to_end_prune_fires_with_real_watermark
+      failing assertion: tombstone_frontier_impl.rs:7020
+      assertion `left == right` failed: epoch 1 (strictly below LWM 2,
+      byte-durable) actually prunes with the real watermark
+        left: 2
+       right: 1
+
+  COLLATERAL, IN service/domain/crdt.rs — THE SERVICE THAT CALLS THE DRAIN:
+
+   7. service::domain::crdt::tests::ac4_prune_wired_into_or_write_path
+      failing assertion: service/domain/crdt.rs:4361
+      epoch-2 tombstone still pinned (LWM 2 not strictly past epoch 2)
+
+   8. service::domain::crdt::tests::or_prune_decrements_gauge_on_real_prune_path
+      failing assertion: service/domain/crdt.rs:4425
+      epoch-2 tombstone still pinned (LWM 2 not strictly past epoch 2)
+
+   9. service::domain::crdt::tests::service_composition_arm_reaches_drained_healthy_through_the_real_write_path
+      failing assertion: service/domain/crdt.rs:4550
+      assertion `left == right` failed: O-0 must hold over the
+      service-composition drain path too, got IndexConservationSnapshot {
+      stamped_refs_total: 2, stamped_bytes_total: 12, drained_refs_total: 1,
+      restored_refs_total: 0, ... }
+        left: 1
+       right: 0
+
+  10. service::domain::crdt::tests::prune_leaves_tombstone_bytes_unmoved_when_the_durable_write_fails
+      failing assertion: service/domain/crdt.rs:5820
+      assertion `left == right` failed: both OR_REMOVE charges stand and the
+      failed prune returns nothing: a decrement from inside the mutate closure
+      would credit back bytes that are still durable
+        left: 2
+       right: 4
+
+  11. service::domain::crdt::tests::prune_exit_ledger_sums_to_considered
+      failing assertion: service/domain/crdt.rs:6295
+      assertion `left == right` failed: the workload must drive
+      topgun_or_prune_absent_total exactly once, or the exhaustiveness identity
+      asserts nothing about that exit
+
+  12. service::domain::crdt::tests::per_epoch_six_exit_identity_holds_on_the_settlement_row
+      failing assertion: service/domain/crdt.rs:6481
+      assertion `left == right` failed: one settlement row per drained epoch,
+      six epochs drained
+
+  13. service::domain::crdt::tests::pass_row_fires_on_every_invocation_including_an_empty_drain
+      failing assertion: service/domain/crdt.rs:6571
+      assertion `left == right` failed: the workload's own explicit call is the
+      last invocation and drains all six seeded refs
+        left: 7
+       right: 6
+
+  14. service::domain::crdt::tests::i1_i2_pass_identity_holds_on_an_empty_and_a_draining_pass
+      failing assertion: service/domain/crdt.rs:6664
+      assertion `left == right` failed: I1: the sum of a pass's own epoch_exit
+      removed_refs_observed must equal that SAME pass's considered
+        left: 6
+       right: 7
+
+  15. service::domain::crdt::tests::prune_record_armed_disarmed_gauge_neutral
+      failing assertion: service/domain/crdt.rs:6733
+      assertion `left == right` failed: the armed run must write its
+      prune-record series, populated
+
+--------------------------------------------------------------------------------
+W6 (a) — THE EXECUTED SET AGAINST THE SPEC'S SEED ROWS
+--------------------------------------------------------------------------------
+
+BOTH SEEDS CAME OUT, AND THE ONE EXPLICIT NON-MEMBER STAYED OUT.
+
+  seed `one_behind_client_pins_epoch_fleet_wide` .......... item 3, observed
+        at :4715 (spec anchor :4677 — line drift, same test)
+  seed `a_laggard_lowers_the_boundary_and_is_recorded_in_either_ack_order` ...
+        item 2, observed at :5120 (spec anchor :4922, REDs at :4981 — drift),
+        and it REDs exactly as the spec predicted: `assert_eq!(forward,
+        vec![1, 2])` fails with `left: [1, 2, 3]`, because its watermark is open
+        and its ceiling is pinned at 3, so `ceiling >= e` admits epoch 3.
+  NON-MEMBER `eligibility_is_strictly_past_not_inclusive` ... CONFIRMED ABSENT
+        from the RED set. It reads `is_epoch_prune_eligible`, whose `>` is a
+        SEPARATE expression from the mutated one, so the arm cannot reach it —
+        exactly as the spec states, and now executed rather than argued.
+
+THIRTEEN MEMBERS THE SEEDS DID NOT NAME (items 4-15). All are drain-path or
+drain-accounting tests reached through the same filter; none was pruned, and a
+wider executed set is the procedure working rather than a checklist failure.
+
+--------------------------------------------------------------------------------
+W6 (a) — LEG 2: THE REVERT
+--------------------------------------------------------------------------------
+
+    $ git checkout -- packages/server-rust/src/tombstone_frontier_impl.rs
+    $ git status --porcelain
+    (empty)
+    $ sed -n '971p' packages/server-rust/src/tombstone_frontier_impl.rs
+                .filter(|&e| watermark >= e && e != 0 && ceiling > e)
+
+--------------------------------------------------------------------------------
+W6 (a) — VERDICT
+--------------------------------------------------------------------------------
+
+EARNED. Assertion 2 REDs when the drain's strictly-below conjunct is relaxed to
+inclusive, with all three decisiveness pins asserted before the drain and all
+three PASSING under the arm. Assertion 1 stayed green, as KL-D requires and as
+this transcript reports rather than claims otherwise. Reverted; nothing survives.
+
+================================================================================
+TRANSCRIPT 3/3 — W6 (b): THE DELIVERY CLAMP
+================================================================================
+
+Owner group : G6 (test authored by G3b at commit 892bf6ab)
+Test under  : tombstone_frontier_impl::tests::
+              margin_zero_retains_the_confirmed_epoch_and_delivery_bounds_an_over_claim
+              (packages/server-rust/src/tombstone_frontier_impl.rs:4856)
+
+--------------------------------------------------------------------------------
+W6 (b) — NAMED OBLIGATION
+--------------------------------------------------------------------------------
+
+ASSERTION 3 — the same-ceiling-under-over-claim read, and the only assertion W6
+is genuinely owed for. An ACK claiming D+k for k >= 1, on a connection delivered
+only through D, produces the SAME ceiling D, because the advance rule clamps to
+the delivery record. The over-claim a reclamation margin exists to hedge is
+therefore ALREADY bounded by the delivery record, which is the substantive fact
+this half contributes: a margin is not what stands between an over-claiming
+client and reclaimed data.
+
+--------------------------------------------------------------------------------
+W6 (b) — ASSERTED DECISIVENESS PRECONDITION (KL-E)
+--------------------------------------------------------------------------------
+
+`bound = claimed.min(delivered).min(self.current_max_epoch)` is a THREE-WAY
+clamp. In the obvious fixture — stamp through D, deliver D — stamping ITSELF
+writes `current_max_epoch = D`, so `current_max_epoch == delivered == D` and
+dropping `.min(delivered)` still yields `min(D+k, D) = D`: the arm would not RED
+and the leg would be silently lost. The fixture must pin
+`current_max_epoch > delivered`.
+
+CONSTRUCTION, AND THE ORDER IS LOAD-BEARING. It stamps through D+k, THEN injects
+the global bound, THEN sets the delivery record — because `stamp_tombstone`
+WRITES `current_max_epoch`, so an injection placed before the last stamp is
+silently overwritten:
+
+    :4866  for i in 1..=(d + k) { f.stamp_tombstone(...); }
+    :4872  f.set_current_max_epoch(d + k);
+    :4874  f.set_delivered(CONN_A, d);
+
+There is no getter for `current_max_epoch`, so the precondition is asserted
+through the injected value plus the getter that does exist, sited IMMEDIATELY
+BEFORE the over-claiming ACK, at :4937:
+
+    assert!(
+        f.delivered(CONN_A) < d + k,
+        "the delivery record must sit strictly below the global bound, or \
+         dropping the delivered term changes nothing and the clamp is not \
+         under test"
+    );
+
+--------------------------------------------------------------------------------
+W6 (b) — LEG 1: THE MUTATION
+--------------------------------------------------------------------------------
+
+FILE: packages/server-rust/src/tombstone_frontier_impl.rs
+SITE: :428, the bound computation inside `advance_on_ack`.
+
+    -       let bound = claimed.min(delivered).min(self.current_max_epoch);
+    +       let bound = claimed.min(self.current_max_epoch);
+
+    $ git diff --stat packages/server-rust/src/tombstone_frontier_impl.rs
+     packages/server-rust/src/tombstone_frontier_impl.rs | 2 +-
+     1 file changed, 1 insertion(+), 1 deletion(-)
+
+The build emitted one warning under the mutation, recorded rather than
+suppressed, because dropping the term leaves its binding unread:
+
+    warning: unused variable: `delivered`
+    warning: `topgun-server` (lib test) generated 1 warning
+
+That warning is an artifact of the arm and disappears with the revert; the
+unmutated tree builds warning-free under `clippy -D warnings` (see POST-ARM).
+
+--------------------------------------------------------------------------------
+W6 (b) — THE RECORDED RED SET (EXECUTED, VERBATIM)
+--------------------------------------------------------------------------------
+
+$ SDKROOT=$(/usr/bin/xcrun --sdk macosx --show-sdk-path) \
+  cargo test --release -p topgun-server --lib
+  exit=101
+
+    test result: FAILED. 1862 passed; 2 failed; 2 ignored; 0 measured;
+    0 filtered out; finished in 88.44s
+
+TWO REDs, and that is the whole set.
+
+  *** THE NAMED OBLIGATION — this is the RED the arm is owed ***
+
+   1. tombstone_frontier_impl::tests::margin_zero_retains_the_confirmed_epoch_and_delivery_bounds_an_over_claim
+      failing assertion: tombstone_frontier_impl.rs:4944
+      an ACK claiming 5 on a connection delivered through 3 must not advance
+      anything
+
+      That is assertion 3's `!f.confirm_apply_ack(&c, d + k, CONN_A)` read. The
+      precondition pin at :4937 PASSED under the mutation, so the delivery record
+      really was strictly below the global bound and the clamp really was the
+      term under test. Assertions 1 and 2 (:4883-:4889, :4923-:4928) and all
+      three of arm (a)'s decisiveness pins stayed GREEN — the test ran the whole
+      retention half before reaching the over-claim, which is the positive check
+      that this arm discriminates assertion 3 and nothing adjacent to it. The
+      ceiling re-read at :4954 was never reached, because :4944 fires first.
+
+  COLLATERAL:
+
+   2. tombstone_frontier_impl::tests::delivered_clamp_fresh_device_ack_high_stays_untracked
+      failing assertion: tombstone_frontier_impl.rs:4486
+      delivered-nothing ACK cannot advance
+
+--------------------------------------------------------------------------------
+W6 (b) — THE EXECUTED SET AGAINST THE SPEC'S SEED ROW
+--------------------------------------------------------------------------------
+
+EXACT MATCH, AND THE ONLY ARM OF THE THREE WHERE THE SEEDS AND THE EXECUTION
+COINCIDE COMPLETELY. The single seed —
+`delivered_clamp_fresh_device_ack_high_stays_untracked` (spec anchor :4474,
+observed at :4486, line drift only) — is the single collateral member, and the
+executed set adds nothing to it. Its mechanism is exactly as seeded: with
+`delivered == 0` the delivery term is the binding one, so removing it lets the
+ACK advance a cursor that must stay untracked.
+
+--------------------------------------------------------------------------------
+W6 (b) — LEG 2: THE REVERT
+--------------------------------------------------------------------------------
+
+    $ git checkout -- packages/server-rust/src/tombstone_frontier_impl.rs
+    $ git status --porcelain
+    (empty)
+    $ sed -n '428p' packages/server-rust/src/tombstone_frontier_impl.rs
+            let bound = claimed.min(delivered).min(self.current_max_epoch);
+
+--------------------------------------------------------------------------------
+W6 (b) — VERDICT
+--------------------------------------------------------------------------------
+
+EARNED. Assertion 3 REDs when the delivery term is dropped from the clamp, with
+its precondition asserted before the arm and PASSING under it, and with
+assertions 1 and 2 green throughout the mutated run. Reverted; nothing survives,
+including the unused-variable warning the arm introduced.
+
+================================================================================
+POST-ARM — THE TREE AFTER ALL THREE REVERTS
+================================================================================
+
+Each arm's revert was a `git checkout --` of the single mutated file, verified
+BYTE-IDENTICAL to the tree that produced the BASELINE green at the top of this
+file, with `git status --porcelain` empty before the next arm was applied. The
+executed green re-run is recorded ONCE here rather than three times, because the
+three reverted trees are the same tree: this is the same convention the sibling
+artifact spec360-witness-arm.txt uses for its "green re-run after all three
+reverts", and the gate run below is strictly broader than the per-arm `--lib`
+runs it stands in for.
+
+    $ git status --porcelain
+    (empty)
+
+THE EXECUTED GREEN RE-RUN, as the workspace gate rather than a narrowed one:
+
+    $ SDKROOT=$(/usr/bin/xcrun --sdk macosx --show-sdk-path) \
+      cargo test --release --all-targets
+      exit=0
+
+    (lib target)
+    test result: ok. 1864 passed; 0 failed; 2 ignored; 0 measured;
+    0 filtered out; finished in 101.39s
+
+1864 / 0 / 2 — the BASELINE numbers at the top of this file, recovered exactly.
+Every other target in the workspace run reported ok with 0 failed. The three
+arms produced 15, 15 and 2 REDs respectively and left none of them behind.
+
+    $ git diff --stat 20edabde2381d2efde9ee150501031eddc83a866
+     packages/server-rust/docs/RECOVERY_ENVELOPE.md     |  67 +++++
+     packages/server-rust/src/reclamation_registry.rs   | 221 +++++++++++++--
+     packages/server-rust/src/tombstone_frontier_impl.rs| 139 +++++++++
+     (this transcript adds the fourth path; exactly TWO of the four are .rs)
+
+The full gate — workspace tests, clippy with warnings denied, fmt, the invariant
+catalog check, the diff shape against BASE_SHA, the value-unchanged diffs, both
+pinned provenance counts and the census test — is recorded in G6's result rather
+than duplicated here; this file's job is the six legs.

--- a/packages/server-rust/docs/RECOVERY_ENVELOPE.md
+++ b/packages/server-rust/docs/RECOVERY_ENVELOPE.md
@@ -1,0 +1,67 @@
+# Recovery Envelope
+
+Three knobs decide how much history the server keeps for a client that has fallen behind. They are
+easy to confuse, because all three sound like "how far back do we go", and two of them are not yet
+implemented. This page is the single place where all three are stated together, with the unit each
+one is denominated in and the reason it does not collapse into the other two.
+
+## The envelope
+
+| Knob | Unit | Value today | Hazard hedged | Owner |
+|---|---|---|---|---|
+| Retention SLA `N` | wall-clock **days** | *not yet implemented* (proposed default: 30 d) | how long a device may be offline before its cursor is fenced | deferred — `TODO-634` |
+| Clock-skew tolerance | wall-clock **minutes** | *not yet implemented* | a stamp from the future (`phys(stamp) > server_now + skew_max`) | deferred — `TODO-634` |
+| Reclamation margin | **epochs** | `0` (`DEFAULT_RECLAMATION_MARGIN_EPOCHS`, overridable via `TOPGUN_RECLAMATION_MARGIN_EPOCHS`) | an over-reported claim | implemented — `packages/server-rust/src/reclamation_registry.rs` |
+
+### Why they do not collapse into each other
+
+- **Retention SLA vs reclamation margin.** The SLA's hazard is *elapsed time*: how long a device may
+  be away before the server stops keeping its place. The margin's hazard is *a wrong number*: a
+  client claiming progress it has not made. One is denominated in days because clocks measure
+  absence; the other in epochs because an over-reported claim is wrong by some count of epochs.
+  Converting between them requires a churn rate — epochs per day — which varies per deployment and
+  per workload. A knob that pretends the conversion is fixed is false precision.
+- **Clock-skew tolerance vs the other two.** Skew tolerance bounds how far a *timestamp* may lead
+  the server's own clock before the stamp is rejected. It gates admission of a stamp; it does not
+  decide how long anything is kept. A deployment can be perfectly clock-synchronised and still need
+  a long SLA, and vice versa.
+- **The reclamation margin hedges over-reported claims only.** It is **not** a durability mechanism
+  (durability is the WAL fsync policy and the write-behind drain) and it is **not** the fix for
+  min-pinning (an abandoned laggard that never releases pins the boundary regardless of the margin;
+  the fix is the cursor-age retention fence, listed as deferred above). Its hedge is also **narrow**
+  by construction: `packages/server-rust/src/tombstone_frontier_impl.rs:420` clamps every ACK to
+  `claimed.min(delivered).min(current_max_epoch)`, so a client cannot claim above the highest epoch
+  its connection was actually delivered. The margin covers only a claim over-reported *within* that
+  delivered range.
+
+## Normative clauses
+
+**(a) These three values may not be changed independently without re-reading this table.** That is
+the reason they are written down in one place. Raising the retention SLA does not license lowering
+the reclamation margin, and tightening the skew tolerance does not shorten the SLA; each hedges a
+hazard the other two do not touch. A change to any one of them is a change to the recovery envelope
+as a whole and must be argued as such.
+
+**(b) A derived margin sits on top of a boundary that already retains one epoch, and must not
+re-add it.** A client cursor at epoch `e` means *applied through `e` inclusive*, while the
+eligibility conjunct the sweep filters on is strictly-below (`ceiling > e`,
+`packages/server-rust/src/tombstone_frontier_impl.rs:963`). The newest epoch the fleet has confirmed
+is therefore already retained: a reclamation margin of `0` is **not** zero conservatism. Any future
+rule that derives the margin from observed client lag — the `ceil(p99.9) + 1` shape sketched for the
+lag-telemetry work — is stated **relative to that already-retained epoch**. Adding `+ 1` on top of
+it double-counts by one epoch, permanently, on every sweep.
+
+## Deferred, and where each item is tracked
+
+None of the following is implemented in this tree. They are recorded here by id so an operator
+reading the table above can see what the envelope is *missing*, not only what it has. All four are
+tracked on **`TODO-634`**:
+
+- the **retention SLA** (`N` days) and the cursor-age fence that enforces it;
+- the **clock-skew tolerance** and its rejection of future-dated stamps;
+- **lag telemetry** — per-sweep client lag with rolling p50 / p99 / p99.9 and a per-client outlier
+  flag;
+- the **derived margin** computed from that telemetry, with a hard cap and operator override in the
+  downward direction only, subject to clause (b) above.
+
+Until they land, the effective envelope is exactly one knob: the reclamation margin, at `0`.

--- a/packages/server-rust/docs/RECOVERY_ENVELOPE.md
+++ b/packages/server-rust/docs/RECOVERY_ENVELOPE.md
@@ -29,7 +29,7 @@ one is denominated in and the reason it does not collapse into the other two.
   (durability is the WAL fsync policy and the write-behind drain) and it is **not** the fix for
   min-pinning (an abandoned laggard that never releases pins the boundary regardless of the margin;
   the fix is the cursor-age retention fence, listed as deferred above). Its hedge is also **narrow**
-  by construction: `packages/server-rust/src/tombstone_frontier_impl.rs:420` clamps every ACK to
+  by construction: `packages/server-rust/src/tombstone_frontier_impl.rs:428` clamps every ACK to
   `claimed.min(delivered).min(current_max_epoch)`, so a client cannot claim above the highest epoch
   its connection was actually delivered. The margin covers only a claim over-reported *within* that
   delivered range.
@@ -45,7 +45,7 @@ as a whole and must be argued as such.
 **(b) A derived margin sits on top of a boundary that already retains one epoch, and must not
 re-add it.** A client cursor at epoch `e` means *applied through `e` inclusive*, while the
 eligibility conjunct the sweep filters on is strictly-below (`ceiling > e`,
-`packages/server-rust/src/tombstone_frontier_impl.rs:963`). The newest epoch the fleet has confirmed
+`packages/server-rust/src/tombstone_frontier_impl.rs:971`). The newest epoch the fleet has confirmed
 is therefore already retained: a reclamation margin of `0` is **not** zero conservatism. Any future
 rule that derives the margin from observed client lag — the `ceil(p99.9) + 1` shape sketched for the
 lag-telemetry work — is stated **relative to that already-retained epoch**. Adding `+ 1` on top of

--- a/packages/server-rust/src/reclamation_registry.rs
+++ b/packages/server-rust/src/reclamation_registry.rs
@@ -436,7 +436,7 @@ pub trait ReclamationBoundary: Send + Sync {
 /// # Why the hedge is NARROW
 ///
 /// A claim cannot exceed what the claimant's connection was actually delivered:
-/// `tombstone_frontier_impl.rs:420` bounds every ACK by
+/// `tombstone_frontier_impl.rs:428` bounds every ACK by
 /// `claimed.min(delivered).min(current_max_epoch)`. Over-reporting is therefore already capped by
 /// the server's own delivery record, and this margin covers only the residue — a claim
 /// over-reported *within* the delivered range.
@@ -465,7 +465,7 @@ pub const DEFAULT_RECLAMATION_MARGIN_EPOCHS: u64 = 0;
 /// - **The unit is EPOCHS,** never wall-clock time. The retention SLA is denominated in days, and
 ///   neither converts to the other without a churn rate; both are tabulated in
 ///   `packages/server-rust/docs/RECOVERY_ENVELOPE.md`.
-/// - **The hedge is narrow,** because `tombstone_frontier_impl.rs:420` already clamps every claim to
+/// - **The hedge is narrow,** because `tombstone_frontier_impl.rs:428` already clamps every claim to
 ///   the highest epoch that connection was delivered.
 const ENV_RECLAMATION_MARGIN_EPOCHS: &str = "TOPGUN_RECLAMATION_MARGIN_EPOCHS";
 

--- a/packages/server-rust/src/reclamation_registry.rs
+++ b/packages/server-rust/src/reclamation_registry.rs
@@ -1795,6 +1795,27 @@ mod proptests {
         )
     }
 
+    /// `(stale_floor, fresh_floor, margin, program)` with **`stale_floor < fresh_floor` strictly**.
+    ///
+    /// The strictness is FORCED rather than left to the draw. At `stale == fresh` a boot-floor
+    /// read that INVERTED the order would still hand back the same number on both sides, the
+    /// comparison would hold, and a monotonicity property drawn over `<=` would go green on a
+    /// registry where the staler checkpoint licenses MORE reclamation. Only a strict pair can
+    /// tell the two directions apart.
+    #[allow(clippy::type_complexity)]
+    fn one_program_over_a_stale_and_a_fresh_floor(
+    ) -> impl Strategy<Value = (Epoch, Epoch, u64, Vec<RawOp>)> {
+        (
+            0..MAX_BOOT_FLOOR,
+            0..=MAX_MARGIN,
+            prop::collection::vec(raw_op(), 1..40),
+        )
+            .prop_flat_map(|(stale, margin, raw)| {
+                ((stale + 1)..=MAX_BOOT_FLOOR)
+                    .prop_map(move |fresh| (stale, fresh, margin, raw.clone()))
+            })
+    }
+
     // ---------------------------------------------------------------------------------------
     // The driver
     // ---------------------------------------------------------------------------------------
@@ -2463,6 +2484,153 @@ mod proptests {
                 laggard_at - margin,
                 "the watermark must follow the consumed token, not the proposal the release \
                  raised"
+            );
+        }
+
+        /// An UNDER-STATING boot floor is the SAFE direction: a staler persisted checkpoint can
+        /// only LOWER the reclamation boundary, never raise it.
+        ///
+        /// Two registries run the SAME claim/sweep program under a strictly staler and a strictly
+        /// fresher floor. Neither the proposal nor the executed watermark of the staler one may
+        /// sit above the fresher one's. That is what makes a floor recovered from behind the true
+        /// frontier merely WASTEFUL — it re-offers epochs a previous pass already reclaimed —
+        /// instead of unsafe. A floor that read the other way would license reclamation no
+        /// claimant ever authorised, which is the failure this property exists to forbid.
+        ///
+        /// The comparison is taken with ZERO live claims on both registries, and that is asserted
+        /// at the read point rather than arranged and assumed. With a claim outstanding the
+        /// proposal is `minimum − margin` and consults the floor not at all, so a pair compared
+        /// only in that state agrees for a reason unrelated to the floor and the property is
+        /// un-falsifiable.
+        ///
+        /// **The pair RELATION is the only new obligation here.** The per-registry facts the
+        /// fixture also carries — the proposal never reaching a live claim, and the empty claim
+        /// set sitting on the boot floor — are already executed by
+        /// `the_proposal_never_reaches_a_live_claim`,
+        /// `the_proposal_is_the_minimum_less_the_margin_with_no_exception`,
+        /// `a_registry_that_never_claimed_and_never_swept_sits_on_its_boot_floor` and
+        /// `releasing_everything_returns_the_proposal_to_the_boot_floor`. They are carried here
+        /// in PAIR form so the boot-floor boundary reads as one coherent fact, and they are
+        /// coverage this test inherits rather than discovers.
+        #[test]
+        fn a_staler_boot_floor_can_only_lower_the_boundary(
+            (stale, fresh, margin, raw) in one_program_over_a_stale_and_a_fresh_floor()
+        ) {
+            // The decisiveness pin the draw owes: an order-inverting boot-floor read is
+            // order-PRESERVING at equality, so an equal pair could never falsify this.
+            prop_assert!(
+                stale < fresh,
+                "the floors must be STRICTLY ordered: {} !< {}",
+                stale,
+                fresh
+            );
+            prop_assert!(
+                stale <= MAX_BOOT_FLOOR && fresh <= MAX_BOOT_FLOOR,
+                "both floors must stay inside the drawable range: {} / {}",
+                stale,
+                fresh
+            );
+
+            let mut staler = Harness::new(stale, margin);
+            let mut fresher = Harness::new(fresh, margin);
+
+            // Never-swept pair: each watermark starts on its OWN floor, so the gap between them
+            // is exactly the gap between the floors before a single op runs. Read as a gap
+            // rather than as two positions — the gap is what the monotone direction is about.
+            prop_assert_eq!(
+                fresher
+                    .registry
+                    .executed_watermark(ClaimScope::Global)
+                    .saturating_sub(staler.registry.executed_watermark(ClaimScope::Global)),
+                fresh - stale,
+                "a never-swept watermark must sit on its own floor, so the pair's gap is the \
+                 floors' gap"
+            );
+
+            for op in lower(&raw) {
+                staler.apply(op);
+                fresher.apply(op);
+                // Inherited safety, restated on the pair: the shared program must not drive
+                // either proposal into its own live claim set. Measured against the model's TRUE
+                // minimum, because a broken fold that both numbers came from would agree with
+                // itself.
+                if let Some(min) = staler.model.min_live_claim() {
+                    prop_assert!(
+                        staler.registry.prune_ceiling(ClaimScope::Global) <= min,
+                        "the staler proposal reached the live claim at {}",
+                        min
+                    );
+                }
+                if let Some(min) = fresher.model.min_live_claim() {
+                    prop_assert!(
+                        fresher.registry.prune_ceiling(ClaimScope::Global) <= min,
+                        "the fresher proposal reached the live claim at {}",
+                        min
+                    );
+                }
+            }
+
+            staler.close_sweep();
+            fresher.close_sweep();
+            staler.release_pool();
+            fresher.release_pool();
+
+            // The other half of the decisiveness pin, asserted at the read point: with no live
+            // claim the floor-INDEPENDENT arm of the proposal is not taken, so the boot-floor
+            // read is the only term left that can decide the comparison below.
+            prop_assert_eq!(
+                staler.registry.live_claims(ClaimScope::Global),
+                0,
+                "the staler registry must reach the empty claim set for the read to be about \
+                 the floor"
+            );
+            prop_assert_eq!(
+                fresher.registry.live_claims(ClaimScope::Global),
+                0,
+                "the fresher registry must reach the empty claim set for the read to be about \
+                 the floor"
+            );
+
+            let stale_ceiling = staler.registry.prune_ceiling(ClaimScope::Global);
+            let fresh_ceiling = fresher.registry.prune_ceiling(ClaimScope::Global);
+            prop_assert!(
+                stale_ceiling <= fresh_ceiling,
+                "the staler floor {} licensed MORE reclamation than the fresher floor {}: {} > {}",
+                stale,
+                fresh,
+                stale_ceiling,
+                fresh_ceiling
+            );
+
+            // A sweep opened over the now-empty claim set snapshots the boot floor itself, which
+            // is the path by which the floor reaches the executed watermark. Without it the
+            // watermark conjunct would only ever be read on a never-swept pair.
+            staler.apply(Op::BeginSweep);
+            fresher.apply(Op::BeginSweep);
+            staler.apply(Op::EndSweep {
+                watermark: MAX_EPOCH,
+            });
+            fresher.apply(Op::EndSweep {
+                watermark: MAX_EPOCH,
+            });
+            prop_assert!(
+                staler.registry.executed_watermark(ClaimScope::Global)
+                    <= fresher.registry.executed_watermark(ClaimScope::Global),
+                "a sweep over an empty claim set carried the staler floor ABOVE the fresher one: \
+                 {} > {}",
+                staler.registry.executed_watermark(ClaimScope::Global),
+                fresher.registry.executed_watermark(ClaimScope::Global)
+            );
+
+            // Inherited empty case, carried in pair form: each proposal tracks its own floor, so
+            // the two proposals are exactly the floors apart. A pair that merely preserved the
+            // ORDER while detaching from the floors would pass the comparison above and fail
+            // here.
+            prop_assert_eq!(
+                fresh_ceiling.saturating_sub(stale_ceiling),
+                fresh - stale,
+                "with no live claim each proposal IS its own floor, so the gap must be the \
+                 floors' gap"
             );
         }
     }

--- a/packages/server-rust/src/reclamation_registry.rs
+++ b/packages/server-rust/src/reclamation_registry.rs
@@ -410,14 +410,63 @@ pub trait ReclamationBoundary: Send + Sync {
 /// Default reclamation margin, in **epochs**, subtracted from the minimum live claim to form the
 /// ceiling proposal. Overridden by `TOPGUN_RECLAMATION_MARGIN_EPOCHS`.
 ///
+/// # What this knob is: the assumed claim-channel trust level
+///
+/// Its honest name is the **assumed claim-channel trust level**. It hedges exactly one hazard — a
+/// client that reports progress it has not made, an **over-reported claim** — and nothing else.
+///
+/// - It is **not a durability mechanism.** Durability belongs to the WAL fsync policy and to the
+///   write-behind drain. A margin subtracted from a claim moves a reclamation boundary; it persists
+///   nothing.
+/// - It is **not the fix for min-pinning.** An abandoned laggard that is never released pins the
+///   boundary regardless of the margin — see *How a claim leaves the fold* on
+///   [`ReclamationBoundary`]. The fix is the cursor-age retention fence, which is deferred and owned
+///   by TODO-634.
+///
+/// Code reaching for this knob to solve durability or min-pinning has mis-diagnosed its problem.
+///
+/// # The unit is EPOCHS, and epochs do not convert to wall clock
+///
+/// The hazard is epoch-denominated: an over-reported claim is wrong by some number of **epochs**.
+/// The retention SLA hedges a different hazard — *how long a device may be offline* — so its unit is
+/// **wall-clock days**. Neither quantity derives from the other without a churn rate, so these are
+/// two parameters and not one. They are tabulated together, with the clock-skew tolerance, in
+/// `packages/server-rust/docs/RECOVERY_ENVELOPE.md`, which exists so the three cannot drift apart.
+///
+/// # Why the hedge is NARROW
+///
+/// A claim cannot exceed what the claimant's connection was actually delivered:
+/// `tombstone_frontier_impl.rs:420` bounds every ACK by
+/// `claimed.min(delivered).min(current_max_epoch)`. Over-reporting is therefore already capped by
+/// the server's own delivery record, and this margin covers only the residue — a claim
+/// over-reported *within* the delivered range.
+///
+/// # Why the default is `0`
+///
 /// `0` is a valid value meaning *no margin*, and it is the default deliberately: at margin `0` the
 /// ceiling is arithmetically the same fleet MIN the pre-registry fold already computed, so
 /// introducing the registry moves the **authority** over the boundary without moving the boundary
-/// itself. A non-zero margin is a behavioural change and belongs with the consumer that needs it;
-/// choosing one on evidence is deferred and owned by TODO-634.
+/// itself. Read as policy, `0` asserts *the claim channel is trusted not to over-report* — a choice
+/// with a stated rationale, not an unexamined default. The knob's cost is continuous (every epoch of
+/// margin is retention nobody asked for, on every sweep, forever) while its benefit is contingent
+/// (it pays only if the channel actually lies), which is why the burden of proof sits on moving it
+/// up rather than on leaving it where it is. Choosing a non-zero value on evidence is deferred and
+/// owned by TODO-634; it is a behavioural change, never a keyboard adjustment.
 pub const DEFAULT_RECLAMATION_MARGIN_EPOCHS: u64 = 0;
 
 /// Environment variable carrying the operator-chosen reclamation margin, in epochs.
+///
+/// Operator-facing restatement of [`DEFAULT_RECLAMATION_MARGIN_EPOCHS`]'s contract, because this is
+/// the name an operator types and therefore the doc they are most likely to reach for:
+///
+/// - **Over-reported claims only.** Not a durability mechanism — that is the WAL fsync policy and
+///   the write-behind drain — and not the fix for min-pinning, which is the deferred cursor-age
+///   retention fence owned by TODO-634.
+/// - **The unit is EPOCHS,** never wall-clock time. The retention SLA is denominated in days, and
+///   neither converts to the other without a churn rate; both are tabulated in
+///   `packages/server-rust/docs/RECOVERY_ENVELOPE.md`.
+/// - **The hedge is narrow,** because `tombstone_frontier_impl.rs:420` already clamps every claim to
+///   the highest epoch that connection was delivered.
 const ENV_RECLAMATION_MARGIN_EPOCHS: &str = "TOPGUN_RECLAMATION_MARGIN_EPOCHS";
 
 /// Resolve the effective margin from the environment, **once**, at registry construction.

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -4828,6 +4828,137 @@ mod tests {
         );
     }
 
+    /// A margin of `0` is NOT zero conservatism: the boundary already retains one epoch
+    /// implicitly, and an over-claiming ACK cannot push it past what the connection was actually
+    /// delivered.
+    ///
+    /// Three facts, read as one:
+    ///
+    /// 1. a fleet delivered and confirmed through epoch `D` puts the boundary AT `D`;
+    /// 2. the sweep's eligibility is strictly BELOW that boundary, so epoch `D` itself is
+    ///    RETAINED while `D − 1` is reclaimed — one epoch of implicit retention. Read off the
+    ///    SET the sweep hands back, not off the standalone predicate: the set is what the sweep
+    ///    acts on, and the predicate's strictness is a separate expression that could agree with
+    ///    the sweep by coincidence;
+    /// 3. an ACK claiming `D + k` on a connection delivered only through `D` leaves the boundary
+    ///    exactly where it was, because the advance rule clamps the claim against the delivery
+    ///    record before it ever reaches the boundary.
+    ///
+    /// **Fact 3 is the new one.** Facts 1 and 2 are already executed by
+    /// `eligibility_is_strictly_past_not_inclusive` and `one_behind_client_pins_epoch_fleet_wide`;
+    /// they are carried here so the retained epoch reads as one coherent fact and so the clamp is
+    /// read against a boundary whose position was ESTABLISHED rather than assumed.
+    ///
+    /// Consequence for a lag-derived margin: the epoch retained here is retained ALREADY, so any
+    /// margin computed from observed client lag must be stated relative to it or it double-counts
+    /// by one (deferred, TODO-634).
+    #[tokio::test]
+    async fn margin_zero_retains_the_confirmed_epoch_and_delivery_bounds_an_over_claim() {
+        let f = frontier();
+        f.set_epoch_width(1);
+
+        // The epoch the fleet confirms, and how far beyond it the over-claim reaches.
+        let d: Epoch = 3;
+        let k: Epoch = 2;
+
+        // Stamp through `D + k`, so an epoch above the confirmed one exists to be over-claimed
+        // and the server's global bound is not itself the term that rejects the over-claim.
+        for i in 1..=(d + k) {
+            f.stamp_tombstone("m", &format!("k{i}"), &format!("{i}:0:n"));
+        }
+        // Injected AFTER the last stamp on purpose: stamping WRITES the global max epoch, so an
+        // injection placed earlier is silently overwritten and the clamp would then face a global
+        // bound equal to the delivery record instead of strictly above it.
+        f.set_current_max_epoch(d + k);
+        // Delivered only through `D`: the delivery record, not the global bound, must bind.
+        f.set_delivered(CONN_A, d);
+
+        let c: ClientId = "a5:alice|dev-1".into();
+        assert!(
+            f.confirm_apply_ack(&c, d, CONN_A).await,
+            "the honest ACK through {d} establishes the fleet cursor"
+        );
+
+        // Fact 1, inherited: the boundary the sweep folds over sits AT the confirmed epoch.
+        assert_eq!(
+            f.reclamation().margin_epochs(),
+            0,
+            "the retained-epoch reading is a margin-0 statement, so margin 0 is asserted here \
+             rather than assumed"
+        );
+        assert_eq!(
+            f.reclamation().prune_ceiling(ClaimScope::Global),
+            d,
+            "a fleet confirmed through {d} puts the boundary at {d}, not past it"
+        );
+
+        // Open the durability fence well past every stamped epoch: it must not be the term that
+        // decides `D`'s fate, and a zero watermark would return the sweep dark before it folds.
+        f.set_durable_epoch_watermark(1000);
+
+        // The decisiveness pins for fact 2, asserted immediately before the sweep. The
+        // eligibility test is a three-way conjunction; unless the other two terms are pinned
+        // non-deciding at `D`, `D` can be retained for a reason that has nothing to do with the
+        // strictness under test, and the fact goes vacuously green.
+        assert!(
+            f.durable_epoch_watermark() >= d,
+            "the durability conjunct must be SATISFIED at {d}, or {d} is retained by the fence \
+             instead of by the boundary"
+        );
+        assert!(
+            d != 0,
+            "the zero-epoch conjunct must be visibly non-deciding at the probe epoch"
+        );
+        assert_eq!(
+            f.reclamation().prune_ceiling(ClaimScope::Global),
+            d,
+            "the boundary must be EXACTLY at {d} when the sweep runs: at exactly {d} the \
+             strictly-below term is what decides {d}, which is the whole point of the read below"
+        );
+
+        let drained = f.drain_prunable_tombstones();
+        let epochs: Vec<Epoch> = drained.iter().map(|(e, _)| *e).collect();
+
+        // Fact 2, inherited: one epoch of implicit retention, read off the set the sweep returns.
+        assert!(
+            !epochs.contains(&d),
+            "epoch {d} is confirmed THROUGH, not past — it must survive the sweep, got {epochs:?}"
+        );
+        assert!(
+            epochs.contains(&(d - 1)),
+            "epoch {} is strictly below the boundary and must be reclaimed, got {epochs:?}",
+            d - 1
+        );
+
+        // The precondition fact 3 owes, asserted immediately before the over-claiming ACK. The
+        // clamp is three-way; the delivery record binds only while it is strictly below the
+        // global bound, which was injected at `D + k` above. There is no getter for that bound,
+        // so it is pinned by the injected value plus the record that does read back.
+        assert!(
+            f.delivered(CONN_A) < d + k,
+            "the delivery record must sit strictly below the global bound, or dropping the \
+             delivered term changes nothing and the clamp is not under test"
+        );
+
+        // Fact 3, the new one: the over-claim the margin exists to hedge is already bounded.
+        assert!(
+            !f.confirm_apply_ack(&c, d + k, CONN_A).await,
+            "an ACK claiming {} on a connection delivered through {d} must not advance anything",
+            d + k
+        );
+        assert_eq!(
+            f.cursor(&c),
+            Some(d),
+            "the cursor stays at the delivery record, never at the claimed value"
+        );
+        assert_eq!(
+            f.reclamation().prune_ceiling(ClaimScope::Global),
+            d,
+            "the boundary is unmoved by the over-claim: the delivery record bounds it, so a \
+             margin is not what stands between an over-claiming client and reclaimed data"
+        );
+    }
+
     /// A drained ref whose storage drop failed is handed back via
     /// `restore_tombstone_ref` and re-drained on the next sweep — a
     /// drained-but-not-dropped tag must never lose its index entry (that would

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -410,6 +410,14 @@ impl FrontierState {
     /// ACK). A delivered-nothing connection (`delivered_conn == 0`) can never
     /// establish or advance a cursor: the bound is 0, so a fresh device stays
     /// untracked.
+    ///
+    /// One epoch is retained implicitly, and a derived margin must not re-add it: a cursor at `e`
+    /// means *applied through `e` inclusive*, while the eligibility conjunct the sweep filters on is
+    /// strictly-below — `ceiling > e`, this file `:963` — so the newest epoch the fleet has
+    /// confirmed is itself retained. A reclamation margin of `0` is therefore not zero
+    /// conservatism, and any margin derived from observed client lag (the `p99.9`-based rule
+    /// deferred to TODO-634) must be stated relative to that already-retained epoch, or it
+    /// double-counts by one.
     fn advance_on_ack(
         &mut self,
         client: &ClientId,

--- a/packages/server-rust/src/tombstone_frontier_impl.rs
+++ b/packages/server-rust/src/tombstone_frontier_impl.rs
@@ -413,7 +413,7 @@ impl FrontierState {
     ///
     /// One epoch is retained implicitly, and a derived margin must not re-add it: a cursor at `e`
     /// means *applied through `e` inclusive*, while the eligibility conjunct the sweep filters on is
-    /// strictly-below — `ceiling > e`, this file `:963` — so the newest epoch the fleet has
+    /// strictly-below — `ceiling > e`, this file `:971` — so the newest epoch the fleet has
     /// confirmed is itself retained. A reclamation margin of `0` is therefore not zero
     /// conservatism, and any margin derived from observed client lag (the `p99.9`-based rule
     /// deferred to TODO-634) must be stated relative to that already-retained epoch, or it


### PR DESCRIPTION
## Summary

SPEC-361b (7 commits, TODO-634 carve 7 half B): §A.1's seven pins land — the reclamation margin becomes a STATED policy at both its knobs, with the boot-floor safety property proven and the whole recovery envelope documented in one place.

- **`docs/RECOVERY_ENVELOPE.md`** — the three knobs (retention SLA in days / clock-skew tolerance in minutes / reclamation margin in epochs) named together, with the unit each is denominated in, why they do not collapse into each other, and honest *not yet implemented* rows for the two deferred ones. Margin is explicitly NOT a durability mechanism and NOT the fix for min-pinning.
- **W7 (property test):** `a_staler_boot_floor_can_only_lower_the_boundary` — the persisted boot floor can only under-state the true min (proptest, not a fixture).
- **W6:** `margin_zero_retains_the_confirmed_epoch_and_delivery_bounds_an_over_claim` — the retained-epoch semantics pinned (ACK is through-e-inclusive; the boundary implicitly retains one epoch) and the delivered-clamp bounds an over-claim; decisiveness preconditions asserted before each arm.
- **Three executed mutation arms** recorded with their EXECUTED collateral sets (applied → RED set recorded verbatim → reverted; `spec361b-witness-arm.txt`).
- Doc-contracts: margin policy stated at both knobs; the one implicitly-retained epoch named.

3 audit rounds + cap discipline, carve fidelity PASS both ways, review + finalize done; parallel half SPEC-361a is file-disjoint and lands separately.

## Test plan

CI runs the full matrix on this exact tip. A local §A run + load harness executes in a dedicated worktree (the shared working copy is in use by the parallel half's executor); results will be posted before merge.