### PR TITLE
chore(ci): raise the Check & Lint job budget to 30 minutes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,10 @@ jobs:
   check:
     name: Check & Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 30, not 15: with the soak-harness test corpus this job runs ~15 min on hosted
+    # runners (clippy ~3 min + debug `cargo test --all-targets` ~10 min), so a 15-minute
+    # budget cancels a job whose every step already passed and skips Simulation Tests.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

`Check & Lint` (`.github/workflows/rust.yml`) hit its `timeout-minutes: 15` ceiling on PR #157 — clippy 2:56 + debug `cargo test --all-targets` 10:20, 15:03 wall — after every step had already succeeded, so the job was reported as **cancelled** and the dependent `Simulation Tests` / soak jobs were **skipped**. Main's own last run (33617664844, 2026-09-02) took 14:30 on the same job, so the budget was already exhausted before that branch.

## Change

`timeout-minutes: 15 → 30` on the `check` job only, with a WHY comment. No step is added, removed or reordered. 30 matches the Performance Gate's budget.

## Verification

This PR's own `Check & Lint` run under the new budget, then PR #157 re-run.

https://claude.ai/code/session_015D671dvDhFhyyj1gDGTncQ