### PR TITLE
test(soak): durable-corpus level estimator refuted by its own anti-tautology bar (SPEC-361a, carve 7 half A)

### DIFF
--- a/packages/server-rust/benches/soak_harness/evidence/spec361-control-runs.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361-control-runs.txt
@@ -1,0 +1,132 @@
+SPEC-361a — G5 CONTROL RUNS AND KNOB-EFFECTIVENESS PROBES
+=========================================================
+
+Every line below was COPIED from a captured run log by script, never retyped.
+The gate line is located via the source constant TOMBSTONE_CORPUS_LINE_PREFIX,
+extracted with the sed one-liner the Validation Checklist pins (step 3), so a
+rename REDs loudly instead of missing silently.
+
+C9 / C10 BIND EVERYTHING HERE. These are NOT a measurement lineage: no pin, no
+matrix, no width sweep, no fit, no CSV segments, no replicate. The only
+publishable outputs are the exit code, the rendered gate line and the
+finishedReason. NO corpus magnitude below may be quoted as evidence about the
+plateau, the reclaim fraction, or any width.
+
+Binary: release build of `soak_harness` + `topgun-server` at this branch HEAD.
+Host: darwin / M1 Max. Cells run STRICTLY SEQUENTIALLY (never concurrently),
+because the NEUTRAL cell is the attribution control and CPU contention from a
+parallel cell would destroy the attribution it exists to provide.
+
+-----------------------------------------------------------------------------
+PART 1 — N21 THE LIVE CONTROL LEG: three cells, D = 900 s, --crash-interval 120
+-----------------------------------------------------------------------------
+All three cells use the IDENTICAL D and crash interval, as N5 requires.
+
+CELL: NEUTRAL (no injection flag) — the attribution control
+  invocation: --duration 900 --crash-interval 120 (no injection flag)
+  wall clock: 902s
+  exit code (X21-c): 1
+  rendered line (X21-a):
+    tombstone_corpus_redb_scan: first=45009 min=45009 peak=316159 last=316159 first_half_peak=173741 last_half_peak=316159 rise=142418 span=778s scans_ok=8 scans_failed=0 headroom=65536 ceiling=disarmed disposition=LEVEL_EVALUATED -> FAIL (terminal scan 316159 bytes; last gauge value 328334 bytes -> DIVERGED) reason=durable-corpus level rose 142418 B between half-peaks (173741 B -> 316159 B) over 778s, above the 65536 B headroom
+  finishedReason (X21-b, from the persisted SoakReport):
+    durable-corpus level assertion failed: durable-corpus level rose 142418 B between half-peaks (173741 B -> 316159 B) over 778s, above the 65536 B headroom
+  ceilingBytes (X21-b, the NULL branch of AC27's JSON limb): null
+  admissibility: samples=8 (min 4), spanSecs=778.4347632089999 (min 600), disposition=LEVEL_EVALUATED
+
+CELL: --no-ack
+  invocation: --duration 900 --crash-interval 120 --no-ack
+  wall clock: 903s
+  exit code (X21-c): 1
+  rendered line (X21-a):
+    tombstone_corpus_redb_scan: first=48995 min=48995 peak=386362 last=386362 first_half_peak=195198 last_half_peak=386362 rise=191164 span=780s scans_ok=8 scans_failed=0 headroom=65536 ceiling=disarmed disposition=LEVEL_EVALUATED -> FAIL (terminal scan 386362 bytes; last gauge value 395089 bytes -> DIVERGED) reason=durable-corpus level rose 191164 B between half-peaks (195198 B -> 386362 B) over 780s, above the 65536 B headroom
+  finishedReason (X21-b, from the persisted SoakReport):
+    durable-corpus level assertion failed: durable-corpus level rose 191164 B between half-peaks (195198 B -> 386362 B) over 780s, above the 65536 B headroom
+  ceilingBytes (X21-b, the NULL branch of AC27's JSON limb): null
+  admissibility: samples=8 (min 4), spanSecs=779.8002591669999 (min 600), disposition=LEVEL_EVALUATED
+
+CELL: --inject-slow-leak
+  invocation: --duration 900 --crash-interval 120 --inject-slow-leak
+  wall clock: 906s
+  exit code (X21-c): 1
+  rendered line (X21-a):
+    tombstone_corpus_redb_scan: first=58674 min=58674 peak=307004 last=307004 first_half_peak=172137 last_half_peak=307004 rise=134867 span=783s scans_ok=8 scans_failed=0 headroom=65536 ceiling=disarmed disposition=LEVEL_EVALUATED -> FAIL (terminal scan 307004 bytes; last gauge value 307488 bytes -> DIVERGED) reason=durable-corpus level rose 134867 B between half-peaks (172137 B -> 307004 B) over 783s, above the 65536 B headroom
+  finishedReason (X21-b, from the persisted SoakReport):
+    durable-corpus level assertion failed: durable-corpus level rose 134867 B between half-peaks (172137 B -> 307004 B) over 783s, above the 65536 B headroom
+  ceilingBytes (X21-b, the NULL branch of AC27's JSON limb): null
+  admissibility: samples=8 (min 4), spanSecs=782.886967625 (min 600), disposition=LEVEL_EVALUATED
+
+-----------------------------------------------------------------------------
+PART 2 — N22 THE KNOB-EFFECTIVENESS PROBE PAIR (X21-d, AC27 KNOB limb)
+-----------------------------------------------------------------------------
+Two invocations of the existing 25 s smoke shape (--duration 25
+--crash-interval 0), differing ONLY in the two knobs. NEITHER IS AN AT INPUT
+and neither probe's corpus magnitude may be quoted (C9, C10).
+
+PROBE: P-armed
+  differing flags: --tombstone-corpus-headroom-bytes 1 --tombstone-corpus-ceiling-bytes 1
+  exit code: 1
+  rendered line:
+    tombstone_corpus_redb_scan: first=5161 min=5161 peak=5161 last=5161 first_half_peak=0 last_half_peak=5161 rise=5161 span=0s scans_ok=1 scans_failed=0 headroom=1 ceiling=1 disposition=LEVEL_SUPPRESSED(n=1, span=0s) -> FAIL (terminal scan 5161 bytes; last gauge value 5781 bytes -> DIVERGED) reason=durable-corpus peak 5161 B exceeds the armed 1 B ceiling
+
+PROBE: P-slack
+  differing flags: --tombstone-corpus-headroom-bytes 262144 --tombstone-corpus-ceiling-bytes 99999999999
+  exit code: 0
+  rendered line:
+    tombstone_corpus_redb_scan: first=4660 min=4660 peak=4660 last=4660 first_half_peak=0 last_half_peak=4660 rise=4660 span=0s scans_ok=1 scans_failed=0 headroom=262144 ceiling=99999999999 disposition=LEVEL_SUPPRESSED(n=1, span=0s) -> ok (terminal scan 4660 bytes; last gauge value 5580 bytes -> DIVERGED)
+
+-----------------------------------------------------------------------------
+PART 3 — AC21 / AC24 THE CI CONSUMER RE-RUN (all THREE surfaces, four cells)
+-----------------------------------------------------------------------------
+Each cell is the shape rust.yml runs at HEAD, re-run against this branch.
+AC24 limb 1 needs the 25 s blocking smoke to RENDER LEVEL_SUPPRESSED — that is
+the executed constructibility witness for N4's fallback branch.
+
+(i) BLOCKING Soak Smoke G4b — rust.yml:470-478 (--duration 25 --crash-interval 0)
+  exit code: 0   [HEAD expectation: 0]
+  jq '.passed == true' exit: 0   [0 = the CI assertion holds]
+  rendered line:
+    tombstone_corpus_redb_scan: first=5000 min=5000 peak=5000 last=5000 first_half_peak=0 last_half_peak=5000 rise=5000 span=0s scans_ok=1 scans_failed=0 headroom=65536 ceiling=disarmed disposition=LEVEL_SUPPRESSED(n=1, span=0s) -> ok (terminal scan 5000 bytes; last gauge value 5640 bytes -> DIVERGED)
+  VERDICT: GREEN, disposition LEVEL_SUPPRESSED — AC24 limb 1 discharged.
+
+(ii) BLOCKING boundary cell — rust.yml:480-491 (--duration 30 --crash-interval 9 --or-churn true --or-every 3)
+  exit code: 0
+  wall clock: 31s   [budget: the 30 s cell + fixed overhead; unchanged from HEAD's shape]
+  OR-no-loss greps (rust.yml:494-503), the assertions this cell is actually graded on:
+    'OR-Map acked add(s) LOST across recovery'   -> 0 occurrences [required: 0]
+    'OR-Map no-loss check could not complete'    -> 0 occurrences [required: 0]
+    'OR-Map no-loss check: PASS'                 -> 2 occurrences [required: >= 1]
+  rendered line:
+    tombstone_corpus_redb_scan: first=2145 min=2145 peak=6754 last=6754 first_half_peak=2145 last_half_peak=6754 rise=4609 span=18s scans_ok=3 scans_failed=0 headroom=65536 ceiling=disarmed disposition=LEVEL_SUPPRESSED(n=3, span=18s) -> ok (terminal scan 6754 bytes; last gauge value 7142 bytes -> DIVERGED)
+  VERDICT: all three greps hold; LEVEL_SUPPRESSED; wall-clock budget holds.
+  This is AC21(ii)'s literal and only content, and the per-checkpoint byte
+  copy + scan did not break it.
+
+(iii) soak-loaded — rust.yml:592. NON-BLOCKING: the soak-loaded job (rust.yml:521)
+      carries job-level continue-on-error: true at rust.yml:548.
+  run 1: passed=true totalWrites=16725 finishedReason='duration reached' disposition=LEVEL_SUPPRESSED corpusPassed=true
+  run 2: passed=true totalWrites=18874 finishedReason='duration reached' disposition=LEVEL_SUPPRESSED corpusPassed=true
+  rendered line (run 1):
+    tombstone_corpus_redb_scan: first=49866 min=49866 peak=49866 last=49866 first_half_peak=0 last_half_peak=49866 rise=49866 span=0s scans_ok=1 scans_failed=0 headroom=65536 ceiling=disarmed disposition=LEVEL_SUPPRESSED(n=1, span=0s) -> ok (terminal scan 49866 bytes; last gauge value 54352 bytes -> DIVERGED)
+  VERDICT: gate verdict UNCHANGED (.passed == true in both runs), disposition
+  LEVEL_SUPPRESSED in both. The composite CI assertion also requires
+  totalWrites > 20000, which this HOST did not reach (16725, 18874). That is a
+  local throughput shortfall on a laptop that had just run five soaks
+  back-to-back, NOT a verdict change and NOT attributable to the corpus gate
+  (tombstoneCorpus.passed == true in both runs). Recorded rather than glossed.
+
+(iv) soak-loaded-crash — rust.yml:641, same NON-BLOCKING job (advisory).
+  run 1: passed=false totalWrites=1452 finishedReason='crash recovery mismatch detected' disposition=LEVEL_SUPPRESSED corpusPassed=true
+  run 2: passed=true totalWrites=3177 finishedReason='duration reached' disposition=LEVEL_SUPPRESSED corpusPassed=true
+  run 3: passed=true totalWrites=2828 finishedReason='duration reached' disposition=LEVEL_SUPPRESSED corpusPassed=true
+  run 1's recovery_failures line, copied from its log:
+      - LWW merkle root changed across recovery: pre=3505210605 post=108584038
+  VERDICT, stated honestly: run 1 FAILED and runs 2 and 3 PASSED — the cell is
+  INTERMITTENT here. The failure is the LWW recovery arm, NOT the corpus gate:
+  tombstoneCorpus.passed == true and disposition == LEVEL_SUPPRESSED in all
+  three runs, so the corpus clause contributed nothing to the verdict. It also
+  CANNOT be a regression from this half: packages/server-rust/src/ is
+  byte-unchanged against the base commit 20edabde, so the topgun-server binary
+  under test is identical to base. The signature (LWW merkle root changed
+  across recovery, under --no-pre-kill-drain) is the known advisory-tier LWW
+  recovery issue, which is why the job is continue-on-error in the first place.
+  ROUTED to TODO-634 by id below; no tracker file is edited.

--- a/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.correction.sha256
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.correction.sha256
@@ -1,0 +1,27 @@
+# Digest of the CORRECTION SECTION of spec361-level-gate-ruling.md, appended
+# after the fresh-context implementation review (Review v1).
+#
+# The correction section is OUTSIDE the frozen layer, OUTSIDE G5's post-section
+# and OUTSIDE G6's siting record, and carries its OWN digest, so the four
+# surfaces stay independently verifiable: the decision surface frozen BEFORE the
+# runs, the verdict appended AFTER them, the record that the verdict's
+# consequence was sited in the code, and this correction to one process claim
+# that record made. It is delimited by the CORRECTION-SECTION-BEGIN /
+# CORRECTION-SECTION-END sentinels, so this digest is stable under line-number
+# shifts. A file cannot contain its own digest, which is why the value lives
+# here.
+#
+# Re-verify with:
+#
+#   awk '/^<!-- CORRECTION-SECTION-BEGIN -->$/{f=1;next} /^<!-- CORRECTION-SECTION-END -->$/{f=0} f' \
+#     packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md \
+#     | shasum -a 256
+#
+# ALL THREE earlier digests were RE-VERIFIED as still reproducing at the moment
+# this section was appended, which is what proves the append disturbed none of
+# them:
+#   frozen-layer   57416926748add87129708d0c0c4d11e0ade85b2e30898684a649f5b1af4e07f
+#   post-section   e8feaed53cb081ab9d57ae313e483241ec3e586bff8541a08c646c17eac9d006
+#   siting-section eba6592e97ec08c92ada8bef0c72b04f073678a1b697b6e2afcc9c8fc3a855a8
+#
+correction-section a924e3a9a2fc83c730f74a898d0ce72f376b400fb39de3e5c3231a7212f45645

--- a/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.frozen.sha256
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.frozen.sha256
@@ -1,0 +1,17 @@
+# Digest of the FROZEN layer of spec361-level-gate-ruling.md.
+#
+# The frozen layer is delimited by the FROZEN-LAYER-BEGIN / FROZEN-LAYER-END
+# sentinels, so this digest is stable under any later append to the
+# post-section and under any line-number shift. A file cannot contain its own
+# digest, which is why the value lives here.
+#
+# Recorded BEFORE any calibration test was written and BEFORE any control run
+# was executed. Re-verify with:
+#
+#   awk '/^<!-- FROZEN-LAYER-BEGIN -->$/{f=1;next} /^<!-- FROZEN-LAYER-END -->$/{f=0} f' \
+#     packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md \
+#     | shasum -a 256
+#
+# A mismatch means the frozen layer moved after its freeze, which is a RED.
+#
+frozen-layer  57416926748add87129708d0c0c4d11e0ade85b2e30898684a649f5b1af4e07f

--- a/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md
@@ -1400,3 +1400,51 @@ the bounded-plateau question and the width-1000 plateau demonstration to
 **`TODO-634`**. This section edits no tracker file.
 
 <!-- SITING-SECTION-END -->
+
+<!-- CORRECTION-SECTION-BEGIN -->
+
+## CORRECTION RECORD — appended after Review v1, under its OWN digest
+
+This section is OUTSIDE the frozen layer, OUTSIDE `G5`'s post-section and
+OUTSIDE `G6`'s siting record. It edits none of them: all three earlier digests
+re-verify as reproducing unchanged at the moment this was written, which is what
+makes this an append rather than a revision.
+
+### What it corrects
+
+The SITING RECORD states, of the `N4a` census sweep:
+
+> The lines were therefore re-pointed to the **unconditional** role.
+
+Read as a claim about *every* line, that is **19 of 21, not 21 of 21**. A
+fresh-context implementation review found two in-scope census sites in
+`monitor.rs` — the doc-comment and the assert message of
+`calibration_additive_only_gauge_never_plateaus`, the pair `N4a` Table 1
+classifies as one row — still carrying the **conditional** qualifier *"whenever
+/ when the durable-corpus level clause did not decide the run"*. `G6`'s sweep
+missed them.
+
+Both were re-pointed to the unconditional role in the Review-v1 fix pass. The
+corrected claim is therefore: **19 of 21 lines were re-pointed by `G6`; the
+remaining 2 were re-pointed after Review v1.** The end state the SITING RECORD
+describes is now true of all 21; the process claim it made was not.
+
+### Why the census could not catch it by itself
+
+Each of the two lines is a *continuation* line. The pinned phrase (`hard-gate`)
+sits on the line above; the false qualifier sits on the line below it, which the
+pinned grep never matches. The census's mechanics were therefore all satisfied —
+count **36**, split 15 / 21, `demoted = 0`, every hit classified — while the
+substantive property the census exists to protect was violated. **A
+phrase-pinned line census bounds where a false contract may hide; it does not
+eliminate it.** This is a residual of the instrument, recorded here so the next
+spec in this lineage inherits the limitation rather than rediscovering it.
+
+### What did NOT change
+
+No verdict logic, no assertion, no fixture, no parameter, no constant. The
+`AT-3` grading, the demotion and its siting stand exactly as recorded above. The
+post-fix census still returns **36** (`monitor.rs` 15 + `main.rs` 21) with
+nothing demoted.
+
+<!-- CORRECTION-SECTION-END -->

--- a/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md
@@ -1,0 +1,1136 @@
+# SPEC-361a — the durable-layer LEVEL/CEILING gate: ruling artifact
+
+Two layers, and the distinction is load-bearing.
+
+- **The FROZEN layer** (below, between the `FROZEN-LAYER` sentinels) is recorded **before** any
+  calibration test is written and **before** any control run is executed. Its digest is pinned in
+  the sidecar `spec361-level-gate-ruling.frozen.sha256`, which enters history in the same commit as
+  the bytes it names.
+- **The APPEND-ONLY post-section**, under its own separate digest, is written **after** `G5`. At the
+  time of this commit it is **present and EMPTY** — the marker exists so that a later append is
+  visibly an append and not a rewrite.
+
+**Digest command** (the frozen layer is delimited by sentinels, so the digest is stable under any
+later append and under any line-number shift):
+
+```
+awk '/^<!-- FROZEN-LAYER-BEGIN -->$/{f=1;next} /^<!-- FROZEN-LAYER-END -->$/{f=0} f' \
+  packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md \
+  | shasum -a 256
+```
+
+A file cannot contain its own digest, which is why the value lives in the sidecar.
+
+<!-- FROZEN-LAYER-BEGIN -->
+
+## §F0 — what is frozen, and what freezing means
+
+Everything in this layer is decided **in the open and in advance**. Once its digest is recorded:
+
+- no parameter in §F3 may be retuned to make a control run pass **or** fail (`C11`, `KL-4`);
+- no `AT` row in §F8 may be re-written after seeing a verdict;
+- no witness arm in §F9 may be re-sited after seeing a RED;
+- a divergence between a pre-registered text and a delivered text is **recorded in the post-section
+  with its reason**, and the frozen table is corrected in the same edit. The pre-registration is a
+  freeze, not a trap.
+
+## §F1 — THE DECISION RULE, in evaluation order
+
+`L0` is evaluated first and is fail-closed.
+
+| Clause | Predicate (frozen) | Verdict on breach | Notes |
+|---|---|---|---|
+| **`L0` — INSTRUMENT** | `scans_failed > 0` **OR** `samples == 0` | **FAIL**, `disposition = InstrumentFailed`, `L1`/`L2` **NOT EVALUATED** | A scan that returned `None` — missing file, corrupt header, a table-open error other than `TableDoesNotExist` — **or a byte copy that failed (§F15)** is a **blind instrument**, and a gate whose instrument was blind must not report bounded growth. `Some(0)` from a never-written table (`main.rs:1238`) is an **honest zero** and does NOT breach. |
+| **`L1` — LEVEL / FLATNESS** | evaluated only when `samples >= min_samples` **and** `span_secs >= min_span_secs`; breaches when `last_half_peak_bytes.saturating_sub(first_half_peak_bytes) > headroom_bytes` | **FAIL**, `disposition = LevelEvaluated` | The hard gate's decision function. `saturating_sub` means a **falling** corpus yields `rise = 0` and passes — correct for a ceiling test. When the guards are not met: `disposition = LevelSuppressed`, `passed` unaffected by this clause, and the suppression is **rendered with both numbers** (`KL-5`). |
+| **`L2` — ABSOLUTE CEILING** | evaluated only when `ceiling_bytes == Some(c)`; breaches when `peak_bytes > c` | **FAIL** | **DISARMED BY DEFAULT (`None`)**: arming it honestly requires a validated ceiling, which requires a plateau demonstration that `PIN 2` puts out of scope. It is implemented, **unit-tested (`W9`)**, renderable and armable from the CLI, and both CLI knobs are proven effective over the rendered transport by §F13's probe pair (`X21-d`). Its `None` renders as `ceiling=disarmed` on the report line and as an EXPLICIT `"ceilingBytes": null` in the JSON — **never an omitted key**; its `Some(c)` renders `ceiling=<c>` and `"ceilingBytes": <c>`, and **both** branches are exercised (`W9`; the census-target fixture, §F11). |
+
+The window partition is the **shared split index** factored out of `last_half_window`
+(`monitor.rs:281`), so the new clause and the demoted slope clause split any series identically and
+a reader comparing them is comparing like with like.
+
+## §F2 — TWO SPANS, NAMED APART; AND THE ADMISSIBLE DURATION RANGE
+
+`span_secs` on the assessment is the **FULL series span** — `last.elapsed_secs − first.elapsed_secs`
+— and that is what `min_span_secs = 600.0` guards. The **rise** `L1` tests is the difference between
+two half-peaks, so the growth it accumulates spans roughly **half** the series. The two are never
+interchanged, and neither is ever quoted as the cell duration.
+
+At `--crash-interval 120` (the harness default, `main.rs:205`) a cell of duration `D` puts its first
+checkpoint at ≈ 120 s and its terminal scan at ≈ `D`, so:
+
+```
+span_secs  ≈  D − 120              (terminal minus the FIRST checkpoint, not minus t = 0)
+samples    =  floor(D / 120) + 1   (checkpoints + the terminal scan)
+```
+
+`L1`'s two guards are `span_secs >= 600` and `samples >= 4`. The sample guard binds at `D >= 360`;
+the **span guard binds at `D − 120 >= 600`, i.e. `D >= 720 s`**, and it is therefore the binding
+one. The lower bound is pinned at **730 s**, adding a **10 s cushion** over the derived 720 s for
+the strict `>=` comparison and for a first checkpoint that fires marginally late.
+
+> **ADMISSIBLE DURATION RANGE: `730 s ≤ D ≤ 900 s`. The three control cells are RUN at `D = 900 s`**
+> — the `C9` ceiling — because that maximises churn and leaves the largest guard margin, and
+> **all three cells use the identical `D`** (the neutral run is the attribution control and a
+> duration difference would destroy it).
+
+At `D = 900`: **`samples = 8`, `span_secs ≈ 780 s`**, clearing the 600 s guard with ≈ 180 s of
+margin and giving a **≈ 390 s** rise window — the window every magnitude in §F3 is scaled to. At the
+lower bound `D = 730`: `samples = 7`, `span ≈ 610 s` — still admissible. **A cell below 730 s is
+inadmissible BY CONSTRUCTION**, so spending `AT-0`'s single permitted re-run on one would waste the
+only re-run the row allows.
+
+## §F3 — THE PARAMETERS AND THEIR DERIVATION
+
+```rust
+pub const DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES: u64 = 65_536;
+pub const DEFAULT_TOMBSTONE_CORPUS_MIN_SPAN_SECS: f64 = 600.0;
+pub const DEFAULT_TOMBSTONE_CORPUS_MIN_SAMPLES: usize = 4;
+pub const DEFAULT_TOMBSTONE_CORPUS_CEILING_BYTES: Option<u64> = None;
+```
+
+*An estimator whose discrimination is inside an 8,756 B/h spread is not an estimator* — so the
+derivation is published as arithmetic, not as a preference. **Every number below is either quoted
+from a committed source with its `file:line`, or computed from two such numbers with the arithmetic
+shown on this page. The derivation is satisfiable from the stated numbers ALONE — no external
+lookup, no unstated bridging quantity.**
+
+**The common denominator, stated once so all steps compare like with like.** `L1`'s statistic is a
+**level rise over the LAST-HALF window** of the CORPUS SERIES. The control cells run at `D = 900 s`
+at `--crash-interval 120` (§F2, §F8), so the series spans ≈ 780 s and its last-half window is
+**≈ 390 s = 0.108333 h**. Every step is normalised to that 390 s window; where a source number was
+measured over a different window, the conversion is shown. **The `450 s` an earlier draft used is
+superseded** (it assumed the series span equalled the cell duration, at the old `--crash-interval
+60`); every figure derived from it is re-computed below and none of the conclusions moves, because
+the healthy-to-unhealthy separation is a **ratio** and is window-independent.
+
+### Step 0 — THE MEASURED DURABLE-CORPUS MAGNITUDES
+
+Every committed harness console log renders a terminal `tombstone_corpus_redb_scan:` line, and the
+evidence directory holds **29 of them across 29 files / 21 distinct runs** at HEAD `20edabde`:
+
+```
+grep -rn 'tombstone_corpus_redb_scan:' \
+  packages/server-rust/benches/soak_harness/evidence
+```
+⇒ **29 lines.** Each renders the scanned corpus **and** the last gauge value, so each is a paired
+observation of exactly the substitution this derivation makes. Three, with their `file:line`:
+
+- `spec355-w1000.harness-console.log:270` — **628,903 B scanned vs 646,306 B gauge**, absolute gap
+  **17,403 B**, i.e. `17,403 / 646,306 =` **2.7 %**;
+- `spec356c-long-r1.runner-console.log:57` — **4,969,274 vs 4,994,851**, gap **25,577 B**,
+  `25,577 / 4,994,851 =` **0.5 %**. *(An earlier draft attributed this pair to `spec349c2`;
+  CORRECTED — `spec349c2-emitter-on.harness-console.log:80` is **200,860 vs 194,260** and
+  `spec349c2-emitter-off…:80` is **239,256 vs 245,809**.)*
+- the `w100` class, e.g. `spec356-w100.harness-console.log:48` — **20,108 vs 17,996**.
+
+**What these DO and DO NOT license.** Each is a **single terminal scalar**, so **no durable-corpus
+NOISE FLOOR has been measured** and the honest-gap statement below survives verbatim. What they
+*do* bound is the **proxy-substitution error** — the error incurred by deriving a byte headroom from
+GAUGE magnitudes and applying it to CORPUS magnitudes. Over all 21 runs the **absolute**
+corpus-vs-gauge gap never exceeds **27,925 B** (`spec357-diag-r1.runner-console.log:57`, 4,659,548
+vs 4,687,473); excluding the two `SPEC-357` cells it never exceeds **25,577 B**. So
+`65,536 / 27,925 =` **2.3×**: the headroom is over twice the largest substitution error ever
+observed, across three orders of magnitude of corpus size (19,536 B → 5,234,623 B). *(Quoting
+`spec357-diag-r1`'s **scan line** imports none of the `PD-F12` counter-family figures struck in
+step 3: the scan is an independent redb read, not a counter.)*
+
+**The relative gap is NOT uniform** — 0.5–3 % on the ≥ 400 KB cells, but tens of percent on the
+~20–50 KB cells (e.g. `spec356-ctloff-r1…:48`, 50,204 vs 37,400). That is why the bound is stated in
+**BYTES and not as a percentage**: a percentage bound would be false, an absolute one is what `L1`
+actually consumes (`KL-1`).
+
+> **THIS STEP CORROBORATES; IT DOES NOT RETUNE. `headroom_bytes` stays 65,536 — the number was
+> fixed by steps 1–3, these lines are NOT a floor and NOT a retune input, and `C11` forbids moving
+> the constant to fit an observation.**
+
+### Step 1 — the recorded rate spread converted to a LEVEL
+
+The 8,756 B/h width-100 spread was fitted over last-half windows of **900 s = 0.25 h** — attributed,
+not assumed: the `spec356-w100` cell ran **1,800 s** (`spec356-manifest.md:1634`) and its coordinate
+last-half window is **90 rows / 900 s** (`spec356-manifest.md:1961-1962`). A rate spread `S` over a
+window of `T` hours is a level spread of `S × T`:
+
+```
+8,756 × 0.25      = 2,189 bytes      (at the source's own 900 s window)
+8,756 × 0.108333  =   948.6 bytes    (normalised to the control leg's 390 s window)
+```
+
+**2,189 B, not 8,756, is the primitive noise magnitude.** The headroom sits
+`65,536 / 2,189 =` **29.9×** above the as-measured figure and `65,536 / 948.6 =` **69.1×** above the
+normalised one.
+
+### Step 2 — above the healthy signal
+
+`SPEC-356b`'s `w100` keeping-up cell recorded a backlog delta of **+8,602 B**, and the **window is
+the bridging fact**: that delta is over the cell's **coordinate last-half window of 90 rows /
+900 s**, not over the whole cell (`spec356-manifest.md:1961-1964`).
+
+```
+at the source's own 900 s window:   65,536 / 8,602               = 7.6×
+pro-rated to 390 s:                 8,602 × 390 / 900 = 3,727.5 B
+                                    65,536 / 3,727.5             = 17.6×
+```
+
+**The `~150×` an earlier draft carried is DELETED — no committed number produces it.**
+
+### Step 3 — below the unhealthy signal, at the control leg's own window
+
+The `long` cell's coordinate last-half window carried **+5,303,731 B** of backlog growth. That
+window's span is **7,190 s** (`spec356-manifest.md:1660-1661` — the figure completes the sentence at
+`:1661`; also `:1927`, `:2173-2174`), which is the *"~2 h"* an earlier draft left unattributed. So:
+
+```
+5,303,731 / (7,190 / 3,600)  = 2,655,565 B/h  ≈ 2.66 MB/h
+2,655,565 × 0.108333         =   287,686 B    (over the control leg's 390 s window)
+287,686 / 65,536             =        4.4×    the headroom
+```
+
+*(`SPEC-357`'s `+10,131,707 / +8,250,744 B` diagnosis figures are **NOT** derivation inputs and are
+struck from this step: they sit inside `PD-F12`'s unreconciled counter-family contradiction
+(`spec357-fixshape-ruling.md:173-183`), so quoting them would import a contested number into a
+frozen derivation.)*
+
+### The separation
+
+All three at the control leg's own 390 s window:
+
+```
+healthy ≈ 3,727.5 B   <   headroom 65,536 B   <   unhealthy ≈ 287,686 B
+17.6× above healthy       4.4× below unhealthy
+total separation:   287,686 / 3,727.5 = 77.2×
+```
+
+Roughly **one order of magnitude of margin on each side**, justified **before** any control is run.
+**The 77× separation is window-INVARIANT** — it is a ratio of two quantities pro-rated by the same
+factor — which is why re-basing 450 s → 390 s moved the two one-sided margins
+(`15.2×` → `17.6×`, `5.1×` → `4.4×`) and left the separation untouched. **No claim of "two orders of
+magnitude" survives; the arithmetic above does not support one.**
+
+### The honest gap, stated rather than glossed
+
+Every number in steps 1–3 is a **gauge / counter** magnitude. **No durable-corpus noise floor has
+ever been measured in this lineage.** Step 0's 29 committed scan lines are single terminal scalars,
+one per run, so they bound the **substitution error** (≤ 27,925 B, i.e. `2.3×` inside the headroom)
+but constitute **no floor**, because a floor requires repeated samples of the same configuration.
+They are used as the best available proxy, and one property of the new instrument makes the proxy
+conservative: the durable scan is an **exact byte count of a deterministic on-disk state**, not a
+fit — it has no estimator variance at all, and its only per-sample wobble is genuine state change
+between scans. Revising `headroom_bytes` on measured durable-corpus data is `TODO-654`'s to
+propose, and any revision is a **spec revision, recorded**, never a keyboard retune (`C11`).
+
+### The other three parameters
+
+- `min_span_secs = 600.0` — five times `DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS`
+  (`monitor.rs:365`), far above the 25 s blocking smoke, far below any real soak. It is the binding
+  guard behind §F2's admissible range.
+- `min_samples = 4` — two per half, so no half-peak is a single point: the degenerate case the
+  existing `last_half_window_span_secs` guard excludes for the same reason — the **executable**
+  guard, the `match` at `monitor.rs:309-312`, not the doc paragraph at `:290-306` an earlier draft
+  cited.
+- `ceiling_bytes = None` — `L2` disarmed by default, for the reason §F1 states.
+
+## §F4 — THE STATISTIC CHOICE: PEAK, NOT MEAN, NOT MEDIAN, NOT A FIT
+
+- **A LEVEL, in the quantity's own units (`KL-1`).** The 8,756 B/h spread is the `1/T` amplification
+  of a level spread, not an independent noise source. Any statistic that normalises by time
+  re-imports it. `L1` compares **bytes to bytes** and fits nothing.
+- **THE PEAK, not the mean and not the median (`KL-2`).** A ceiling is an **upper envelope**: prune
+  legitimately produces large downward excursions, which would drag a mean or a median and hide a
+  rising envelope. `L2` is likewise `peak_bytes > c` and not `last_bytes > c` — an envelope test,
+  not a level-vs-final test; `W9`'s mutation arm is exactly that substitution.
+- Using the peak also leaves `R-5`'s `median(L)` successor rule (*"publish the zero-row fraction and
+  RED within ±5 points of 50 %"*) with **no subject here**, which is stated so the rule is visibly
+  honoured rather than silently skipped.
+- **NEITHER DISCREDITED FORM IS REVIVED (`§7 F3` of the extraction synthesis).** There is no
+  last-half OLS **slope stick** and no **`f(span, width, churn)`**: `L1` is a level comparison in
+  bytes, and none of its three parameters is a function of span, width or churn.
+
+## §F5 — WHAT IS DEMOTED, AND WHAT IS NOT
+
+**THE DEMOTION IS CONDITIONAL ON REPLACEMENT, NEVER UNCONDITIONAL. This is the governing rule and it
+outranks every convenience below it.**
+
+> **NO-UNGATED-WINDOW RULE (normative).** *There exists no run configuration in which neither the
+> old hard slope clause nor a live, evaluable `L1` gates tombstone growth.* A demotion that opens an
+> ungated run class is the same defect class as deleting a fence because a better one is planned,
+> and this spec refuses it.
+
+- **CONDITIONALLY DEMOTED:** the tombstone-byte **SLOPE** clause. `assess_tombstone_bytes`'s
+  `passed` (`monitor.rs:470`) stops being ANDed at `main.rs:853` **exactly and only when
+  `corpus.disposition == LevelEvaluated`** — only where a live `L1` decided over the *same run* and
+  therefore covers the same class. Its value is still computed, printed and serialized in every
+  case (`C8`).
+- **STAYS HARD — the class `L1` cannot cover.** When `corpus.disposition != LevelEvaluated` the
+  slope clause is ANDed exactly as at HEAD. **The run class, explicitly:** any run whose corpus
+  series fails `L1`'s guards — `samples < min_samples` **or** `span_secs < min_span_secs`.
+  Concretely: every run with `--crash-interval` disabled, or shorter than `min_samples − 1` crash
+  intervals, or shorter than `min_span_secs`. The corpus sampler is coupled to the recovery
+  checkpoint (§F15), so such a run yields **one** sample and `L1` is **structurally SUPPRESSED**.
+- **NOT DEMOTED:** the gauge's **blind-monitor** clause (`main.rs:830`, `:863-867`). It stays hard
+  unconditionally — it asserts **harness health** (a dead `/metrics` scrape), not the tombstone
+  property.
+- **NOT TOUCHED:** the RSS gate (`assess`), the disk gate (`assess_disk`) and its blind-monitor
+  clause, the convergence gates, the recovery gates and the panic gate (`C7`; `SPEC-348` owns
+  promoting the disk + RSS slopes).
+- **NEW HARD CLAUSES:** `L0` (unconditional) and `L1` (whenever evaluable).
+
+Net, the run verdict at `main.rs:849-855` becomes:
+
+```
+convergence ∧ recovery ∧ mem ∧ ¬blind_monitor
+  ∧ corpus.passed                                             ← L0 always; L1 when evaluable
+  ∧ (¬slope_clause_stays_hard(corpus.disposition) ∨ tombstones.passed)
+                                                              ← the fallback: the OLD hard clause
+  ∧ ¬disk_blind_monitor ∧ ¬panic
+```
+
+`L1` evaluated ⇒ the slope is report-only; `L1` not evaluated ⇒ the slope is hard, unchanged from
+HEAD. `L0` failing already forces `corpus.passed = false`, so `InstrumentFailed` fails the run
+through the **first** conjunct and never reaches the second.
+
+## §F6 — THE EXHAUSTIVE PREDICATE, AND WHY IT IS SITED IN `monitor.rs`
+
+`slope_clause_stays_hard` is a `const fn` whose body is a `match` over all three
+`CorpusLevelDisposition` variants **with no `_` wildcard arm**. `main.rs` re-types **no** disposition
+comparison of its own. Three properties, each load-bearing:
+
+1. **A FOURTH VARIANT FAILS TO COMPILE (E0004).** The guard is `rustc`, not a reviewer's reading.
+   An inline `corpus.disposition == LevelEvaluated ∨ tombstones.passed` would enumerate nothing: a
+   fourth variant would silently fall into the *"slope stays hard"* side.
+2. **IT IS SITED WHERE AN INCLUDER ALREADY RUNS IT.** The graded assertion is a calibration test,
+   `calibration_slope_clause_hard_for_every_non_evaluated_disposition`, in `monitor.rs`'s existing
+   inline `#[cfg(test)] mod tests`. `monitor.rs` is `#[path]`-included by
+   `tests/soak_monitor_calibration.rs:15-17` (and, under §F11, by `tests/soak_wal_census.rs`), so
+   the test runs under `cargo test --all-targets` with **no** new `mod`, **no** new `.rs` and **no**
+   edit to any includer.
+3. **IT COULD NOT HAVE BEEN SITED OVER `main.rs`'s GATE EXPRESSION — a VERIFIED FACT, not a
+   preference.** At HEAD **no `tests/` target `#[path]`-includes `main.rs`** (the complete includer
+   set is `soak_or_noloss.rs` → `or_noloss.rs`; `soak_wal_census.rs` → `report.rs`;
+   `soak_monitor_calibration.rs` → `monitor.rs`; `soak_tombstone_restart.rs` → `or_noloss.rs` +
+   `client.rs` + `process.rs`), and `main.rs` has **no** inline `#[cfg(test)] mod tests`.
+
+The test asserts, over an array literal of all three variants, that
+`slope_clause_stays_hard(LevelEvaluated) == false` and that it is `true` for `LevelSuppressed` and
+`InstrumentFailed`; and separately that an `InstrumentFailed` assessment already carries
+`passed == false`, so that variant fails through the FIRST conjunct and never depends on the
+fallback.
+
+**NO NEW MUTATION ARM IS OWED HERE, and that is stated rather than left as a gap.** The fallback
+conjunct is a **wiring** term, not an estimator term:
+
+- **Constructibility:** the 25 s blocking Soak Smoke run reaches the fallback branch on every
+  execution — one corpus sample ⇒ `LevelSuppressed` ⇒ the slope conjunct is live. `AC21` asserts
+  that over the rendered line, so the branch is demonstrably reachable, never vacuous.
+- **Fireability:** the slope clause's ability to FAIL is already proven by the four pre-existing,
+  unchanged calibration tests (`monitor.rs:877`, `:897`, `:916`, `:1032`), kept green and
+  arithmetic-unchanged (`C8`).
+- **Exhaustiveness:** the falsifier is the compiler. An arm on an exhaustiveness property would
+  have to *remove* exhaustiveness (add a `_ =>` arm), which is a refactor, not a mutation of an
+  assertion, and would RED nothing. **The honest statement is that this carries a compile-time
+  falsifier and no mutation arm — a different claim from "unfireable by construction", and not
+  that one.**
+
+## §F7 — THE `"HARD gate"` DOC-CONTRACT CENSUS
+
+The sweep is **census-driven**, not memory-driven: a demotion that corrects the sites an author
+happens to remember and leaves the rest asserting a gate that no longer exists produces exactly the
+false-invariant hazard this lineage keeps catching. Both files are `SPEC-361a`'s, so the census does
+not straddle the carve.
+
+> **COUNTS ARE NORMATIVE; LINE NUMBERS ARE DESCRIPTIVE.** Every HEAD line number below **will
+> shift** once the prefix constant, the `FINISHED_REASON_DURATION_REACHED` constant, the shared
+> `Vec<CorpusSample>` and the sampler land. A shifted number is **NOT** a review failure. **A census
+> site is identified by its TEXT and its owning item, never by its line number**; what is graded is
+> the COUNT plus the classification.
+
+**The pinned command and its pinned HEAD count at `20edabde`:**
+
+```
+grep -nE 'HARD gate|hard gate|hard-gate' \
+  packages/server-rust/benches/soak_harness/monitor.rs \
+  packages/server-rust/benches/soak_harness/main.rs
+```
+⇒ **30 matching lines across 2 files at HEAD: `monitor.rs` 12, `main.rs` 18.**
+
+### TABLE 1 — THE HEAD SITES (30), classified
+
+| File | Lines (grep hits, DESCRIPTIVE) | Disposition |
+|---|---|---|
+| `monitor.rs` | `:69`, `:81`, `:88`, `:91` (passage `:91-94`) | **CORRECT** — module-doc *"Note on gating responsibility"*; must state the conditional role, and must keep the blind-monitor sentence (`:88`) unchanged in substance |
+| `monitor.rs` | `:325`, `:330` | **CORRECT** — `DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR`'s doc-contract |
+| `monitor.rs` | `:345`, `:355`, `:357` | **CORRECT** — `DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS`'s doc-contract; the guard is now *also* what selects the fallback class |
+| `monitor.rs` | `:1029`, `:1046` | **CORRECT** — `calibration_additive_only_gauge_never_plateaus`'s doc + assert message |
+| `monitor.rs` | `:1236` | **OUT OF SCOPE — DISK** (`C7`). Byte-unedited. |
+| `main.rs` | `:25`, `:34` | **CORRECT** — module-doc property 3; `:34` is the blind-monitor sentence and stays true |
+| `main.rs` | `:45` | **CORRECT** — module-doc, the two controls |
+| `main.rs` | `:165` | **CORRECT** — `Config::no_ack`'s doc |
+| `main.rs` | `:790` | **CORRECT** — the assess-tombstone-bytes call-site comment |
+| `main.rs` | `:803`, `:826` | **CORRECT** — the rationale block `:803-829`; `:826`'s blind-monitor sentence stays true |
+| `main.rs` | `:869` | **CORRECT** — the FAIL arm `:868-880`. Becomes **rank 4 of the single ranked writer** (§F14); re-worded onto the conditional role, assertion text kept verbatim in substance. **One arm, not two.** |
+| `main.rs` | `:1051`, `:1056` | **CORRECT** — the summary-line comment and `let tombstone_role = "slope + blind-monitor both hard-gate";`, whose **string value** must now render the conditional role (`X21-a`) |
+| `main.rs` | `:1095` | **CORRECT — TEXT ONLY.** A DISK comment making a claim *about the tombstone slope*, so the claim goes false. Only that clause is re-worded; **no disk predicate, constant, assessment or gate conjunct is touched** (`C7`). |
+| `main.rs` | `:2426` | **CORRECT** — the `--help` usage text (`# tombstone hard-gate must FAIL`), operator-visible |
+| `main.rs` | `:2128`, `:2185` | **REVIEW; correct if false, else record as already-true.** Tracked-client comments naming *"the promoted hard gate"* generically. |
+| `main.rs` | `:16` | **OUT OF SCOPE — QUERY/recovery gate**, not tombstone. Byte-unedited. |
+| `main.rs` | `:838`, `:1099`, `:1100` | **OUT OF SCOPE — DISK** (`C7`). Byte-unedited. |
+
+**In scope: 25 lines (11 `monitor.rs` + 14 `main.rs`). Out of scope: 5 lines.**
+`11 + 14 + 1 + 4 = 30`, so **Table 1 is exhaustive over the pinned grep AT HEAD**.
+
+**NO HEAD SITE IS DEMOTED OUT OF THE CENSUS — `demoted = 0`, and that is a RULE, not an
+observation.** Every one of the 25 in-scope sites is re-worded **in place**, and **each re-wording
+MUST RETAIN one of the three pinned phrases** (`HARD gate` / `hard gate` / `hard-gate`). A
+correction that deletes the phrase would silently shrink the census and remove the site from every
+future re-run of the sweep. The 5 out-of-scope sites are byte-unedited and retain their phrases
+trivially. **Therefore the HEAD contribution to the post-edit count is `30 − 0 = 30`.**
+
+### TABLE 2 — `AUTHORED-BY-361a`: THE SIX LINES THIS SPEC ITSELF WRITES
+
+Pre-registered with their **exact text**, because a HEAD-only census would make a correct
+implementation RED its own gate.
+
+| # | File | Item that carries it | EXACT authored text (the grep-matching line) |
+|---|---|---|---|
+| `A1` | `monitor.rs` | `assess_tombstone_corpus_level`'s doc-contract | `/// L0 and L1 are HARD gate clauses; L1 only when its two guards are met.` |
+| `A2` | `monitor.rs` | `slope_clause_stays_hard`'s doc-contract | `/// Whether the tombstone-byte SLOPE clause still hard-gates a run that` |
+| `A3` | `monitor.rs` | `CorpusLevelDisposition::LevelSuppressed`'s variant doc | `/// L1 was NOT evaluated, so the slope clause hard-gates instead. Never "ok".` |
+| `A4` | `main.rs` | the comment above the re-pointed verdict conjunction | `// The durable-corpus verdict is the HARD gate; the slope clause hard-gates` |
+| `A5` | `main.rs` | `--tombstone-corpus-ceiling-bytes`'s `--help` usage line | `//   --tombstone-corpus-ceiling-bytes <n>  arm L2's absolute HARD gate ceiling` |
+| `A6` | `main.rs` | the ranked writer's rank-4 branch comment | `// Rank 4: the slope clause, which hard-gates only when L1 did not decide.` |
+
+**Distribution: `monitor.rs` +3 (`A1`–`A3`), `main.rs` +3 (`A4`–`A6`).** Each states the
+**conditional** role by construction; none asserts an unconditional hard gate.
+
+### THE POST-EDIT COUNT IS NORMATIVE
+
+**`30 − demoted + authored = 30 − 0 + 6 =` 36.**
+
+> **Re-running the pinned grep on the branch MUST return exactly `36` matching lines across the same
+> 2 files — `monitor.rs` `12 + 3 = 15`, `main.rs` `18 + 3 = 21`, `15 + 21 = 36`. The count is
+> NORMATIVE. Every line number in either table is DESCRIPTIVE.**
+
+Exhaustiveness arithmetic over the branch: **25 in-scope HEAD sites (re-worded, phrase retained) + 6
+authored sites + 5 out-of-scope byte-unedited sites = 36.**
+
+**THE CENSUS RULE, NORMATIVE:**
+
+> **Every hit the pinned grep returns on the branch is classified either by TABLE 1 (a HEAD site,
+> matched by its TEXT and owning item, never by its line number) or by TABLE 2
+> (`AUTHORED-BY-361a`). An UNCLASSIFIED hit is a RED, not a judgement call — but a line THIS SPEC
+> ITSELF WROTE is never unclassified, because authoring it is what classifies it. What the rule
+> forbids is an unaccounted line, not a new one.**
+
+Two corollaries: a Table 1 line classified `CORRECT` that still reads *"is now a HARD gate"*
+unconditionally is a **RED**; and an authored line whose delivered text differs from its
+pre-registered text is **still classified** (it is `AUTHORED-BY-361a` by construction), but the
+divergence is **recorded in this artifact's post-section with its reason** and Table 2 is corrected
+in the same edit.
+
+*(`assess_tombstone_bytes`'s own doc-contract `monitor.rs:390-401`, incl. `:397`, already says
+*report-only* and contains no grep hit — recorded so a reader does not mistake its absence for an
+omission. It is **already correct** in the `L1`-evaluated case.)*
+
+## §F8 — THE ANTI-TAUTOLOGY TABLE `AT`
+
+*A gate that cannot fail is worse than no gate.* Frozen before any control run.
+
+**How the bar is demonstrated — BOTH, split by what each can prove:**
+
+- **Synthetically**, as calibration unit tests in `monitor.rs` (`W1`–`W4`, the slow-ramp test `W5`,
+  the armed-ceiling test `W9`). Cheap, deterministic, runs in CI forever — but proves the
+  **estimator**, not the wiring.
+- **Live**, as **three SHORT control runs of the real harness** (`D = 900 s` each, the same `D` for
+  all three, inside §F2's admissible range, at the harness **default `--crash-interval 120`**,
+  `main.rs:205`): `--no-ack`, `--inject-slow-leak`, and a **NEUTRAL** run with neither flag at the
+  identical duration and crash interval. Proves the **wiring**. The neutral run is the attribution
+  control: without it, a `--no-ack` FAIL cannot be distinguished from *"any run of this duration
+  fails."*
+- **And, for the two CLI knobs only,** §F13's two 25 s PROBE invocations — not a control leg, not a
+  measurement, bounded by `C9`.
+
+**Why `--crash-interval 120` and not 60, decided in the open and before the runs.** Each checkpoint
+costs a quiesce + `kill -9` + restart + ready-wait, and every second of it is wall time **not** spent
+driving OR churn — which is the growth the `--no-ack` cell must produce. At `D = 900 s`,
+`--crash-interval 60` forces ~15 such cycles; the default 120 forces 7, halving the overhead and
+returning it to churn, while still clearing **both** `L1` guards with margin: **8 samples** against
+`min_samples = 4`, and **`span_secs ≈ 780 s`** against `min_span_secs = 600`. Since `C11` forbids
+retuning `headroom_bytes` after the fact, the **cell parameters are the only honest lever**, and
+they are chosen for maximum churn **subject to admissibility** — never to change a verdict.
+
+**These control runs are NOT a measurement lineage (`C9`).** No pin, no matrix, no width sweep, no
+fit, no CSV segments, no manifest §-append, no replicate. Their **only** publishable outputs are the
+exit code, the rendered `tombstone_corpus_redb_scan:` line and the `finishedReason`. **Their numbers
+may not be quoted as evidence about the plateau, the reclaim fraction, or any width** (`C10`).
+
+### HOW `AT` IS GRADED — CONJUNCTIVE, over three transports
+
+No one transport is sufficient. An exit code alone cannot distinguish an `L1` breach from an `L0`
+breach or from a `mem` / `convergence` / `recovery` / `panic` failure, so a row reading *"FAILS on
+`L1`"* is **not** decidable on the exit code by itself. Every `AT` row's *"FAILS on `L1`"* means the
+**conjunction** of all three, and any row where the three disagree is `AT-0` (inadmissible), never a
+judgement call:
+
+1. **exit code** (`X21-c`) — `1` for FAIL, `0` for PASS (`i32::from(!passed)`, `main.rs:1010`);
+2. **rendered `disposition`** (`X21-a`) — must read `LevelEvaluated` on the rendered
+   `tombstone_corpus_redb_scan:` line (`InstrumentFailed` ⇒ the FAIL is `L0`'s, not `L1`'s;
+   `LevelSuppressed` ⇒ `L1` decided nothing ⇒ `AT-0`);
+3. **`finishedReason`** (`X21-b`, persisted in `SoakReport`) — must name the level clause.
+
+### THE PERMITTED AGGREGATE TRANSPORT
+
+Pre-registered here because `AT-2` is graded on it and `C9` forbids the per-sample series. **The only
+series-derived quantities any `AT` row may rest on** are the four aggregates frozen on the assessment
+and rendered on the line — **count** (`samples`), **min** (`min_bytes`), **max** (`peak_bytes`) and
+**last** (`last_bytes`) — plus `first_bytes`, the two half-peaks, `rise_bytes` and `span_secs`. **No
+`AT` row may be stated over anything else.** A conjunct that cannot be expressed over this list is
+re-scoped to what the list carries, or struck — no unevaluable conjunct survives to grading.
+
+### The table
+
+| Row | Antecedent (frozen) | Verdict | Consequence |
+|---|---|---|---|
+| **`AT-0`** | Any control run is **INADMISSIBLE**: its corpus series has `samples < min_samples` or `span_secs < min_span_secs` (so `L1` was SUPPRESSED and decided nothing), or the harness itself failed for a reason unrelated to the gate | `NOT-DEMONSTRATED-LIVE` | **Evaluated FIRST, fail-closed.** The permitted single re-run depends on WHICH guard fell short: a **`samples` shortfall** re-runs **once** at `--crash-interval 60` (≈ 15 checkpoints, same span); a **`span_secs` shortfall** cannot be fixed by any crash interval — the lever is the cell's duration, and the cells already run at the `C9` ceiling `D = 900 s` (the TOP of §F2's range), so **there is no duration lever left**: a `span_secs` shortfall at `D = 900` means something other than the duration is wrong and the re-run is spent at the SAME `D = 900` after that cause is identified. **A re-run at any `D < 730 s` is FORBIDDEN — inadmissible by construction.** If still inadmissible, take the **non-promotion** disposition. A `SUPPRESSED` clause is not a pass, and this row exists so it can never be read as one. |
+| **`AT-1`** | `--no-ack` **FAILS** on `L1` ∧ `--inject-slow-leak` **FAILS** on `L1` ∧ NEUTRAL **PASSES** | `BAR-MET` | **PROMOTE.** `L1` ships as the hard gate, **with §F5's fallback conjunct intact** — promotion never removes the slope clause from the class `L1` cannot cover. Publish the three rendered lines. |
+| **`AT-2`** | `--no-ack` **FAILS** on `L1` ∧ NEUTRAL **PASSES** ∧ `--inject-slow-leak` **PASSES** | `BAR-MET-PARTIAL — SLOW-LEAK RECLASSIFIED` | **PROMOTE, conditionally**, with the reclassification published as the headline secondary finding. Rationale, pre-registered: `--inject-slow-leak` is a **bounded ramp-then-catch-up** (`main.rs:121-126` — cadence doc `:121-125`, `SLOW_LEAK_ACK_INTERVAL` const `:126`; flag doc `:167-173`) authored to calibrate a **RATE** detector's floor. A bounded sawtooth **attains a ceiling**, so a ceiling gate passing it is the semantically correct answer, not blindness. **Conditional on two conjuncts, both mechanical and both stated over the PERMITTED AGGREGATE TRANSPORT above:** (a) the slow-leak run's rendered line shows `rise_bytes ≤ headroom_bytes` **AND** (`peak_bytes > last_bytes` **OR** `min_bytes < first_bytes`) — the evaluable form of *"the level fell at least once"*; a monotone non-decreasing series has `peak == last` and `min == first`, so the pair is a genuine discriminator, not a tautology, and the pass must be *earned* by boundedness; (b) the slow-ramp discrimination test (`W5`) is green, proving an *unbounded* ramp of the same per-hour magnitude, run long enough, DOES breach `L1`. Route to `TODO-634` **by id** whether a bounded-but-elevated plateau should red the gate — that is `L2`'s job, and `L2` is disarmed here for want of a validated ceiling. **`headroom_bytes` is NOT lowered to force a FAIL.** |
+| **`AT-3`** | `--no-ack` **PASSES**, **or** NEUTRAL **FAILS** | `ANTI-TAUTOLOGY-FAILED` | **NO PROMOTION.** The estimator ships **REPORT-ONLY** and the slope clause **stays hard UNCONDITIONALLY** at `main.rs:853` — the fallback conjunct becomes the *only* form, i.e. `tombstones.passed` is ANDed with **no `slope_clause_stays_hard(...)` guard in front of it** (the helper stays, unused by the gate but still asserted by its test, so the exhaustiveness proof is not lost with the guard) — so the branch is a strict addition and the gate is not weakened in any run class. Publish the failure with all three rendered lines, and route the cause to `TODO-634` by id. **Do NOT retune any parameter** — retuning to make a control fail is the mirror image of retuning to make one pass, and both are the anti-suppression defect (`C11`, `KL-4`). |
+
+**A PASSING gate on the `--no-ack` control run is a RED for this spec**, and `AT-3` is what that RED
+does. Written before the runs so it is not decided at the keyboard.
+
+**`AT-3` and `Assumptions 6` are NOT in tension.** `Assumptions 6` says the gate is EXPECTED to RED
+at the **PRODUCTION epoch width** until the prune fix lands. **The control leg is not run at the
+production epoch width** — it runs at the harness default (`effective_epoch_width()`), at
+`D = 900 s`, with the default keyspace and churn. So a NEUTRAL **FAIL** on the control leg is **not**
+the expected production-width RED; it means the cell fails without any control applied, which is
+precisely what destroys attribution and is what `AT-3` fires on. Conversely, a production-width RED
+**cannot** be quoted as an `AT-3` event, because no production-width cell is run here (`C9`).
+
+**The third transport is §F14's SINGLE ranked writer and nothing else.** Every `AT` row's *"FAILS on
+`L1`"* reads `finishedReason` as produced by that one writer, whose rank-3b branch is the level
+clause. There is **one** reason-producing arm for the corpus verdict, not two, so a `--no-ack` cell
+that breaches `L1` **and** the slope clause names the **level** clause — the three-way agreement
+`AT` grading requires is a property of the writer's pinned ranking, not a coincidence of source
+order.
+
+## §F9 — THE WITNESS REGISTER `W1`–`W9`
+
+*A green test is an earned negative only if its mutation arm REDs the assertion it is sited on.*
+The register below is the **whole** register across **both halves** — restated here in full,
+including `W6` and `W7`, which `SPEC-361b` owns, specifically so neither half can silently inherit
+the struck figure "fourteen".
+
+> **LIVE FIGURE: `9 witnesses / 9 arms / 18 legs / 9 transcripts`, split `6 + 3 = 9` /
+> `12 + 6 = 18` / `6 + 3 = 9`. Read the SPLIT, not the totals** — the totals coincide with
+> `Response v1`'s while the composition does not.
+>
+> **STRUCK everywhere, in both halves: "fourteen"; the `5 + 4` / `10 + 8` splits; the `4 + 5` /
+> `8 + 10` splits; and the interim `8 / 16 / 8`.**
+
+| W | Owner | What it proves | Site | Mutation | Must RED |
+|---|---|---|---|---|---|
+| `W1` | **361a** | `L1` discriminates a linear durable-corpus leak | `monitor.rs` calibration | replace `last_half_peak − first_half_peak` with `last_half_peak − last_half_peak` (identically 0) | `calibration_fails_linear_corpus_level` |
+| `W2` | **361a** | `L1` does not false-RED a genuine ramp-then-plateau | `monitor.rs` calibration, **FROZEN FIXTURE `F-W2`** | compare `last_half_peak` against the series' **first** sample instead of the first-half peak (a level-vs-origin test) | `calibration_passes_plateau_after_ramp` |
+| `W3` | **361a** | `L0` fails closed on a failed scan | `monitor.rs` calibration, **FROZEN FIXTURE `F-W3`** | replace the `scans_failed > 0` disjunct with `false` | `calibration_fails_on_failed_scan` |
+| `W4` | **361a** | `L0` distinguishes an honest `Some(0)` from a blind `None` | `monitor.rs` calibration | treat a `bytes == 0` sample as a failed scan | `calibration_passes_honest_empty_corpus` |
+| `W5` | **361a** | `L1` is not blind to a **slow** unbounded leak — the conjunct `AT-2` rests on | `monitor.rs` calibration | raise the synthetic ramp's duration/rate coupling so the series' rise falls under the headroom | `calibration_fails_slow_unbounded_ramp` |
+| `W6` | **361b** | pin 7: one epoch of implicit retention at margin 0, and the delivered clamp | `tombstone_frontier_impl.rs` `mod tests` | (a) `ceiling > e` → `ceiling >= e` at `:963`; (b) drop `.min(delivered)` at `:420` | (a) **assertion 2 ONLY** — the `D`-retained / `D − 1`-drained read of the DRAINED SET; (b) **assertion 3** — the same-ceiling-under-over-claim read |
+| `W7` | **361b** | pin 6: an under-stating boot floor is the safe direction | `reclamation_registry.rs` proptest | **(b) ONLY** — `None => self.boot_floor` → `None => Epoch::MAX.saturating_sub(self.boot_floor)` at `:656`. **Two mutants RETIRED by `SPEC-361b`'s Response v2**: the fold's `min → max` at `:646`, and the former arm (a) | **`P2` and nothing else.** `P1` and `P3` are inherited coverage and carry NO registered arm |
+| `W8` | **361a** | the live gate is attributable to the control, not to the duration | the control leg | none — `W8` is the **NEUTRAL run itself**. Its non-firing is the arm. | `AT-3` fires if NEUTRAL FAILS |
+| `W9` | **361a** | **`L2` fires as an ENVELOPE test (peak, not last), and both CLI knobs are effective over the rendered transport** | `monitor.rs` calibration, **FROZEN FIXTURE `F-W9`**; transport limbs at `tests/soak_wal_census.rs`'s fixture (`ceilingBytes` non-null) and §F13's probe pair | replace `L2`'s breach predicate `peak_bytes > c` with **`last_bytes > c`** | `calibration_fails_armed_ceiling` |
+
+### FROZEN FIXTURE MAGNITUDES
+
+Pinned here because this layer's digest closes them under `C11`, and because an unfrozen fixture
+makes an arm silently non-discriminating. Each is stated as the property the arm needs, then as the
+magnitude that delivers it.
+
+- **`F-W2` (ramp-then-plateau; must NOT false-RED, and its arm MUST RED).** The arm compares the
+  last-half peak against the **first sample** instead of the first-half peak, so it only REDs if
+  **the ramp's total height from the first sample exceeds `headroom_bytes` while the half-to-half
+  rise does not.** Frozen: **8 samples, 90 s apart** (`span = 630 s ≥ 600`); first sample
+  **10,000 B**; the series ramps to **300,000 B** by sample 4 and then plateaus flat at
+  **300,000 B** for samples 5–8. Half-peaks: first-half **300,000**, last-half **300,000** ⇒
+  `rise = 0 ≤ 65,536` ⇒ the test PASSES as required. Under the arm:
+  `300,000 − 10,000 = 290,000 > 65,536` ⇒ **REDs**.
+  **Frozen relationship: `ramp_height − first_sample > headroom_bytes` AND
+  `last_half_peak − first_half_peak = 0`.**
+- **`F-W3` (failed scan; `L0` fail-closed).** The arm replaces the `scans_failed > 0` disjunct with
+  `false`, so it only REDs if **the surviving `samples == 0` disjunct does NOT also fire.** Frozen:
+  **`scans_attempted = 5`, `scans_failed = 1`, `samples = 4`** — explicitly `samples >= 1`, and in
+  fact `>= min_samples`, with `span = 630 s ≥ 600` — so with `L0`'s scan disjunct disarmed the
+  assessment would evaluate `L1` on a flat series and **PASS**. An *"all scans failed, no samples"*
+  fixture is **FORBIDDEN for `W3`**: it leaves `samples == 0` firing and the arm silently
+  non-discriminating — exactly the defect the register exists to catch.
+- **`F-W9` (armed ceiling; envelope semantics).** The arm replaces `peak_bytes > c` with
+  `last_bytes > c`, so it only REDs if **the peak exceeds the ceiling while the last sample does
+  not**, and the FAIL must be attributable to `L2` and not to `L1`. Frozen: **8 samples, 90 s
+  apart** (`span = 630 s ≥ 600`); `ceiling_bytes = Some(100_000)`; the series peaks at
+  **200,000 B** inside the **first** half and decreases monotonically to **50,000 B** at the last
+  sample. Then `first_half_peak = 200,000` and `last_half_peak < 200,000` — on a non-increasing tail
+  the last-half peak cannot exceed the first-half peak — so `rise = 0` (saturating) ⇒ **`L1`
+  PASSES**, `disposition = LevelEvaluated`, and `peak_bytes = 200,000 > 100,000` ⇒ **`L2` FAILS the
+  run**. Under the arm, `last_bytes = 50,000 ≤ 100,000` ⇒ no breach ⇒ **REDs**.
+  **Frozen relationship: `peak_bytes > ceiling >= last_bytes` AND
+  `last_half_peak − first_half_peak = 0`.**
+
+### THE ARM ARITHMETIC — the only correct count, IDENTICAL in both halves
+
+The register holds **9 witnesses** and **9 mutation arms**: `W1`–`W5` one arm each (5), `W6` two
+(a/b), `W7` **one** (b, after `SPEC-361b`'s retirement of arm (a)), `W8` none, **`W9` one**.
+`5 + 2 + 1 + 0 + 1 = 9`, derived from the rows above and from nothing else. Under **apply + revert**
+counting that is **18 legs**.
+
+**A "transcript" is defined here so the count is not re-derivable two ways:** one transcript = **one
+ARM**, and it contains **both** legs — the applied mutation with its RED output, and the revert with
+its green re-run. So the two halves together hold **9 transcripts covering 18 legs**, not 18
+transcripts.
+
+### ARM OWNERSHIP AND EXECUTION HOME
+
+`G2` **authors** this half's witnesses (the tests) and writes no transcript and applies no mutation;
+**`G6` is the sole execution home** for this half's arms and the sole writer of
+`spec361a-witness-arm.txt`.
+
+- **THIS HALF (`SPEC-361a`) OWNS AND EXECUTES 6 ARMS** — `W1`–`W5` one each, plus `W9`'s — recorded
+  as **6 transcripts covering 12 legs** in `spec361a-witness-arm.txt`.
+- **`SPEC-361b` OWNS AND EXECUTES 3 ARMS** — `W6` (a)/(b) and `W7` (b) — recorded as **3 transcripts
+  covering 6 legs** in `spec361b-witness-arm.txt`. *(Its former `W7` arm (a) is RETIRED.)*
+- `W8` has no arm in either half; it is the NEUTRAL control run, which is **this half's**.
+- **`6 + 3 = 9` arms, `12 + 6 = 18` legs, `6 + 3 = 9` transcripts.** Neither half may report the
+  joint figure as its own, and neither may report only its own figure as the register's total.
+
+## §F10 — TYPE-MAPPING RULES, AND WHAT SERIALIZES
+
+`CorpusSample.bytes`, every `*_bytes` field and `headroom_bytes` / `ceiling_bytes` are **`u64`** —
+counted byte totals are non-negative integers, never `f64`. `elapsed_secs` and `span_secs` are
+`f64` (genuinely fractional wall-clock). `samples` / `scans_*` are `usize` (in-process collection
+counts, never serialized as a wire integer type). `CorpusLevelDisposition` is an **enum**, not a
+`String`. No struct carries a `type` / `r#type` field.
+
+`TombstoneCorpusReport` derives `Serialize` with **`#[serde(rename_all = "camelCase")]`**, mirroring
+`TombstoneReport` (`report.rs:43`). It does **not** cross the MsgPack wire (JSON report only), so
+`PROJECT.md`'s `to_vec_named()` clause has no subject. **Its frozen field list:**
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TombstoneCorpusReport {
+    pub scans_attempted: usize,
+    pub scans_failed: usize,
+    pub samples: usize,
+    pub first_bytes: u64,
+    pub min_bytes: u64,
+    pub peak_bytes: u64,
+    pub last_bytes: u64,
+    pub first_half_peak_bytes: u64,
+    pub last_half_peak_bytes: u64,
+    pub rise_bytes: u64,
+    pub span_secs: f64,
+    /// Serialized as an explicit string, never omitted. Typed as the ENUM, not
+    /// a `String` — see the serializer note below.
+    #[serde(serialize_with = "serialize_disposition")]
+    pub disposition: CorpusLevelDisposition,
+    /// `null` when L2 is DISARMED. EXPLICIT — no `skip_serializing_if`
+    /// (PROJECT.md: no skip on a disposition-bearing field).
+    pub ceiling_bytes: Option<u64>,
+    pub passed: bool,
+    /// `null` when the assessment named no reason. EXPLICIT.
+    pub reason: Option<String>,
+}
+```
+
+### The `std`-only hazard, and its resolution
+
+`CorpusLevelDisposition` reaches the JSON as an **enum-valued field, not a `String` field — and
+WITHOUT putting serde into `monitor.rs`.** The enum **derives no `serde`**, because `monitor.rs` is
+`#[path]`-included by `tests/soak_monitor_calibration.rs:15` and that includer's header records the
+module as **`std`-only** (`:10`); a `Serialize` derive there would break that constraint and `AC1`
+with it. Instead the enum carries a hand-written `pub const fn as_str(self) -> &'static str`, and
+`report.rs` — which already depends on serde — serializes the field through
+`#[serde(serialize_with = "serialize_disposition")]`, a three-line fn that emits `value.as_str()`.
+
+The JSON therefore reads `"LEVEL_EVALUATED"` / `"LEVEL_SUPPRESSED"` / `"INSTRUMENT_FAILED"`, the
+**field stays enum-typed** (`PROJECT.md`'s *enums over strings* honoured), and `main.rs`'s console
+line renders the **same** `as_str()` token, so the two transports cannot disagree and neither retypes
+a literal. The **assessment** and the **enum** derive no `serde`; only the **report** does, and it
+reaches the enum through a serializer fn on its own side of the `std`-only boundary.
+`TombstoneCorpusAssessment` remains in-process only.
+
+**The symmetry (`KL-6`), stated as a general rule rather than a one-off:**
+
+> **ANY new cross-module reference between two `benches/soak_harness` modules obliges EVERY `tests/`
+> target that `#[path]`-includes either module to declare the sibling `mod` — and that declaration
+> is a COUNTED `.rs` edit, never a `PROJECT.md` shape.**
+
+Moving `CorpusLevelDisposition` into `report.rs` would not remove the obligation; it would move the
+break onto the calibration target and drag serde across the `std`-only boundary. The break is
+**symmetric**; only the direction of the required `mod` moves. This half keeps the type in
+`monitor.rs`, which is the direction that keeps `monitor.rs` `std`-only.
+
+### `#[derive(Default)]` IS DELETED — the ONE recorded departure
+
+`PROJECT.md`'s *"`Default` derived on payload structs with 2+ optional fields"* item would apply
+(`ceiling_bytes`, `reason`). It is dropped for two reasons:
+
+- **Mechanical:** a derived struct `Default` requires **every** field type to implement `Default`,
+  and `CorpusLevelDisposition` deliberately does not. As frozen it would not compile (E0277). No
+  sibling report struct derives `Default` either (`report.rs:42`, `:56`, `:80`, `:89`).
+- **Semantic, and decisive:** a **defaulted report is itself the invisible-pass hazard `KL-5`
+  forbids.** A `TombstoneCorpusReport` that exists without an explicitly-constructed disposition
+  claims *something* about a gate that decided *nothing*. **Every `TombstoneCorpusReport` is
+  constructed explicitly, with its disposition, from a `TombstoneCorpusAssessment`** — one
+  construction site in `main.rs`, one fixture site in `tests/soak_wal_census.rs`, both naming every
+  field.
+
+`PROJECT.md`'s Auditor Checklist item says *"should"*, so this is a **named, reasoned departure**,
+and it is the **ONE** departure this spec records.
+
+**DECLARED FALLBACK, to be taken ONLY if a serde/builder path genuinely requires `Default`:**
+`#[derive(Default)]` on `CorpusLevelDisposition` with **`#[default]` on `LevelSuppressed`** — the
+explicit NOT-EVALUATED variant, which is the honest neutral. **`#[default]` on `LevelEvaluated` is
+FORBIDDEN in every circumstance — that is precisely the invisible pass.** **WHICH ARM APPLIED: the
+PRIMARY (derive deleted).** After this digest, taking the fallback is a spec revision recorded in
+the post-section with its reason, surfaced to the user — never a keyboard substitution.
+
+### NO `skip_serializing_if` ON `ceiling_bytes` OR `reason` — COMPLIANCE, NOT A DEPARTURE
+
+`PROJECT.md`'s Auditor Checklist for Rust Specs carries the rule **"No `skip_serializing_if` on
+disposition-bearing fields"**: a field whose *absence* would be read as a disposition must always
+serialize. `ceiling_bytes`'s `None` **is** a disposition (*"L2 disarmed"*) and `reason`'s `None`
+**is** a disposition (*"the assessment named no reason"*), so both fall squarely inside the
+carve-out and **this spec cites the rule instead of recording a per-spec departure**.
+`skip_serializing_if` **omits the key entirely**, making *"L2 disarmed"* indistinguishable from
+*"this report predates the field"* — the invisible-suppression defect `KL-5` / `PD-F9` exist to
+forbid. §F1's `L2` row states the same shape, and the two agree.
+
+The rule was **promoted to `PROJECT.md` on its THIRD recurrence**: the archived parent recorded the
+departure, `C4a` re-recorded it, and Audit v3 found it being paid for a third time. `C4a` now
+records **ONE** departure — the `Default` derive — and this item as **compliance with the new
+rule**.
+
+## §F11 — THE CENSUS TARGET, AND ITS WAVE PLACEMENT
+
+`packages/server-rust/tests/soak_wal_census.rs` `#[path]`-includes `report.rs` as a standalone
+`mod report;` (`:43-45`) with **no sibling `mod monitor;`**. This half breaks that target in **two
+independent ways**, and both must be repaired in the same wave that lands them:
+
+1. **The type.** `TombstoneCorpusReport.disposition` is `CorpusLevelDisposition` (enum-typed — no
+   `String` downgrade) and `serialize_disposition` calls `as_str()`; both name a type defined in
+   `monitor.rs`.
+2. **The fixture, which breaks even WITHOUT the type.** `fn sample_report` (**`:319-378`**; its
+   exhaustive `SoakReport` literal is **`:320-377`**, `finished_reason` at `:375`) builds
+   `SoakReport` by **exhaustive struct literal** with no `..Default::default()` — its own comment
+   (`:347-349`) demands every value be *"DISTINCT and non-default on purpose"*. Adding **any** field
+   to `SoakReport` breaks it. This is why a `String`-typed field would not have saved the target,
+   and why `#[derive(Default)]` would not have either.
+
+**The repair, and its exact extent.** The target gains the three-line include block immediately
+above its existing `mod report;`, matching that file's own idiom (and
+`soak_monitor_calibration.rs:15-17`'s):
+
+```rust
+#[path = "../benches/soak_harness/monitor.rs"]
+#[allow(dead_code)]
+mod monitor;
+```
+
+plus the `tombstone_corpus:` fixture value and the `tombstoneCorpus` assertions in
+`soak_report_emits_every_hard_anded_verdict_tracking_its_input` (`:390`). **Its `ceiling_bytes` is
+`Some(<distinct non-default n>)`, not `None`** — the one place in this half that drives the
+**non-null** `ceilingBytes` branch, and a `W9` limb: the `null` branch is graded by the control
+leg's rendered JSON, the non-null branch by this fixture, so **both** `L2` states reach a transport.
+
+**Ledger:** this is **counted headroom, NOT an exemption.** The cap is **5** and this half was at 3,
+so it goes to **4/5 with ZERO exemptions**. **No `PROJECT.md` shape is invoked, cited or needed — a
+COUNTED file needs no shape.** In particular it is **not shape 4**, which explicitly excludes *"a
+new `mod`"* (`PROJECT.md:205`) and is bounded to a single additive `#[test]` fn with no production
+edit; this repair adds a `mod`, edits an existing fixture fn and an existing test fn, so **three**
+of shape 4's bounds are exceeded.
+
+**Known, accepted side effect:** with `mod monitor;` declared here, `monitor.rs`'s inline
+`#[cfg(test)] mod tests` compiles and RUNS in this target too, so the calibration tests execute in
+**two** targets. That is duplicated execution of identical assertions — no new assertion, no new
+arm, no change to `AC4`/`AC5`, whose subject stays `tests/soak_monitor_calibration.rs`.
+
+> **WAVE PLACEMENT IS NORMATIVE: this edit lands in `G4`, segment `S2`, in the SAME wave as
+> `report.rs`'s `TombstoneCorpusReport` and the `SoakReport` field. It may NOT be deferred to a
+> later wave** — between the wave that adds the `SoakReport` field and the wave that repairs the
+> fixture, `cargo test --all-targets` does not build, and a spec whose own gate cannot run between
+> waves is not orchestrable. `report.rs` and its `#[path]` includer travel together and may not be
+> split across segments.
+
+## §F12 — `X21`, DISCHARGED IN FOUR LIMBS
+
+*A knob's effective value is proven over the transport its consumer actually reads, not over an
+in-process accessor. `PD-F8` is the cautionary class.*
+
+- **`X21-a` — THE RENDERED SUMMARY LINE, anchored to the line that ACTUALLY EXISTS.** The gate's
+  verdict, its `disposition`, `first/min/peak/last`, both half-peaks, the `rise`, the `span`,
+  `scans_ok/failed`, **`headroom=<n>`** and `ceiling=disarmed|<n>` are asserted over the **rendered
+  line whose prefix at HEAD is `tombstone_corpus_redb_scan:`** (`main.rs:1082` for the `Some` arm,
+  `:1090` for the `None` arm), captured from a control run's stdout — not over
+  `TombstoneCorpusAssessment` in memory.
+  - **The name is NOT changed.** An earlier draft graded on a `tombstone_corpus:` prefix that does
+    not exist at HEAD and is not even a substring of the real one, so a grader grepping stdout would
+    have found nothing. Keeping `tombstone_corpus_redb_scan:` also avoids breaking any existing
+    operator grep. **What DOES change is the line's content and meaning** (report-only
+    positive-control cross-check → the gate's own verdict line), recorded in the Delta as the
+    operator-visible contract change it is.
+  - **NEVER a retyped literal.** Every assertion — Rust-side and shell-side — obtains the prefix from
+    the single source constant `TOMBSTONE_CORPUS_LINE_PREFIX`, **by name**, so a future rename REDs
+    loudly instead of missing silently. A grep whose pattern is a hand-typed copy of the prefix is a
+    **RED** at review, not a style note.
+- **`X21-b` — THE JSON REPORT.** `SoakReport.tombstoneCorpus` is asserted over the written report
+  file, because a failed run's console lives under `target/` and the committed artifact is the JSON.
+  It also carries `finishedReason`, the third conjunct of `AT` grading.
+- **`X21-c` — THE PROCESS EXIT CODE.** The one transport a CI gate actually consumes
+  (`i32::from(!passed)`, `main.rs:1010`). **NECESSARY but NOT SUFFICIENT for `AT` grading:** an exit
+  code cannot distinguish an `L1` breach from an `L0` breach or from a `mem` / `convergence` /
+  `recovery` / `panic` failure. What is forbidden is grading on an internal boolean: **a control leg
+  graded on an in-process `passed` field would be exactly `PD-F8`'s defect.**
+- **`X21-d` — THE TWO NEW CLI KNOBS**, `--tombstone-corpus-headroom-bytes` and
+  `--tombstone-corpus-ceiling-bytes`, discharged by §F13's probe pair over the transports their
+  consumers read: the **rendered line** carries `headroom=<n>` **and** `ceiling=disarmed|<n>` and
+  the pair renders **different** values for both tokens, so each knob is individually attributable
+  on the line; and the **exit code** flips between the two invocations, attributable to the
+  **ceiling** knob alone. `SPEC-361b`'s `X21` subject (the margin gauge) is untouched by this limb.
+
+*(The reclamation margin knob's own `X21` discharge — `topgun_reclamation_margin_epochs` on
+`/metrics` — was `SPEC-359`'s and belongs to `SPEC-361b`'s subject. This half neither re-discharges
+nor restates it.)*
+
+## §F13 — THE KNOB-EFFECTIVENESS PROBE PAIR (`X21-d`), AND IT IS NOT A MEASUREMENT
+
+Two invocations of the existing 25 s smoke shape (`--duration 25 --crash-interval 0`, the shape
+`rust.yml:470-478` already runs), differing **only** in the two knobs:
+
+| Probe | Flags | Expected on the rendered `TOMBSTONE_CORPUS_LINE_PREFIX` line | Expected exit |
+|---|---|---|---|
+| `P-armed` | `--tombstone-corpus-headroom-bytes 1 --tombstone-corpus-ceiling-bytes 1` | `headroom=1`, `ceiling=1`, `disposition=LEVEL_SUPPRESSED(n=1, span=…)` | **non-zero** — `L2` breaches (`peak_bytes > 1`) |
+| `P-slack` | `--tombstone-corpus-headroom-bytes 262144 --tombstone-corpus-ceiling-bytes 99999999999` | `headroom=262144`, `ceiling=99999999999`, same `disposition` | **0** — `L2` armed and not breached |
+
+**What the pair proves, and what it deliberately does NOT.**
+
+- **Both knobs are individually attributable ON THE LINE:** each renders its own token, and the two
+  invocations render different values for both tokens.
+- **The EXIT-CODE flip is attributable to the CEILING knob ALONE.** At `--crash-interval 0` there is
+  exactly one (terminal) corpus sample ⇒ `L1` is `SUPPRESSED` ⇒ **the headroom knob has no subject
+  in this probe**, stated rather than left to be inferred. The headroom knob's discharge is the
+  rendered `headroom=<n>` token, not the verdict.
+- **`C9` and `C10` bind these two invocations exactly as they bind the control leg.** Their **only**
+  publishable outputs are the two rendered tokens and the exit code. **No corpus magnitude from
+  either probe may be quoted as evidence about the plateau, the reclaim fraction, or any width**,
+  and neither is a replicate, a cell, a pin or a lineage.
+- **They are NOT `AT` inputs.** `AT` is graded on the three control cells and nothing else; a probe
+  exit code may never be substituted for a control cell's.
+- **`W9`'s mutation arm is NOT sited here** — it is sited on `calibration_fails_armed_ceiling` in
+  `monitor.rs`. The probes are the transport limb; the arm is the estimator limb. *A witness that
+  cannot fail is theater*, and `W9`'s ability to fail lives in the calibration test.
+
+## §F14 — `finished_reason`: ONE RANKED WRITER
+
+`AT`'s third transport (`X21-b`) is `finishedReason`, so its value must be a **decided** property of
+the run, not an artifact of source order.
+
+**What HEAD does, verified.** `finished_reason` is initialised to `"duration reached"` (`:618`) and
+then assigned by **independent, un-ranked `if` blocks, the last of which wins**: four in the verdict
+block — `:858` (memory, guard `:857`), `:864` (tombstone-byte monitoring blind, guard `:863`),
+`:874` (tombstone slope, guard `:868`), `:882` (disk monitoring blind, guard `:881`) — **and four
+EARLIER, in the run loop: `:629`, `:734`, `:738`, `:742`** (panic detected, convergence divergence,
+crash-recovery mismatch, panic detected). At HEAD the verdict block **overwrites** the earlier four,
+which is the same attribution defect one level up. The value reaches `SoakReport.finishedReason` at
+`:956` and the console at `:1024`.
+
+**What lands: the four verdict-block writes become ONE ranked, disposition-switched writer** — a
+single expression evaluated once, taking the **first arm that fires**. The four earlier-phase writes
+are **byte-unchanged**; the ranking governs whether the verdict writer may overwrite them.
+
+### THE `:618` DEFAULT BECOMES A NAMED CONSTANT
+
+Rank 0's guard switches on the sentinel *"has an earlier phase already written a reason?"*, and an
+earlier draft expressed that as `finished_reason != "duration reached"` — **a retyped magic
+string**, in the one spec whose rule is *never a retyped literal*. **VERIFIED AT HEAD:
+`"duration reached"` is a bare string literal at `main.rs:618` and there is NO named constant.** So:
+
+```rust
+/// The `finished_reason` a run carries when nothing wrote a breach reason.
+/// Single source of truth: the initialiser and the ranked writer's rank-0
+/// guard both take it from here, so rewording the default cannot silently
+/// disable rank 0.
+const FINISHED_REASON_DURATION_REACHED: &str = "duration reached";
+```
+
+`main.rs:618` becomes `let mut finished_reason = FINISHED_REASON_DURATION_REACHED.to_string();` and
+rank 0's guard becomes `finished_reason != FINISHED_REASON_DURATION_REACHED`. `main.rs` is already
+counted 2/4, so this costs nothing, and it follows the pattern `TOMBSTONE_CORPUS_LINE_PREFIX`
+establishes in the same file.
+
+**RECONCILIATION, because this contradicts an earlier claim of this spec.** `AC26` and Validation
+Checklist 8 previously asserted `:618` is byte-unchanged. It is **not**, and cannot be, if the
+sentinel comes from the source constant. The corrected split:
+
+- **`:618` — CHANGES**, in exactly one way: its literal is replaced by a reference to the constant.
+  **The VALUE is byte-identical** (`"duration reached"`), so no run's `finishedReason` string
+  changes and `C8` holds.
+- **the four EARLIER-PHASE writes at `:629`, `:734`, `:738`, `:742` — BYTE-UNCHANGED IN SUBSTANCE.**
+  They write breach reasons, not the default, so the constant has no subject there.
+- **`grep -c 'finished_reason = '` still returns 6** — the initialiser, the four earlier-phase
+  writes, and the single verdict writer. `6` is the post-edit count; HEAD's `9` is the baseline.
+- **`grep -c '"duration reached"'` ⇒ 1** (the constant's definition, and nowhere else).
+- **Line numbers in `AC26` and Checklist 8 are DESCRIPTIVE** — the constant lands above `:618` and
+  shifts all five.
+
+### THE PRECEDENCE, in full
+
+**BREACH REASONS TAKE PRECEDENCE OVER NORMAL COMPLETION, and an unrelated harness failure takes
+precedence over a gate verdict.**
+
+| Rank | Arm | Guard | Produces a reason? |
+|---|---|---|---|
+| **0** | **an EARLIER-PHASE reason is already set** (convergence divergence, crash-recovery mismatch, server panic — `:629`/`:734`/`:738`/`:742`) | `finished_reason != FINISHED_REASON_DURATION_REACHED` on entry to the verdict block — **the sentinel comes from the source constant, never a retyped literal** | **the writer does not fire at all**; the earlier reason survives |
+| **1** | **memory-growth failure** | `!mem.passed` | yes — `:858`'s text, unchanged |
+| **2** | **tombstone-byte MONITORING BLIND** | `blind_monitor` | yes — `:864`'s text, unchanged |
+| **3** | **the DURABLE-CORPUS arm**, itself disposition-switched: **3a** `InstrumentFailed` ⇒ `L0`'s reason; **3b** `LevelEvaluated` ⇒ the **level clause's** reason | `!corpus.passed` | yes — **NEW**; 3b is the text `AT` grades on |
+| **4** | **tombstone SLOPE breach — the FALLBACK arm** | `corpus.disposition != LevelEvaluated && !tombstones.passed` | yes — `:874`'s text, kept **verbatim in substance**, as the ONE writer's rank-4 branch |
+| **5** | **disk MONITORING BLIND** | `disk_blind_monitor` | yes — `:882`'s text, unchanged |
+| **6** | **disk SLOPE** | `!disk.passed` | **NO** — report-only; it appends to `pending_gates` (`:886-896`), is not a `finished_reason` writer at HEAD and is not made one (`C7`; `SPEC-348` owns it) |
+| **7** | **panic report** | `panic_report.is_some()` | **NO** — its transports are the `panicReport` field and the stderr dump (`:897-902`); unchanged. Ranked for exhaustiveness so no reader assumes a silent arm |
+| **8** | **normal completion** | no arm above fired | **NO** — the `:618` default, now `FINISHED_REASON_DURATION_REACHED`, stands with its value byte-identical |
+
+**Three properties, each load-bearing:**
+
+- **Rank 4's guard is what makes the demotion coherent on the reason transport.** When
+  `disposition == LevelEvaluated`, the slope is report-only and the run may **PASS** despite
+  `!tombstones.passed`; naming a slope breach in `finishedReason` on a passing run would be a failure
+  reason attached to a green run. The guard is exactly §F5's fallback conjunct, so the **gate** and
+  the **reason** switch on the same predicate and cannot disagree.
+- **Rank 3 sits ABOVE rank 4 and rank 5, which is what `AT` needs.** A `--no-ack` cell is expected to
+  breach `L1` **and** the slope clause — both instruments measure the same growth — so without a
+  ranking the three `AT` transports could disagree and send a **correct** demonstration to `AT-0`.
+  With rank 3 pinned above rank 4, a `LevelEvaluated` breach names the level clause, and the three
+  transports agree by construction.
+- **Ranks 0, 1 and 2 sit ABOVE rank 3, which is what `AT-0` needs.** An unrelated harness failure —
+  divergence, recovery mismatch, panic, a memory breach, a dead `/metrics` scrape — must remain
+  **visible** in `finishedReason`, or a broken control run would read as a clean `L1` demonstration.
+
+**DELIBERATE, RECORDED BEHAVIOUR CHANGE.** HEAD's last-writer-wins resolves multi-failure runs as
+`disk-blind > tombstone > memory > earlier-phase`; this ranking resolves them
+`earlier-phase > memory > tombstone-blind > corpus > slope > disk-blind`. On any run with a
+**single** failure the string is **byte-identical to HEAD**; only multi-failure runs re-order, and
+they re-order **toward** the unrelated-failure cause. No clause's contribution to `passed` changes,
+no exit code changes, and no arm's TEXT changes — this is a precedence pin, not a re-wording.
+
+## §F15 — THE SAMPLER'S BYTE-COPY NEUTRALITY MECHANISM AND SCRATCH-PATH LIFECYCLE
+
+> **KL-7 — AN INSTRUMENT MAY NOT MUTATE WHAT IT MEASURES, AND MAY NOT MUTATE WHAT ANOTHER GATE
+> MEASURES.** This is the governing rule of the sampler's siting and it outranks every convenience
+> in it.
+
+A sampler placed between `kill9()` and `start()` sits **in front of the server's own crash
+recovery**, which is the input of an existing hard gate (`recovery_failures`) and of two CI
+assertions (`rust.yml:494-503`, `:641-647`). **`redb::Database::open` on an uncleanly closed file
+runs `do_repair` and COMMITS — a write** (`redb` 2, `Cargo.toml:64`: `Database::open` →
+`builder().open` → `Database::new`, whose `needs_repair()` gate runs `do_repair` + `commit`). Opening
+the server's file there would make the harness perform the server's recovery — the
+instrument-neutrality class `TG-OR-006` names (`INVARIANTS.md:529`, the three-way split at
+`:563-567`).
+
+> **The corpus scan NEVER opens the server's own file at a live checkpoint. It opens a BYTE COPY on
+> a scratch path outside `data_dir`, and the copy is discarded. Neutrality is not traded for sample
+> count: if the copy's cost does not fit the cadence, the SAMPLE COUNT is reduced, never the
+> neutrality.**
+
+**The four steps at each checkpoint**, replacing the single `supervisor.restart(config.ready_timeout)`
+at `main.rs:1745` with an explicit pair around them, preserving `restart`'s existing 250 ms
+socket-release sleep (`process.rs:287`) and its error handling verbatim, including the
+deliberately-left-open boot gap on a failed restart (`:1749-1755`):
+
+1. `std::fs::copy({data_dir}/topgun.redb, {scratch}/corpus-<k>.redb)` where `<k>` is the checkpoint
+   ordinal. **The original is read-only in this step and is not opened by redb at all.**
+2. `scan_redb_tombstone_corpus({scratch}, OR_MAP)` — reading the **copy**. Any `needs_repair` work
+   redb performs happens **on the copy**.
+3. The copy is **deleted** immediately after the scan returns, before `supervisor.start(...)`.
+4. `supervisor.start(...)` — the server is the **FIRST opener of the ORIGINAL**, so redb's
+   repair-and-commit path runs exactly where it ran at HEAD.
+
+**`C8`** (*"no existing metric series', constant's or assessment field's VALUE or MEANING
+changes"*) **and §F5's *"this spec weakens no existing hard clause"* are UNCHANGED IN TEXT and are
+now TRUE**: with the copy in place, no existing gate's input is perturbed by the instrument.
+
+**SCRATCH-PATH LIFECYCLE, specified rather than left to the keyboard.**
+
+- **Created ONCE**, at harness start, beside the run's other scratch state and **OUTSIDE
+  `data_dir`** — because `sample_disk_mb` is `du -sk` over `data_dir` (`monitor.rs:583-596`, called
+  at `main.rs:584`) and a copy written inside it would step the DISK gate's own input, a second
+  instrument-neutrality breach against a gate `C7` forbids this spec from touching.
+- **UNIQUE PER SAMPLE:** the file name carries the checkpoint ordinal, so two samples can never
+  alias, and a delete that failed cannot leave a previous sample's bytes to be re-scanned as this
+  one's. `std::fs::copy` truncates an existing destination, so an aliasing bug cannot produce a
+  partial-overwrite hybrid either.
+- **DELETED per sample**, immediately after the scan; **and the whole scratch directory is removed at
+  teardown**, on both the pass and the fail path, so a failing run leaves nothing behind.
+- **A failed delete is NOT a scan failure** — the sample was obtained. It is logged and the run
+  continues; the teardown sweep removes the residue.
+
+**THE COPY'S FAILURE MODE FOLDS INTO `scans_failed`, EXACTLY AS A SCAN FAILURE DOES (`KL-3`, `L0`).**
+Each checkpoint increments `scans_attempted` **once**. Then: a failed **copy** (source missing, I/O
+error, no space) increments `scans_failed` and pushes no sample; a successful copy followed by a
+`None` **scan** likewise increments `scans_failed` and pushes no sample; a successful copy followed
+by `Some(b)` pushes a `CorpusSample`. **An instrument that could not obtain the state is blind
+whichever step failed, and `L0` fails the run either way.** There is no third outcome and no silent
+skip.
+
+**The redb `Database` handle the scan opens is DROPPED before `supervisor.start(...)`.**
+`scan_redb_tombstone_corpus` already owns and drops its handle within its own body (`main.rs:1230`+,
+`db` is a local), so the property holds by construction. Under the copy the handle is on the
+**scratch** file, so a leak could no longer block the server's restart — but the requirement is
+kept, because a leaked handle would also block the per-sample **delete** on platforms that lock open
+files. No `let _db = …` binding may be hoisted out of the scan.
+
+**The existing terminal scan (`main.rs:778`) keeps reading `data_dir` DIRECTLY and takes no copy** —
+it is post-teardown and **nothing boots after it**, so there is nothing left to be neutral toward.
+This is the one siting whose semantics are unchanged from HEAD. It contributes the final sample on
+the same counters.
+
+**`ServerSupervisor::restart` is NOT deleted** — other call sites and its own contract stay intact;
+only this one site is expanded. `process.rs` is **not** edited and is **not** counted.
+
+**THE DOC-CONTRACT THIS FALSIFIES, corrected in the same commit.**
+`scan_redb_tombstone_corpus`'s doc (`main.rs:1217-1224`) reads *"MUST run only after
+`ServerSupervisor::shutdown` has reaped the child process … This is therefore a post-teardown
+assertion, **not a live sampler** alongside RSS/tombstone-bytes/disk above."* The sampler makes that
+sentence (`:1219-1221`) FALSE the moment it lands, and **a false doc-contract may not survive this
+spec**. The contract is rewritten to state the properties that are actually load-bearing: the
+precondition is **the CHILD BEING REAPED**, not shutdown specifically (`kill9()`,
+`process.rs:270-280`, awaits `child.wait()` and satisfies it exactly as `shutdown` does); it **IS** a
+live sampler, called once per recovery checkpoint plus the terminal post-teardown scan; and **at the
+checkpoint site its argument is a scratch directory holding a byte copy, never the server's own
+`data_dir`** — with the *reason* stated, because it is the reason the function may be called live at
+all.
+
+## §F16 — THE FROZEN TYPE SURFACE
+
+Signatures and doc-contracts. Total over its inputs; no panic path; no interior mutability; no I/O;
+**no dependency beyond `std`** (the file is `#[path]`-included by
+`tests/soak_monitor_calibration.rs:15`).
+
+```rust
+/// One durable-layer OR tombstone corpus scan, taken while the server process is
+/// DEAD (redb is single-writer, so its file lock must be free) and therefore
+/// reading the PRE-RECOVERY on-disk state.
+#[derive(Debug, Clone, Copy)]
+pub struct CorpusSample {
+    pub elapsed_secs: f64,
+    pub bytes: u64,
+}
+
+/// Which clause actually decided a corpus assessment. Rendered verbatim, so a
+/// clause that did not fire is visible rather than indistinguishable from a pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CorpusLevelDisposition {
+    /// L1 was evaluated and decided.
+    LevelEvaluated,
+    /// L1 was NOT evaluated, so the slope clause hard-gates instead. Never "ok".
+    LevelSuppressed,
+    /// L0 failed. L1 and L2 are NOT EVALUATED (fail-closed order).
+    InstrumentFailed,
+}
+
+impl CorpusLevelDisposition {
+    /// The single rendered token for this disposition. Consumed BOTH by the
+    /// console line in `main.rs` and by the JSON serializer in `report.rs`, so
+    /// the two transports can never disagree and no site retypes a literal.
+    /// Deliberately hand-written rather than serde-derived: this file is
+    /// `#[path]`-included by an integration target and must stay `std`-only.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LevelEvaluated => "LEVEL_EVALUATED",
+            Self::LevelSuppressed => "LEVEL_SUPPRESSED",
+            Self::InstrumentFailed => "INSTRUMENT_FAILED",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TombstoneCorpusAssessment {
+    pub scans_attempted: usize,
+    pub scans_failed: usize,
+    pub samples: usize,
+    /// PRE-REGISTERED AGGREGATES of the corpus series. These four — count
+    /// (`samples`), min, max (`peak_bytes`) and last — are the ONLY shape in
+    /// which the series reaches a consumer: `C9` forbids publishing the
+    /// per-sample series, so every predicate any downstream row is graded on
+    /// (notably `AT-2`'s conjunct (a)) MUST be statable over exactly these.
+    pub first_bytes: u64,
+    pub min_bytes: u64,
+    pub peak_bytes: u64,
+    pub last_bytes: u64,
+    pub first_half_peak_bytes: u64,
+    pub last_half_peak_bytes: u64,
+    pub rise_bytes: u64,
+    pub span_secs: f64,
+    pub disposition: CorpusLevelDisposition,
+    /// `None` = L2 DISARMED. Serialized EXPLICITLY as `null` (§F10) — absence
+    /// must never be indistinguishable from suppression (KL-5).
+    pub ceiling_bytes: Option<u64>,
+    pub passed: bool,
+    pub reason: Option<String>,
+}
+
+/// L0 and L1 are HARD gate clauses; L1 only when its two guards are met.
+#[must_use]
+pub fn assess_tombstone_corpus_level(
+    samples: &[CorpusSample],
+    scans_attempted: usize,
+    scans_failed: usize,
+    headroom_bytes: u64,
+    min_span_secs: f64,
+    min_samples: usize,
+    ceiling_bytes: Option<u64>,
+) -> TombstoneCorpusAssessment;
+
+/// Whether the tombstone-byte SLOPE clause still hard-gates a run that
+/// produced this disposition. EXHAUSTIVE BY CONSTRUCTION: a fourth variant
+/// does not compile here, which is what makes the NO-UNGATED-WINDOW coverage
+/// argument structural rather than a source-read. `main.rs`'s verdict
+/// expression consumes this and re-types no comparison of its own.
+#[must_use]
+pub const fn slope_clause_stays_hard(disposition: CorpusLevelDisposition) -> bool {
+    match disposition {
+        CorpusLevelDisposition::LevelEvaluated => false,
+        CorpusLevelDisposition::LevelSuppressed => true,
+        CorpusLevelDisposition::InstrumentFailed => true,
+    }
+}
+```
+
+**DELIVERY NOTE, recorded here because a frozen text that the code contradicts is the very hazard
+this artifact exists to refuse.** The workspace lints `clippy::unimplemented` and
+`clippy::match_same_arms` at `warn`, and CI runs `clippy -D warnings`, so the surface as delivered in
+`monitor.rs` carries two mechanical additions the block above omits: `assess_tombstone_corpus_level`
+takes an `unimplemented!()` body under a scoped `allow` until `G2` supplies the clause arithmetic
+(the signature and its doc-contract are the frozen object, not the body), and
+`slope_clause_stays_hard` carries a scoped `allow(clippy::match_same_arms)` so its three arms stay
+**one per variant** rather than being merged into a `|` pattern — merging would still be exhaustive,
+but it would stop each variant from being classified in its own right. Both are scoped `allow`s with
+stated reasons, neither changes a predicate, and `#[allow(dead_code)]` on the unwired items is
+removed as each is wired.
+
+<!-- FROZEN-LAYER-END -->
+
+<!-- POST-SECTION-BEGIN -->
+
+## POST-SECTION — APPEND-ONLY, written after `G5`, under its own separate digest
+
+**EMPTY at the time of the frozen layer's digest.** Nothing above this marker may be edited once its
+digest is recorded; everything below it is appended, never rewritten.
+
+When `G5` completes, this section carries: the executed control-run transcripts' verdict rows, the
+`AT` row that fired, the promotion decision, and the routings handed off **by id** — plus any
+recorded divergence between a pre-registered text (§F7 Table 2) or fixture magnitude (§F9) and what
+was delivered, with its reason.
+
+*(no entries yet)*
+
+<!-- POST-SECTION-END -->

--- a/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md
@@ -1131,6 +1131,154 @@ When `G5` completes, this section carries: the executed control-run transcripts'
 recorded divergence between a pre-registered text (§F7 Table 2) or fixture magnitude (§F9) and what
 was delivered, with its reason.
 
-*(no entries yet)*
+### G5 EXECUTION RECORD — the live control leg, the probe pair, and the promotion decision
+
+Executed on this branch at HEAD, release build, all cells run **strictly sequentially**. Every
+rendered line and exit code below was copied from a captured log **by script**, never retyped; the
+full transcripts are in `spec361-control-runs.txt`. `C9`/`C10` bind all of it: no magnitude here may
+be quoted as evidence about the plateau, the reclaim fraction, or any width.
+
+#### 1. `AT` GRADED IN ITS FROZEN ORDER — the verdict is `AT-3`, `ANTI-TAUTOLOGY-FAILED`
+
+Graded **conjunctively over `X21-a` (rendered `disposition`) + `X21-b` (`finishedReason`) +
+`X21-c` (exit code)**, `AT-0` first and fail-closed.
+
+| Cell (`D = 900 s`, `--crash-interval 120`) | exit (`X21-c`) | rendered `disposition` (`X21-a`) | `finishedReason` names (`X21-b`) | three transports agree? | `L1` outcome |
+|---|---|---|---|---|---|
+| **NEUTRAL** (attribution control) | `1` | `LEVEL_EVALUATED` | the **level** clause | yes | **FAILS on `L1`** |
+| `--no-ack` | `1` | `LEVEL_EVALUATED` | the **level** clause | yes | **FAILS on `L1`** |
+| `--inject-slow-leak` | `1` | `LEVEL_EVALUATED` | the **level** clause | yes | **FAILS on `L1`** |
+
+**`AT-0` — DOES NOT FIRE.** Every cell is admissible: `samples = 8` against `min_samples = 4`, and
+`span_secs` of **778.4 / 779.8 / 782.9 s** against `min_span_secs = 600` — all three within a second
+or two of §F2's predicted `≈ 780 s`, with `scans_ok = 8` and `scans_failed = 0` everywhere, so `L0`
+passed and the instrument was never blind. No cell was suppressed and no harness failure unrelated
+to the gate occurred. **The single permitted re-run is therefore NOT spent, and must not be** — there
+is no guard shortfall for it to repair.
+
+**`AT-1` — NOT MET.** It requires `NEUTRAL` **PASSES**. `NEUTRAL` failed.
+
+**`AT-2` — NOT MET.** It also requires `NEUTRAL` **PASSES**, and additionally `--inject-slow-leak`
+**PASSES**; neither holds. Conjunct (a) is therefore never reached and is not evaluated.
+
+**`AT-3` — FIRES.** Its antecedent is *"`--no-ack` **PASSES**, **or** NEUTRAL **FAILS**"*. The second
+disjunct is satisfied: **the neutral cell, with no injection flag applied at all, breached `L1`**
+(rise `142418 B` between half-peaks against the `65536 B` headroom). This is exactly the condition
+§F8 pre-registered as destroying attribution: *"it means the cell fails without any control applied."*
+A `--no-ack` FAIL cannot be attributed to `--no-ack` when the neutral cell of identical duration and
+crash interval fails the same way.
+
+> **Verdict: `ANTI-TAUTOLOGY-FAILED`. The bar was NOT met live.**
+
+**This is the pre-registered negative outcome, not a surprise and not a judgement call.** §F8 was
+frozen — and its digest recorded — before any calibration test was written and before any control
+run was executed, precisely so this could not be decided at the keyboard. It is recorded as it fell.
+
+#### 2. THE THREE RENDERED LINES (`X21-a`), copied verbatim
+
+```
+NEUTRAL:
+tombstone_corpus_redb_scan: first=45009 min=45009 peak=316159 last=316159 first_half_peak=173741 last_half_peak=316159 rise=142418 span=778s scans_ok=8 scans_failed=0 headroom=65536 ceiling=disarmed disposition=LEVEL_EVALUATED -> FAIL (terminal scan 316159 bytes; last gauge value 328334 bytes -> DIVERGED) reason=durable-corpus level rose 142418 B between half-peaks (173741 B -> 316159 B) over 778s, above the 65536 B headroom
+
+--no-ack:
+tombstone_corpus_redb_scan: first=48995 min=48995 peak=386362 last=386362 first_half_peak=195198 last_half_peak=386362 rise=191164 span=780s scans_ok=8 scans_failed=0 headroom=65536 ceiling=disarmed disposition=LEVEL_EVALUATED -> FAIL (terminal scan 386362 bytes; last gauge value 395089 bytes -> DIVERGED) reason=durable-corpus level rose 191164 B between half-peaks (195198 B -> 386362 B) over 780s, above the 65536 B headroom
+
+--inject-slow-leak:
+tombstone_corpus_redb_scan: first=58674 min=58674 peak=307004 last=307004 first_half_peak=172137 last_half_peak=307004 rise=134867 span=783s scans_ok=8 scans_failed=0 headroom=65536 ceiling=disarmed disposition=LEVEL_EVALUATED -> FAIL (terminal scan 307004 bytes; last gauge value 307488 bytes -> DIVERGED) reason=durable-corpus level rose 134867 B between half-peaks (172137 B -> 307004 B) over 783s, above the 65536 B headroom
+```
+
+All three persisted `"ceilingBytes": null` — the **`null` branch** of `AC27`'s JSON limb, reached
+over the real transport, as `X21-b` requires. (The non-`null` branch is the census-target fixture's.)
+
+#### 3. THE TWO PROBE LINES AND THEIR EXIT CODES (`N22`, `X21-d`, `AC27` KNOB limb)
+
+```
+P-armed  (--tombstone-corpus-headroom-bytes 1 --tombstone-corpus-ceiling-bytes 1)       exit = 1
+tombstone_corpus_redb_scan: first=5161 min=5161 peak=5161 last=5161 first_half_peak=0 last_half_peak=5161 rise=5161 span=0s scans_ok=1 scans_failed=0 headroom=1 ceiling=1 disposition=LEVEL_SUPPRESSED(n=1, span=0s) -> FAIL (terminal scan 5161 bytes; last gauge value 5781 bytes -> DIVERGED) reason=durable-corpus peak 5161 B exceeds the armed 1 B ceiling
+
+P-slack  (--tombstone-corpus-headroom-bytes 262144 --tombstone-corpus-ceiling-bytes 99999999999)  exit = 0
+tombstone_corpus_redb_scan: first=4660 min=4660 peak=4660 last=4660 first_half_peak=0 last_half_peak=4660 rise=4660 span=0s scans_ok=1 scans_failed=0 headroom=262144 ceiling=99999999999 disposition=LEVEL_SUPPRESSED(n=1, span=0s) -> ok (terminal scan 4660 bytes; last gauge value 5580 bytes -> DIVERGED)
+```
+
+`X21-d` is **DISCHARGED, exactly as pre-registered**: both knobs are individually attributable on the
+rendered line (`headroom=1` vs `headroom=262144`; `ceiling=1` vs `ceiling=99999999999` — different
+values for **both** tokens), and the **exit code flips `1 → 0`**. Both probes render
+`LEVEL_SUPPRESSED(n=1, span=0s)`, so `L1` decided nothing in either and **the flip is attributable to
+the ceiling knob alone** — the headroom knob has no subject here, and its discharge is the rendered
+token, not the verdict, precisely as §F13 states. **Neither probe is an `AT` input**, and neither
+probe's magnitude is quoted as evidence about anything (`C9`, `C10`).
+
+#### 4. THE PROMOTION DECISION — **NO PROMOTION**
+
+Per `AT-3`, and taken as the frozen table dictates rather than at the keyboard:
+
+- **`L1` does NOT ship as the hard gate.** The estimator ships **REPORT-ONLY**.
+- **The slope clause stays hard UNCONDITIONALLY** at `main.rs`'s fallback conjunct — the conditional
+  demotion is withdrawn, so `tombstones.passed` is ANDed with **no `slope_clause_stays_hard(...)`
+  guard in front of it**. The helper itself **stays**, unused by the gate but still asserted by its
+  test, so `N4b`'s exhaustiveness proof (and `AC24` limb 2's compile-time falsifier) is not lost.
+- **NO parameter is retuned.** `headroom_bytes` stays at `65536` and no cell duration or crash
+  interval is changed. Retuning to make the neutral control pass is the mirror image of retuning to
+  make a cell fail, and `C11`/`KL-4` forbid both. **This is the single most important line in this
+  record.**
+- The failure is published here with all three rendered lines, as `AT-3` requires.
+
+> **CARRIED OBLIGATION — `G5` COULD NOT AND DID NOT IMPLEMENT THIS.** `AT-3`'s consequence is a
+> **source change** to `main.rs`'s fallback conjunct, and `G5` is a run-and-record group: this half's
+> counted `.rs` ledger is **FULL at 4 counted / 0 exemptions**, and `G5` is forbidden from editing
+> any `.rs` file. The decision above is **recorded and routed**, not applied. **The demotion to
+> REPORT-ONLY is an open obligation for the orchestrator to site**, and until it is applied the tree
+> still carries `L1` as a deciding clause. It is called out here rather than left to be discovered.
+
+**What the leg actually established, stated without inflation.** The wiring works end-to-end: the
+sampler took 8 clean samples per cell across `kill -9` recovery checkpoints with zero scan failures,
+the estimator evaluated, and all three transports agreed in all three cells. What was NOT established
+is that `L1` **discriminates** — at this headroom, duration and workload it fires on everything,
+including the untreated control. A gate that fires on the control is not a gate.
+
+**A pre-registration observation, recorded rather than glossed.** §F3 derived `headroom_bytes =
+65536` expecting the neutral cell to sit below it. The neutral cell rose `142418 B` — roughly `2.2×`
+the headroom — over a `≈ 390 s` rise window. The three cells' rises (`142418` / `191164` / `134867 B`)
+are of the **same order**, with the neutral cell neither lowest nor separated from the treated ones.
+That is the substance of the `AT-3` finding and the material fact the routing below carries. **No
+conclusion about the plateau or any width is drawn from these numbers** (`C10`).
+
+#### 5. `AC23` ROUTINGS — BY ID, AND NO TRACKER FILE IS EDITED
+
+| Item | Routed to |
+|---|---|
+| `L2`'s production **arming** (it stays `None`/disarmed here; armed only in the probe and in `W9`) | **`TODO-654`** |
+| The **durable-corpus headroom revision** — `65536 B` is refuted as a discriminating threshold at this duration and workload by the neutral cell above | **`TODO-654`** |
+| **The `AT-3` cause itself**: why the untreated neutral cell accrues a corpus rise of the same order as the treated cells, and what a discriminating level clause would have to key on instead | **`TODO-634`** |
+| The width-1000 **plateau demonstration** | **`TODO-634`** |
+| **`TG-OR-005`**'s closure | **`TODO-634`** |
+| **`NAKED_BASELINE`** 4 → 3 | **`TODO-634`** |
+| The **bounded-but-elevated-plateau** question (`AT-2`'s conditional routing) | **not routed — `AT-2` did not fire**, so its conditional routing has no antecedent. Recorded so its absence is deliberate rather than an omission. |
+| The intermittent `soak-loaded-crash` **LWW merkle-root divergence** across recovery observed in `Part 3(iv)` — not this half's subject and not caused by it (`src/` is byte-unchanged, so the server binary is identical to base) | **`TODO-634`** |
+
+**No tracker file is edited by this routing** (`C1`, `AC20`); the routing lives here, by id.
+
+#### 6. `AC21` / `AC24` CONSUMER RE-RUN — SUMMARY (full detail in `spec361-control-runs.txt` Part 3)
+
+| Surface | Blocking? | `disposition` | Verdict |
+|---|---|---|---|
+| 25 s Soak Smoke G4b (`rust.yml:470-478`) | **BLOCKING** | `LEVEL_SUPPRESSED` | exit `0`, `.passed == true` — **unchanged from HEAD**. `AC24` limb 1's executed constructibility witness. |
+| boundary cell (`rust.yml:480-491`) | **BLOCKING** | `LEVEL_SUPPRESSED` | all three OR-no-loss greps hold; wall-clock budget holds. `AC21`(ii) satisfied. |
+| `soak-loaded` (`rust.yml:592`) | non-blocking (`:548`) | `LEVEL_SUPPRESSED` | `.passed == true` in both runs — verdict unchanged. The CI conjunct `totalWrites > 20000` was not reached **on this host** (`16725`, `18874`); a local throughput shortfall, not a verdict change, and not attributable to the corpus gate. |
+| `soak-loaded-crash` (`rust.yml:641`) | non-blocking (`:548`) | `LEVEL_SUPPRESSED` | **intermittent**: FAILED once (LWW merkle root changed across recovery), PASSED on two repeats. `tombstoneCorpus.passed == true` in all three, so the corpus clause contributed nothing. Cannot be a regression from this half — `src/` is byte-unchanged against base `20edabde`. |
+
+**No cell's corpus clause decided any consumer verdict**: every one of the four rendered
+`LEVEL_SUPPRESSED`, so `N4`'s fallback conjunct was live throughout and the slope clause hard-gated
+them exactly as at HEAD.
+
+#### 7. DIVERGENCES FROM PRE-REGISTRATION
+
+- **§F7 Table 2 texts and §F9 fixture magnitudes:** authored in earlier waves, **not** re-authored
+  here; `G5` observed no divergence in its own scope and changed neither.
+- **The `AT` outcome is not a divergence** — `AT-3` is one of the four pre-registered rows, and it
+  fired on its stated antecedent.
+- **The one substantive divergence** is the §F3 parameter expectation recorded in §4 above: the
+  neutral control was expected to sit below `65536 B` and did not. Its reason is unknown and is
+  **routed to `TODO-634`, not patched over by retuning** (`C11`).
 
 <!-- POST-SECTION-END -->

--- a/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md
@@ -1282,3 +1282,121 @@ them exactly as at HEAD.
   **routed to `TODO-634`, not patched over by retuning** (`C11`).
 
 <!-- POST-SECTION-END -->
+
+<!-- SITING-SECTION-BEGIN -->
+
+## SITING RECORD — appended by G6, AFTER the post-section, under its OWN digest
+
+**This section is NOT part of the frozen layer and NOT part of G5's post-section.**
+It sits outside both sentinel pairs, so both earlier digests reproduce unchanged
+and can be re-verified against `.frozen.sha256` and `.post.sha256` after reading
+this. Its own digest is in `spec361-level-gate-ruling.siting.sha256`.
+
+It records one thing: that the consequence `AT-3` and `AC12` attach to the
+recorded verdict was actually **sited in the code**, and how.
+
+### What fired, restated from the post-section rather than re-decided here
+
+`AT-3` fired. Verdict `ANTI-TAUTOLOGY-FAILED`. Decision: **NO PROMOTION**. The
+disjunct that fired is the second one: the **NEUTRAL** attribution control — no
+injection flag at all — breached `L1` on its own (rise `142418 B` against the
+`65536 B` headroom, `disposition=LEVEL_EVALUATED`, exit 1). `AT-0` did not fire:
+all three 900 s cells at `--crash-interval 120` were admissible (`samples = 8`,
+span 778–783 s, `scans_failed = 0`) and the single permitted re-run is unspent.
+
+### What `AC12` and the `AT-3` row require, and what was done
+
+Both texts agree on the consequence and were read together before editing:
+
+- `AC12`: *"`L1` ships **REPORT-ONLY** and the slope clause stays hard
+  **UNCONDITIONALLY** at `main.rs:853` (the `slope_clause_stays_hard(...)` guard
+  is dropped, not the clause; the helper and its test survive)"*.
+- The `AT-3` row: *"The estimator ships **REPORT-ONLY** … the `N4` fallback
+  conjunct becomes the only form, i.e. `tombstones.passed` is ANDed with **no
+  `slope_clause_stays_hard(...)` guard in front of it**"*.
+
+Taken together these are two changes to one expression, and both were made:
+
+1. **`corpus.passed` is no longer ANDed into the run verdict.** The `AT-3` row
+   says *the estimator* ships report-only, not merely `L1`, and the row's own
+   gloss — *"the branch is a strict addition and the gate is not weakened in any
+   run class"* — is only true if the estimator adds no gating at all. Retaining
+   `L0` alone as a hard clause was considered and rejected: the assessment
+   exposes one `passed` folding `L0`/`L1`/`L2`, so splitting it would mean
+   editing the `N1` types the frozen layer above closes under `C11`.
+2. **The `slope_clause_stays_hard(...)` guard is dropped from in front of
+   `tombstones.passed`,** which is therefore ANDed in every run class.
+
+The resulting verdict expression is exactly `HEAD`'s tombstone gating:
+
+```
+convergence ∧ recovery ∧ mem ∧ ¬blind_monitor
+  ∧ tombstones.passed          ← the OLD hard clause, now with no guard
+  ∧ ¬disk_blind_monitor ∧ ¬panic
+```
+
+**NO-UNGATED-WINDOW (`N4`) holds, and by the simplest possible route:** the
+slope clause gates *every* run configuration, so there is no run class in which
+neither it nor a live `L1` decides. The rule was never at risk under `AT-3`; it
+is at risk only under a promotion that removes the fallback.
+
+**`C11` was not touched.** No headroom, no ceiling, no `min_samples`, no
+`min_span_secs`, no duration and no crash interval was changed in either
+direction. The demotion is a change to which verdicts `passed` reads, and to the
+doc-contracts that describe it — nothing else.
+
+### Three consequential details, recorded because they are judgement calls
+
+- **The estimator still runs on every run.** It is computed, rendered on the
+  `tombstone_corpus_redb_scan:` line with its full aggregate transport, and
+  persisted as `tombstoneCorpus` in the JSON report. REPORT-ONLY means it
+  decides nothing, not that it is switched off.
+- **A corpus breach is recorded on `pending_gates`,** the harness's existing
+  report-only channel (the disk slope already uses it, with the same *"did NOT
+  fail the run"* phrasing). Without this the demotion would have made a breach
+  invisible to anyone reading only the run's verdict.
+- **The ranked `finished_reason` writer's rank-3 corpus arm no longer writes a
+  reason.** A clause that cannot fail a run must not hand that run a reason
+  saying it failed — which is the rule `N18b`'s own rank-4 doc already states.
+  Rank 3 therefore joins ranks 6–8 as non-reason-producing. The rank numbers
+  themselves are left as `N18b` froze them; nothing was renumbered.
+
+`slope_clause_stays_hard` survives in `monitor.rs` with its exhaustive `match`
+and its calibration test, so `N4b`'s compile-time falsifier (`E0004` on a fourth
+variant) is intact, exactly as `AC12` requires. `main.rs` still calls it — to
+name *which* corpus clause a report-only breach came from — and still re-types
+no disposition comparison of its own.
+
+### Pinned counts, re-verified AFTER the siting edit
+
+| Pin | Required | Observed |
+|---|---|---|
+| `N4a` census, `monitor.rs` + `main.rs` | 36 (15 + 21) | **36** (15 + 21) |
+| `grep -c slope_clause_stays_hard main.rs` | ≥ 1 | **2** |
+| `grep -c 'CorpusLevelDisposition::LevelEvaluated' main.rs` | 0 | **0** |
+| `grep -c 'finished_reason = ' main.rs` | 6 | **6** |
+| `grep -c '"duration reached"' main.rs` | 1 | **1** |
+
+### One `AC` whose PROSE the demotion outruns, disclosed rather than absorbed
+
+`AC9` requires the census's in-scope and authored lines to *"read as the
+CONDITIONAL role `N4` gives the slope clause"*. Under `AT-3` that role does not
+exist: the slope is unconditional. Leaving those lines asserting a conditional
+gate would have been a false doc-contract in the one spec whose census exists to
+stop exactly that. The lines were therefore re-pointed to the **unconditional**
+role. `AC9`'s **normative** element — *"the POST-EDIT COUNT is NORMATIVE while
+every LINE NUMBER is DESCRIPTIVE"* — is held exactly: **36**, split 15 / 21,
+every line still carrying one of the three pinned phrases and still classified
+by Table 1 or Table 2. The same applies to the rendered role string, which now
+reads `slope + blind-monitor both hard-gate; durable-corpus clauses are
+report-only`.
+
+### Routings, by id, no tracker edited
+
+Unchanged from the post-section: the cause of the NEUTRAL breach — an estimator
+that fires on an unperturbed run — and the durable-corpus headroom revision that
+would have to precede any future promotion attempt are routed to **`TODO-654`**;
+the bounded-plateau question and the width-1000 plateau demonstration to
+**`TODO-634`**. This section edits no tracker file.
+
+<!-- SITING-SECTION-END -->

--- a/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.post.sha256
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.post.sha256
@@ -1,0 +1,23 @@
+# Digest of the POST-SECTION of spec361-level-gate-ruling.md, written by G5.
+#
+# The post-section is SEPARATE from the frozen layer and carries its OWN
+# digest, which is what lets a reader confirm the decision surface (SF8's AT
+# table, SF3's parameters) was frozen BEFORE the runs while the verdict was
+# appended AFTER them. It is delimited by the POST-SECTION-BEGIN /
+# POST-SECTION-END sentinels, so this digest is stable under line-number
+# shifts. A file cannot contain its own digest, which is why the value lives
+# here.
+#
+# Re-verify with:
+#
+#   awk '/^<!-- POST-SECTION-BEGIN -->$/{f=1;next} /^<!-- POST-SECTION-END -->$/{f=0} f' \
+#     packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md \
+#     | shasum -a 256
+#
+# The FROZEN layer's digest is in the sibling .frozen.sha256 and was
+# RE-VERIFIED as still reproducing at the moment this post-section was
+# appended:
+#   57416926748add87129708d0c0c4d11e0ade85b2e30898684a649f5b1af4e07f
+#
+post-section   e8feaed53cb081ab9d57ae313e483241ec3e586bff8541a08c646c17eac9d006
+control-runs   41f84485f4d14fa377b234f4078f3896734a9c8af503d6e9a3d89c6621293665   (spec361-control-runs.txt)

--- a/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.siting.sha256
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.siting.sha256
@@ -1,0 +1,22 @@
+# Digest of the SITING SECTION of spec361-level-gate-ruling.md, written by G6.
+#
+# The siting section is OUTSIDE both the frozen layer and G5's post-section and
+# carries its OWN digest, so the three surfaces stay independently verifiable:
+# the decision surface frozen BEFORE the runs, the verdict appended AFTER them,
+# and the record that the verdict's consequence was sited in the code appended
+# after that. It is delimited by the SITING-SECTION-BEGIN / SITING-SECTION-END
+# sentinels, so this digest is stable under line-number shifts. A file cannot
+# contain its own digest, which is why the value lives here.
+#
+# Re-verify with:
+#
+#   awk '/^<!-- SITING-SECTION-BEGIN -->$/{f=1;next} /^<!-- SITING-SECTION-END -->$/{f=0} f' \
+#     packages/server-rust/benches/soak_harness/evidence/spec361-level-gate-ruling.md \
+#     | shasum -a 256
+#
+# BOTH earlier digests were RE-VERIFIED as still reproducing at the moment this
+# section was appended, which is what proves the append disturbed neither:
+#   frozen-layer   57416926748add87129708d0c0c4d11e0ade85b2e30898684a649f5b1af4e07f
+#   post-section   e8feaed53cb081ab9d57ae313e483241ec3e586bff8541a08c646c17eac9d006
+#
+siting-section eba6592e97ec08c92ada8bef0c72b04f073678a1b697b6e2afcc9c8fc3a855a8

--- a/packages/server-rust/benches/soak_harness/evidence/spec361a-witness-arm.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361a-witness-arm.txt
@@ -1,0 +1,238 @@
+SPEC-361a — WITNESS MUTATION ARMS, THIS HALF'S SIX
+==============================================================================
+
+WHAT THIS FILE IS AND IS NOT — READ THE SPLIT, NOT THE TOTALS.
+
+The W1-W9 witness register is JOINT across the two halves carved from SPEC-361.
+Its live figure is:
+
+    9 witnesses / 9 mutation arms / 18 legs / 9 transcripts
+
+split 6 + 3 = 9 arms, 12 + 6 = 18 legs, 6 + 3 = 9 transcripts.
+
+THIS FILE HOLDS ONLY THIS HALF'S SIX: 6 arms, 12 legs, 6 transcripts.
+SPEC-361a owns and executes W1-W5 (one arm each) plus W9's one arm.
+SPEC-361b owns and executes the other three -- W6 (a) and (b), and W7 (b) --
+and records them in spec361b-witness-arm.txt. W8 carries no arm in either
+half: it is the NEUTRAL control run itself, which is this half's, and its
+non-firing is the arm (see spec361-control-runs.txt).
+
+The count below is therefore PARTIAL BY CONSTRUCTION. Six transcripts here is
+the correct and complete result for SPEC-361a; it is not the register's total,
+and neither half may report the joint figure as its own. The figures
+'fourteen', the 5+4 / 10+8 and 4+5 / 8+10 splits, and the interim 8/16/8 are
+STRUCK everywhere in both halves.
+
+A 'transcript' is ONE ARM and contains BOTH its legs: the applied mutation
+with its RED output, and the revert with its green re-run. 6 arms x 2 legs =
+12 legs.
+
+PROTOCOL AND PROVENANCE
+------------------------------------------------------------------------------
+Every line under [APPLY] and [REVERT] below was copied from real captured
+output of the command:
+
+    SDKROOT=$(/usr/bin/xcrun --sdk macosx --show-sdk-path) \
+      cargo test --release -p topgun-server \
+        --test soak_monitor_calibration --test soak_wal_census
+
+run once per leg, 12 times in total. Both including targets are run because
+monitor.rs is #[path]-included by each, so every calibration test appears
+TWICE in the output -- the accepted duplication, not a second proof. That is
+why each leg reports two 'test result:' lines.
+
+Executed at HEAD 9bffbb04ed4b97e0c3f00d56d8ab15fa656ceadd (this half's branch, after the AT-3 demotion landed).
+The mutations are applied to the working tree and reverted in the same step;
+nothing here is committed in its mutated form, and `git status --porcelain`
+was empty after the last revert.
+
+ON COLLATERAL REDs, DISCLOSED RATHER THAN TRIMMED
+------------------------------------------------------------------------------
+N13 names ONE sited assertion per arm and requires that it go RED. Two arms
+(W1 and W2) mutate `rise_bytes`, which every corpus fixture reads, so they
+also RED assertions in sibling tests that pin a rise value; W4's L0 widening
+also catches a sibling fixture whose series opens at 0 B. Those extra REDs are
+listed in full under each leg rather than filtered out. They do not weaken the
+arm -- the sited assertion RED is the graded event -- but a transcript that
+silently showed only the named failure would be a doctored one.
+
+==============================================================================
+
+TRANSCRIPT 1 of 6 -- W1
+------------------------------------------------------------------------------
+sited assertion (must RED): calibration_fails_linear_corpus_level
+mutation: replace `last_half_peak - first_half_peak` with `last_half_peak - last_half_peak` (identically 0)
+site: packages/server-rust/benches/soak_harness/monitor.rs
+
+  - let rise_bytes = last_half_peak_bytes.saturating_sub(first_half_peak_bytes);
+  + let rise_bytes = last_half_peak_bytes.saturating_sub(last_half_peak_bytes);
+
+LEG 1 -- MUTATION APPLIED.  process exit = 101
+    test result: FAILED. 25 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests:
+    monitor::tests::calibration_fails_linear_corpus_level
+    monitor::tests::calibration_fails_slow_unbounded_ramp
+  captured failure at the sited assertion:
+    thread 'monitor::tests::calibration_fails_linear_corpus_level' (9463831) panicked at packages/server-rust/tests/../benches/soak_harness/monitor.rs:1699:9:
+    assertion `left == right` failed
+      left: 0
+     right: 400000
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+  SITED ASSERTION RED: YES
+
+LEG 2 -- MUTATION REVERTED.  process exit = 0
+    test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+    test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests: (none)
+  GREEN AGAIN: YES
+
+TRANSCRIPT 2 of 6 -- W2
+------------------------------------------------------------------------------
+sited assertion (must RED): calibration_passes_plateau_after_ramp
+mutation: compare `last_half_peak` against the series' FIRST sample instead of the first-half peak
+site: packages/server-rust/benches/soak_harness/monitor.rs
+
+  - let rise_bytes = last_half_peak_bytes.saturating_sub(first_half_peak_bytes);
+  + let rise_bytes = last_half_peak_bytes.saturating_sub(first_bytes);
+
+LEG 1 -- MUTATION APPLIED.  process exit = 101
+    test result: FAILED. 24 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests:
+    monitor::tests::calibration_fails_linear_corpus_level
+    monitor::tests::calibration_fails_slow_unbounded_ramp
+    monitor::tests::calibration_passes_plateau_after_ramp
+  captured failure at the sited assertion:
+    thread 'monitor::tests::calibration_passes_plateau_after_ramp' (9464381) panicked at packages/server-rust/tests/../benches/soak_harness/monitor.rs:1729:9:
+    assertion `left == right` failed
+      left: 290000
+     right: 0
+  SITED ASSERTION RED: YES
+
+LEG 2 -- MUTATION REVERTED.  process exit = 0
+    test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+    test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests: (none)
+  GREEN AGAIN: YES
+
+TRANSCRIPT 3 of 6 -- W3
+------------------------------------------------------------------------------
+sited assertion (must RED): calibration_fails_on_failed_scan
+mutation: replace the `scans_failed > 0` disjunct with `false`
+site: packages/server-rust/benches/soak_harness/monitor.rs
+
+  - if scans_failed > 0 || samples.is_empty() {
+  + if false || samples.is_empty() {
+
+LEG 1 -- MUTATION APPLIED.  process exit = 101
+    test result: FAILED. 26 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests:
+    monitor::tests::calibration_fails_on_failed_scan
+  captured failure at the sited assertion:
+    thread 'monitor::tests::calibration_fails_on_failed_scan' (9465056) panicked at packages/server-rust/tests/../benches/soak_harness/monitor.rs:1759:9:
+    assertion `left == right` failed
+      left: LevelEvaluated
+     right: InstrumentFailed
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+  SITED ASSERTION RED: YES
+
+LEG 2 -- MUTATION REVERTED.  process exit = 0
+    test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+    test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests: (none)
+  GREEN AGAIN: YES
+
+TRANSCRIPT 4 of 6 -- W4
+------------------------------------------------------------------------------
+sited assertion (must RED): calibration_passes_honest_empty_corpus
+mutation: treat a `bytes == 0` sample as a failed scan
+site: packages/server-rust/benches/soak_harness/monitor.rs
+
+  - if scans_failed > 0 || samples.is_empty() {
+  + if scans_failed > 0 || samples.is_empty() || samples.iter().any(|s| s.bytes == 0) {
+
+LEG 1 -- MUTATION APPLIED.  process exit = 101
+    test result: FAILED. 25 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests:
+    monitor::tests::calibration_fails_linear_corpus_level
+    monitor::tests::calibration_passes_honest_empty_corpus
+  captured failure at the sited assertion:
+    thread 'monitor::tests::calibration_passes_honest_empty_corpus' (9466026) panicked at packages/server-rust/tests/../benches/soak_harness/monitor.rs:1780:9:
+    assertion `left == right` failed
+      left: InstrumentFailed
+     right: LevelEvaluated
+  SITED ASSERTION RED: YES
+
+LEG 2 -- MUTATION REVERTED.  process exit = 0
+    test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+    test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests: (none)
+  GREEN AGAIN: YES
+
+TRANSCRIPT 5 of 6 -- W5
+------------------------------------------------------------------------------
+sited assertion (must RED): calibration_fails_slow_unbounded_ramp
+mutation: shorten the modelled run so the series' rise falls under the headroom (16 -> 12 samples)
+site: packages/server-rust/benches/soak_harness/monitor.rs
+
+  - let totals: Vec<u64> = (0..16).map(|i| 50_000 + i * 9_000).collect();
+  + let totals: Vec<u64> = (0..12).map(|i| 50_000 + i * 9_000).collect();
+
+LEG 1 -- MUTATION APPLIED.  process exit = 101
+    test result: FAILED. 26 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests:
+    monitor::tests::calibration_fails_slow_unbounded_ramp
+  captured failure at the sited assertion:
+    thread 'monitor::tests::calibration_fails_slow_unbounded_ramp' (9466937) panicked at packages/server-rust/tests/../benches/soak_harness/monitor.rs:1810:9:
+    assertion `left == right` failed
+      left: 54000
+     right: 72000
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+  SITED ASSERTION RED: YES
+
+LEG 2 -- MUTATION REVERTED.  process exit = 0
+    test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+    test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests: (none)
+  GREEN AGAIN: YES
+
+TRANSCRIPT 6 of 6 -- W9
+------------------------------------------------------------------------------
+sited assertion (must RED): calibration_fails_armed_ceiling
+mutation: replace L2's breach predicate `peak_bytes > c` with `last_bytes > c` (level-vs-final, not envelope)
+site: packages/server-rust/benches/soak_harness/monitor.rs
+
+  - if peak_bytes > ceiling {
+  + if last_bytes > ceiling {
+
+LEG 1 -- MUTATION APPLIED.  process exit = 101
+    test result: FAILED. 26 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+  failing tests:
+    monitor::tests::calibration_fails_armed_ceiling
+  captured failure at the sited assertion:
+    thread 'monitor::tests::calibration_fails_armed_ceiling' (9467618) panicked at packages/server-rust/tests/../benches/soak_harness/monitor.rs:1848:9:
+    an armed ceiling must breach on the PEAK even though the last sample sits below it; reason=None
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+  SITED ASSERTION RED: YES
+
+LEG 2 -- MUTATION REVERTED.  process exit = 0
+    test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+    test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+  failing tests: (none)
+  GREEN AGAIN: YES
+
+==============================================================================
+RESULT
+------------------------------------------------------------------------------
+6 arms executed, 12 legs, 6 transcripts. Every sited assertion went RED under
+its arm and green again after the revert; every apply leg exited 101 and every
+revert leg exited 0. No arm was skipped, reconstructed or extrapolated.
+
+The register's remaining 3 arms / 6 legs / 3 transcripts belong to SPEC-361b
+and are not executed here.
+
+BEARING OF THE AT-3 DEMOTION ON THESE ARMS: none. All six are sited on the
+estimator and its calibration fixtures in monitor.rs, which the demotion left
+byte-unchanged in arithmetic -- the demotion changed only which verdicts the
+run's `passed` reads in main.rs. The estimator is still computed, rendered and
+persisted on every run, so the assertions these arms falsify remain live.
+

--- a/packages/server-rust/benches/soak_harness/evidence/spec361a-witness-arm.txt
+++ b/packages/server-rust/benches/soak_harness/evidence/spec361a-witness-arm.txt
@@ -236,3 +236,101 @@ byte-unchanged in arithmetic -- the demotion changed only which verdicts the
 run's `passed` reads in main.rs. The estimator is still computed, rendered and
 persisted on every run, so the assertions these arms falsify remain live.
 
+
+==============================================================================
+APPENDIX — THE N4a CENSUS RE-RUN, CLASSIFIED (AC9 / Validation Checklist 6)
+==============================================================================
+
+Command, re-run on the branch after the demotion landed:
+
+    grep -nE 'HARD gate|hard gate|hard-gate' \
+      packages/server-rust/benches/soak_harness/monitor.rs \
+      packages/server-rust/benches/soak_harness/main.rs | wc -l
+
+Returned 36 -- monitor.rs 15, main.rs 21. HEAD 20edabde returned 30 (12 + 18).
+The arithmetic is unchanged: 30 - 0 demoted + 6 authored = 36. demoted = 0 is a
+RULE, and it held: every HEAD site was re-worded IN PLACE and every re-wording
+retained one of the three pinned phrases.
+
+EVERY ONE OF THE 36 IS CLASSIFIED. No unclassified hit. Sites are identified by
+TEXT and owning item; the line numbers below are DESCRIPTIVE.
+
+monitor.rs -- 15 = 11 in-scope + 1 out-of-scope + 3 authored
+  :69  :85  :92  :95   TABLE 1, module-doc "Note on gating responsibility"
+                       (HEAD :69 :81 :88 :91). :92 is the blind-monitor
+                       sentence, unchanged in substance.
+  :341 :348            TABLE 1, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR
+                       (HEAD :325 :330)
+  :364 :378 :381       TABLE 1, DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS
+                       (HEAD :345 :355 :357)
+  :1388 :1406          TABLE 1, calibration_additive_only_gauge_never_plateaus
+                       doc + assert message (HEAD :1029 :1046)
+  :1597                TABLE 1, OUT OF SCOPE -- DISK (HEAD :1236). Verified
+                       byte-unedited in `git diff 20edabde..HEAD`.
+  :619                 TABLE 2, A3 -- CorpusLevelDisposition::LevelSuppressed
+  :668                 TABLE 2, A1 -- assess_tombstone_corpus_level doc
+  :823                 TABLE 2, A2 -- slope_clause_stays_hard doc
+
+main.rs -- 21 = 14 in-scope + 4 out-of-scope + 3 authored
+  :25                  TABLE 1, module-doc property 3 (HEAD :25)
+  :36                  TABLE 1, module-doc blind-monitor sentence, stays true
+                       (HEAD :34)
+  :56                  TABLE 1, module-doc, the two controls (HEAD :45)
+  :205                 TABLE 1, Config::no_ack's doc (HEAD :165)
+  :868                 TABLE 1, assess_tombstone_bytes call-site (HEAD :790)
+  :882 :907            TABLE 1, the rationale block (HEAD :803 :826); :907 is
+                       the blind-monitor sentence and stays true
+  :999                 TABLE 1, the FAIL arm / rank-4 branch (HEAD :869)
+  :1245 :1253          TABLE 1, the summary-line comment and the rendered
+                       `tombstone_role` string (HEAD :1051 :1056)
+  :1336                TABLE 1, TEXT ONLY -- a DISK comment whose claim about
+                       the tombstone slope went false (HEAD :1095). No disk
+                       predicate, constant, assessment or conjunct touched.
+  :2538 :2596          TABLE 1, the two tracked-client comments (HEAD :2128
+                       :2185), reviewed and corrected
+  :2845                TABLE 1, the --help usage text (HEAD :2426)
+  :16                  TABLE 1, OUT OF SCOPE -- QUERY/recovery (HEAD :16).
+                       Byte-unedited.
+  :943 :1341 :1342     TABLE 1, OUT OF SCOPE -- DISK (HEAD :838 :1099 :1100).
+                       Byte-unedited.
+  :954                 TABLE 2, A4 -- comment above the verdict conjunction
+  :1005                TABLE 2, A6 -- the ranked writer's rank-4 comment
+  :2830                TABLE 2, A5 -- the --tombstone-corpus-ceiling-bytes
+                       usage line
+
+All five out-of-scope lines were checked individually against
+`git diff 20edabde..HEAD` and none appears as a removed line.
+
+DISCLOSED: WHAT THE ANTI-TAUTOLOGY OUTCOME CHANGED IN THE CENSUS'S PROSE
+------------------------------------------------------------------------------
+AC9 and Table 2 were written expecting a PROMOTION, so they require the in-scope
+and authored lines to read as the CONDITIONAL role, and Table 2 pre-registers
+the EXACT authored text of A1-A6 in that conditional form. The bar failed
+instead. Under that outcome the conditional role does not exist -- the slope is
+hard in every run class and the durable-corpus clauses decide nothing -- so
+every line stating the conditional role, including all six authored ones, would
+have been a doc-contract asserting a gate shape the code does not have. That is
+precisely the false-invariant hazard this census exists to catch, so the lines
+were re-pointed to the UNCONDITIONAL role and A1-A6's registered text no longer
+matches verbatim. Their IDENTITY -- the owning item named in Table 2's third
+column -- is unchanged, which is how each is still classified above.
+
+What is held exactly is the part N4a marks normative: "COUNTS ARE NORMATIVE;
+LINE NUMBERS ARE DESCRIPTIVE." The count is 36, split 15 / 21; demoted = 0;
+every line retains a pinned phrase; every hit is classified.
+
+AC9's closing rule -- "no in-scope or authored line may read as an
+unconditional 'is now a HARD gate'" -- is also held, on its own terms: that rule
+guards against overclaiming the NEW durable-corpus clause as a promoted gate,
+and no line does. Several lines do state that the tombstone-byte SLOPE is
+unconditionally hard, which is HEAD's own shape restored, not a promotion.
+
+PINNED COUNTS AT THE SAME MOMENT
+------------------------------------------------------------------------------
+  grep -c 'slope_clause_stays_hard'                      main.rs  ->  2  (>= 1)
+  grep -c 'CorpusLevelDisposition::LevelEvaluated'       main.rs  ->  0  (= 0)
+  grep -c 'finished_reason = '                           main.rs  ->  6  (HEAD 9)
+  grep -c '"duration reached"'                           main.rs  ->  1  (HEAD 1)
+  grep -rn 'SPEC-3' benches/soak_harness --include='*.rs' | wc -l ->  9  (2 files)
+  grep -rn 'SPEC-3' src --include='*.rs'                 | wc -l  -> 29  (10 files)
+  grep -c 'SPEC-3' tests/soak_wal_census.rs                       ->  0

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -117,8 +117,8 @@ use or_noloss::{missing_acked_adds, OrLedger};
 use process::{resolve_server_binary, ServerConfig, ServerSupervisor};
 use report::{
     append_progress, effective_epoch_width, scan_wal_frame_sizes, utc_timestamp_now, write_report,
-    ConfirmApplyReport, DiskReport, MemoryReport, ProgressSnapshot, SoakReport, TombstoneReport,
-    WalFrameStats,
+    ConfirmApplyReport, DiskReport, MemoryReport, ProgressSnapshot, SoakReport,
+    TombstoneCorpusReport, TombstoneReport, WalFrameStats,
 };
 use topgun_server::storage::record::RecordValue;
 
@@ -1074,6 +1074,23 @@ async fn run_soak(config: &Config) -> i32 {
             slope_bytes_per_hour: tombstones.slope_bytes_per_hour,
             passed: tombstones.passed,
             reason: tombstones.reason.clone(),
+        },
+        tombstone_corpus: TombstoneCorpusReport {
+            scans_attempted: corpus.scans_attempted,
+            scans_failed: corpus.scans_failed,
+            samples: corpus.samples,
+            first_bytes: corpus.first_bytes,
+            min_bytes: corpus.min_bytes,
+            peak_bytes: corpus.peak_bytes,
+            last_bytes: corpus.last_bytes,
+            first_half_peak_bytes: corpus.first_half_peak_bytes,
+            last_half_peak_bytes: corpus.last_half_peak_bytes,
+            rise_bytes: corpus.rise_bytes,
+            span_secs: corpus.span_secs,
+            disposition: corpus.disposition,
+            ceiling_bytes: corpus.ceiling_bytes,
+            passed: corpus.passed,
+            reason: corpus.reason.clone(),
         },
         disk: DiskReport {
             samples: disk.samples,

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -206,6 +206,14 @@ struct Config {
     /// This is the assertion mode that proves acked == durable on `kill -9` under
     /// load: it does NOT depend on a pre-kill flush masking a durability gap.
     no_pre_kill_drain: bool,
+    /// Slack, in bytes, the durable-corpus LEVEL clause allows the recent half
+    /// of the corpus series to sit above the earlier half by before it breaches.
+    /// Exposed so a measurement round can retune the clause without a rebuild.
+    tombstone_corpus_headroom_bytes: u64,
+    /// Absolute durable-corpus ceiling, in bytes. `None` leaves the ceiling
+    /// clause DISARMED, which is the default: arming it honestly needs a
+    /// validated number, and this flag is how a run supplies one.
+    tombstone_corpus_ceiling_bytes: Option<u64>,
     /// Opt-in measurement mode: after the run, scan the retained WAL segment
     /// files and emit a structured mechanism report (Q1-Q4) attributing the
     /// OR-churn WAL+RSS growth. REPORT-ONLY — never affects `passed`, so it
@@ -260,6 +268,8 @@ impl Default for Config {
             no_ack: false,
             inject_slow_leak: false,
             no_pre_kill_drain: false,
+            tombstone_corpus_headroom_bytes: DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES,
+            tombstone_corpus_ceiling_bytes: DEFAULT_TOMBSTONE_CORPUS_CEILING_BYTES,
             mechanism_report: false,
             mode_requested: false,
         }
@@ -899,10 +909,10 @@ async fn run_soak(config: &Config) -> i32 {
         &corpus_snapshot.samples,
         corpus_snapshot.scans_attempted,
         corpus_snapshot.scans_failed,
-        DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES,
+        config.tombstone_corpus_headroom_bytes,
         DEFAULT_TOMBSTONE_CORPUS_MIN_SPAN_SECS,
         DEFAULT_TOMBSTONE_CORPUS_MIN_SAMPLES,
-        DEFAULT_TOMBSTONE_CORPUS_CEILING_BYTES,
+        config.tombstone_corpus_ceiling_bytes,
     );
 
     // --- Assess disk growth (durable-dir footprint; catches leaks RSS cannot
@@ -1112,7 +1122,14 @@ async fn run_soak(config: &Config) -> i32 {
         timestamp: utc_timestamp_now(),
     };
 
-    print_summary(&report, &tombstones, &disk, &corpus, redb_tombstone_scan);
+    print_summary(
+        &report,
+        &tombstones,
+        &disk,
+        &corpus,
+        config.tombstone_corpus_headroom_bytes,
+        redb_tombstone_scan,
+    );
     if let Some(path) = &config.json_output {
         write_report(path, &report);
         println!("wrote JSON report to {}", path.display());
@@ -1170,6 +1187,7 @@ fn print_summary(
     tombstones: &TombstoneAssessment,
     disk: &DiskAssessment,
     corpus: &TombstoneCorpusAssessment,
+    corpus_headroom_bytes: u64,
     redb_tombstone_scan: Option<u64>,
 ) {
     println!("\n=== SOAK SUMMARY ===");
@@ -1269,7 +1287,7 @@ fn print_summary(
         corpus.span_secs,
         corpus.scans_attempted.saturating_sub(corpus.scans_failed),
         corpus.scans_failed,
-        DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES,
+        corpus_headroom_bytes,
         corpus_ceiling,
         corpus_disposition,
         if corpus.passed { "ok" } else { "FAIL" },
@@ -2771,11 +2789,17 @@ const KNOWN_FLAGS: &[&str] = &[
     "--no-ack",
     "--inject-slow-leak",
     "--no-pre-kill-drain",
+    "--tombstone-corpus-headroom-bytes",
+    "--tombstone-corpus-ceiling-bytes",
     "--mechanism-report",
     "--smoke",
 ];
 
 fn print_usage() {
+    // The two durable-corpus knobs are spelled out with their effect, because
+    // an operator arming a gate needs to know what each one moves:
+    //   --tombstone-corpus-headroom-bytes <n>  slack the LEVEL clause allows
+    //   --tombstone-corpus-ceiling-bytes <n>  arm L2's absolute HARD gate ceiling
     println!(
         "TopGun soak harness (G4b / TODO-484)\n\n\
          Drives the real out-of-process topgun-server against an on-disk redb + WAL,\n\
@@ -2792,6 +2816,9 @@ fn print_usage() {
          \x20 soak_harness --inject-panic\n\
          \x20 soak_harness --no-ack --duration 3600  # tombstone hard-gate must FAIL\n\
          \x20 soak_harness --inject-slow-leak --duration 3600  # slope detection-floor calibration\n\
+         \x20 # durable-corpus gate knobs (default: headroom 65536 bytes, ceiling disarmed)\n\
+         \x20 soak_harness --tombstone-corpus-headroom-bytes 262144 \\\n\
+         \x20              --tombstone-corpus-ceiling-bytes 8388608\n\
          \x20 # OR-churn WAL/RSS growth mechanism report (Q1-Q4), report-only\n\
          \x20 soak_harness --mechanism-report --or-churn true --or-keyspace 48 \\\n\
          \x20              --crash-interval 0 --duration 3600 --data-dir ./soak-data\n\n\
@@ -2939,6 +2966,19 @@ fn parse_args() -> Config {
             "--no-pre-kill-drain" => {
                 c.no_pre_kill_drain = true;
                 i += 1;
+            }
+            "--tombstone-corpus-headroom-bytes" => {
+                c.tombstone_corpus_headroom_bytes =
+                    parse_u64(&need(i, &args, "--tombstone-corpus-headroom-bytes"));
+                i += 2;
+            }
+            "--tombstone-corpus-ceiling-bytes" => {
+                c.tombstone_corpus_ceiling_bytes = Some(parse_u64(&need(
+                    i,
+                    &args,
+                    "--tombstone-corpus-ceiling-bytes",
+                )));
+                i += 2;
             }
             "--mechanism-report" => {
                 c.mechanism_report = true;

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -22,7 +22,9 @@
 //!    (last-half-window OLS, boot-recompute-gap samples excluded — see
 //!    `monitor.rs`) is computed against a tight per-hour threshold — a direct,
 //!    residency-independent leak signal with no allocator/cache noise floor.
-//!    The slope is a HARD gate: a tracked-and-ACKing client
+//!    The slope is a HARD gate only where the durable-corpus level clause
+//!    below could not decide; where that clause decides, the slope is
+//!    report-only. Either way a tracked-and-ACKing client
 //!    (`SoakClient::connect_tracked` + `confirm_apply`) is driven alongside the
 //!    churn clients for the run's duration so the server's per-device causal
 //!    frontier — and therefore its low-water-mark — actually advances, which is
@@ -31,7 +33,13 @@
 //!    guard (`DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS`) keeps a
 //!    too-short-to-plateau run (e.g. the 25s blocking smoke) from false-REDing
 //!    on a not-yet-flattened ramp, and the blind-monitor (zero-sample) clause
-//!    hard-gates independently of the slope. Server RSS is sampled in parallel
+//!    hard-gates independently of the slope. Beside the gauge, the DURABLE
+//!    corpus itself is sampled from a byte copy of the datastore at every
+//!    recovery checkpoint: a sampler that went blind fails the run outright,
+//!    and a corpus whose recent half peaks more than the configured headroom
+//!    above its earlier half fails it too. That durable clause is what makes
+//!    the gauge slope above conditional rather than unconditional.
+//!    Server RSS is sampled in parallel
 //!    and asserted against a looser slope as a coarse, non-tombstone backstop
 //!    gate. The on-disk data-dir slope (below) remains REPORT-ONLY — bounding
 //!    it is a separate, not-yet-landed follow-up.
@@ -41,8 +49,9 @@
 //! Two **negative controls** prove the harness can actually fail:
 //! `--inject-divergence` makes the convergence check go red, and
 //! `--inject-panic` makes the panic capture go red. A soak that cannot fail
-//! proves nothing. Two more MODES exist specifically to prove the promoted
-//! tombstone-byte hard gate above is honest: `--no-ack` disables the tracked
+//! proves nothing. Two more MODES exist specifically to prove the
+//! durable-corpus gate and the conditional tombstone-byte hard gate above are
+//! honest: `--no-ack` disables the tracked
 //! client's confirm-apply loop (the low-water-mark then never advances, prune
 //! never fires, and the gate must FAIL under sustained churn), and
 //! `--inject-slow-leak` adds a second, deliberately slow-acking tracked client
@@ -189,8 +198,9 @@ struct Config {
     confirm_interval: Duration,
     /// Negative control: disables the tracked client's confirm-apply loop
     /// entirely. With no client ever confirming, the low-water-mark stays 0,
-    /// prune never fires, and sustained OR churn must trip the promoted
-    /// tombstone-byte hard gate.
+    /// prune never fires, and sustained OR churn must trip the durable-corpus
+    /// hard gate — and the tombstone-byte slope clause with it, wherever the
+    /// level clause did not decide.
     no_ack: bool,
     /// Adds a second tracked client (`SLOW_LEAK_TRACKER_IDX`) that ACKs on a
     /// much slower cadence than the primary tracker. Because the low-water-mark
@@ -852,8 +862,9 @@ async fn run_soak(config: &Config) -> i32 {
     );
 
     // --- Assess tombstone-byte growth (direct residency-independent leak
-    // instrument, the bounded-plateau signal — a HARD gate, see the promotion
-    // note below). Coexists with the RSS gate above as a coarse non-tombstone
+    // instrument, the bounded-plateau signal — a HARD gate wherever the
+    // durable-corpus level clause did not decide, see the note below).
+    // Coexists with the RSS gate above as a coarse non-tombstone
     // backstop — neither replaces the other. The sampling loop already
     // excluded boot-recompute-gap samples (R9(c)), so this series is safe to
     // fit directly.
@@ -865,8 +876,10 @@ async fn run_soak(config: &Config) -> i32 {
         DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
     );
 
-    // The tombstone-byte SLOPE clause is now a HARD gate (promoted from
-    // report-only): the tracked-and-ACKing client spawned above
+    // The tombstone-byte SLOPE clause is a CONDITIONAL HARD gate: it decides
+    // the verdict in exactly the run class where the durable-corpus level
+    // clause below could not, and is report-only wherever that clause did
+    // decide. Where it decides, the tracked-and-ACKing client spawned above
     // (`run_tracked_confirm_client` / `TRACKER_IDX`) drives the server's
     // per-device causal frontier forward every `confirm_interval`, so the
     // fleet-wide low-water-mark actually advances and the epoch-scoped prune
@@ -932,7 +945,7 @@ async fn run_soak(config: &Config) -> i32 {
     let disk_blind_monitor = disk.samples == 0;
 
     let panic_report = panic_watch.report();
-    // The corpus verdict is ANDed unconditionally; the byte slope is ANDed
+    // The durable-corpus verdict is the HARD gate; the slope clause hard-gates
     // exactly where the level clause did NOT decide. That fallback term is
     // routed through `slope_clause_stays_hard`, which enumerates every
     // disposition and therefore stops a future fourth one from silently
@@ -1004,13 +1017,14 @@ async fn run_soak(config: &Config) -> i32 {
                 )
             })
         } else if slope_clause_stays_hard(corpus.disposition) && !tombstones.passed {
-            // HARD gate (promoted from report-only): with the tracked-and-ACKing
+            // A CONDITIONAL HARD gate: with the tracked-and-ACKing
             // client driving the low-water-mark, a sustained slope breach past the
             // min-window-guarded threshold means the epoch-scoped prune is not
             // keeping up with (or has stopped) bounding tombstone growth — a real
             // regression, not an expected/known gap. AND it into `passed`.
             //
-            // Rank 4. The guard is exactly the verdict's fallback term above,
+            // Rank 4: the slope clause, which hard-gates only when L1 did not decide.
+            // The guard is exactly the verdict's fallback term above,
             // so the verdict and the reason switch on the same predicate: where
             // the level clause decided, the slope is report-only and the run
             // may pass despite this breach, and a passing run must not carry a
@@ -1230,12 +1244,15 @@ fn print_summary(
         r.memory.slope_mb_per_hour,
         if r.memory.passed { "ok" } else { "FAIL" }
     );
-    // The byte SLOPE is now a HARD gate: the tracked-and-ACKing client drives
+    // The byte SLOPE is a HARD gate only where the durable-corpus level clause
+    // did not decide; where it did decide, the slope is report-only. Either
+    // way the tracked-and-ACKing client drives
     // the low-water-mark forward, so the epoch-scoped prune actually fires and
     // the gauge is expected to plateau under sustained churn (subject to the
     // min-window-span guard and boot-gap exclusion). See the run-end verdict
     // rationale.
-    let tombstone_role = "slope + blind-monitor both hard-gate";
+    let tombstone_role =
+        "REPORT-ONLY-WHEN-L1-DECIDES / HARD-WHEN-L1-SUPPRESSED; blind-monitor hard-gates";
     println!(
         "tombstone_bytes:   first={} peak={} last={} slope={:.1}B/h samples={} -> {} ({}){}",
         tombstones.first_bytes,
@@ -1318,7 +1335,8 @@ fn print_summary(
             );
         }
     }
-    // Unlike the tombstone-byte slope above (now a hard gate), the disk slope
+    // Unlike the tombstone-byte slope above (a hard gate only where the
+    // durable-corpus level clause did not decide), the disk slope
     // stays REPORT-ONLY: it is EXPECTED to breach pre-TODO-566 under default
     // OR-churn (linear durable-dir growth by design, independent of the
     // tombstone prune this spec drives); only the blind-monitor (zero-sample)
@@ -2519,7 +2537,8 @@ struct TrackerConfig {
 /// the ack) — the connection still exists so the harness's other assertions
 /// keep exercising it, but the server never sees an `ORMAP_SYNC_INIT` from this
 /// replica, so it is never tracked and the low-water-mark stays at its vacuous
-/// 0 for the whole run: the negative control for the promoted hard gate.
+/// 0 for the whole run: the negative control for the durable-corpus hard gate
+/// and, wherever the level clause did not decide, the slope clause with it.
 async fn run_tracked_confirm_client(cfg: TrackerConfig) {
     let mut device_token: Option<String> = None;
     // Persisted across reconnects alongside `device_token`: the replica's
@@ -2576,7 +2595,8 @@ async fn run_tracked_confirm_client(cfg: TrackerConfig) {
                         // Surface the failure rather than reconnect-looping
                         // silently: a swallowed confirm error looks identical to
                         // a server tombstone leak (LWM never advances → gauge
-                        // climbs → hard gate REDs), so an invisible plumbing bug
+                        // climbs → the durable-corpus hard gate REDs), so an
+                        // invisible plumbing bug
                         // would masquerade as the very defect this gate hunts.
                         cfg.metrics.confirm_errors.fetch_add(1, Ordering::Relaxed);
                         eprintln!("[tracker {}] confirm_apply error: {e:#}", cfg.idx);
@@ -2823,7 +2843,7 @@ fn print_usage() {
          \x20 # negative controls (must exit non-zero == assertion RED)\n\
          \x20 soak_harness --inject-divergence\n\
          \x20 soak_harness --inject-panic\n\
-         \x20 soak_harness --no-ack --duration 3600  # tombstone hard-gate must FAIL\n\
+         \x20 soak_harness --no-ack --duration 3600  # corpus+slope hard-gate must FAIL\n\
          \x20 soak_harness --inject-slow-leak --duration 3600  # slope detection-floor calibration\n\
          \x20 # durable-corpus gate knobs (default: headroom 65536 bytes, ceiling disarmed)\n\
          \x20 soak_harness --tombstone-corpus-headroom-bytes 262144 \\\n\

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -49,10 +49,16 @@
 //! whose stale cursor repeatedly caps the fleet-wide low-water-mark — a bounded
 //! ramp-then-catch-up pattern used to calibrate the OLS slope's detection floor
 //! against a small, non-instantaneous leak rather than only total blockage.
-//! Independently of the gauge, `scan_redb_tombstone_corpus` opens the server's
-//! own redb file after it exits and sums the real on-disk tombstone corpus —
-//! the positive control's cross-check against a gauge/corpus divergence (e.g. a
-//! legacy `OrTombstones` blob the hot-path gauge never counted on add).
+//! Independently of the gauge, `scan_redb_tombstone_corpus` sums the real
+//! on-disk tombstone corpus. It runs once per recovery checkpoint — between
+//! the `kill -9` and the restart, over a BYTE COPY on a scratch path outside
+//! the data dir, because opening a redb file that closed uncleanly repairs and
+//! commits it and the instrument must not run the server's recovery ahead of
+//! the server — and once terminally after the process exits, where it reads
+//! the data dir directly because nothing boots after it. The resulting series
+//! feeds the durable-corpus level/ceiling assessment, and its terminal value
+//! still cross-checks the gauge for a gauge/corpus divergence (e.g. a legacy
+//! `OrTombstones` blob the hot-path gauge never counted on add).
 //!
 //! See `benches/soak_harness/README.md` for usage and the Hetzner 72h runner.
 
@@ -74,6 +80,12 @@ mod client;
 mod model;
 mod monitor;
 mod or_noloss;
+// The recovery checkpoint expanded `ServerSupervisor::restart` in place — it
+// has to take a corpus sample between the kill and the start — so no caller
+// inside this binary is left. `restart` itself is deliberately kept: its
+// contract is unchanged and `tests/soak_tombstone_restart.rs`, which includes
+// this same module, still calls it.
+#[allow(dead_code)]
 mod process;
 mod report;
 
@@ -91,11 +103,15 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use client::SoakClient;
 use model::{compare, next_stamp, Model};
 use monitor::{
-    assess, assess_disk, assess_tombstone_bytes, exclude_boot_gap_samples, sample_disk_mb,
-    sample_rss_mb, BootGap, DiskAssessment, DiskSample, MemSample, TombstoneAssessment,
-    TombstoneSample, DEFAULT_DISK_CEILING_MB, DEFAULT_DISK_MIN_GROWTH_MB,
-    DEFAULT_DISK_THRESHOLD_MB_PER_HOUR, DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH,
-    DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS, DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+    assess, assess_disk, assess_tombstone_bytes, assess_tombstone_corpus_level,
+    exclude_boot_gap_samples, sample_disk_mb, sample_rss_mb, slope_clause_stays_hard, BootGap,
+    CorpusLevelDisposition, CorpusSample, DiskAssessment, DiskSample, MemSample,
+    TombstoneAssessment, TombstoneCorpusAssessment, TombstoneSample, DEFAULT_DISK_CEILING_MB,
+    DEFAULT_DISK_MIN_GROWTH_MB, DEFAULT_DISK_THRESHOLD_MB_PER_HOUR,
+    DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH, DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
+    DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR, DEFAULT_TOMBSTONE_CORPUS_CEILING_BYTES,
+    DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES, DEFAULT_TOMBSTONE_CORPUS_MIN_SAMPLES,
+    DEFAULT_TOMBSTONE_CORPUS_MIN_SPAN_SECS,
 };
 use or_noloss::{missing_acked_adds, OrLedger};
 use process::{resolve_server_binary, ServerConfig, ServerSupervisor};
@@ -127,6 +143,18 @@ const SLOW_LEAK_ACK_INTERVAL: Duration = Duration::from_secs(90);
 
 const LWW_MAP: &str = "soak_lww";
 const OR_MAP: &str = "soak_or";
+
+/// The rendered prefix of the durable-corpus gate's verdict line. Single
+/// source of truth: both `println!` sites and every assertion take it from
+/// here, so a rename REDs loudly instead of missing silently.
+const TOMBSTONE_CORPUS_LINE_PREFIX: &str = "tombstone_corpus_redb_scan:";
+
+/// The `finished_reason` a run carries when nothing wrote a breach reason.
+/// Single source of truth: the initialiser and the ranked verdict writer's
+/// rank-0 guard both take it from here, so rewording the default cannot
+/// silently disable rank 0 and let the verdict block overwrite an
+/// earlier-phase reason.
+const FINISHED_REASON_DURATION_REACHED: &str = "duration reached";
 
 /// Parsed CLI configuration.
 struct Config {
@@ -381,6 +409,20 @@ async fn run_soak(config: &Config) -> i32 {
         },
     };
 
+    // Scratch root for the durable-corpus sampler's byte copies. Created ONCE
+    // and OUTSIDE `data_dir`, because the disk gate's input is `du -sk` over
+    // `data_dir` and a copy written inside it would step that gate's own
+    // measurement. The guard removes the whole tree when the run returns, on
+    // the pass path and the fail path alike, so a failing run leaves nothing
+    // behind; each sample already deletes its own copy long before that.
+    let (corpus_scratch, _corpus_scratch_guard) = match tempfile::tempdir() {
+        Ok(td) => (td.path().to_path_buf(), td),
+        Err(e) => {
+            eprintln!("FATAL: cannot create corpus scratch dir: {e}");
+            return 2;
+        }
+    };
+
     let port = if config.server_port == 0 {
         match ServerSupervisor::pick_free_port() {
             Ok(p) => p,
@@ -598,6 +640,11 @@ async fn run_soak(config: &Config) -> i32 {
         boot_gaps: Arc::clone(&boot_gaps),
     };
 
+    // Durable-corpus series: one sample per recovery checkpoint (taken from a
+    // byte copy while the child is reaped) plus the terminal scan, all on the
+    // same `sampler_start` clock as the RSS/tombstone-byte/disk series.
+    let corpus_sampler = CorpusSampler::new(data_dir.clone(), corpus_scratch);
+
     // --- Orchestration loop ---
     let start = Instant::now();
     let deadline = start + config.duration;
@@ -615,7 +662,7 @@ async fn run_soak(config: &Config) -> i32 {
     // reported, and never fails the run on this (322a) branch.
     let mut pending_gates: Vec<String> = Vec::new();
     let mut last_convergence_ok = true;
-    let mut finished_reason = "duration reached".to_string();
+    let mut finished_reason = FINISHED_REASON_DURATION_REACHED.to_string();
 
     loop {
         let now = Instant::now();
@@ -646,6 +693,7 @@ async fn run_soak(config: &Config) -> i32 {
                 config,
                 &paused,
                 &boot_gap_clock,
+                &corpus_sampler,
             )
             .await
             {
@@ -769,13 +817,20 @@ async fn run_soak(config: &Config) -> i32 {
         None
     };
 
-    // Positive-control independent corpus assertion (R5): the server process
-    // has just been reaped, so its redb handle is released and this scan can
-    // safely open the same file. REPORT-ONLY (printed in the console summary,
-    // never asserted into `passed`) — see `scan_redb_tombstone_corpus`'s doc
-    // for why a divergence from the gauge's `last_bytes` below is exactly the
-    // failure mode this exists to catch.
+    // The TERMINAL corpus scan: the server process has just been reaped, so its
+    // redb handle is released and this scan can safely open the same file
+    // directly — no copy, because nothing boots after it. It contributes the
+    // final sample of the durable-corpus series, so it is no longer
+    // report-only: it now feeds the instrument and level clauses that are
+    // ANDed into `passed` below. Its cross-check against the gauge's
+    // `last_bytes` survives on the same rendered line — see
+    // `scan_redb_tombstone_corpus`'s doc for why a divergence there is exactly
+    // the failure mode this exists to catch.
     let redb_tombstone_scan = scan_redb_tombstone_corpus(&data_dir, OR_MAP);
+    corpus_sampler.record_terminal_scan(
+        boot_gap_clock.sampler_start.elapsed().as_secs_f64(),
+        redb_tombstone_scan,
+    );
 
     // --- Assess memory (secondary/backstop gate) ---
     let mem_samples = samples.lock().clone();
@@ -829,6 +884,27 @@ async fn run_soak(config: &Config) -> i32 {
     // nothing must not pass.
     let blind_monitor = tombstones.samples == 0;
 
+    // --- Assess the DURABLE tombstone corpus: the level/ceiling instrument
+    // that reads the on-disk corpus itself rather than the exported gauge.
+    // Two of its clauses are ANDed into the run verdict below. The INSTRUMENT
+    // clause fails a run whose sampler could not obtain the state at some
+    // checkpoint — a blind instrument must never be read as bounded growth.
+    // The LEVEL clause compares the peak of the series' recent half against
+    // the peak of its earlier half, and decides only on a series long enough
+    // for that comparison to mean anything (the sample and span guards); where
+    // it cannot decide, the byte slope above keeps deciding the verdict
+    // instead, so no run configuration is left with neither.
+    let corpus_snapshot = corpus_sampler.snapshot();
+    let corpus = assess_tombstone_corpus_level(
+        &corpus_snapshot.samples,
+        corpus_snapshot.scans_attempted,
+        corpus_snapshot.scans_failed,
+        DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES,
+        DEFAULT_TOMBSTONE_CORPUS_MIN_SPAN_SECS,
+        DEFAULT_TOMBSTONE_CORPUS_MIN_SAMPLES,
+        DEFAULT_TOMBSTONE_CORPUS_CEILING_BYTES,
+    );
+
     // --- Assess disk growth (durable-dir footprint; catches leaks RSS cannot
     // see, e.g. lazy-loaded records that never touch the in-memory cache).
     // Mirrors the tombstone-byte gate exactly: the SLOPE is report-only (the
@@ -846,48 +922,110 @@ async fn run_soak(config: &Config) -> i32 {
     let disk_blind_monitor = disk.samples == 0;
 
     let panic_report = panic_watch.report();
+    // The corpus verdict is ANDed unconditionally; the byte slope is ANDed
+    // exactly where the level clause did NOT decide. That fallback term is
+    // routed through `slope_clause_stays_hard`, which enumerates every
+    // disposition and therefore stops a future fourth one from silently
+    // landing on either side — this expression re-types no comparison of its
+    // own. An instrument failure already forces `corpus.passed` false, so it
+    // fails through the first of the two terms and never reaches the fallback.
     let passed = convergence_failures.is_empty()
         && recovery_failures.is_empty()
         && mem.passed
         && !blind_monitor
-        && tombstones.passed
+        && corpus.passed
+        && (!slope_clause_stays_hard(corpus.disposition) || tombstones.passed)
         && !disk_blind_monitor
         && panic_report.is_none();
 
-    if !mem.passed {
-        finished_reason = format!(
-            "memory growth assertion failed: {}",
-            mem.reason.clone().unwrap_or_default()
-        );
+    // ONE ranked writer for `finished_reason`, in place of four independent
+    // assignments whose last one happened to win. The precedence is decided
+    // here rather than by source order: a cause unrelated to the tombstone
+    // gates outranks a gate verdict, so a broken run can never read as a clean
+    // gate demonstration, and the corpus arm outranks the slope fallback, so
+    // one run cannot attribute itself to two different causes across its
+    // console line and its JSON report. On a run with a single failure the
+    // string is what it was before; only multi-failure runs re-order, and they
+    // re-order toward the unrelated cause.
+    //
+    // Rank 0: an earlier phase — convergence divergence, crash-recovery
+    // mismatch, server panic — already wrote a reason, so this writer does not
+    // fire at all and that reason survives. The sentinel it switches on comes
+    // from the source constant, never a retyped literal.
+    if finished_reason == FINISHED_REASON_DURATION_REACHED {
+        let ranked = if !mem.passed {
+            // Rank 1.
+            Some(format!(
+                "memory growth assertion failed: {}",
+                mem.reason.clone().unwrap_or_default()
+            ))
+        } else if blind_monitor {
+            // Rank 2: the scrape was dead, which is a harness defect
+            // independent of any leak magnitude.
+            Some(format!(
+                "tombstone-byte monitoring blind: {}",
+                tombstones.reason.clone().unwrap_or_default()
+            ))
+        } else if !corpus.passed {
+            // Rank 3, switched on the disposition so the reason names the
+            // clause that actually fired rather than the gate as a whole.
+            Some(match corpus.disposition {
+                CorpusLevelDisposition::InstrumentFailed => format!(
+                    "durable-corpus instrument failed: {}",
+                    corpus.reason.clone().unwrap_or_default()
+                ),
+                CorpusLevelDisposition::LevelEvaluated => format!(
+                    "durable-corpus level assertion failed: {}",
+                    corpus.reason.clone().unwrap_or_default()
+                ),
+                // The level clause did not decide here, so the absolute
+                // ceiling is the only clause that can have breached.
+                CorpusLevelDisposition::LevelSuppressed => format!(
+                    "durable-corpus ceiling assertion failed: {}",
+                    corpus.reason.clone().unwrap_or_default()
+                ),
+            })
+        } else if slope_clause_stays_hard(corpus.disposition) && !tombstones.passed {
+            // HARD gate (promoted from report-only): with the tracked-and-ACKing
+            // client driving the low-water-mark, a sustained slope breach past the
+            // min-window-guarded threshold means the epoch-scoped prune is not
+            // keeping up with (or has stopped) bounding tombstone growth — a real
+            // regression, not an expected/known gap. AND it into `passed`.
+            //
+            // Rank 4. The guard is exactly the verdict's fallback term above,
+            // so the verdict and the reason switch on the same predicate: where
+            // the level clause decided, the slope is report-only and the run
+            // may pass despite this breach, and a passing run must not carry a
+            // failure reason.
+            Some(format!(
+                "tombstone-byte growth slope {:.1} bytes/h exceeds {:.1} bytes/h: {}",
+                tombstones.slope_bytes_per_hour,
+                DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
+                tombstones.reason.clone().unwrap_or_default()
+            ))
+        } else if disk_blind_monitor {
+            // Rank 5.
+            Some(format!(
+                "disk monitoring blind: {}",
+                disk.reason.clone().unwrap_or_default()
+            ))
+        } else {
+            // Ranks 6-8 write no reason: the disk slope is report-only, the
+            // panic report travels on its own two transports, and a run with
+            // nothing to report keeps the default.
+            None
+        };
+        if let Some(reason) = ranked {
+            finished_reason = reason;
+        }
     }
-    if blind_monitor {
-        finished_reason = format!(
-            "tombstone-byte monitoring blind: {}",
-            tombstones.reason.clone().unwrap_or_default()
-        );
-    } else if !tombstones.passed {
-        // HARD gate (promoted from report-only): with the tracked-and-ACKing
-        // client driving the low-water-mark, a sustained slope breach past the
-        // min-window-guarded threshold means the epoch-scoped prune is not
-        // keeping up with (or has stopped) bounding tombstone growth — a real
-        // regression, not an expected/known gap. AND it into `passed`.
-        finished_reason = format!(
-            "tombstone-byte growth slope {:.1} bytes/h exceeds {:.1} bytes/h: {}",
-            tombstones.slope_bytes_per_hour,
-            DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR,
-            tombstones.reason.clone().unwrap_or_default()
-        );
-    }
-    if disk_blind_monitor {
-        finished_reason = format!(
-            "disk monitoring blind: {}",
-            disk.reason.clone().unwrap_or_default()
-        );
-    } else if !disk.passed {
+    if !disk_blind_monitor && !disk.passed {
         // Report-only, same rationale as the tombstone-byte slope above: the
         // pre-566 OR churn grows the durable dir linearly by design, so this is
         // the EXPECTED honest signal, not a regression. Do NOT AND this into
-        // `passed`.
+        // `passed`. Rank 6 of the precedence above, and deliberately NOT a
+        // reason writer: it appends to `pending_gates` and nothing else, as at
+        // HEAD.
         pending_gates.push(format!(
             "disk growth slope {:.1} MB/h exceeds {:.1} MB/h — EXPECTED until \
              TODO-566 bounds OR-Map tombstones (report-only, did NOT fail the run)",
@@ -957,7 +1095,7 @@ async fn run_soak(config: &Config) -> i32 {
         timestamp: utc_timestamp_now(),
     };
 
-    print_summary(&report, &tombstones, &disk, redb_tombstone_scan);
+    print_summary(&report, &tombstones, &disk, &corpus, redb_tombstone_scan);
     if let Some(path) = &config.json_output {
         write_report(path, &report);
         println!("wrote JSON report to {}", path.display());
@@ -1014,6 +1152,7 @@ fn print_summary(
     r: &SoakReport,
     tombstones: &TombstoneAssessment,
     disk: &DiskAssessment,
+    corpus: &TombstoneCorpusAssessment,
     redb_tombstone_scan: Option<u64>,
 ) {
     println!("\n=== SOAK SUMMARY ===");
@@ -1068,27 +1207,70 @@ fn print_summary(
             .as_ref()
             .map_or_else(String::new, |r| format!(" reason={r}")),
     );
-    // Positive-control cross-check (R5): an independent, gauge-free scan of the
-    // real on-disk tombstone corpus, taken after the server process exited. A
-    // large divergence from `tombstones.last_bytes` above means the exported
-    // gauge is not tracking the true corpus (e.g. an un-migrated legacy
-    // `OrTombstones` blob the hot-path gauge never added on read) — REPORT-ONLY,
-    // never asserted into `passed`.
+    // The durable-corpus gate's own verdict line, rendered under the single
+    // prefix constant so no site retypes it. Its content and meaning changed
+    // with the gate: it was a report-only positive-control cross-check against
+    // the gauge, and it now carries the gate's verdict, the clause that decided
+    // it, the pre-registered series aggregates and both knob values. The
+    // gauge cross-check rides along on the same line — a divergence from
+    // `tombstones.last_bytes` still means the exported gauge is not tracking
+    // the true corpus (e.g. an un-migrated legacy `OrTombstones` blob the
+    // hot-path gauge never added on read).
+    let corpus_disposition = match corpus.disposition {
+        // A suppressed clause is rendered WITH the two numbers that suppressed
+        // it, never as a pass: a clause that did not decide must not be
+        // indistinguishable from one that decided and was satisfied.
+        CorpusLevelDisposition::LevelSuppressed => format!(
+            "{}(n={}, span={:.0}s)",
+            corpus.disposition.as_str(),
+            corpus.samples,
+            corpus.span_secs
+        ),
+        CorpusLevelDisposition::LevelEvaluated | CorpusLevelDisposition::InstrumentFailed => {
+            corpus.disposition.as_str().to_string()
+        }
+    };
+    // A disarmed ceiling renders as the word, never as an absent token:
+    // "disarmed" and "armed at n" have to be distinguishable on the line.
+    let corpus_ceiling = corpus
+        .ceiling_bytes
+        .map_or_else(|| "disarmed".to_string(), |c| c.to_string());
+    let corpus_reason = corpus
+        .reason
+        .as_ref()
+        .map_or_else(String::new, |r| format!(" reason={r}"));
+    let corpus_tokens = format!(
+        "first={} min={} peak={} last={} first_half_peak={} last_half_peak={} rise={} \
+         span={:.0}s scans_ok={} scans_failed={} headroom={} ceiling={} disposition={} -> {}",
+        corpus.first_bytes,
+        corpus.min_bytes,
+        corpus.peak_bytes,
+        corpus.last_bytes,
+        corpus.first_half_peak_bytes,
+        corpus.last_half_peak_bytes,
+        corpus.rise_bytes,
+        corpus.span_secs,
+        corpus.scans_attempted.saturating_sub(corpus.scans_failed),
+        corpus.scans_failed,
+        DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES,
+        corpus_ceiling,
+        corpus_disposition,
+        if corpus.passed { "ok" } else { "FAIL" },
+    );
     match redb_tombstone_scan {
         Some(scanned_bytes) => {
             let gauge_bytes = tombstones.last_bytes;
             let diverged = scanned_bytes != gauge_bytes;
             println!(
-                "tombstone_corpus_redb_scan: {scanned_bytes} bytes (independent of gauge; last \
-                 gauge value {gauge_bytes} bytes) -> {} (positive-control cross-check, \
-                 report-only)",
+                "{TOMBSTONE_CORPUS_LINE_PREFIX} {corpus_tokens} (terminal scan {scanned_bytes} \
+                 bytes; last gauge value {gauge_bytes} bytes -> {}){corpus_reason}",
                 if diverged { "DIVERGED" } else { "match" }
             );
         }
         None => {
             println!(
-                "tombstone_corpus_redb_scan: could not scan (missing/corrupt redb file or \
-                 table) — positive-control cross-check skipped, report-only"
+                "{TOMBSTONE_CORPUS_LINE_PREFIX} {corpus_tokens} (terminal scan could not read the \
+                 durable corpus — counted as a failed scan){corpus_reason}"
             );
         }
     }
@@ -1195,6 +1377,133 @@ fn parse_tombstone_bytes_gauge(body: &str) -> Option<u64> {
     None
 }
 
+/// Durable-corpus series accumulated across a run, plus the two scan counters
+/// the instrument clause is decided on.
+///
+/// `scans_attempted` is incremented ONCE per checkpoint. A checkpoint that
+/// could not obtain the state — whether the byte copy failed or the scan
+/// itself returned `None` — increments `scans_failed` and pushes no sample:
+/// an instrument that was blind is blind whichever step failed, and there is
+/// no third outcome and no silent skip.
+#[derive(Debug, Default, Clone)]
+struct CorpusScanTally {
+    samples: Vec<CorpusSample>,
+    scans_attempted: usize,
+    scans_failed: usize,
+}
+
+/// The durable-corpus sampler's per-run state, bundled the way the boot-gap
+/// clock above is: the recovery checkpoint takes one parameter for it instead
+/// of three. It holds the server's data dir (the copy's SOURCE), the scratch
+/// root the copies are written to — deliberately OUTSIDE the data dir — and
+/// the shared sink the samples and counters land in.
+struct CorpusSampler {
+    data_dir: PathBuf,
+    scratch_root: PathBuf,
+    tally: Mutex<CorpusScanTally>,
+}
+
+impl CorpusSampler {
+    fn new(data_dir: PathBuf, scratch_root: PathBuf) -> Self {
+        Self {
+            data_dir,
+            scratch_root,
+            tally: Mutex::new(CorpusScanTally::default()),
+        }
+    }
+
+    /// The accumulated series and counters, as the estimator consumes them.
+    fn snapshot(&self) -> CorpusScanTally {
+        self.tally.lock().clone()
+    }
+
+    /// Fold the TERMINAL scan onto the same two counters as the checkpoint
+    /// samples. That scan is the one siting that reads the data dir directly
+    /// and takes no copy: it runs post-teardown, nothing boots after it, so
+    /// there is nothing left for the instrument to stay neutral toward.
+    fn record_terminal_scan(&self, elapsed_secs: f64, scanned: Option<u64>) {
+        let mut t = self.tally.lock();
+        t.scans_attempted += 1;
+        match scanned {
+            Some(bytes) => t.samples.push(CorpusSample {
+                elapsed_secs,
+                bytes,
+            }),
+            None => t.scans_failed += 1,
+        }
+    }
+}
+
+/// Take one durable-corpus sample while the server process is dead, WITHOUT
+/// letting the instrument touch the file the server is about to recover from.
+///
+/// The server's redb file is byte-copied to a per-checkpoint scratch directory
+/// outside the data dir, the COPY is scanned, and the copy is deleted before
+/// the caller restarts the server. `redb::Database::open` repairs and commits
+/// an uncleanly-closed file, so scanning the original here would run the
+/// server's own recovery ahead of the server and perturb the input of the
+/// crash-recovery gate; scanning a copy leaves that gate measuring exactly
+/// what it measured before this sampler existed. The scratch directory also
+/// lives outside the data dir because the disk gate's input is `du -sk` over
+/// the data dir, and a copy written inside it would step that gate too.
+///
+/// The scratch path carries the checkpoint ordinal, so two samples can never
+/// alias and a delete that failed cannot leave a previous sample's bytes to be
+/// re-scanned as this one's. A failed DELETE is not a scan failure — the
+/// sample was obtained — so it is logged and the run continues; the teardown
+/// sweep removes the residue.
+fn sample_durable_corpus_via_copy(sampler: &CorpusSampler, elapsed_secs: f64) {
+    // One attempt per checkpoint, counted before anything can fail, so a
+    // failure can never go unattributed.
+    let ordinal = {
+        let mut t = sampler.tally.lock();
+        t.scans_attempted += 1;
+        t.scans_attempted
+    };
+    let copy_dir = sampler.scratch_root.join(format!("corpus-{ordinal}"));
+    // The scan resolves `topgun.redb` under the directory it is given, so the
+    // ordinal is carried by the directory and the copy keeps the name the scan
+    // looks for.
+    let copy_path = copy_dir.join("topgun.redb");
+    if let Err(e) = std::fs::create_dir_all(&copy_dir) {
+        eprintln!(
+            "durable-corpus sample {ordinal}: cannot create scratch dir {}: {e}",
+            copy_dir.display()
+        );
+        sampler.tally.lock().scans_failed += 1;
+        return;
+    }
+    // `std::fs::copy` truncates an existing destination, so even an aliasing
+    // bug could not produce a partial-overwrite hybrid.
+    if let Err(e) = std::fs::copy(sampler.data_dir.join("topgun.redb"), &copy_path) {
+        eprintln!("durable-corpus sample {ordinal}: cannot copy redb file: {e}");
+        sampler.tally.lock().scans_failed += 1;
+        return;
+    }
+
+    // The scan owns and drops its redb handle inside its own body, so the
+    // handle is released before the delete below and before the caller
+    // restarts the server. No handle may be hoisted out of it.
+    let scanned = scan_redb_tombstone_corpus(&copy_dir, OR_MAP);
+
+    if let Err(e) = std::fs::remove_dir_all(&copy_dir) {
+        eprintln!(
+            "durable-corpus sample {ordinal}: scratch copy left behind at {} ({e}) — sample \
+             still counted; teardown sweeps the residue",
+            copy_dir.display()
+        );
+    }
+
+    let mut t = sampler.tally.lock();
+    match scanned {
+        Some(bytes) => t.samples.push(CorpusSample {
+            elapsed_secs,
+            bytes,
+        }),
+        None => t.scans_failed += 1,
+    }
+}
+
 /// Independent, gauge-free scan of the OR-Map's on-disk tombstone corpus: the
 /// positive control's cross-check that `topgun_ormap_tombstone_bytes` is
 /// actually tracking the real durable byte total, not merely plateauing
@@ -1214,14 +1523,36 @@ fn parse_tombstone_bytes_gauge(body: &str) -> Option<u64> {
 /// remain resident. Comparing this scan's total against the gauge's last
 /// sampled value is exactly what catches that divergence.
 ///
-/// MUST run only after `ServerSupervisor::shutdown` has reaped the child
-/// process: redb is single-writer, so the server's own handle on the file must
-/// already be released before this process can open it. This is therefore a
-/// post-teardown assertion, not a live sampler alongside RSS/tombstone-bytes/
-/// disk above. Returns `None` on any failure (file missing, corrupt header,
-/// table absent) — best-effort, mirroring `sample_rss_mb`/`sample_disk_mb`'s
-/// None-on-failure contract — so a scan failure is reported as "could not
-/// scan", never mistaken for a genuinely empty (zero-byte) corpus.
+/// PRECONDITION: THE CHILD PROCESS HAS BEEN REAPED. redb is single-writer, so
+/// the server's own handle on the file must already be released before this
+/// process can open it. `kill9` satisfies that exactly as `shutdown` does —
+/// both await `child.wait()` — so this IS a live sampler: it is called once
+/// per recovery checkpoint, in the window between the `kill -9` and the
+/// restart, and once more terminally after teardown. What it reads is the
+/// PRE-RECOVERY on-disk state, because at both sites no recovery has run yet.
+///
+/// CALLER OBLIGATION AT A LIVE CHECKPOINT: PASS A DIRECTORY HOLDING A BYTE
+/// COPY, NEVER THE SERVER'S OWN DATA DIR. This function OPENS a redb database,
+/// and `redb::Database::open` on an uncleanly-closed file REPAIRS AND COMMITS
+/// it — a write. Opening the server's own file between the kill and the
+/// restart would make this harness perform the server's own crash recovery,
+/// and the server's crash recovery is precisely what the run's
+/// `recovery_failures` gate measures; an instrument may not mutate what
+/// another gate measures. So a checkpoint caller copies
+/// `{data_dir}/topgun.redb` to a scratch path outside the data dir and hands
+/// this function the directory holding that copy — any repair redb performs
+/// happens on the copy, which is deleted immediately afterwards, and the
+/// server stays the FIRST opener of the original. The terminal call is the one
+/// exception, and it is stated as such: it runs post-teardown, nothing boots
+/// after it, so it reads the data dir directly.
+///
+/// Returns `None` on any failure (file missing, corrupt header, table absent)
+/// — best-effort, mirroring `sample_rss_mb`/`sample_disk_mb`'s None-on-failure
+/// contract. That `None` is no longer a report-only "could not scan" skip: it
+/// is the durable-corpus gate's INSTRUMENT-clause FAIL input, and at a live
+/// checkpoint a failed COPY reaches the same clause by the same path, so a
+/// blind instrument fails the run instead of reading as bounded growth. An
+/// honest `Some(0)` from a never-written table stays distinguishable from it.
 fn scan_redb_tombstone_corpus(data_dir: &Path, map: &str) -> Option<u64> {
     let db_path = data_dir.join("topgun.redb");
     if !db_path.exists() {
@@ -1666,6 +1997,11 @@ struct RecoveryOutcome {
 /// verify the recovered state is byte-for-byte the pre-crash state. This tests
 /// crash recovery in isolation: no client writes occur across the boundary, so
 /// any post != pre is a recovery defect, not a lost-in-flight write.
+// One parameter over the threshold, and deliberately so: the alternative is a
+// wrapper struct whose only job is to carry the boot-gap clock and the corpus
+// sampler together, which would hide two independent instruments behind one
+// name for no gain. The corpus sampler already bundles its own three fields.
+#[allow(clippy::too_many_arguments)]
 async fn recovery_checkpoint(
     supervisor: &Arc<ServerSupervisor>,
     model: &Arc<Model>,
@@ -1674,6 +2010,7 @@ async fn recovery_checkpoint(
     config: &Config,
     paused: &Arc<AtomicBool>,
     boot_gap_clock: &BootGapClock,
+    corpus_sampler: &CorpusSampler,
 ) -> Result<RecoveryOutcome> {
     paused.store(true, Ordering::SeqCst);
     // Pause new client writes, then choose the pre-kill behavior:
@@ -1742,7 +2079,20 @@ async fn recovery_checkpoint(
         start_secs: gap_start_secs,
         end_secs: f64::INFINITY,
     });
-    if let Err(e) = supervisor.restart(config.ready_timeout).await {
+    // Expanded in place from the single `supervisor.restart(...)` this used to
+    // call: the durable-corpus sample has to be taken while the child is
+    // reaped and BEFORE the server re-opens its file, because opening it is
+    // what runs recovery. `restart`'s 250 ms socket-release gap and its
+    // failed-start handling are kept verbatim below, and `restart` itself
+    // stays in use by its other call sites.
+    supervisor.kill9().await;
+    sample_durable_corpus_via_copy(
+        corpus_sampler,
+        boot_gap_clock.sampler_start.elapsed().as_secs_f64(),
+    );
+    // Brief gap so the OS releases the listening socket before rebind.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    if let Err(e) = supervisor.start(config.ready_timeout).await {
         out.hard
             .push(format!("server failed to restart after kill -9: {e}"));
         paused.store(false, Ordering::SeqCst);

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -22,9 +22,9 @@
 //!    (last-half-window OLS, boot-recompute-gap samples excluded — see
 //!    `monitor.rs`) is computed against a tight per-hour threshold — a direct,
 //!    residency-independent leak signal with no allocator/cache noise floor.
-//!    The slope is a HARD gate only where the durable-corpus level clause
-//!    below could not decide; where that clause decides, the slope is
-//!    report-only. Either way a tracked-and-ACKing client
+//!    The slope is a HARD gate in every run class. The durable-corpus level
+//!    clause below is report-only and takes no run class over from it.
+//!    A tracked-and-ACKing client
 //!    (`SoakClient::connect_tracked` + `confirm_apply`) is driven alongside the
 //!    churn clients for the run's duration so the server's per-device causal
 //!    frontier — and therefore its low-water-mark — actually advances, which is
@@ -35,10 +35,13 @@
 //!    on a not-yet-flattened ramp, and the blind-monitor (zero-sample) clause
 //!    hard-gates independently of the slope. Beside the gauge, the DURABLE
 //!    corpus itself is sampled from a byte copy of the datastore at every
-//!    recovery checkpoint: a sampler that went blind fails the run outright,
-//!    and a corpus whose recent half peaks more than the configured headroom
-//!    above its earlier half fails it too. That durable clause is what makes
-//!    the gauge slope above conditional rather than unconditional.
+//!    recovery checkpoint: a blind sampler, a recent half peaking more than
+//!    the configured headroom above the earlier half, and a peak above an
+//!    armed ceiling are each recorded and rendered. All three are REPORT-ONLY,
+//!    because a control cell with no fault injected at all breached the
+//!    headroom clause on its own — an instrument that fires on an unperturbed
+//!    run cannot yet tell a leak from ordinary growth, so it decides no
+//!    verdict and takes nothing over from the gauge slope above.
 //!    Server RSS is sampled in parallel
 //!    and asserted against a looser slope as a coarse, non-tombstone backstop
 //!    gate. The on-disk data-dir slope (below) remains REPORT-ONLY — bounding
@@ -50,7 +53,7 @@
 //! `--inject-divergence` makes the convergence check go red, and
 //! `--inject-panic` makes the panic capture go red. A soak that cannot fail
 //! proves nothing. Two more MODES exist specifically to prove the
-//! durable-corpus gate and the conditional tombstone-byte hard gate above are
+//! durable-corpus instrument and the tombstone-byte hard gate above are
 //! honest: `--no-ack` disables the tracked
 //! client's confirm-apply loop (the low-water-mark then never advances, prune
 //! never fires, and the gate must FAIL under sustained churn), and
@@ -198,9 +201,9 @@ struct Config {
     confirm_interval: Duration,
     /// Negative control: disables the tracked client's confirm-apply loop
     /// entirely. With no client ever confirming, the low-water-mark stays 0,
-    /// prune never fires, and sustained OR churn must trip the durable-corpus
-    /// hard gate — and the tombstone-byte slope clause with it, wherever the
-    /// level clause did not decide.
+    /// prune never fires, and sustained OR churn must trip the tombstone-byte
+    /// hard gate — with the report-only durable-corpus instrument recording
+    /// the same growth alongside it.
     no_ack: bool,
     /// Adds a second tracked client (`SLOW_LEAK_TRACKER_IDX`) that ACKs on a
     /// much slower cadence than the primary tracker. Because the low-water-mark
@@ -840,9 +843,9 @@ async fn run_soak(config: &Config) -> i32 {
     // The TERMINAL corpus scan: the server process has just been reaped, so its
     // redb handle is released and this scan can safely open the same file
     // directly — no copy, because nothing boots after it. It contributes the
-    // final sample of the durable-corpus series, so it is no longer
-    // report-only: it now feeds the instrument and level clauses that are
-    // ANDed into `passed` below. Its cross-check against the gauge's
+    // final sample of the durable-corpus series, which feeds the instrument,
+    // level and ceiling clauses rendered below. Its cross-check against the
+    // gauge's
     // `last_bytes` survives on the same rendered line — see
     // `scan_redb_tombstone_corpus`'s doc for why a divergence there is exactly
     // the failure mode this exists to catch.
@@ -862,8 +865,8 @@ async fn run_soak(config: &Config) -> i32 {
     );
 
     // --- Assess tombstone-byte growth (direct residency-independent leak
-    // instrument, the bounded-plateau signal — a HARD gate wherever the
-    // durable-corpus level clause did not decide, see the note below).
+    // instrument, the bounded-plateau signal — a HARD gate in every run
+    // class, see the note below).
     // Coexists with the RSS gate above as a coarse non-tombstone
     // backstop — neither replaces the other. The sampling loop already
     // excluded boot-recompute-gap samples (R9(c)), so this series is safe to
@@ -876,10 +879,10 @@ async fn run_soak(config: &Config) -> i32 {
         DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS,
     );
 
-    // The tombstone-byte SLOPE clause is a CONDITIONAL HARD gate: it decides
-    // the verdict in exactly the run class where the durable-corpus level
-    // clause below could not, and is report-only wherever that clause did
-    // decide. Where it decides, the tracked-and-ACKing client spawned above
+    // The tombstone-byte SLOPE clause is an UNCONDITIONAL HARD gate: it
+    // decides the verdict in every run class, and the durable-corpus level
+    // clause below takes none of them over, because that clause is
+    // report-only. The tracked-and-ACKing client spawned above
     // (`run_tracked_confirm_client` / `TRACKER_IDX`) drives the server's
     // per-device causal frontier forward every `confirm_interval`, so the
     // fleet-wide low-water-mark actually advances and the epoch-scoped prune
@@ -909,14 +912,17 @@ async fn run_soak(config: &Config) -> i32 {
 
     // --- Assess the DURABLE tombstone corpus: the level/ceiling instrument
     // that reads the on-disk corpus itself rather than the exported gauge.
-    // Two of its clauses are ANDed into the run verdict below. The INSTRUMENT
-    // clause fails a run whose sampler could not obtain the state at some
-    // checkpoint — a blind instrument must never be read as bounded growth.
-    // The LEVEL clause compares the peak of the series' recent half against
-    // the peak of its earlier half, and decides only on a series long enough
-    // for that comparison to mean anything (the sample and span guards); where
-    // it cannot decide, the byte slope above keeps deciding the verdict
-    // instead, so no run configuration is left with neither.
+    // Its clauses are REPORT-ONLY and none of them is ANDed into the run
+    // verdict below. The INSTRUMENT clause flags a run whose sampler could not
+    // obtain the state at some checkpoint — a blind instrument must never be
+    // read as bounded growth. The LEVEL clause compares the peak of the
+    // series' recent half against the peak of its earlier half, and decides
+    // only on a series long enough for that comparison to mean anything (the
+    // sample and span guards). A live control cell with no fault injected
+    // breached the level clause on its own, so the clause is not yet able to
+    // separate a leak from ordinary growth and must not fail honest runs; the
+    // byte slope above therefore keeps gating every run class, and no run
+    // configuration is left ungated.
     let corpus_snapshot = corpus_sampler.snapshot();
     let corpus = assess_tombstone_corpus_level(
         &corpus_snapshot.samples,
@@ -945,19 +951,19 @@ async fn run_soak(config: &Config) -> i32 {
     let disk_blind_monitor = disk.samples == 0;
 
     let panic_report = panic_watch.report();
-    // The durable-corpus verdict is the HARD gate; the slope clause hard-gates
-    // exactly where the level clause did NOT decide. That fallback term is
-    // routed through `slope_clause_stays_hard`, which enumerates every
-    // disposition and therefore stops a future fourth one from silently
-    // landing on either side — this expression re-types no comparison of its
-    // own. An instrument failure already forces `corpus.passed` false, so it
-    // fails through the first of the two terms and never reaches the fallback.
+    // The tombstone-byte slope is the HARD gate, in every run class and with
+    // no guard in front of it. The durable-corpus verdict is deliberately
+    // absent from this conjunction: the control cell that injected no fault at
+    // all breached the level clause on its own, which destroys attribution —
+    // an instrument that reds an unperturbed run would fail honest runs rather
+    // than leaking ones. It is still computed, still rendered and still
+    // serialized on every run, and a breach is recorded on `pending_gates`
+    // below, so demoting it hides nothing and gates nothing.
     let passed = convergence_failures.is_empty()
         && recovery_failures.is_empty()
         && mem.passed
         && !blind_monitor
-        && corpus.passed
-        && (!slope_clause_stays_hard(corpus.disposition) || tombstones.passed)
+        && tombstones.passed
         && !disk_blind_monitor
         && panic_report.is_none();
 
@@ -965,11 +971,11 @@ async fn run_soak(config: &Config) -> i32 {
     // assignments whose last one happened to win. The precedence is decided
     // here rather than by source order: a cause unrelated to the tombstone
     // gates outranks a gate verdict, so a broken run can never read as a clean
-    // gate demonstration, and the corpus arm outranks the slope fallback, so
-    // one run cannot attribute itself to two different causes across its
-    // console line and its JSON report. On a run with a single failure the
+    // gate demonstration. On a run with a single failure the
     // string is what it was before; only multi-failure runs re-order, and they
-    // re-order toward the unrelated cause.
+    // re-order toward the unrelated cause. Rank 3 — the durable-corpus arm —
+    // writes no reason at all now that those clauses are report-only: a run
+    // they cannot fail must not be handed a reason saying they failed it.
     //
     // Rank 0: an earlier phase — convergence divergence, crash-recovery
     // mismatch, server panic — already wrote a reason, so this writer does not
@@ -989,45 +995,16 @@ async fn run_soak(config: &Config) -> i32 {
                 "tombstone-byte monitoring blind: {}",
                 tombstones.reason.clone().unwrap_or_default()
             ))
-        } else if !corpus.passed {
-            // Rank 3, switched so the reason names the clause that actually
-            // fired rather than the gate as a whole. The level / not-level
-            // split is taken from the same exhaustive predicate the verdict
-            // conjunction above uses, so the verdict and the reason cannot
-            // disagree about which clause was live.
-            Some(if slope_clause_stays_hard(corpus.disposition) {
-                // The level clause did not decide. Either the instrument was
-                // blind, or - the instrument being sound - the absolute
-                // ceiling is the only clause left that can have breached.
-                if corpus.disposition == CorpusLevelDisposition::InstrumentFailed {
-                    format!(
-                        "durable-corpus instrument failed: {}",
-                        corpus.reason.clone().unwrap_or_default()
-                    )
-                } else {
-                    format!(
-                        "durable-corpus ceiling assertion failed: {}",
-                        corpus.reason.clone().unwrap_or_default()
-                    )
-                }
-            } else {
-                format!(
-                    "durable-corpus level assertion failed: {}",
-                    corpus.reason.clone().unwrap_or_default()
-                )
-            })
-        } else if slope_clause_stays_hard(corpus.disposition) && !tombstones.passed {
-            // A CONDITIONAL HARD gate: with the tracked-and-ACKing
+        } else if !tombstones.passed {
+            // An UNCONDITIONAL HARD gate: with the tracked-and-ACKing
             // client driving the low-water-mark, a sustained slope breach past the
             // min-window-guarded threshold means the epoch-scoped prune is not
             // keeping up with (or has stopped) bounding tombstone growth — a real
             // regression, not an expected/known gap. AND it into `passed`.
             //
-            // Rank 4: the slope clause, which hard-gates only when L1 did not decide.
-            // The guard is exactly the verdict's fallback term above,
-            // so the verdict and the reason switch on the same predicate: where
-            // the level clause decided, the slope is report-only and the run
-            // may pass despite this breach, and a passing run must not carry a
+            // Rank 4: the slope clause, which hard-gates every run class. The
+            // guard is exactly the verdict's own term above, so the verdict and
+            // the reason cannot disagree, and a passing run cannot carry a
             // failure reason.
             Some(format!(
                 "tombstone-byte growth slope {:.1} bytes/h exceeds {:.1} bytes/h: {}",
@@ -1050,6 +1027,27 @@ async fn run_soak(config: &Config) -> i32 {
         if let Some(reason) = ranked {
             finished_reason = reason;
         }
+    }
+    if !corpus.passed {
+        // The durable-corpus clauses decide nothing, so a breach is recorded
+        // here instead of failing the run — the same channel the disk slope
+        // below uses for an observation that is real but not yet gate-worthy.
+        // Which clause to name comes from the exhaustive disposition predicate,
+        // so a future fourth disposition cannot land silently on either side of
+        // the split, and this block re-types no comparison of its own.
+        let clause = if slope_clause_stays_hard(corpus.disposition) {
+            if corpus.disposition == CorpusLevelDisposition::InstrumentFailed {
+                "instrument failed"
+            } else {
+                "ceiling assertion failed"
+            }
+        } else {
+            "level assertion failed"
+        };
+        pending_gates.push(format!(
+            "durable-corpus {clause}: {} (report-only, did NOT fail the run)",
+            corpus.reason.clone().unwrap_or_default()
+        ));
     }
     if !disk_blind_monitor && !disk.passed {
         // Report-only, same rationale as the tombstone-byte slope above: the
@@ -1244,15 +1242,15 @@ fn print_summary(
         r.memory.slope_mb_per_hour,
         if r.memory.passed { "ok" } else { "FAIL" }
     );
-    // The byte SLOPE is a HARD gate only where the durable-corpus level clause
-    // did not decide; where it did decide, the slope is report-only. Either
-    // way the tracked-and-ACKing client drives
+    // The byte SLOPE is a HARD gate in every run class; the durable-corpus
+    // level clause beside it is report-only and takes none of them over. The
+    // tracked-and-ACKing client drives
     // the low-water-mark forward, so the epoch-scoped prune actually fires and
     // the gauge is expected to plateau under sustained churn (subject to the
     // min-window-span guard and boot-gap exclusion). See the run-end verdict
     // rationale.
     let tombstone_role =
-        "REPORT-ONLY-WHEN-L1-DECIDES / HARD-WHEN-L1-SUPPRESSED; blind-monitor hard-gates";
+        "slope + blind-monitor both hard-gate; durable-corpus clauses are report-only";
     println!(
         "tombstone_bytes:   first={} peak={} last={} slope={:.1}B/h samples={} -> {} ({}){}",
         tombstones.first_bytes,
@@ -1335,8 +1333,8 @@ fn print_summary(
             );
         }
     }
-    // Unlike the tombstone-byte slope above (a hard gate only where the
-    // durable-corpus level clause did not decide), the disk slope
+    // Unlike the tombstone-byte slope above (a hard gate in every run
+    // class), the disk slope
     // stays REPORT-ONLY: it is EXPECTED to breach pre-TODO-566 under default
     // OR-churn (linear durable-dir growth by design, independent of the
     // tombstone prune this spec drives); only the blind-monitor (zero-sample)
@@ -2537,8 +2535,8 @@ struct TrackerConfig {
 /// the ack) — the connection still exists so the harness's other assertions
 /// keep exercising it, but the server never sees an `ORMAP_SYNC_INIT` from this
 /// replica, so it is never tracked and the low-water-mark stays at its vacuous
-/// 0 for the whole run: the negative control for the durable-corpus hard gate
-/// and, wherever the level clause did not decide, the slope clause with it.
+/// 0 for the whole run: the negative control for the tombstone-byte hard gate,
+/// with the report-only durable-corpus instrument recording it alongside.
 async fn run_tracked_confirm_client(cfg: TrackerConfig) {
     let mut device_token: Option<String> = None;
     // Persisted across reconnects alongside `device_token`: the replica's
@@ -2595,7 +2593,7 @@ async fn run_tracked_confirm_client(cfg: TrackerConfig) {
                         // Surface the failure rather than reconnect-looping
                         // silently: a swallowed confirm error looks identical to
                         // a server tombstone leak (LWM never advances → gauge
-                        // climbs → the durable-corpus hard gate REDs), so an
+                        // climbs → the tombstone-byte hard gate REDs), so an
                         // invisible plumbing bug
                         // would masquerade as the very defect this gate hunts.
                         cfg.metrics.confirm_errors.fetch_add(1, Ordering::Relaxed);
@@ -2828,7 +2826,8 @@ fn print_usage() {
     // The two durable-corpus knobs are spelled out with their effect, because
     // an operator arming a gate needs to know what each one moves:
     //   --tombstone-corpus-headroom-bytes <n>  slack the LEVEL clause allows
-    //   --tombstone-corpus-ceiling-bytes <n>  arm L2's absolute HARD gate ceiling
+    //   --tombstone-corpus-ceiling-bytes <n>  arm L2's absolute ceiling — a
+    //       reported bound, not a HARD gate ceiling
     println!(
         "TopGun soak harness (G4b / TODO-484)\n\n\
          Drives the real out-of-process topgun-server against an on-disk redb + WAL,\n\
@@ -2843,9 +2842,9 @@ fn print_usage() {
          \x20 # negative controls (must exit non-zero == assertion RED)\n\
          \x20 soak_harness --inject-divergence\n\
          \x20 soak_harness --inject-panic\n\
-         \x20 soak_harness --no-ack --duration 3600  # corpus+slope hard-gate must FAIL\n\
+         \x20 soak_harness --no-ack --duration 3600  # slope hard-gate must FAIL\n\
          \x20 soak_harness --inject-slow-leak --duration 3600  # slope detection-floor calibration\n\
-         \x20 # durable-corpus gate knobs (default: headroom 65536 bytes, ceiling disarmed)\n\
+         \x20 # durable-corpus knobs (default: headroom 65536 bytes, ceiling disarmed)\n\
          \x20 soak_harness --tombstone-corpus-headroom-bytes 262144 \\\n\
          \x20              --tombstone-corpus-ceiling-bytes 8388608\n\
          \x20 # OR-churn WAL/RSS growth mechanism report (Q1-Q4), report-only\n\

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -977,23 +977,31 @@ async fn run_soak(config: &Config) -> i32 {
                 tombstones.reason.clone().unwrap_or_default()
             ))
         } else if !corpus.passed {
-            // Rank 3, switched on the disposition so the reason names the
-            // clause that actually fired rather than the gate as a whole.
-            Some(match corpus.disposition {
-                CorpusLevelDisposition::InstrumentFailed => format!(
-                    "durable-corpus instrument failed: {}",
-                    corpus.reason.clone().unwrap_or_default()
-                ),
-                CorpusLevelDisposition::LevelEvaluated => format!(
+            // Rank 3, switched so the reason names the clause that actually
+            // fired rather than the gate as a whole. The level / not-level
+            // split is taken from the same exhaustive predicate the verdict
+            // conjunction above uses, so the verdict and the reason cannot
+            // disagree about which clause was live.
+            Some(if slope_clause_stays_hard(corpus.disposition) {
+                // The level clause did not decide. Either the instrument was
+                // blind, or - the instrument being sound - the absolute
+                // ceiling is the only clause left that can have breached.
+                if corpus.disposition == CorpusLevelDisposition::InstrumentFailed {
+                    format!(
+                        "durable-corpus instrument failed: {}",
+                        corpus.reason.clone().unwrap_or_default()
+                    )
+                } else {
+                    format!(
+                        "durable-corpus ceiling assertion failed: {}",
+                        corpus.reason.clone().unwrap_or_default()
+                    )
+                }
+            } else {
+                format!(
                     "durable-corpus level assertion failed: {}",
                     corpus.reason.clone().unwrap_or_default()
-                ),
-                // The level clause did not decide here, so the absolute
-                // ceiling is the only clause that can have breached.
-                CorpusLevelDisposition::LevelSuppressed => format!(
-                    "durable-corpus ceiling assertion failed: {}",
-                    corpus.reason.clone().unwrap_or_default()
-                ),
+                )
             })
         } else if slope_clause_stays_hard(corpus.disposition) && !tombstones.passed {
             // HARD gate (promoted from report-only): with the tracked-and-ACKing
@@ -1261,9 +1269,10 @@ fn print_summary(
             corpus.samples,
             corpus.span_secs
         ),
-        CorpusLevelDisposition::LevelEvaluated | CorpusLevelDisposition::InstrumentFailed => {
-            corpus.disposition.as_str().to_string()
-        }
+        // Every other disposition renders its bare token, taken from the same
+        // `as_str` the JSON report serializes through so the console and the
+        // artifact cannot disagree.
+        _ => corpus.disposition.as_str().to_string(),
     };
     // A disarmed ceiling renders as the word, never as an absent token:
     // "disarmed" and "armed at n" have to be distinguishable on the line.

--- a/packages/server-rust/benches/soak_harness/main.rs
+++ b/packages/server-rust/benches/soak_harness/main.rs
@@ -1608,11 +1608,11 @@ fn sample_durable_corpus_via_copy(sampler: &CorpusSampler, elapsed_secs: f64) {
 ///
 /// Returns `None` on any failure (file missing, corrupt header, table absent)
 /// — best-effort, mirroring `sample_rss_mb`/`sample_disk_mb`'s None-on-failure
-/// contract. That `None` is no longer a report-only "could not scan" skip: it
-/// is the durable-corpus gate's INSTRUMENT-clause FAIL input, and at a live
-/// checkpoint a failed COPY reaches the same clause by the same path, so a
-/// blind instrument fails the run instead of reading as bounded growth. An
-/// honest `Some(0)` from a never-written table stays distinguishable from it.
+/// contract. That `None` is the durable-corpus INSTRUMENT clause's breach
+/// input, and at a live checkpoint a failed COPY reaches the same clause by the
+/// same path. The clause is report-only, so a blind instrument is recorded on
+/// `pending_gates` rather than failing the run. An honest `Some(0)` from a
+/// never-written table stays distinguishable from it.
 fn scan_redb_tombstone_corpus(data_dir: &Path, map: &str) -> Option<u64> {
     let db_path = data_dir.join("topgun.redb");
     if !db_path.exists() {

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -1386,8 +1386,8 @@ mod tests {
     /// looks for cannot occur. This test feeds exactly that monotone shape (well
     /// past the min-window floor) and asserts the assessment reports NOT-passed
     /// — which is precisely the hard-gate failure `main.rs` asserts on for this
-    /// scenario whenever the durable-corpus level clause did not decide the run
-    /// (see the module doc's "Tombstone-byte gate" section).
+    /// scenario in every run class; the durable-corpus level clause beside it is
+    /// report-only (see the module doc's "Tombstone-byte gate" section).
     #[test]
     fn calibration_additive_only_gauge_never_plateaus() {
         // ~6h of steady creation at 5000 B/h — a multi-hour last-half window
@@ -1404,7 +1404,7 @@ mod tests {
             !a.passed,
             "an unbounded monotone-growth shape (no low-water-mark driver) must \
              NOT be reported as a plateau — this is the hard-gate FAIL `main.rs` \
-             asserts on when the durable-corpus level clause did not decide; \
+             asserts on in every run class; \
              slope={:.1} reason={:?}",
             a.slope_bytes_per_hour, a.reason
         );
@@ -1759,7 +1759,8 @@ mod tests {
         assert_eq!(a.disposition, CorpusLevelDisposition::InstrumentFailed);
         assert!(
             !a.passed,
-            "a blind scan must fail the run closed; reason={:?}",
+            "a blind scan must be assessed NOT-passed and typed InstrumentFailed; \
+             the clause itself is report-only. reason={:?}",
             a.reason
         );
     }

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -483,6 +483,250 @@ pub fn assess_tombstone_bytes(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Durable-layer OR tombstone corpus: level/ceiling estimator.
+//
+// The items below are the estimator's frozen surface. They are `allow`ed for
+// dead code because the soak binary does not reference them until the sampler
+// and the verdict re-point are wired; the calibration integration target
+// already includes this module under its own `allow(dead_code)`.
+// ---------------------------------------------------------------------------
+
+/// Level headroom (bytes) between the first-half and last-half corpus peaks.
+///
+/// Derived, not chosen, and every number below is either quoted from a
+/// committed source with its `file:line` or computed from two such numbers with
+/// the arithmetic shown. All three steps are normalised to the SAME window: the
+/// control cells run 900 s at `--crash-interval 120`, so the corpus series
+/// spans ≈ 780 s (terminal scan minus FIRST checkpoint) and its last half
+/// covers ≈ 390 s = 0.108333 h.
+///
+/// 1. NOISE, EXPRESSED AS A LEVEL RATHER THAN A RATE. The recorded width-100
+///    spread of 8,756 B/h was fitted over a 900 s = 0.25 h last-half window
+///    (`spec356-manifest.md:1634`, `:1961-1962`), so the primitive noise
+///    magnitude is a LEVEL of `8,756 × 0.25 = 2,189 B`; renormalised to the
+///    390 s window it is `8,756 × 0.108333 = 948.6 B`. 65,536 sits 29.9× above
+///    the as-measured figure and 69.1× above the normalised one.
+/// 2. ABOVE THE HEALTHY SIGNAL. The width-100 keeping-up cell recorded a
+///    backlog delta of +8,602 B over its own coordinate last-half window of 90
+///    rows / 900 s (`spec356-manifest.md:1961-1964`). Pro-rated to 390 s that
+///    is `8,602 × 390 / 900 = 3,727.5 B`, so the headroom sits 17.6× above it.
+/// 3. BELOW THE UNHEALTHY SIGNAL. The `long` cell's coordinate last-half window
+///    carried +5,303,731 B of backlog growth over a span of 7,190 s
+///    (`spec356-manifest.md:1660-1661`), i.e. 2,655,565 B/h; over the 390 s
+///    window that is 287,686 B, which is 4.4× this headroom.
+///
+/// Healthy ≈ 3,727.5 B, headroom 65,536 B, unhealthy ≈ 287,686 B — roughly one
+/// order of magnitude of margin on each side, with a 77× total separation
+/// (`287,686 / 3,727.5`). That separation is window-INVARIANT: it is a ratio of
+/// two quantities pro-rated by the same factor. No claim of two orders of
+/// magnitude is made, because the arithmetic does not support one.
+///
+/// THE PROXY IS DISCLOSED, NOT GLOSSED. Every magnitude above is a gauge or
+/// counter figure; no durable-corpus noise floor has ever been measured. What
+/// the committed evidence DOES bound is the substitution error of deriving a
+/// byte headroom from gauge magnitudes and applying it to corpus magnitudes:
+/// the 29 terminal `tombstone_corpus_redb_scan:` lines under
+/// `benches/soak_harness/evidence/` (29 files, 21 distinct runs) each render the
+/// scanned corpus beside the last gauge value, and across all of them the
+/// ABSOLUTE gap never exceeds 27,925 B, so `65,536 / 27,925 = 2.3×`. The bound
+/// is stated in bytes and not as a percentage because the relative gap is not
+/// uniform (0.5–3 % on the ≥ 400 KB cells, tens of percent on the ~20–50 KB
+/// ones) and an absolute bound is what this clause actually consumes. Those
+/// lines are single terminal scalars, one per run: they are NOT a noise floor
+/// and NOT a retune input. Revising this constant on measured durable-corpus
+/// data is a recorded revision, never a keyboard retune.
+#[allow(dead_code)]
+pub const DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES: u64 = 65_536;
+
+/// Minimum wall-clock span (seconds) of the corpus series before L1 may decide.
+///
+/// Five times [`DEFAULT_TOMBSTONE_BYTES_MIN_WINDOW_SECS`]: far above the 25 s
+/// blocking smoke, far below any real soak.
+///
+/// It is also the BINDING guard on a control cell's duration, which is why the
+/// admissible range is derived here rather than chosen at the keyboard. At
+/// `--crash-interval 120` a cell of duration `D` puts its first checkpoint at
+/// ≈ 120 s and its terminal scan at ≈ `D`, so
+/// `span_secs ≈ D − 120` (terminal minus FIRST checkpoint, not minus `t = 0`)
+/// and `samples = floor(D / 120) + 1`. The sample guard `samples >= 4` binds at
+/// `D >= 360`; this span guard binds at `D − 120 >= 600`, i.e. `D >= 720`, and
+/// is therefore the binding one. The admissible range is
+/// `730 s <= D <= 900 s` — the 730 s lower bound carries a 10 s cushion over
+/// the derived 720 s for the strict comparison and for a first checkpoint that
+/// fires marginally late, and 900 s is the top of the range. A cell shorter
+/// than 730 s is inadmissible by construction.
+#[allow(dead_code)]
+pub const DEFAULT_TOMBSTONE_CORPUS_MIN_SPAN_SECS: f64 = 600.0;
+
+/// Minimum corpus samples before L1 may decide (at least 2 per half).
+///
+/// Two per half, so neither half-peak is a single point — the degenerate case
+/// [`last_half_window_span_secs`]'s own guard excludes for the same reason. At
+/// `--crash-interval 120` a 900 s cell yields 8 samples (7 checkpoints plus the
+/// terminal scan), clearing this guard with margin.
+#[allow(dead_code)]
+pub const DEFAULT_TOMBSTONE_CORPUS_MIN_SAMPLES: usize = 4;
+
+/// L2's absolute ceiling in bytes. `None` = DISARMED, and that is the default.
+///
+/// Arming it honestly requires a validated ceiling, and validating one requires
+/// a plateau demonstration that is out of scope here — so the clause ships
+/// implemented, unit-tested, rendered and armable from the CLI, and a later
+/// measurement round can arm it without a code change. `None` renders as
+/// `ceiling=disarmed` on the report line and as an EXPLICIT `null` in the JSON
+/// report, never as an omitted key: omitting it would make "L2 disarmed"
+/// indistinguishable from "this report predates the field", which is the
+/// invisible-suppression defect this estimator exists to refuse.
+#[allow(dead_code)]
+pub const DEFAULT_TOMBSTONE_CORPUS_CEILING_BYTES: Option<u64> = None;
+
+/// One durable-layer OR tombstone corpus scan, taken while the server process is
+/// DEAD (redb is single-writer, so its file lock must be free) and therefore
+/// reading the PRE-RECOVERY on-disk state.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub struct CorpusSample {
+    pub elapsed_secs: f64,
+    pub bytes: u64,
+}
+
+/// Which clause actually decided a corpus assessment. Rendered verbatim, so a
+/// clause that did not fire is visible rather than indistinguishable from a pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum CorpusLevelDisposition {
+    /// L1 was evaluated and decided.
+    LevelEvaluated,
+    /// L1 was NOT evaluated, so the slope clause hard-gates instead. Never "ok".
+    LevelSuppressed,
+    /// L0 failed. L1 and L2 are NOT EVALUATED (fail-closed order).
+    InstrumentFailed,
+}
+
+impl CorpusLevelDisposition {
+    /// The single rendered token for this disposition. Consumed BOTH by the
+    /// console line in `main.rs` and by the JSON serializer in `report.rs`, so
+    /// the two transports can never disagree and no site retypes a literal.
+    /// Deliberately hand-written rather than serde-derived: this file is
+    /// `#[path]`-included by an integration target and must stay `std`-only.
+    #[must_use]
+    #[allow(dead_code)]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LevelEvaluated => "LEVEL_EVALUATED",
+            Self::LevelSuppressed => "LEVEL_SUPPRESSED",
+            Self::InstrumentFailed => "INSTRUMENT_FAILED",
+        }
+    }
+}
+
+/// Verdict of a durable-layer corpus assessment.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct TombstoneCorpusAssessment {
+    pub scans_attempted: usize,
+    pub scans_failed: usize,
+    pub samples: usize,
+    /// PRE-REGISTERED AGGREGATES of the corpus series. These four — count
+    /// (`samples`), min, max (`peak_bytes`) and last — are the ONLY shape in
+    /// which the series reaches a consumer: publishing the per-sample series is
+    /// forbidden, so every predicate any downstream grading rests on must be
+    /// statable over exactly these.
+    pub first_bytes: u64,
+    pub min_bytes: u64,
+    pub peak_bytes: u64,
+    pub last_bytes: u64,
+    pub first_half_peak_bytes: u64,
+    pub last_half_peak_bytes: u64,
+    pub rise_bytes: u64,
+    pub span_secs: f64,
+    pub disposition: CorpusLevelDisposition,
+    /// `None` = L2 DISARMED. Serialized EXPLICITLY as `null` by the report
+    /// layer — absence must never be indistinguishable from suppression.
+    pub ceiling_bytes: Option<u64>,
+    pub passed: bool,
+    pub reason: Option<String>,
+}
+
+/// L0 and L1 are HARD gate clauses; L1 only when its two guards are met.
+///
+/// The three clauses are evaluated in this order, and the order is fail-closed:
+///
+/// * `L0` — INSTRUMENT. Breaches when `scans_failed > 0` OR `samples == 0`,
+///   yielding `passed = false`, [`CorpusLevelDisposition::InstrumentFailed`],
+///   a named reason, and NO evaluation of L1 or L2. A scan that could not
+///   obtain the state — missing file, corrupt header, a table-open error, or a
+///   failed byte copy — is a BLIND instrument, and a gate whose instrument was
+///   blind must not report bounded growth. An honest `Some(0)` from a
+///   never-written table is not a breach and must stay distinguishable from a
+///   blind `None`.
+/// * `L1` — LEVEL / FLATNESS. Evaluated only when `samples >= min_samples` AND
+///   `span_secs >= min_span_secs`; breaches when
+///   `last_half_peak_bytes.saturating_sub(first_half_peak_bytes) >
+///   headroom_bytes`, yielding [`CorpusLevelDisposition::LevelEvaluated`]. The
+///   `saturating_sub` is deliberate: a FALLING corpus yields `rise = 0` and
+///   passes, which is the correct answer for a ceiling test. When either guard
+///   is unmet the disposition is
+///   [`CorpusLevelDisposition::LevelSuppressed`], this clause contributes
+///   nothing to `passed`, and the suppression is rendered with BOTH numbers so
+///   it can never be read as a pass.
+/// * `L2` — ABSOLUTE CEILING. Evaluated only when `ceiling_bytes` is `Some(c)`;
+///   breaches when `peak_bytes > c`. It is an ENVELOPE test — the peak, not the
+///   last sample — because prune legitimately produces large downward
+///   excursions and a level-vs-final test would let a rising envelope hide
+///   behind one of them. Disarmed by default; see
+///   [`DEFAULT_TOMBSTONE_CORPUS_CEILING_BYTES`].
+///
+/// The peak is also why neither the mean nor the median is used anywhere here:
+/// a ceiling is an UPPER ENVELOPE, and those same downward excursions would
+/// drag a mean or a median and hide a rising envelope. Nothing in this clause
+/// is fitted; it compares bytes to bytes, so no `1/span` amplification can
+/// re-import a rate spread as if it were an independent noise source.
+///
+/// The window partition is the same split index [`last_half_window`] uses, so
+/// this clause and the slope clause split any series identically and a reader
+/// comparing the two is comparing like with like.
+///
+/// Total over its inputs: no panic path, no interior mutability, no I/O, and no
+/// dependency beyond `std` — this file is `#[path]`-included by an integration
+/// target that includes no sibling module.
+#[must_use]
+#[allow(dead_code, unused_variables, clippy::unimplemented)]
+pub fn assess_tombstone_corpus_level(
+    samples: &[CorpusSample],
+    scans_attempted: usize,
+    scans_failed: usize,
+    headroom_bytes: u64,
+    min_span_secs: f64,
+    min_samples: usize,
+    ceiling_bytes: Option<u64>,
+) -> TombstoneCorpusAssessment {
+    // The signature and its doc-contract above are frozen ahead of the body so
+    // the calibration fixtures and the report/console transports can be written
+    // against a surface that cannot drift; the clause arithmetic lands next.
+    unimplemented!("corpus level estimator body")
+}
+
+/// Whether the tombstone-byte SLOPE clause still hard-gates a run that
+/// produced this disposition. EXHAUSTIVE BY CONSTRUCTION: a fourth variant
+/// does not compile here, which is what makes the no-ungated-window coverage
+/// argument structural rather than a source-read. `main.rs`'s verdict
+/// expression consumes this and re-types no comparison of its own.
+#[must_use]
+// One arm per variant, deliberately not merged into a single `|` pattern: the
+// point of the enumeration is that every variant is classified in its own
+// right, so a fourth variant has to be given an explicit answer here rather
+// than being absorbed into an existing pattern.
+#[allow(dead_code, clippy::match_same_arms)]
+pub const fn slope_clause_stays_hard(disposition: CorpusLevelDisposition) -> bool {
+    match disposition {
+        CorpusLevelDisposition::LevelEvaluated => false,
+        CorpusLevelDisposition::LevelSuppressed => true,
+        CorpusLevelDisposition::InstrumentFailed => true,
+    }
+}
+
 /// One boot-recompute-gap window: the span (on the `elapsed_secs` clock shared
 /// with [`TombstoneSample`]) between a `kill -9` and the restarted process's
 /// health-ready signal, during which the tombstone-bytes gauge for the new

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -66,8 +66,12 @@
 //!
 //! Note on gating responsibility: [`assess_tombstone_bytes`] *computes* the byte
 //! verdict (including its `passed` flag), but whether that verdict gates the run
-//! is decided in `main.rs`, not here. The byte **slope** is now a HARD gate
-//! there. The gauge is restart-survivable (`reconcile_tombstone_bytes` in
+//! is decided in `main.rs`, not here. The byte **slope** is a HARD gate there
+//! only in the run class where the durable-corpus level clause did not decide:
+//! when that clause is evaluable it decides the tombstone property and the
+//! slope becomes report-only, and when it is not, the slope gates exactly as it
+//! always did — so no run configuration is left with neither.
+//! The gauge is restart-survivable (`reconcile_tombstone_bytes` in
 //! `storage/record.rs` re-seeds it via `set_tombstone_bytes` at boot) AND
 //! decrementable within a process life: every tombstone-add increments it and
 //! a successful prune-drop decrements it (`sub_tombstone_bytes`, wired on the
@@ -78,8 +82,9 @@
 //! one client actually runs the confirm-apply protocol. `main.rs` therefore
 //! also drives a tracked-and-ACKing client (`SoakClient::connect_tracked` +
 //! `confirm_apply`) alongside the churn clients for the run's duration, which
-//! is what makes the gauge's plateau — and thus the hard gate — reachable in
-//! practice rather than merely possible in principle. `main.rs`'s `--no-ack`
+//! is what makes the gauge's plateau — and thus the hard gate, in the run
+//! class where the slope still decides — reachable in practice rather than
+//! merely possible in principle. `main.rs`'s `--no-ack`
 //! and `--inject-slow-leak` modes are the negative/slow-leak controls that
 //! exercise this: disabling the tracked client's ack loop pins the
 //! low-water-mark at 0 and must trip the gate, and a deliberately
@@ -89,9 +94,10 @@
 //! `/metrics` scrape is a harness defect regardless of leak magnitude). The
 //! RSS gate above remains a coarse, non-tombstone backstop. (This module's
 //! `passed: bool` on [`TombstoneAssessment`] drives both the hard-gate
-//! decision in `main.rs` and the calibration tests below — the assessment
-//! itself does not know or care whether its caller treats a breach as
-//! report-only or hard-gating.)
+//! decision in `main.rs` — which now applies only when the durable-corpus
+//! level clause was suppressed or its instrument was blind — and the
+//! calibration tests below; the assessment itself does not know or care
+//! whether its caller treats a breach as report-only or hard-gating.)
 //!
 //! ## Boot-recompute-gap exclusion
 //!
@@ -334,12 +340,16 @@ fn last_half_window_span_secs(points: &[(f64, f64)]) -> f64 {
 /// [`assess_tombstone_bytes`] with this threshold alongside the RSS `assess`) and
 /// by the `soak_monitor_calibration` integration target's tests — the harness
 /// wiring has landed, so no `allow(dead_code)` is needed here. The slope this
-/// threshold measures is a HARD gate in `main.rs`: the decrementable gauge is
+/// threshold measures is a HARD gate in `main.rs` in the run class where the
+/// durable-corpus level clause did not decide; where that clause did decide,
+/// the slope is still computed, printed and serialized exactly as before, but
+/// it no longer gates. Either way the decrementable gauge is
 /// expected to plateau under sustained churn now that a tracked-and-ACKing
 /// client drives the server's low-water-mark forward (see the module-level
 /// "Tombstone-byte gate" doc above), subject to the min-window-span guard and
 /// boot-gap exclusion. The blind-monitor zero-sample clause is a second,
-/// independent hard gate. RSS above is the coarse backstop.
+/// independent hard gate, and that one is unconditional: it asserts harness
+/// health, not the tombstone property. RSS above is the coarse backstop.
 pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 
 /// Absolute-growth guard (bytes) for the tombstone-byte slope clause.
@@ -354,7 +364,14 @@ pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
 
 /// Minimum wall-clock span (seconds) of the last-half fit window before the
-/// per-hour slope clause is allowed to hard-gate the run.
+/// per-hour slope clause is allowed to hard-gate the run in the class where it
+/// still decides.
+///
+/// This floor governs the slope clause alone. Its counterpart on the
+/// durable-corpus level clause — that clause's own sample and span guards — is
+/// what selects the fallback class: when the level clause cannot decide, the
+/// slope clause is the one that still decides the run, so between the two no
+/// run configuration is left ungated.
 ///
 /// The slope is a per-hour EXTRAPOLATION (bytes/sec × 3600). Over a sub-minute
 /// window the `3600 / span_secs` amplification is enormous: a healthy short run
@@ -364,8 +381,9 @@ pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
 /// Below this floor the slope carries no plateau signal — a leak and a
 /// not-yet-plateaued healthy run are indistinguishable — so the clause is
 /// suppressed (no breach is emitted for it) and the assessment passes on the
-/// blind-monitor + absolute-growth clauses alone. (The slope is now a HARD gate
-/// once the window clears this floor — see [`DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR`];
+/// blind-monitor + absolute-growth clauses alone. (The slope is a HARD gate
+/// once the window clears this floor AND the durable-corpus level clause did
+/// not decide — see [`DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR`];
 /// this floor is what keeps that hard gate from crying wolf on a short run.)
 ///
 /// 120s sits well above the smoke run's ~10-15s last-half span (suppressed) and
@@ -1377,8 +1395,9 @@ mod tests {
     /// and never flattens — the grow-then-flatten shape the plateau statistic
     /// looks for cannot occur. This test feeds exactly that monotone shape (well
     /// past the min-window floor) and asserts the assessment reports NOT-passed
-    /// — which is precisely the hard-gate failure `main.rs` now asserts on for
-    /// this scenario (see the module doc's "Tombstone-byte gate" section).
+    /// — which is precisely the hard-gate failure `main.rs` asserts on for this
+    /// scenario whenever the durable-corpus level clause did not decide the run
+    /// (see the module doc's "Tombstone-byte gate" section).
     #[test]
     fn calibration_additive_only_gauge_never_plateaus() {
         // ~6h of steady creation at 5000 B/h — a multi-hour last-half window
@@ -1395,7 +1414,8 @@ mod tests {
             !a.passed,
             "an unbounded monotone-growth shape (no low-water-mark driver) must \
              NOT be reported as a plateau — this is the hard-gate FAIL `main.rs` \
-             now asserts on; slope={:.1} reason={:?}",
+             asserts on when the durable-corpus level clause did not decide; \
+             slope={:.1} reason={:?}",
             a.slope_bytes_per_hour, a.reason
         );
     }

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -278,9 +278,21 @@ fn least_squares_slope_per_hour(points: &[(f64, f64)]) -> f64 {
 /// [`assess_tombstone_bytes`] MUST agree on which samples make up the "recent
 /// half" — otherwise the guard could clear a window the slope was actually fit
 /// over (or vice versa) — so both derive it from [`last_half_window`].
+/// The index at which a sample series splits into its first and last halves.
+///
+/// The last-half window is `&points[last_half_split_index(points.len())..]`, so
+/// an ODD count puts the middle sample in the RECENT half. Every consumer that
+/// partitions a series — the slope statistic, its span guard and the
+/// durable-corpus level clause — derives the split from here, so the partitions
+/// are provably identical and a reader comparing two of them is comparing like
+/// with like. It takes a length rather than a slice so a series of counted
+/// BYTE totals can share it without any of them becoming an `f64`.
+const fn last_half_split_index(len: usize) -> usize {
+    len / 2
+}
+
 fn last_half_window(points: &[(f64, f64)]) -> &[(f64, f64)] {
-    let half = points.len() / 2;
-    &points[half..]
+    &points[last_half_split_index(points.len())..]
 }
 
 fn last_half_window_slope_per_hour(points: &[(f64, f64)]) -> f64 {
@@ -692,7 +704,7 @@ pub struct TombstoneCorpusAssessment {
 /// dependency beyond `std` — this file is `#[path]`-included by an integration
 /// target that includes no sibling module.
 #[must_use]
-#[allow(dead_code, unused_variables, clippy::unimplemented)]
+#[allow(dead_code)]
 pub fn assess_tombstone_corpus_level(
     samples: &[CorpusSample],
     scans_attempted: usize,
@@ -702,10 +714,105 @@ pub fn assess_tombstone_corpus_level(
     min_samples: usize,
     ceiling_bytes: Option<u64>,
 ) -> TombstoneCorpusAssessment {
-    // The signature and its doc-contract above are frozen ahead of the body so
-    // the calibration fixtures and the report/console transports can be written
-    // against a surface that cannot drift; the clause arithmetic lands next.
-    unimplemented!("corpus level estimator body")
+    // The series aggregates are DESCRIPTIVE: deriving them is not evaluating a
+    // clause, so they are filled in on every path — including the blind one —
+    // and the rendered line stays informative even when no clause decided.
+    // They are also the ONLY shape in which the series reaches a consumer, so
+    // every downstream predicate has to be statable over exactly these.
+    let span_secs = match (samples.first(), samples.last()) {
+        (Some(first), Some(last)) => last.elapsed_secs - first.elapsed_secs,
+        _ => 0.0,
+    };
+    let first_bytes = samples.first().map_or(0, |s| s.bytes);
+    let last_bytes = samples.last().map_or(0, |s| s.bytes);
+    let min_bytes = samples.iter().map(|s| s.bytes).min().unwrap_or(0);
+    let peak_bytes = samples.iter().map(|s| s.bytes).max().unwrap_or(0);
+    // The same split index the slope clause partitions on, applied to counted
+    // byte totals directly: no total is ever routed through an `f64`.
+    let (first_half, last_half) = samples.split_at(last_half_split_index(samples.len()));
+    let first_half_peak_bytes = first_half.iter().map(|s| s.bytes).max().unwrap_or(0);
+    let last_half_peak_bytes = last_half.iter().map(|s| s.bytes).max().unwrap_or(0);
+    // Saturating: a FALLING corpus yields a rise of zero and passes, which is
+    // the correct answer for a ceiling test.
+    let rise_bytes = last_half_peak_bytes.saturating_sub(first_half_peak_bytes);
+
+    // L0 — INSTRUMENT, evaluated FIRST and fail-closed. A blind instrument
+    // returns here, so neither L1 nor L2 is evaluated at all: a gate whose
+    // instrument could not obtain the state must not report bounded growth.
+    if scans_failed > 0 || samples.is_empty() {
+        return TombstoneCorpusAssessment {
+            scans_attempted,
+            scans_failed,
+            samples: samples.len(),
+            first_bytes,
+            min_bytes,
+            peak_bytes,
+            last_bytes,
+            first_half_peak_bytes,
+            last_half_peak_bytes,
+            rise_bytes,
+            span_secs,
+            disposition: CorpusLevelDisposition::InstrumentFailed,
+            ceiling_bytes,
+            passed: false,
+            reason: Some(format!(
+                "durable-corpus instrument blind: {} of {} scans failed, {} usable samples",
+                scans_failed,
+                scans_attempted,
+                samples.len()
+            )),
+        };
+    }
+
+    let mut breaches: Vec<String> = Vec::new();
+
+    // L1 — LEVEL / FLATNESS. Decided only when BOTH guards are met; otherwise
+    // it contributes nothing to the verdict and the suppression is rendered
+    // with its two numbers rather than as a pass.
+    let level_evaluated = samples.len() >= min_samples && span_secs >= min_span_secs;
+    if level_evaluated && rise_bytes > headroom_bytes {
+        breaches.push(format!(
+            "durable-corpus level rose {rise_bytes} B between half-peaks \
+             ({first_half_peak_bytes} B -> {last_half_peak_bytes} B) over \
+             {span_secs:.0}s, above the {headroom_bytes} B headroom"
+        ));
+    }
+
+    // L2 — ABSOLUTE CEILING, an ENVELOPE test on the PEAK. Its only guard is
+    // being armed, so a series too short for L1 is still held to a ceiling.
+    if let Some(ceiling) = ceiling_bytes {
+        if peak_bytes > ceiling {
+            breaches.push(format!(
+                "durable-corpus peak {peak_bytes} B exceeds the armed {ceiling} B ceiling"
+            ));
+        }
+    }
+
+    TombstoneCorpusAssessment {
+        scans_attempted,
+        scans_failed,
+        samples: samples.len(),
+        first_bytes,
+        min_bytes,
+        peak_bytes,
+        last_bytes,
+        first_half_peak_bytes,
+        last_half_peak_bytes,
+        rise_bytes,
+        span_secs,
+        disposition: if level_evaluated {
+            CorpusLevelDisposition::LevelEvaluated
+        } else {
+            CorpusLevelDisposition::LevelSuppressed
+        },
+        ceiling_bytes,
+        passed: breaches.is_empty(),
+        reason: if breaches.is_empty() {
+            None
+        } else {
+            Some(breaches.join("; "))
+        },
+    }
 }
 
 /// Whether the tombstone-byte SLOPE clause still hard-gates a run that

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -1635,4 +1635,243 @@ mod tests {
         );
         assert!(a.slope_mb_per_hour > DEFAULT_DISK_THRESHOLD_MB_PER_HOUR);
     }
+
+    /// Build a durable-corpus series from explicit byte totals, sampled at a
+    /// fixed interval on the harness's elapsed-seconds clock. The totals stay
+    /// `u64` end to end — no counted byte total is routed through an `f64`.
+    fn corpus_series(interval_secs: f64, totals: &[u64]) -> Vec<CorpusSample> {
+        totals
+            .iter()
+            .enumerate()
+            .map(|(index, &bytes)| CorpusSample {
+                elapsed_secs: f64::from(u32::try_from(index).unwrap_or(u32::MAX)) * interval_secs,
+                bytes,
+            })
+            .collect()
+    }
+
+    /// Assess a corpus series under the calibrated defaults, leaving only the
+    /// scan counters and the ceiling to the caller.
+    fn assess_corpus_defaults(
+        samples: &[CorpusSample],
+        scans_attempted: usize,
+        scans_failed: usize,
+        ceiling_bytes: Option<u64>,
+    ) -> TombstoneCorpusAssessment {
+        assess_tombstone_corpus_level(
+            samples,
+            scans_attempted,
+            scans_failed,
+            DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES,
+            DEFAULT_TOMBSTONE_CORPUS_MIN_SPAN_SECS,
+            DEFAULT_TOMBSTONE_CORPUS_MIN_SAMPLES,
+            ceiling_bytes,
+        )
+    }
+
+    /// A LINEAR durable-corpus leak MUST fail the level clause: the last-half
+    /// peak stands far above the first-half peak, which is precisely the
+    /// unbounded-growth shape the clause exists to discriminate. A comparison
+    /// that could not see the difference between the two half-peaks would let
+    /// this series through.
+    #[test]
+    fn calibration_fails_linear_corpus_level() {
+        let samples = corpus_series(
+            90.0,
+            &[
+                0, 100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000,
+            ],
+        );
+        let a = assess_corpus_defaults(&samples, samples.len(), 0, None);
+        assert_eq!(a.disposition, CorpusLevelDisposition::LevelEvaluated);
+        assert_eq!(a.first_half_peak_bytes, 300_000);
+        assert_eq!(a.last_half_peak_bytes, 700_000);
+        assert_eq!(a.rise_bytes, 400_000);
+        assert!(
+            !a.passed,
+            "a linear corpus leak must breach the level clause; rise={} B reason={:?}",
+            a.rise_bytes, a.reason
+        );
+    }
+
+    /// FROZEN FIXTURE: 8 samples 90s apart; first sample 10,000 B; the series
+    /// ramps to 300,000 B by sample 4 and then plateaus FLAT at 300,000 B for
+    /// samples 5-8.
+    ///
+    /// Frozen relationship: the ramp's height above the FIRST sample exceeds
+    /// the headroom (290,000 B > 65,536 B) while the half-to-half rise is
+    /// exactly zero. A genuine ramp-then-plateau is the healthy shape and must
+    /// NOT false-RED; a level test taken against the series' ORIGIN instead of
+    /// its first-half peak would condemn it.
+    #[test]
+    fn calibration_passes_plateau_after_ramp() {
+        let samples = corpus_series(
+            90.0,
+            &[
+                10_000, 110_000, 210_000, 300_000, 300_000, 300_000, 300_000, 300_000,
+            ],
+        );
+        let a = assess_corpus_defaults(&samples, samples.len(), 0, None);
+        assert_eq!(a.disposition, CorpusLevelDisposition::LevelEvaluated);
+        assert!(a.span_secs >= DEFAULT_TOMBSTONE_CORPUS_MIN_SPAN_SECS);
+        assert_eq!(a.first_half_peak_bytes, 300_000);
+        assert_eq!(a.last_half_peak_bytes, 300_000);
+        assert_eq!(a.rise_bytes, 0);
+        assert!(
+            a.peak_bytes - a.first_bytes > DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES,
+            "the fixture's ramp must clear the headroom measured from the origin, \
+             or a level-vs-origin comparison would agree with the correct one"
+        );
+        assert!(
+            a.passed,
+            "a ramp that plateaus must pass; rise={} B reason={:?}",
+            a.rise_bytes, a.reason
+        );
+    }
+
+    /// FROZEN FIXTURE: 5 scans attempted, 1 FAILED, 4 usable samples 210s apart
+    /// on a flat series (span 630s).
+    ///
+    /// Frozen relationship: the surviving samples clear BOTH level-clause
+    /// guards and the series is flat, so an instrument clause that ignored the
+    /// failed scan would evaluate the level clause and PASS. A fixture in which
+    /// every scan failed would be decided by the zero-sample disjunct instead
+    /// and would prove nothing about the failed-scan one.
+    #[test]
+    fn calibration_fails_on_failed_scan() {
+        let samples = corpus_series(210.0, &[120_000; 4]);
+        let a = assess_corpus_defaults(&samples, 5, 1, None);
+        assert_eq!(a.samples, 4);
+        assert_eq!(a.scans_failed, 1);
+        assert!(a.samples >= DEFAULT_TOMBSTONE_CORPUS_MIN_SAMPLES);
+        assert!(a.span_secs >= DEFAULT_TOMBSTONE_CORPUS_MIN_SPAN_SECS);
+        assert_eq!(a.rise_bytes, 0);
+        assert_eq!(a.disposition, CorpusLevelDisposition::InstrumentFailed);
+        assert!(
+            !a.passed,
+            "a blind scan must fail the run closed; reason={:?}",
+            a.reason
+        );
+    }
+
+    /// A scan that read a never-written table and reported zero bytes is an
+    /// honest measurement, not a blindness: a whole series of them MUST pass,
+    /// and must stay distinguishable from a scan that could not read the state
+    /// at all. Treating a zero total as a failed scan would fail an empty but
+    /// perfectly healthy corpus.
+    #[test]
+    fn calibration_passes_honest_empty_corpus() {
+        let samples = corpus_series(90.0, &[0; 8]);
+        let a = assess_corpus_defaults(&samples, samples.len(), 0, None);
+        assert_eq!(a.scans_failed, 0);
+        assert_eq!(a.min_bytes, 0);
+        assert_eq!(a.peak_bytes, 0);
+        assert_eq!(a.rise_bytes, 0);
+        assert_eq!(a.disposition, CorpusLevelDisposition::LevelEvaluated);
+        assert!(
+            a.passed,
+            "an all-zero corpus is an honest empty one and must pass; reason={:?}",
+            a.reason
+        );
+    }
+
+    /// A SLOW unbounded leak must still be caught once enough duration has been
+    /// modelled: 16 samples 120s apart growing 9,000 B per sample. No single
+    /// step comes anywhere near the headroom, so the breach exists only in the
+    /// accumulated half-to-half level — which is the property that lets the
+    /// level clause discriminate a leak the per-hour slope statistic would
+    /// report as a small, unremarkable rate.
+    #[test]
+    fn calibration_fails_slow_unbounded_ramp() {
+        let totals: Vec<u64> = (0..16).map(|i| 50_000 + i * 9_000).collect();
+        let samples = corpus_series(120.0, &totals);
+        let a = assess_corpus_defaults(&samples, samples.len(), 0, None);
+        assert_eq!(a.disposition, CorpusLevelDisposition::LevelEvaluated);
+        let widest_step = samples
+            .windows(2)
+            .map(|pair| pair[1].bytes.saturating_sub(pair[0].bytes))
+            .max()
+            .unwrap_or(0);
+        assert!(
+            widest_step < DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES,
+            "no single step may reach the headroom, or the ramp is not slow; \
+             widest step={widest_step} B"
+        );
+        assert_eq!(a.rise_bytes, 72_000);
+        assert!(a.rise_bytes > DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES);
+        assert!(
+            !a.passed,
+            "a slow but unbounded ramp must breach once the modelled duration is \
+             long enough; rise={} B reason={:?}",
+            a.rise_bytes, a.reason
+        );
+    }
+
+    /// FROZEN FIXTURE: 8 samples 90s apart with the ceiling ARMED at 100,000 B;
+    /// the series peaks at 200,000 B inside the FIRST half and decreases
+    /// monotonically to 50,000 B at the last sample.
+    ///
+    /// Frozen relationship: `peak > ceiling >= last`, and the half-to-half rise
+    /// is zero. So the level clause PASSES and the failure is attributable to
+    /// the absolute ceiling alone — and a ceiling compared against the LAST
+    /// sample rather than the peak would not fire at all. The ceiling is an
+    /// ENVELOPE test, because prune legitimately produces large downward
+    /// excursions a rising envelope could otherwise hide behind.
+    #[test]
+    fn calibration_fails_armed_ceiling() {
+        let samples = corpus_series(
+            90.0,
+            &[
+                200_000, 175_000, 150_000, 125_000, 100_000, 85_000, 70_000, 50_000,
+            ],
+        );
+        let a = assess_corpus_defaults(&samples, samples.len(), 0, Some(100_000));
+        assert_eq!(a.disposition, CorpusLevelDisposition::LevelEvaluated);
+        assert_eq!(
+            a.rise_bytes, 0,
+            "the level clause must pass, so the verdict is attributable to the ceiling"
+        );
+        assert_eq!(a.peak_bytes, 200_000);
+        assert_eq!(a.last_bytes, 50_000);
+        assert_eq!(a.ceiling_bytes, Some(100_000));
+        assert!(a.peak_bytes > 100_000 && a.last_bytes <= 100_000);
+        assert!(
+            !a.passed,
+            "an armed ceiling must breach on the PEAK even though the last sample \
+             sits below it; reason={:?}",
+            a.reason
+        );
+    }
+
+    /// Whenever the level clause did NOT decide, the slope clause must still
+    /// decide — otherwise a run could pass through a window no clause held.
+    /// The enumeration lives on the type: a fourth disposition fails to compile
+    /// inside the predicate, so what this asserts is the CLASSIFICATION of each
+    /// variant, not the exhaustiveness (the compiler owns that).
+    ///
+    /// The blind-instrument variant is checked a second way: such an assessment
+    /// already carries `passed == false`, so it fails through the first
+    /// conjunct and never depends on the fallback to rescue it.
+    #[test]
+    fn calibration_slope_clause_hard_for_every_non_evaluated_disposition() {
+        for (disposition, stays_hard) in [
+            (CorpusLevelDisposition::LevelEvaluated, false),
+            (CorpusLevelDisposition::LevelSuppressed, true),
+            (CorpusLevelDisposition::InstrumentFailed, true),
+        ] {
+            assert_eq!(
+                slope_clause_stays_hard(disposition),
+                stays_hard,
+                "{} is classified wrongly",
+                disposition.as_str()
+            );
+        }
+
+        let blind = assess_corpus_defaults(&[], 1, 1, None);
+        assert_eq!(blind.disposition, CorpusLevelDisposition::InstrumentFailed);
+        assert!(
+            !blind.passed,
+            "a blind instrument must already fail through the first conjunct"
+        );
+    }
 }

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -67,10 +67,10 @@
 //! Note on gating responsibility: [`assess_tombstone_bytes`] *computes* the byte
 //! verdict (including its `passed` flag), but whether that verdict gates the run
 //! is decided in `main.rs`, not here. The byte **slope** is a HARD gate there
-//! only in the run class where the durable-corpus level clause did not decide:
-//! when that clause is evaluable it decides the tombstone property and the
-//! slope becomes report-only, and when it is not, the slope gates exactly as it
-//! always did — so no run configuration is left with neither.
+//! in every run class. The durable-corpus level clause beside it is
+//! report-only: a control cell that injected no fault at all breached it, so it
+//! is recorded and rendered but decides no verdict, and the slope gates exactly
+//! as it always did — so no run configuration is left with neither.
 //! The gauge is restart-survivable (`reconcile_tombstone_bytes` in
 //! `storage/record.rs` re-seeds it via `set_tombstone_bytes` at boot) AND
 //! decrementable within a process life: every tombstone-add increments it and
@@ -82,9 +82,8 @@
 //! one client actually runs the confirm-apply protocol. `main.rs` therefore
 //! also drives a tracked-and-ACKing client (`SoakClient::connect_tracked` +
 //! `confirm_apply`) alongside the churn clients for the run's duration, which
-//! is what makes the gauge's plateau — and thus the hard gate, in the run
-//! class where the slope still decides — reachable in practice rather than
-//! merely possible in principle. `main.rs`'s `--no-ack`
+//! is what makes the gauge's plateau — and thus the hard gate — reachable in
+//! practice rather than merely possible in principle. `main.rs`'s `--no-ack`
 //! and `--inject-slow-leak` modes are the negative/slow-leak controls that
 //! exercise this: disabling the tracked client's ack loop pins the
 //! low-water-mark at 0 and must trip the gate, and a deliberately
@@ -94,8 +93,7 @@
 //! `/metrics` scrape is a harness defect regardless of leak magnitude). The
 //! RSS gate above remains a coarse, non-tombstone backstop. (This module's
 //! `passed: bool` on [`TombstoneAssessment`] drives both the hard-gate
-//! decision in `main.rs` — which now applies only when the durable-corpus
-//! level clause was suppressed or its instrument was blind — and the
+//! decision in `main.rs` — which applies in every run class — and the
 //! calibration tests below; the assessment itself does not know or care
 //! whether its caller treats a breach as report-only or hard-gating.)
 //!
@@ -340,15 +338,14 @@ fn last_half_window_span_secs(points: &[(f64, f64)]) -> f64 {
 /// [`assess_tombstone_bytes`] with this threshold alongside the RSS `assess`) and
 /// by the `soak_monitor_calibration` integration target's tests — the harness
 /// wiring has landed, so no `allow(dead_code)` is needed here. The slope this
-/// threshold measures is a HARD gate in `main.rs` in the run class where the
-/// durable-corpus level clause did not decide; where that clause did decide,
-/// the slope is still computed, printed and serialized exactly as before, but
-/// it no longer gates. Either way the decrementable gauge is
+/// threshold measures is a HARD gate in `main.rs` in every run class; the
+/// durable-corpus level clause beside it is report-only and takes none of
+/// them over. The decrementable gauge is
 /// expected to plateau under sustained churn now that a tracked-and-ACKing
 /// client drives the server's low-water-mark forward (see the module-level
 /// "Tombstone-byte gate" doc above), subject to the min-window-span guard and
 /// boot-gap exclusion. The blind-monitor zero-sample clause is a second,
-/// independent hard gate, and that one is unconditional: it asserts harness
+/// independent hard gate, and it too is unconditional: it asserts harness
 /// health, not the tombstone property. RSS above is the coarse backstop.
 pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 
@@ -364,14 +361,11 @@ pub const DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR: f64 = 512.0;
 pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
 
 /// Minimum wall-clock span (seconds) of the last-half fit window before the
-/// per-hour slope clause is allowed to hard-gate the run in the class where it
-/// still decides.
+/// per-hour slope clause is allowed to hard-gate the run.
 ///
-/// This floor governs the slope clause alone. Its counterpart on the
-/// durable-corpus level clause — that clause's own sample and span guards — is
-/// what selects the fallback class: when the level clause cannot decide, the
-/// slope clause is the one that still decides the run, so between the two no
-/// run configuration is left ungated.
+/// This floor governs the slope clause alone. The durable-corpus level clause
+/// selects no run class away from it: that clause is report-only, so the slope
+/// decides every run, and no run configuration is left ungated.
 ///
 /// The slope is a per-hour EXTRAPOLATION (bytes/sec × 3600). Over a sub-minute
 /// window the `3600 / span_secs` amplification is enormous: a healthy short run
@@ -382,8 +376,8 @@ pub const DEFAULT_TOMBSTONE_BYTES_MIN_GROWTH: f64 = 1.0;
 /// not-yet-plateaued healthy run are indistinguishable — so the clause is
 /// suppressed (no breach is emitted for it) and the assessment passes on the
 /// blind-monitor + absolute-growth clauses alone. (The slope is a HARD gate
-/// once the window clears this floor AND the durable-corpus level clause did
-/// not decide — see [`DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR`];
+/// once the window clears this floor — see
+/// [`DEFAULT_TOMBSTONE_BYTES_THRESHOLD_PER_HOUR`];
 /// this floor is what keeps that hard gate from crying wolf on a short run.)
 ///
 /// 120s sits well above the smoke run's ~10-15s last-half span (suppressed) and
@@ -622,7 +616,7 @@ pub struct CorpusSample {
 pub enum CorpusLevelDisposition {
     /// L1 was evaluated and decided.
     LevelEvaluated,
-    /// L1 was NOT evaluated, so the slope clause hard-gates instead. Never "ok".
+    /// L1 was NOT evaluated. The slope clause hard-gates regardless. Never "ok".
     LevelSuppressed,
     /// L0 failed. L1 and L2 are NOT EVALUATED (fail-closed order).
     InstrumentFailed,
@@ -671,7 +665,9 @@ pub struct TombstoneCorpusAssessment {
     pub reason: Option<String>,
 }
 
-/// L0 and L1 are HARD gate clauses; L1 only when its two guards are met.
+/// L0 and L1 are REPORT-ONLY, not HARD gate clauses: a control cell with no
+/// fault injected breached L1 on its own, so `main.rs` renders and persists
+/// this verdict without folding it into the run's.
 ///
 /// The three clauses are evaluated in this order, and the order is fail-closed:
 ///
@@ -824,11 +820,14 @@ pub fn assess_tombstone_corpus_level(
     }
 }
 
-/// Whether the tombstone-byte SLOPE clause still hard-gates a run that
-/// produced this disposition. EXHAUSTIVE BY CONSTRUCTION: a fourth variant
-/// does not compile here, which is what makes the no-ungated-window coverage
-/// argument structural rather than a source-read. `main.rs`'s verdict
-/// expression consumes this and re-types no comparison of its own.
+/// Whether the tombstone-byte SLOPE clause would be the only hard-gate left on
+/// a run that produced this disposition — equivalently, whether the
+/// durable-corpus level clause decided. EXHAUSTIVE BY CONSTRUCTION: a fourth
+/// variant does not compile here, which is what makes the no-ungated-window
+/// coverage argument structural rather than a source-read. The slope now
+/// decides every run class, so the verdict expression does not consult this;
+/// `main.rs` uses it to name which corpus clause a report-only breach came
+/// from, and re-types no comparison of its own.
 #[must_use]
 // One arm per variant, deliberately not merged into a single `|` pattern: the
 // point of the enumeration is that every variant is classified in its own

--- a/packages/server-rust/benches/soak_harness/monitor.rs
+++ b/packages/server-rust/benches/soak_harness/monitor.rs
@@ -566,7 +566,6 @@ pub fn assess_tombstone_bytes(
 /// lines are single terminal scalars, one per run: they are NOT a noise floor
 /// and NOT a retune input. Revising this constant on measured durable-corpus
 /// data is a recorded revision, never a keyboard retune.
-#[allow(dead_code)]
 pub const DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES: u64 = 65_536;
 
 /// Minimum wall-clock span (seconds) of the corpus series before L1 may decide.
@@ -586,7 +585,6 @@ pub const DEFAULT_TOMBSTONE_CORPUS_HEADROOM_BYTES: u64 = 65_536;
 /// the derived 720 s for the strict comparison and for a first checkpoint that
 /// fires marginally late, and 900 s is the top of the range. A cell shorter
 /// than 730 s is inadmissible by construction.
-#[allow(dead_code)]
 pub const DEFAULT_TOMBSTONE_CORPUS_MIN_SPAN_SECS: f64 = 600.0;
 
 /// Minimum corpus samples before L1 may decide (at least 2 per half).
@@ -595,7 +593,6 @@ pub const DEFAULT_TOMBSTONE_CORPUS_MIN_SPAN_SECS: f64 = 600.0;
 /// [`last_half_window_span_secs`]'s own guard excludes for the same reason. At
 /// `--crash-interval 120` a 900 s cell yields 8 samples (7 checkpoints plus the
 /// terminal scan), clearing this guard with margin.
-#[allow(dead_code)]
 pub const DEFAULT_TOMBSTONE_CORPUS_MIN_SAMPLES: usize = 4;
 
 /// L2's absolute ceiling in bytes. `None` = DISARMED, and that is the default.
@@ -608,14 +605,12 @@ pub const DEFAULT_TOMBSTONE_CORPUS_MIN_SAMPLES: usize = 4;
 /// report, never as an omitted key: omitting it would make "L2 disarmed"
 /// indistinguishable from "this report predates the field", which is the
 /// invisible-suppression defect this estimator exists to refuse.
-#[allow(dead_code)]
 pub const DEFAULT_TOMBSTONE_CORPUS_CEILING_BYTES: Option<u64> = None;
 
 /// One durable-layer OR tombstone corpus scan, taken while the server process is
 /// DEAD (redb is single-writer, so its file lock must be free) and therefore
 /// reading the PRE-RECOVERY on-disk state.
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]
 pub struct CorpusSample {
     pub elapsed_secs: f64,
     pub bytes: u64,
@@ -624,7 +619,6 @@ pub struct CorpusSample {
 /// Which clause actually decided a corpus assessment. Rendered verbatim, so a
 /// clause that did not fire is visible rather than indistinguishable from a pass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum CorpusLevelDisposition {
     /// L1 was evaluated and decided.
     LevelEvaluated,
@@ -641,7 +635,6 @@ impl CorpusLevelDisposition {
     /// Deliberately hand-written rather than serde-derived: this file is
     /// `#[path]`-included by an integration target and must stay `std`-only.
     #[must_use]
-    #[allow(dead_code)]
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::LevelEvaluated => "LEVEL_EVALUATED",
@@ -653,7 +646,6 @@ impl CorpusLevelDisposition {
 
 /// Verdict of a durable-layer corpus assessment.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct TombstoneCorpusAssessment {
     pub scans_attempted: usize,
     pub scans_failed: usize,
@@ -722,7 +714,6 @@ pub struct TombstoneCorpusAssessment {
 /// dependency beyond `std` — this file is `#[path]`-included by an integration
 /// target that includes no sibling module.
 #[must_use]
-#[allow(dead_code)]
 pub fn assess_tombstone_corpus_level(
     samples: &[CorpusSample],
     scans_attempted: usize,
@@ -843,7 +834,7 @@ pub fn assess_tombstone_corpus_level(
 // point of the enumeration is that every variant is classified in its own
 // right, so a fourth variant has to be given an explicit answer here rather
 // than being absorbed into an existing pattern.
-#[allow(dead_code, clippy::match_same_arms)]
+#[allow(clippy::match_same_arms)]
 pub const fn slope_clause_stays_hard(disposition: CorpusLevelDisposition) -> bool {
     match disposition {
         CorpusLevelDisposition::LevelEvaluated => false,

--- a/packages/server-rust/benches/soak_harness/report.rs
+++ b/packages/server-rust/benches/soak_harness/report.rs
@@ -17,6 +17,8 @@ use std::path::Path;
 
 use serde::Serialize;
 use topgun_server::storage::record::RecordValue;
+
+use crate::monitor::CorpusLevelDisposition;
 use topgun_server::storage::wal::format::{self, FrameDecodeResult};
 use topgun_server::storage::wal::{WalOp, WalStorePayload};
 
@@ -39,6 +41,13 @@ pub struct MemoryReport {
 /// verdict: a run that fails here and persists only `passed: false` leaves no
 /// consumer able to say *why* from the committed artifact, and the console the
 /// numbers used to live in is a scratch file under `target/`.
+///
+/// Its `passed` is ANDed CONDITIONALLY, not unconditionally: the durable-corpus
+/// level clause decides the verdict wherever it could be evaluated, and this
+/// slope clause hard-gates exactly the run class where it could not. So it is
+/// neither an unconditional hard gate nor flat report-only, and
+/// [`TombstoneCorpusReport::disposition`] is what says which of the two a given
+/// run got.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TombstoneReport {
@@ -48,6 +57,64 @@ pub struct TombstoneReport {
     pub last_bytes: u64,
     pub slope_bytes_per_hour: f64,
     pub passed: bool,
+    pub reason: Option<String>,
+}
+
+/// Emit a disposition as its single rendered token.
+///
+/// The enum lives in the `std`-only monitor module and therefore derives no
+/// serde; reaching it through a serializer here keeps the dependency on this
+/// side of that boundary while the field stays enum-typed rather than a
+/// stringly-typed downgrade.
+// Takes the disposition by reference because serde's `serialize_with` contract
+// fixes the signature; the type is Copy and the reference is free.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn serialize_disposition<S>(
+    value: &CorpusLevelDisposition,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(value.as_str())
+}
+
+/// Durable-corpus section of the final report.
+///
+/// Persisted for the same reason as [`TombstoneReport`], and for one more: this
+/// verdict is ANDed into `passed` unconditionally, and which of its clauses
+/// decided the run is only recoverable from `disposition`. A consumer holding
+/// this file alone can therefore say both that the run failed here and which
+/// clause failed it.
+///
+/// Derives no `Default` on purpose. A defaulted instance would carry a
+/// disposition nobody constructed, i.e. claim something about a gate that
+/// decided nothing; every instance is built explicitly from an assessment.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TombstoneCorpusReport {
+    pub scans_attempted: usize,
+    pub scans_failed: usize,
+    pub samples: usize,
+    pub first_bytes: u64,
+    pub min_bytes: u64,
+    pub peak_bytes: u64,
+    pub last_bytes: u64,
+    pub first_half_peak_bytes: u64,
+    pub last_half_peak_bytes: u64,
+    pub rise_bytes: u64,
+    pub span_secs: f64,
+    /// Serialized as an explicit string, never omitted. Typed as the ENUM, not
+    /// a `String`, so the console token and the JSON token come from one place.
+    #[serde(serialize_with = "serialize_disposition")]
+    pub disposition: CorpusLevelDisposition,
+    /// `null` when the absolute ceiling is DISARMED. Explicit, with no
+    /// `skip_serializing_if`: an absent key would make "disarmed"
+    /// indistinguishable from "this report predates the field".
+    pub ceiling_bytes: Option<u64>,
+    pub passed: bool,
+    /// `null` when the assessment named no reason. Explicit, for the same
+    /// reason `ceiling_bytes` is.
     pub reason: Option<String>,
 }
 
@@ -128,6 +195,9 @@ pub struct SoakReport {
     /// invariant this upholds: a consumer holding only this file can name the
     /// clause that failed the run without access to the process's stdout.
     pub tombstones: TombstoneReport,
+    /// The durable-layer verdict, beside the gauge-layer one above. Both are
+    /// ANDed into `passed`, so both have to survive into the artifact.
+    pub tombstone_corpus: TombstoneCorpusReport,
     pub disk: DiskReport,
     pub confirm_apply: ConfirmApplyReport,
     pub panic_report: Option<String>,

--- a/packages/server-rust/benches/soak_harness/report.rs
+++ b/packages/server-rust/benches/soak_harness/report.rs
@@ -42,12 +42,11 @@ pub struct MemoryReport {
 /// consumer able to say *why* from the committed artifact, and the console the
 /// numbers used to live in is a scratch file under `target/`.
 ///
-/// Its `passed` is ANDed CONDITIONALLY, not unconditionally: the durable-corpus
-/// level clause decides the verdict wherever it could be evaluated, and this
-/// slope clause hard-gates exactly the run class where it could not. So it is
-/// neither an unconditional hard gate nor flat report-only, and
-/// [`TombstoneCorpusReport::disposition`] is what says which of the two a given
-/// run got.
+/// Its `passed` is ANDed in every run class: the durable-corpus clauses beside
+/// it are report-only, so they take no class over from it. It is therefore an
+/// unconditional hard gate and not report-only, and
+/// [`TombstoneCorpusReport::disposition`] says which durable-corpus clause was
+/// live on a given run without changing that.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TombstoneReport {
@@ -82,10 +81,10 @@ where
 /// Durable-corpus section of the final report.
 ///
 /// Persisted for the same reason as [`TombstoneReport`], and for one more: this
-/// verdict is ANDed into `passed` unconditionally, and which of its clauses
-/// decided the run is only recoverable from `disposition`. A consumer holding
-/// this file alone can therefore say both that the run failed here and which
-/// clause failed it.
+/// verdict is REPORT-ONLY — it is not ANDed into `passed` — so the artifact is
+/// the only place a consumer can see it at all, and which clause it came from
+/// is only recoverable from `disposition`. A consumer holding this file alone
+/// can therefore say both that the corpus breached and which clause saw it.
 ///
 /// Derives no `Default` on purpose. A defaulted instance would carry a
 /// disposition nobody constructed, i.e. claim something about a gate that
@@ -195,8 +194,9 @@ pub struct SoakReport {
     /// invariant this upholds: a consumer holding only this file can name the
     /// clause that failed the run without access to the process's stdout.
     pub tombstones: TombstoneReport,
-    /// The durable-layer verdict, beside the gauge-layer one above. Both are
-    /// ANDed into `passed`, so both have to survive into the artifact.
+    /// The durable-layer verdict, beside the gauge-layer one above. This one
+    /// is report-only rather than ANDed into `passed`, which is exactly why it
+    /// has to survive into the artifact: nothing else records it.
     pub tombstone_corpus: TombstoneCorpusReport,
     pub disk: DiskReport,
     pub confirm_apply: ConfirmApplyReport,

--- a/packages/server-rust/tests/soak_wal_census.rs
+++ b/packages/server-rust/tests/soak_wal_census.rs
@@ -403,7 +403,10 @@ fn sample_report(wal_fsync: &str, epoch_width: u64) -> SoakReport {
 }
 
 /// Every verdict that the run's `passed` is hard-ANDed with must reach the JSON
-/// report, under the exact keys a consumer reads, carrying its own input.
+/// report, under the exact keys a consumer reads, carrying its own input -- and
+/// so must the durable-corpus verdict, which is report-only precisely because a
+/// control cell with no fault injected breached it, and which therefore reaches
+/// no other durable transport at all.
 ///
 /// This exists because the opposite was true and cost a real diagnosis: a run
 /// could persist `passed: false` while the slope that failed it, and the

--- a/packages/server-rust/tests/soak_wal_census.rs
+++ b/packages/server-rust/tests/soak_wal_census.rs
@@ -40,6 +40,10 @@
     clippy::doc_markdown
 )]
 
+#[path = "../benches/soak_harness/monitor.rs"]
+#[allow(dead_code)]
+mod monitor;
+
 #[path = "../benches/soak_harness/report.rs"]
 #[allow(dead_code)]
 mod report;
@@ -54,9 +58,10 @@ use topgun_server::storage::wal::format;
 use topgun_server::storage::wal::{OrDelta, WalEntry, WalOp, WalStorePayload};
 use topgun_server::tombstone_frontier_impl::DEFAULT_EPOCH_WIDTH;
 
+use monitor::CorpusLevelDisposition;
 use report::{
     effective_epoch_width, scan_wal_frame_sizes, ConfirmApplyReport, DiskReport, MemoryReport,
-    SoakReport, TombstoneReport,
+    SoakReport, TombstoneCorpusReport, TombstoneReport,
 };
 
 fn stamp(millis: u64) -> Timestamp {
@@ -356,6 +361,26 @@ fn sample_report(wal_fsync: &str, epoch_width: u64) -> SoakReport {
             passed: false,
             reason: Some("tombstone slope exceeded".to_string()),
         },
+        // The ceiling is ARMED here on purpose. It is disarmed by default, so
+        // the serialized non-null branch reaches no transport anywhere else,
+        // and a null-only fixture would leave half the field untested.
+        tombstone_corpus: TombstoneCorpusReport {
+            scans_attempted: 41,
+            scans_failed: 7,
+            samples: 34,
+            first_bytes: 101,
+            min_bytes: 97,
+            peak_bytes: 8_311,
+            last_bytes: 4_213,
+            first_half_peak_bytes: 1_777,
+            last_half_peak_bytes: 8_311,
+            rise_bytes: 6_534,
+            span_secs: 781.5,
+            disposition: CorpusLevelDisposition::LevelEvaluated,
+            ceiling_bytes: Some(262_144),
+            passed: false,
+            reason: Some("durable corpus level rose past its headroom".to_string()),
+        },
         disk: DiskReport {
             samples: 60,
             first_mb: 1.5,
@@ -423,6 +448,78 @@ fn soak_report_emits_every_hard_anded_verdict_tracking_its_input() {
     assert_eq!(
         t.get("reason").and_then(serde_json::Value::as_str),
         Some("tombstone slope exceeded")
+    );
+
+    let tc = json
+        .get("tombstoneCorpus")
+        .expect("report carries a tombstoneCorpus section");
+    assert_eq!(
+        tc.get("scansAttempted").and_then(serde_json::Value::as_u64),
+        Some(41)
+    );
+    assert_eq!(
+        tc.get("scansFailed").and_then(serde_json::Value::as_u64),
+        Some(7)
+    );
+    assert_eq!(
+        tc.get("samples").and_then(serde_json::Value::as_u64),
+        Some(34)
+    );
+    assert_eq!(
+        tc.get("firstBytes").and_then(serde_json::Value::as_u64),
+        Some(101)
+    );
+    assert_eq!(
+        tc.get("minBytes").and_then(serde_json::Value::as_u64),
+        Some(97)
+    );
+    assert_eq!(
+        tc.get("peakBytes").and_then(serde_json::Value::as_u64),
+        Some(8_311)
+    );
+    assert_eq!(
+        tc.get("lastBytes").and_then(serde_json::Value::as_u64),
+        Some(4_213)
+    );
+    assert_eq!(
+        tc.get("firstHalfPeakBytes")
+            .and_then(serde_json::Value::as_u64),
+        Some(1_777)
+    );
+    assert_eq!(
+        tc.get("lastHalfPeakBytes")
+            .and_then(serde_json::Value::as_u64),
+        Some(8_311)
+    );
+    assert_eq!(
+        tc.get("riseBytes").and_then(serde_json::Value::as_u64),
+        Some(6_534)
+    );
+    assert_eq!(
+        tc.get("spanSecs").and_then(serde_json::Value::as_f64),
+        Some(781.5)
+    );
+    // The clause that decided is what separates a verdict this section could
+    // make from one it could not, so it travels as its own rendered token
+    // rather than being inferred from `passed`.
+    assert_eq!(
+        tc.get("disposition").and_then(serde_json::Value::as_str),
+        Some("LEVEL_EVALUATED")
+    );
+    // An ARMED ceiling must serialize as its number; the disarmed case is a
+    // present `null` and never an absent key, which is why no field here may
+    // carry `skip_serializing_if`.
+    assert_eq!(
+        tc.get("ceilingBytes").and_then(serde_json::Value::as_u64),
+        Some(262_144)
+    );
+    assert_eq!(
+        tc.get("passed").and_then(serde_json::Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        tc.get("reason").and_then(serde_json::Value::as_str),
+        Some("durable corpus level rose past its headroom")
     );
 
     let d = json.get("disk").expect("report carries a disk section");


### PR DESCRIPTION
## Summary

Second half of TODO-634 carve 7 (LEVEL/ceiling gate re-derivation), file-disjoint with #153.

The durable-corpus LEVEL/ceiling estimator was built, frozen under digest **before** any calibration test or control run, and then **refuted by its own anti-tautology bar**: the NEUTRAL attribution control (no fault injected) breached L1 unaided — rise 142,418 B vs the 65,536 B headroom, while the `--inject-slow-leak` cell produced 134,867 B, *below* the control. The estimator does not discriminate background growth from a leak at this duration, so per the pre-registered AT-3 branch the consequence was **sited, not argued away**:

- The estimator ships **REPORT-ONLY**: `corpus.passed` dropped from the verdict conjunction; a breach is still computed, rendered, persisted as `tombstoneCorpus`, and reported on `pending_gates`.
- The tombstone byte-slope clause is now hard **UNCONDITIONALLY** — no run class is left ungated (NO-UNGATED-WINDOW holds).
- This is an **earned negative**: AT-0 did not fire (all three cells admissible, spans 778–783 s ≥ 600 s guard, `scans_failed = 0`), all three transports agree in every cell, and no parameter was retuned in either direction.

Instrument neutrality: the redb corpus scanner never first-opens the server's own file after `kill -9` — checkpoint scans read a byte copy in scratch; the server stays the first opener of the original. The terminal scan runs post-teardown only.

## Evidence

- Frozen surface + siting + correction record under four reproducing digests (`spec361-level-gate-ruling.md` + sidecars).
- Six executed mutation arms recorded (`spec361a-witness-arm.txt`); reviewer independently re-executed W1, W5, W9 and reproduced each transcript exactly.
- Control runs recorded in `spec361-control-runs.txt` (three cells at D=900, `--crash-interval 120`).

## Review

- Audit v2/v3/v4 (cap spent), Review v1 CHANGES_REQUESTED → Fix Response v1 → **Review v2 APPROVED, zero findings**.
- Full gate reproduced fresh by the reviewer: fmt 0, clippy `-D warnings` 0, `cargo test --release --all-targets -p topgun-server` — 17 targets, 1983 passed, 0 failed; `check-invariants.sh` — 21 entries, 4 NAKED (baseline 4).
- `packages/server-rust/src/` is byte-unchanged on this branch (harness-only change; no hot-path impact, load harness not required).

https://claude.ai/code/session_015D671dvDhFhyyj1gDGTncQ