### PR TITLE
fix(server): make timeouts and load-shed rejections countable

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -668,8 +668,9 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
   `TimeoutLayer` may fail *after* the inner future has started — it drops that future mid-flight, so a
   sub-batch under it can already have applied operations — which is safe for this row because
   `Timeout` is `Transient`, and a Transient failure enters no singleton fallback at all.
-  `AuthorizationLayer` builds the inner future before it decides, but fails before that future is
-  ever *polled*: the Deny arm returns `Forbidden` and drops it un-awaited, and nothing has been
+  `AuthorizationLayer` builds the inner future before the RBAC decision — the reserved-map refusal
+  returns `Forbidden` before any future exists — but fails before that future is ever *polled*: the
+  Deny arm returns `Forbidden` and drops it un-awaited, and nothing has been
   applied because `Arc<CrdtService>::call` does all of its work inside the boxed future it returns —
   since `Forbidden` is Permanent, this row's guarantee on the Authorization path rests on exactly
   that property. The Router dispatches to the domain service, where the rest of this bullet takes

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -662,8 +662,18 @@ CI check it lacks. Origin: extraction memo 2026-07-16 + SPEC-350/351 closures.
   operation of that sub-batch was applied. This is what the per-op singleton re-dispatch relies on:
   if a Permanent failure could occur *after* some ops were applied, the fallback would apply them a
   second time.
-- **Maintaining code:** the basis is layer-by-layer. LoadShed, Timeout, Metrics, Authorization and
-  the Router all fail *before* the inner call; `handle_op_batch` raises every Permanent variant in
+- **Maintaining code:** the basis is layer-by-layer, in stack order. `MetricsLayer` only observes: it
+  records the outcome and returns the inner result unchanged, so it raises no error of its own and
+  applies nothing. `LoadShedLayer` fails with `Overloaded` before the inner future is built at all.
+  `TimeoutLayer` may fail *after* the inner future has started — it drops that future mid-flight, so a
+  sub-batch under it can already have applied operations — which is safe for this row because
+  `Timeout` is `Transient`, and a Transient failure enters no singleton fallback at all.
+  `AuthorizationLayer` builds the inner future before it decides, but fails before that future is
+  ever *polled*: the Deny arm returns `Forbidden` and drops it un-awaited, and nothing has been
+  applied because `Arc<CrdtService>::call` does all of its work inside the boxed future it returns —
+  since `Forbidden` is Permanent, this row's guarantee on the Authorization path rests on exactly
+  that property. The Router dispatches to the domain service, where the rest of this bullet takes
+  over; `handle_op_batch` raises every Permanent variant in
   its validate loops *before* its apply loops; `apply_single_op` and `broadcast_event` return only
   `Internal`, which is Transient. A future Permanent error raised mid-apply breaks this row, and
   this row is what a reviewer trips over.

--- a/packages/server-rust/src/service/middleware/pipeline.rs
+++ b/packages/server-rust/src/service/middleware/pipeline.rs
@@ -63,7 +63,9 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
     use std::task::{Context, Poll};
+    use std::time::Duration;
 
+    use metrics_exporter_prometheus::PrometheusBuilder;
     use topgun_core::Timestamp;
     use tower::{Service, ServiceExt};
 
@@ -95,7 +97,38 @@ mod tests {
         }
     }
 
+    /// Service that sleeps past any plausible budget before answering, so the
+    /// timeout layer always wins the race in the timeout test.
+    struct SleepingStub;
+
+    impl Service<Operation> for SleepingStub {
+        type Response = OperationResponse;
+        type Error = OperationError;
+        type Future =
+            Pin<Box<dyn Future<Output = Result<OperationResponse, OperationError>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, op: Operation) -> Self::Future {
+            let call_id = op.ctx().call_id;
+            let name = op.ctx().service_name;
+            Box::pin(async move {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                Ok(OperationResponse::NotImplemented {
+                    service_name: name,
+                    call_id,
+                })
+            })
+        }
+    }
+
     fn make_op() -> Operation {
+        make_op_with_timeout(5000)
+    }
+
+    fn make_op_with_timeout(call_timeout_ms: u64) -> Operation {
         let ctx = OperationContext::new(
             42,
             service_names::CRDT,
@@ -104,9 +137,42 @@ mod tests {
                 counter: 0,
                 node_id: "test".to_string(),
             },
-            5000,
+            call_timeout_ms,
         );
         Operation::GarbageCollect { ctx }
+    }
+
+    /// Read one counter out of a Prometheus render by name plus a label subset.
+    ///
+    /// Matching on the parsed label set rather than on a raw substring keeps the
+    /// assertion independent of the order the exporter happens to emit labels in,
+    /// and returning `None` for an absent series is what lets a test distinguish
+    /// "counted zero" from "never registered".
+    fn rendered_counter(render: &str, name: &str, labels: &[(&str, &str)]) -> Option<u64> {
+        'lines: for line in render.lines() {
+            if line.starts_with('#') {
+                continue;
+            }
+            let Some((head, value)) = line.rsplit_once(' ') else {
+                continue;
+            };
+            let (line_name, label_blob) = match head.split_once('{') {
+                Some((n, rest)) => (n, rest.trim_end_matches('}')),
+                None => (head, ""),
+            };
+            if line_name != name {
+                continue;
+            }
+            for (key, want) in labels {
+                let needle = format!("{key}=\"{want}\"");
+                if !label_blob.split(',').any(|pair| pair == needle) {
+                    continue 'lines;
+                }
+            }
+            let raw = value.trim();
+            return raw.strip_suffix(".0").unwrap_or(raw).parse::<u64>().ok();
+        }
+        None
     }
 
     #[tokio::test]
@@ -128,5 +194,141 @@ mod tests {
                 call_id: 42,
             }
         ));
+    }
+
+    /// An operation that exhausts its budget must be COUNTED, not merely refused.
+    ///
+    /// The recorder is a thread-local, so the runtime is built and driven inside
+    /// the binding and everything is polled on that one current-thread runtime.
+    /// The clock is paused: the runtime then auto-advances to the earliest
+    /// deadline, which is the 50 ms budget rather than the stub's 200 ms sleep,
+    /// so the outcome cannot depend on wall-clock scheduling.
+    #[test]
+    fn timed_out_operation_increments_the_timeout_error_counter() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        let rendered = metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .start_paused(true)
+                .build()
+                .expect("current-thread runtime");
+            rt.block_on(async {
+                let mut router = OperationRouter::new();
+                router.register(service_names::CRDT, SleepingStub);
+
+                let config = ServerConfig {
+                    max_concurrent_operations: 100,
+                    ..ServerConfig::default()
+                };
+
+                let svc = build_operation_pipeline(router, &config, None);
+                let err = svc.oneshot(make_op_with_timeout(50)).await.unwrap_err();
+                assert!(
+                    matches!(err, OperationError::Timeout { timeout_ms: 50 }),
+                    "the budget must be what fails the call, got {err:?}"
+                );
+            });
+            handle.render()
+        });
+
+        assert_eq!(
+            rendered_counter(
+                &rendered,
+                "topgun_operation_errors_total",
+                &[("service", "crdt"), ("error", "timeout")],
+            ),
+            Some(1),
+            "a real timeout must reach the error counter; render was:\n{rendered}"
+        );
+        assert_eq!(
+            rendered_counter(
+                &rendered,
+                "topgun_operations_total",
+                &[("service", "crdt"), ("outcome", "error")],
+            ),
+            Some(1),
+            "a timed-out operation must count as an error outcome; render was:\n{rendered}"
+        );
+    }
+
+    /// A shed operation must be COUNTED, not silently dropped.
+    ///
+    /// The permit is taken synchronously inside `call`, so holding the first
+    /// future WITHOUT polling it is enough to occupy the only permit — no sleep
+    /// and no spawn, and therefore no timing assumption at all.
+    #[test]
+    fn shed_operation_increments_the_overloaded_error_counter() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        let rendered = metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("current-thread runtime");
+            rt.block_on(async {
+                let mut router = OperationRouter::new();
+                router.register(service_names::CRDT, StubService);
+
+                let config = ServerConfig {
+                    max_concurrent_operations: 1,
+                    ..ServerConfig::default()
+                };
+
+                let mut svc = build_operation_pipeline(router, &config, None);
+
+                // Created, deliberately not polled: it already owns the permit.
+                let in_flight = svc.ready().await.unwrap().call(make_op());
+
+                let shed = svc.ready().await.unwrap().call(make_op()).await;
+                assert!(
+                    matches!(shed, Err(OperationError::Overloaded)),
+                    "the second operation must be shed, got {shed:?}"
+                );
+
+                let held = in_flight.await.unwrap();
+                assert!(
+                    matches!(
+                        held,
+                        OperationResponse::NotImplemented {
+                            service_name: "crdt",
+                            call_id: 42,
+                        }
+                    ),
+                    "the permit holder must still complete normally"
+                );
+            });
+            handle.render()
+        });
+
+        assert_eq!(
+            rendered_counter(
+                &rendered,
+                "topgun_operation_errors_total",
+                &[("service", "crdt"), ("error", "overloaded")],
+            ),
+            Some(1),
+            "a real shed must reach the error counter; render was:\n{rendered}"
+        );
+        assert_eq!(
+            rendered_counter(
+                &rendered,
+                "topgun_operations_total",
+                &[("service", "crdt"), ("outcome", "error")],
+            ),
+            Some(1),
+            "a shed operation must count as an error outcome; render was:\n{rendered}"
+        );
+        assert_eq!(
+            rendered_counter(
+                &rendered,
+                "topgun_operations_total",
+                &[("service", "crdt"), ("outcome", "ok")],
+            ),
+            Some(1),
+            "the permit holder must count as an ok outcome; render was:\n{rendered}"
+        );
     }
 }

--- a/packages/server-rust/src/service/middleware/pipeline.rs
+++ b/packages/server-rust/src/service/middleware/pipeline.rs
@@ -19,9 +19,12 @@ use crate::service::router::OperationRouter;
 /// Build the operation pipeline by wrapping the `OperationRouter` with middleware layers.
 ///
 /// Layer order (outermost to innermost):
-/// 1. `LoadShedLayer` -- reject when overloaded (fail fast before doing any work)
-/// 2. `TimeoutLayer` -- enforce per-operation timeouts
-/// 3. `MetricsLayer` -- record timing and outcome (before auth so denied requests are tracked)
+/// 1. `MetricsLayer` -- record timing and outcome. Outermost, so shed, timed-out and
+///    denied operations are all counted: any layer placed outside it can drop or
+///    short-circuit the inner future, and that operation's outcome would then be
+///    unobservable on `/metrics` no matter what the error kinds say.
+/// 2. `LoadShedLayer` -- reject when overloaded (fail fast before doing any work)
+/// 3. `TimeoutLayer` -- enforce per-operation timeouts
 /// 4. `AuthorizationLayer` (optional) -- RBAC policy enforcement; omitted when `None`
 /// 5. `OperationRouter` -- domain service dispatch
 ///
@@ -38,17 +41,17 @@ pub fn build_operation_pipeline(
 ) -> OperationPipeline {
     if let Some(evaluator) = policy_evaluator {
         let svc = ServiceBuilder::new()
+            .layer(MetricsLayer)
             .layer(LoadShedLayer::new(config.max_concurrent_operations))
             .layer(TimeoutLayer)
-            .layer(MetricsLayer)
             .layer(AuthorizationLayer::new(evaluator))
             .service(router);
         OperationPipeline::new(svc)
     } else {
         let svc = ServiceBuilder::new()
+            .layer(MetricsLayer)
             .layer(LoadShedLayer::new(config.max_concurrent_operations))
             .layer(TimeoutLayer)
-            .layer(MetricsLayer)
             .service(router);
         OperationPipeline::new(svc)
     }

--- a/packages/server-rust/src/service/middleware/pipeline.rs
+++ b/packages/server-rust/src/service/middleware/pipeline.rs
@@ -28,6 +28,11 @@ use crate::service::router::OperationRouter;
 /// 4. `AuthorizationLayer` (optional) -- RBAC policy enforcement; omitted when `None`
 /// 5. `OperationRouter` -- domain service dispatch
 ///
+/// One accepted consequence of this order: the timeout layer now sits inside the
+/// metrics layer, so an operation's budget no longer has to cover the work of
+/// recording its own outcome. That shift is microseconds wide and is the price of
+/// making a timed-out operation observable at all.
+///
 /// When `policy_evaluator` is `None` (RBAC not configured), the authorization layer
 /// is omitted entirely so there is zero overhead for non-RBAC deployments.
 ///
@@ -205,7 +210,10 @@ mod tests {
     /// the binding and everything is polled on that one current-thread runtime.
     /// The clock is paused: the runtime then auto-advances to the earliest
     /// deadline, which is the 50 ms budget rather than the stub's 200 ms sleep,
-    /// so the outcome cannot depend on wall-clock scheduling.
+    /// so the outcome cannot depend on wall-clock scheduling. That determinism
+    /// assumes the timeout layer keeps arming its deadline through `tokio::time`;
+    /// were it ever moved to another clock source, the paused runtime would stop
+    /// governing this test and the stub's sleep would start winning the race.
     #[test]
     fn timed_out_operation_increments_the_timeout_error_counter() {
         let recorder = PrometheusBuilder::new().build_recorder();
@@ -258,9 +266,11 @@ mod tests {
 
     /// A shed operation must be COUNTED, not silently dropped.
     ///
-    /// The permit is taken synchronously inside `call`, so holding the first
-    /// future WITHOUT polling it is enough to occupy the only permit — no sleep
-    /// and no spawn, and therefore no timing assumption at all.
+    /// `LoadShedService::call` takes the permit synchronously: its
+    /// `try_acquire_owned` runs before the future it returns even exists. Holding
+    /// that first future WITHOUT polling it is therefore enough to occupy the only
+    /// permit — no sleep and no spawn, and so no timing assumption at all. This is
+    /// a property of this crate's own load-shed layer, not of a generic one.
     #[test]
     fn shed_operation_increments_the_overloaded_error_counter() {
         let recorder = PrometheusBuilder::new().build_recorder();


### PR DESCRIPTION
## What and why

`topgun_operation_errors_total{error="timeout"}` and `{error="overloaded"}` were **unreachable in
production**, and `topgun_operations_total{outcome="error"}`, `topgun_operation_duration_seconds` and
`/api/status` `total_operations` omitted exactly those failures.

`MetricsLayer` sat *inside* `TimeoutLayer` and `LoadShedLayer`:

- a timeout wrapped the inner future in `tokio::time::timeout` and, on elapse, **dropped** it — and the
  dropped future was the metrics future, which records only after its own `await`;
- a shed returned `Overloaded` from `LoadShedService::call` **without ever invoking** the inner service.

Either way nothing counted. The two error kinds existed in the match arm but were dead code in
production. This came out of a reclamation investigation where 5 s operation timeouts were cancelling
inline prune passes — and nothing on `/metrics` recorded that it was happening.

**The fix is a pure reorder** of both arms of `build_operation_pipeline`, to
`Metrics → LoadShed → Timeout → [Authz] → Router`. No layer's own code changes.

`build_operation_pipeline` is the **single construction site** — the server binary, the load harness
and all nine test call sites route through it, and `network/middleware.rs` uses the unrelated
`tower_http` HTTP `TimeoutLayer` — so a reorder confined to one file cannot leave a stale order
anywhere.

## Commits

| Commit | What |
|---|---|
| `bffac427` | tests only, RED at the pin order |
| `98e8135c` | the reorder + doc-comment order list + the `TG-SYNC-003` bullet |
| `6863d68f` | three one-sentence comments naming the budget/permit/clock assumptions |
| `f4b67245` | scope the `TG-SYNC-003` authorization clause to the RBAC path |

Two files change in total: `packages/server-rust/src/service/middleware/pipeline.rs` (the only `.rs`,
ledger 1/5) and `INVARIANTS.md`.

## RED → GREEN proof

The tests were committed **first** and run at that commit. The renders are quoted because they show the
*mechanism*, not merely a failure — the timeout test's render is **empty** (the metrics future was
dropped before recording anything) and the shed test's render carries **only** the permit holder's
`outcome="ok"` row with no error series at all:

```
running 3 tests
test pipeline_routes_through_all_layers ... ok
test shed_operation_increments_the_overloaded_error_counter ... FAILED
test timed_out_operation_increments_the_timeout_error_counter ... FAILED

---- shed_operation_increments_the_overloaded_error_counter ----
assertion `left == right` failed: a real shed must reach the error counter; render was:
# TYPE topgun_operations_total counter
topgun_operations_total{service="crdt",outcome="ok"} 1
# TYPE topgun_operation_duration_seconds summary
...
  left: None
 right: Some(1)

---- timed_out_operation_increments_the_timeout_error_counter ----
assertion `left == right` failed: a real timeout must reach the error counter; render was:

  left: None
 right: Some(1)

test result: FAILED. 1 passed; 2 failed
```

`left: None` means the series was never **registered** — not that it counted zero. After the reorder:
`test result: ok. 3 passed; 0 failed`.

**Honesty note on the RED evidence.** The independent reviewer's own RED build at `bffac427` did not
finish inside its window; it was terminated (SIGTERM) and produced no result, which is claimed nowhere.
The RED output above is the executor's run at that commit, and it is corroborated structurally:
`git diff 550936dc..bffac427` touches only hunks inside `mod tests`, while
`git show bffac427:…/pipeline.rs` still carries the pin order `LoadShed → Timeout → Metrics`, at which
the counters are unreachable by construction.

## Test design

- **Shed test** — no sleep, no spawn, no `Notify`. `LoadShedService::call` takes its permit
  synchronously (`try_acquire_owned` runs before the future it returns exists), so *creating but never
  polling* the first future is enough to hold the only permit. Deterministic by construction.
- **Timeout test** — paused clock (`start_paused(true)`), so the runtime auto-advances to the 50 ms
  budget rather than racing the stub's 200 ms sleep on wall-clock time.
- Both use a thread-local Prometheus recorder driven on a single current-thread runtime, the pattern
  already proven in `websocket.rs`.

## Behaviour changes (intended)

- `outcome="error"`, the duration histogram and `/api/status` `total_operations` now include shed and
  timed-out operations.
- The `operation` span and its `operation complete` line now enclose the timeout and the shed decision.
- The per-operation budget no longer covers the cost of recording the operation's own outcome
  (microseconds; the timeout layer now sits inside the metrics layer).
- `refused_op_metric_arithmetic` is unaffected: metrics still sits above authorization.

## INVARIANTS.md

`TG-SYNC-003`'s *Maintaining code* bullet narrated the old stack order and claimed every layer "fails
before the inner call". That was already imprecise before this change — a timeout fires **after** the
inner future has started — so the bullet is restated per layer, with why the row still holds:
`Timeout` is `Transient` and a Transient failure enters no singleton fallback; authorization builds the
inner future before the RBAC decision (the reserved-map refusal returns `Forbidden` before any future
exists) but fails before it is ever **polled**, and nothing is applied because `Arc<CrdtService>::call`
does all its work inside the boxed future it returns.

`scripts/check-invariants.sh` exits 0 at `24 entries, 4 NAKED (baseline 4)` — identical to the pin.

## Gate — section A matrix, true exit codes (14/14)

| Command | Exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `SDKROOT=… cargo test --release -p topgun-server --lib` | 0 |
| `cargo build --release --bin topgun-server -p topgun-server` | 0 |
| `pnpm test:sim` | 0 |
| `pnpm install --frozen-lockfile` | 0 |
| `pnpm -r build` | 0 |
| `pnpm -r exec jest --runInBand --passWithNoTests` | 0 |
| `pnpm lint` | 0 |
| `pnpm format:check` | 0 |
| `pnpm --filter apps-docs-astro build` | 0 |
| `cargo clippy --all-targets --all-features -- -D warnings` | 0 |
| `bash scripts/check-invariants.sh` | 0 |
| load harness at the pin | 0 |
| load harness at the branch | 0 |

Nothing failed, so nothing was fixed or deferred under the "pre-existing errors are owned" rule. The
matrix was run at `6863d68f`; commit `f4b67245` changes one sentence of a markdown file, so it was not
re-run — only `check-invariants.sh`, which passes.

## Gate — load harness (fire-and-wait, 50 connections × 10 s)

| Run | ops/sec | p50 µs | p95 µs | p99 µs | max µs | verdict |
|---|---|---|---|---|---|---|
| pin `550936dc` | 8600 | 3575 | 8487 | 12655 | 29103 | PASS |
| branch | 9000 | 3669 | 8083 | 9263 | 10991 | PASS |

**No regression** — 104.7 % of pin throughput against an 80 % floor, both runs passing the harness's own
baseline (acked ≥ 80 %, p99 < 500 ms).

**This is not a speed-up claim.** Each side is a single 10 s run, and run-to-run variance on one binary
in this repo has been measured as large; the +4.7 % and the lower p99 are within noise. Mechanically a
speed-up would be surprising: the reorder adds one boxed future and one span per *shed* operation and
changes nothing on the admitted-op path, and at 50 connections nothing is being shed.

## Review

Fresh-context audit: APPROVED, 0 criticals. Fresh-context implementation review: APPROVED, 0 critical,
0 major, 2 minor.

- Minor 1 — the test-local `rendered_counter` helper returns `None` both for an absent series and an
  unparseable value, so an exporter format change would be misdiagnosed by the assertion message.
  Deliberately left: test-local diagnosability, no correctness impact.
- Minor 2 — the authorization clause in `TG-SYNC-003`; **fixed** in `f4b67245`.

Cross-vendor adversarial review (glm-5.3) raised 8 points; 4 were refuted against the tree (the
`metrics` 0.24 recorder signature, `poll_ready` delegation, a supposedly missing enforcing test, and
missing dependencies — all already present), 3 became the one-sentence comments in `6863d68f`, and 1
was rejected as not worth the code.

## Deferred

`TODO-674` — alert recalibration. The docs describe the error counter's healthy range as "near 0" with
a `HighErrorRate` alert at `rate(...) > 10`; now that sheds are countable, sustained overload trips that
alert where it was previously silent. No doc or dashboard change is made here.

https://claude.ai/code/session_01B2xaMuzMZAF7AWECdSjAN4
